### PR TITLE
[AutoRot] Fix default Single-Target Heal thresholds

### DIFF
--- a/XIVSlothCombo/AutoRotation/AutoRotationConfig.cs
+++ b/XIVSlothCombo/AutoRotation/AutoRotationConfig.cs
@@ -19,8 +19,8 @@ namespace XIVSlothCombo.AutoRotation
 
     public class HealerSettings
     {
-        public int SingleTargetHPP = 70;
+        public int SingleTargetHPP = 80;
         public int AoETargetHPP = 60;
-        public int SingleTargetRegenHPP = 80;
+        public int SingleTargetRegenHPP = 70;
     }
 }


### PR DESCRIPTION
In [AutoRotationConfig](<https://github.com/PunishXIV/WrathCombo/blob/9ed71a81e8876ed40bc5053609032d300d75e949/XIVSlothCombo/AutoRotation/AutoRotationConfig.cs#L24>) the new `SingleTargetRegenHPP` is set to `80` by default, however its [help tip](<https://github.com/PunishXIV/WrathCombo/blob/9ed71a81e8876ed40bc5053609032d300d75e949/XIVSlothCombo/Window/Tabs/AutoRotationTab.cs#L61>) says it should be lower than `SingleTargetHPP` which is `70` by default.

I have simply swapped the values to make the defaults line up with the suggestion from the help text.