### PR TITLE
[AutoRot] Fix default AoE target count thresholds

### DIFF
--- a/XIVSlothCombo/AutoRotation/AutoRotationConfig.cs
+++ b/XIVSlothCombo/AutoRotation/AutoRotationConfig.cs
@@ -20,7 +20,7 @@ namespace XIVSlothCombo.AutoRotation
     {
         public bool FATEPriority = false;
         public bool QuestPriority = false;
-        public int? DPSAoETargets = 2;
+        public int? DPSAoETargets = 3;
     }
 
     public class HealerSettings


### PR DESCRIPTION
AoEs generally surpass Single-Target actions in DPS at 3 targets not 2, adjusting default to match this.