### PR TITLE
[Core] Keep Option #s consistent

### DIFF
--- a/XIVSlothCombo/Window/Functions/Presets.cs
+++ b/XIVSlothCombo/Window/Functions/Presets.cs
@@ -236,6 +236,9 @@ namespace XIVSlothCombo.Window.Functions
                             {
                                 Service.Configuration.EnabledActions.Remove(childPreset);
                                 Service.Configuration.Save();
+
+                                // Keep removed items in the counter
+                                i += 1 + AllChildren(presetChildren[childPreset]);
                             }
 
                             else

--- a/XIVSlothCombo/Window/Tabs/PvEFeatures.cs
+++ b/XIVSlothCombo/Window/Tabs/PvEFeatures.cs
@@ -177,6 +177,10 @@ namespace XIVSlothCombo.Window.Tabs
                     {
                         Service.Configuration.EnabledActions.Remove(preset);
                         Service.Configuration.Save();
+
+                        // Keep removed items in the counter
+                        var parent = PresetStorage.GetParent(preset) ?? preset;
+                        i += 1 + Presets.AllChildren(presetChildren[parent]);
                     }
 
                     else

--- a/XIVSlothCombo/Window/Tabs/PvPFeatures.cs
+++ b/XIVSlothCombo/Window/Tabs/PvPFeatures.cs
@@ -141,6 +141,10 @@ namespace XIVSlothCombo.Window.Tabs
                     {
                         Service.Configuration.EnabledActions.Remove(preset);
                         Service.Configuration.Save();
+
+                        // Keep removed items in the counter
+                        var parent = PresetStorage.GetParent(preset) ?? preset;
+                        i += 1 + Presets.AllChildren(presetChildren[parent]);
                     }
 
                     else


### PR DESCRIPTION
- [X] Changes removal of conflicting Options to still track how many items are being removed, resulting in the # for Options always being consistent.
  - [X] Accounting for removed items at the top level of PVE
  - [X] Accounting for removed items at the top level of PVP
  - [X] Accounting for removed items beneath the top level of both PVE and PVP