### PR TITLE
[Core] Content difficulty filtering

### DIFF
--- a/XIVSlothCombo/CustomCombo/Functions/Config.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Config.cs
@@ -132,8 +132,21 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         }
     }
 
-    internal class UserBoolArray(string v) : UserData(v)
+    internal class UserBoolArray : UserData
     {
+        // Constructor with only the string parameter
+        public UserBoolArray(string v) : this(v, []) { }
+
+        // Constructor with both string and bool array parameters
+        public UserBoolArray(string v, bool[] defaults) : base(v)
+        {
+            if (!PluginConfiguration.CustomBoolArrayValues.ContainsKey(this.pName))
+            {
+                PluginConfiguration.SetCustomBoolArrayValue(this.pName, defaults);
+                Service.Configuration.Save();
+            }
+        }
+
         public int Count => PluginConfiguration.GetCustomBoolArrayValue(this.pName).Length;
         public static implicit operator bool[](UserBoolArray o) => PluginConfiguration.GetCustomBoolArrayValue(o.pName);
         public bool this[int index]
@@ -156,7 +169,6 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         {
             var array = PluginConfiguration.GetCustomBoolArrayValue(this.pName);
             return array.All(predicate);
-
         }
     }
 

--- a/XIVSlothCombo/Data/ContentCheck.cs
+++ b/XIVSlothCombo/Data/ContentCheck.cs
@@ -1,0 +1,320 @@
+﻿#region
+
+using System.Collections.Generic;
+using System.Linq;
+using ECommons.GameHelpers;
+
+#endregion
+
+namespace XIVSlothCombo.Data;
+
+public class ContentCheck
+{
+    /// <summary>
+    ///     Whether the current content is considered casual.
+    /// </summary>
+    /// <returns>
+    ///     If the
+    ///     <see cref="Content.DetermineContentDifficulty">
+    ///         determined difficulty
+    ///     </see>
+    ///     is in the list of <see cref="CasualContent" />.
+    /// </returns>
+    /// <remarks>
+    ///     The rest of the list set would be checked by
+    ///     <see cref="IsInHardContent" />.
+    /// </remarks>
+    /// <seealso cref="CasualContent" />
+    public static bool IsInCasualContent() =>
+        CasualContent.Contains(
+            Content.ContentDifficulty ?? ContentDifficulty.Unknown
+        );
+
+    /// <summary>
+    ///     Whether the current content is considered hard.
+    /// </summary>
+    /// <returns>
+    ///     If the
+    ///     <see cref="Content.DetermineContentDifficulty">
+    ///         determined difficulty
+    ///     </see>
+    ///     is in the list of <see cref="HardContent" />.
+    /// </returns>
+    /// <remarks>
+    ///     The rest of the list set would be checked by
+    ///     <see cref="IsInCasualContent" />.
+    /// </remarks>
+    /// <seealso cref="HardContent" />
+    public static bool IsInHardContent() =>
+        HardContent.Contains(
+            Content.ContentDifficulty ?? ContentDifficulty.Unknown
+        );
+
+    /// <summary>
+    ///     Whether the current content is in the bottom half of the list of content
+    ///     difficulties.
+    /// </summary>
+    /// <returns>
+    ///     If the
+    ///     <see cref="Content.DetermineContentDifficulty">
+    ///         determined difficulty
+    ///     </see>
+    ///     is in the list of <see cref="BottomHalfContent" />.
+    /// </returns>
+    /// <remarks>
+    ///     The rest of the list set would be checked by
+    ///     <see cref="IsInTopHalfContent" />.
+    /// </remarks>
+    /// <seealso cref="BottomHalfContent" />
+    public static bool IsInBottomHalfContent() =>
+        BottomHalfContent.Contains(
+            Content.ContentDifficulty ?? ContentDifficulty.Unknown
+        );
+
+    /// <summary>
+    ///     Whether the current content is in the top half of the list of content
+    ///     difficulties.
+    /// </summary>
+    /// <returns>
+    ///     If the
+    ///     <see cref="Content.DetermineContentDifficulty">
+    ///         determined difficulty
+    ///     </see>
+    ///     is in the list of <see cref="TopHalfContent" />.
+    /// </returns>
+    /// <remarks>
+    ///     The rest of the list set would be checked by
+    ///     <see cref="IsInBottomHalfContent" />.
+    /// </remarks>
+    /// <seealso cref="TopHalfContent" />
+    public static bool IsInTopHalfContent() =>
+        TopHalfContent.Contains(
+            Content.ContentDifficulty ?? ContentDifficulty.Unknown
+        );
+
+    /// <summary>
+    ///     Whether the current content is considered soft-core.
+    /// </summary>
+    /// <returns>
+    ///     If the
+    ///     <see cref="Content.DetermineContentDifficulty">
+    ///         determined difficulty
+    ///     </see>
+    ///     is in the list of <see cref="SoftCoreContent" />.
+    /// </returns>
+    /// <remarks>
+    ///     The rest of the list set would be <see cref="IsInMidCoreContent" /> and
+    ///     <see cref="IsInHardCoreContent" />.
+    /// </remarks>
+    /// <seealso cref="SoftCoreContent" />
+    public static bool IsInSoftCoreContent() =>
+        SoftCoreContent.Contains(
+            Content.ContentDifficulty ?? ContentDifficulty.Unknown
+        );
+
+    /// <summary>
+    ///     Whether the current content is considered mid-core.
+    /// </summary>
+    /// <returns>
+    ///     If the
+    ///     <see cref="Content.DetermineContentDifficulty">
+    ///         determined difficulty
+    ///     </see>
+    ///     is in the list of <see cref="MidCoreContent" />.
+    /// </returns>
+    /// <remarks>
+    ///     The rest of the list set would be <see cref="IsInSoftCoreContent" /> and
+    ///     <see cref="IsInHardCoreContent" />.
+    /// </remarks>
+    /// <seealso cref="MidCoreContent" />
+    public static bool IsInMidCoreContent() =>
+        MidCoreContent.Contains(
+            Content.ContentDifficulty ?? ContentDifficulty.Unknown
+        );
+
+    /// <summary>
+    ///     Whether the current content is considered hard-core.
+    /// </summary>
+    /// <returns>
+    ///     If the
+    ///     <see cref="Content.DetermineContentDifficulty">
+    ///         determined difficulty
+    ///     </see>
+    ///     is in the list of <see cref="HardCoreContent" />.
+    /// </returns>
+    /// <remarks>
+    ///     The rest of the list set would be <see cref="IsInSoftCoreContent" /> and
+    ///     <see cref="IsInMidCoreContent" />.
+    /// </remarks>
+    /// <seealso cref="HardCoreContent" />
+    public static bool IsInHardCoreContent() =>
+        HardCoreContent.Contains(
+            Content.ContentDifficulty ?? ContentDifficulty.Unknown
+        );
+
+    #region Halved Content Lists
+
+    /// <summary>
+    ///     Roughly the bottom half of the list of content difficulties.
+    /// </summary>
+    /// <remarks>
+    ///     The rest of the list set would be <see cref="TopHalfContent" />.
+    /// </remarks>
+    private static readonly List<ContentDifficulty> BottomHalfContent =
+    [
+        ContentDifficulty.Normal,
+        ContentDifficulty.Hard,
+        ContentDifficulty.Unreal,
+        ContentDifficulty.FieldRaidsSavage,
+    ];
+
+    /// <summary>
+    ///     A string representation of the bottom half of the list of content
+    ///     difficulties.
+    /// </summary>
+    /// <seealso cref="BottomHalfContent" />
+    public static readonly string BottomHalfContentList =
+        string.Join(", ", BottomHalfContent.Select(x => x.ToString()));
+
+    /// <summary>
+    ///     Roughly the top half of the list of content difficulties.
+    /// </summary>
+    /// <remarks>
+    ///     The rest of the list set would be <see cref="BottomHalfContent" />.
+    /// </remarks>
+    private static readonly List<ContentDifficulty> TopHalfContent =
+    [
+        ContentDifficulty.Chaotic,
+        ContentDifficulty.Criterion,
+        ContentDifficulty.Extreme,
+        ContentDifficulty.Savage,
+        ContentDifficulty.CriterionSavage,
+        ContentDifficulty.Ultimate
+    ];
+
+    /// <summary>
+    ///     A string representation of the top half of the list of content
+    ///     difficulties.
+    /// </summary>
+    /// <seealso cref="TopHalfContent" />
+    public static readonly string TopHalfContentList =
+        string.Join(", ", TopHalfContent.Select(x => x.ToString()));
+
+    #endregion
+
+    #region Casual vs Hard Content Lists
+
+    /// <summary>
+    ///     A list of content difficulties that are considered casual.
+    /// </summary>
+    /// <remarks>
+    ///     The rest of the list set would be <see cref="HardContent" />.
+    /// </remarks>
+    private static readonly List<ContentDifficulty> CasualContent =
+    [
+        ContentDifficulty.Normal,
+        ContentDifficulty.Hard,
+    ];
+
+    /// <summary>
+    ///     A string representation of the list of casual content difficulties.
+    /// </summary>
+    /// <seealso cref="CasualContent" />
+    public static readonly string CasualContentList =
+        string.Join(", ", CasualContent.Select(x => x.ToString()));
+
+    /// <summary>
+    ///     A list of content difficulties that are considered not casual.
+    /// </summary>
+    /// <remarks>
+    ///     The rest of the list set would be <see cref="CasualContent" />.
+    /// </remarks>
+    private static readonly List<ContentDifficulty> HardContent =
+    [
+        ContentDifficulty.Unreal,
+        ContentDifficulty.FieldRaidsSavage,
+        ContentDifficulty.Chaotic,
+        ContentDifficulty.Criterion,
+        ContentDifficulty.Extreme,
+        ContentDifficulty.Savage,
+        ContentDifficulty.CriterionSavage,
+        ContentDifficulty.Ultimate
+    ];
+
+    /// <summary>
+    ///     A string representation of the list of hard content difficulties.
+    /// </summary>
+    /// <seealso cref="HardContent" />
+    public static readonly string HardContentList =
+        string.Join(", ", HardContent.Select(x => x.ToString()));
+
+    #endregion
+
+    #region Cored Content Lists
+
+    /// <summary>
+    ///     A list of content difficulties that are considered soft-core.
+    /// </summary>
+    /// <remarks>
+    ///     The rest of the list set would be <see cref="MidCoreContent" /> and
+    ///     <see cref="HardCoreContent" />.
+    /// </remarks>
+    private static readonly List<ContentDifficulty> SoftCoreContent =
+    [
+        ContentDifficulty.Normal,
+        ContentDifficulty.Hard,
+    ];
+
+    /// <summary>
+    ///     A string representation of the list of soft-core content difficulties.
+    /// </summary>
+    /// <seealso cref="SoftCoreContent" />
+    public static readonly string SoftCoreContentList =
+        string.Join(", ", SoftCoreContent.Select(x => x.ToString()));
+
+    /// <summary>
+    ///     A list of content difficulties that are considered mid-core.
+    /// </summary>
+    /// <remarks>
+    ///     The rest of the list set would be <see cref="SoftCoreContent" /> and
+    ///     <see cref="HardCoreContent" />.
+    /// </remarks>
+    private static readonly List<ContentDifficulty> MidCoreContent =
+    [
+        ContentDifficulty.Unreal,
+        ContentDifficulty.FieldRaidsSavage,
+        ContentDifficulty.Extreme,
+        ContentDifficulty.Chaotic,
+    ];
+
+    /// <summary>
+    ///     A string representation of the list of mid-core content difficulties.
+    /// </summary>
+    /// <seealso cref="MidCoreContent" />
+    public static readonly string MidCoreContentList =
+        string.Join(", ", MidCoreContent.Select(x => x.ToString()));
+
+    /// <summary>
+    ///     A list of content difficulties that are considered hard-core.
+    /// </summary>
+    /// <remarks>
+    ///     The rest of the list set would be <see cref="SoftCoreContent" /> and
+    ///     <see cref="MidCoreContent" />.
+    /// </remarks>
+    private static List<ContentDifficulty> HardCoreContent =
+    [
+        ContentDifficulty.Criterion,
+        ContentDifficulty.Savage,
+        ContentDifficulty.CriterionSavage,
+        ContentDifficulty.Ultimate,
+    ];
+
+    /// <summary>
+    ///     A string representation of the list of hard-core content difficulties.
+    /// </summary>
+    /// <seealso cref="HardCoreContent" />
+    public static readonly string HardCoreContentList =
+        string.Join(", ", HardCoreContent.Select(x => x.ToString()));
+
+    #endregion
+}

--- a/XIVSlothCombo/Data/ContentCheck.cs
+++ b/XIVSlothCombo/Data/ContentCheck.cs
@@ -10,45 +10,7 @@ namespace XIVSlothCombo.Data;
 
 public class ContentCheck
 {
-    /// <summary>
-    ///     Whether the current content is considered casual.
-    /// </summary>
-    /// <returns>
-    ///     If the
-    ///     <see cref="Content.DetermineContentDifficulty">
-    ///         determined difficulty
-    ///     </see>
-    ///     is in the list of <see cref="CasualContent" />.
-    /// </returns>
-    /// <remarks>
-    ///     The rest of the list set would be checked by
-    ///     <see cref="IsInHardContent" />.
-    /// </remarks>
-    /// <seealso cref="CasualContent" />
-    public static bool IsInCasualContent() =>
-        CasualContent.Contains(
-            Content.ContentDifficulty ?? ContentDifficulty.Unknown
-        );
-
-    /// <summary>
-    ///     Whether the current content is considered hard.
-    /// </summary>
-    /// <returns>
-    ///     If the
-    ///     <see cref="Content.DetermineContentDifficulty">
-    ///         determined difficulty
-    ///     </see>
-    ///     is in the list of <see cref="HardContent" />.
-    /// </returns>
-    /// <remarks>
-    ///     The rest of the list set would be checked by
-    ///     <see cref="IsInCasualContent" />.
-    /// </remarks>
-    /// <seealso cref="HardContent" />
-    public static bool IsInHardContent() =>
-        HardContent.Contains(
-            Content.ContentDifficulty ?? ContentDifficulty.Unknown
-        );
+    #region Halved Content Lists
 
     /// <summary>
     ///     Whether the current content is in the bottom half of the list of content
@@ -91,6 +53,144 @@ public class ContentCheck
         TopHalfContent.Contains(
             Content.ContentDifficulty ?? ContentDifficulty.Unknown
         );
+
+    /// <summary>
+    ///     Roughly the bottom half of the list of content difficulties.
+    /// </summary>
+    /// <remarks>
+    ///     The rest of the list set would be <see cref="TopHalfContent" />.
+    /// </remarks>
+    private static readonly List<ContentDifficulty> BottomHalfContent =
+    [
+        ContentDifficulty.Normal,
+        ContentDifficulty.Hard,
+        ContentDifficulty.Unreal,
+        ContentDifficulty.FieldRaidsSavage,
+    ];
+
+    /// <summary>
+    ///     A string representation of the bottom half of the list of content
+    ///     difficulties.
+    /// </summary>
+    /// <seealso cref="BottomHalfContent" />
+    public static readonly string BottomHalfContentList =
+        string.Join(", ", BottomHalfContent.Select(x => x.ToString()));
+
+    /// <summary>
+    ///     Roughly the top half of the list of content difficulties.
+    /// </summary>
+    /// <remarks>
+    ///     The rest of the list set would be <see cref="BottomHalfContent" />.
+    /// </remarks>
+    private static readonly List<ContentDifficulty> TopHalfContent =
+    [
+        ContentDifficulty.Chaotic,
+        ContentDifficulty.Criterion,
+        ContentDifficulty.Extreme,
+        ContentDifficulty.Savage,
+        ContentDifficulty.CriterionSavage,
+        ContentDifficulty.Ultimate
+    ];
+
+    /// <summary>
+    ///     A string representation of the top half of the list of content
+    ///     difficulties.
+    /// </summary>
+    /// <seealso cref="TopHalfContent" />
+    public static readonly string TopHalfContentList =
+        string.Join(", ", TopHalfContent.Select(x => x.ToString()));
+
+    #endregion
+
+    #region Casual vs Hard Content Lists
+
+    /// <summary>
+    ///     Whether the current content is considered casual.
+    /// </summary>
+    /// <returns>
+    ///     If the
+    ///     <see cref="Content.DetermineContentDifficulty">
+    ///         determined difficulty
+    ///     </see>
+    ///     is in the list of <see cref="CasualContent" />.
+    /// </returns>
+    /// <remarks>
+    ///     The rest of the list set would be checked by
+    ///     <see cref="IsInHardContent" />.
+    /// </remarks>
+    /// <seealso cref="CasualContent" />
+    public static bool IsInCasualContent() =>
+        CasualContent.Contains(
+            Content.ContentDifficulty ?? ContentDifficulty.Unknown
+        );
+
+    /// <summary>
+    ///     Whether the current content is considered hard.
+    /// </summary>
+    /// <returns>
+    ///     If the
+    ///     <see cref="Content.DetermineContentDifficulty">
+    ///         determined difficulty
+    ///     </see>
+    ///     is in the list of <see cref="HardContent" />.
+    /// </returns>
+    /// <remarks>
+    ///     The rest of the list set would be checked by
+    ///     <see cref="IsInCasualContent" />.
+    /// </remarks>
+    /// <seealso cref="HardContent" />
+    public static bool IsInHardContent() =>
+        HardContent.Contains(
+            Content.ContentDifficulty ?? ContentDifficulty.Unknown
+        );
+
+    /// <summary>
+    ///     A list of content difficulties that are considered casual.
+    /// </summary>
+    /// <remarks>
+    ///     The rest of the list set would be <see cref="HardContent" />.
+    /// </remarks>
+    private static readonly List<ContentDifficulty> CasualContent =
+    [
+        ContentDifficulty.Normal,
+        ContentDifficulty.Hard,
+    ];
+
+    /// <summary>
+    ///     A string representation of the list of casual content difficulties.
+    /// </summary>
+    /// <seealso cref="CasualContent" />
+    public static readonly string CasualContentList =
+        string.Join(", ", CasualContent.Select(x => x.ToString()));
+
+    /// <summary>
+    ///     A list of content difficulties that are considered not casual.
+    /// </summary>
+    /// <remarks>
+    ///     The rest of the list set would be <see cref="CasualContent" />.
+    /// </remarks>
+    private static readonly List<ContentDifficulty> HardContent =
+    [
+        ContentDifficulty.Unreal,
+        ContentDifficulty.FieldRaidsSavage,
+        ContentDifficulty.Chaotic,
+        ContentDifficulty.Criterion,
+        ContentDifficulty.Extreme,
+        ContentDifficulty.Savage,
+        ContentDifficulty.CriterionSavage,
+        ContentDifficulty.Ultimate
+    ];
+
+    /// <summary>
+    ///     A string representation of the list of hard content difficulties.
+    /// </summary>
+    /// <seealso cref="HardContent" />
+    public static readonly string HardContentList =
+        string.Join(", ", HardContent.Select(x => x.ToString()));
+
+    #endregion
+
+    #region Cored Content Lists
 
     /// <summary>
     ///     Whether the current content is considered soft-core.
@@ -151,106 +251,6 @@ public class ContentCheck
         HardCoreContent.Contains(
             Content.ContentDifficulty ?? ContentDifficulty.Unknown
         );
-
-    #region Halved Content Lists
-
-    /// <summary>
-    ///     Roughly the bottom half of the list of content difficulties.
-    /// </summary>
-    /// <remarks>
-    ///     The rest of the list set would be <see cref="TopHalfContent" />.
-    /// </remarks>
-    private static readonly List<ContentDifficulty> BottomHalfContent =
-    [
-        ContentDifficulty.Normal,
-        ContentDifficulty.Hard,
-        ContentDifficulty.Unreal,
-        ContentDifficulty.FieldRaidsSavage,
-    ];
-
-    /// <summary>
-    ///     A string representation of the bottom half of the list of content
-    ///     difficulties.
-    /// </summary>
-    /// <seealso cref="BottomHalfContent" />
-    public static readonly string BottomHalfContentList =
-        string.Join(", ", BottomHalfContent.Select(x => x.ToString()));
-
-    /// <summary>
-    ///     Roughly the top half of the list of content difficulties.
-    /// </summary>
-    /// <remarks>
-    ///     The rest of the list set would be <see cref="BottomHalfContent" />.
-    /// </remarks>
-    private static readonly List<ContentDifficulty> TopHalfContent =
-    [
-        ContentDifficulty.Chaotic,
-        ContentDifficulty.Criterion,
-        ContentDifficulty.Extreme,
-        ContentDifficulty.Savage,
-        ContentDifficulty.CriterionSavage,
-        ContentDifficulty.Ultimate
-    ];
-
-    /// <summary>
-    ///     A string representation of the top half of the list of content
-    ///     difficulties.
-    /// </summary>
-    /// <seealso cref="TopHalfContent" />
-    public static readonly string TopHalfContentList =
-        string.Join(", ", TopHalfContent.Select(x => x.ToString()));
-
-    #endregion
-
-    #region Casual vs Hard Content Lists
-
-    /// <summary>
-    ///     A list of content difficulties that are considered casual.
-    /// </summary>
-    /// <remarks>
-    ///     The rest of the list set would be <see cref="HardContent" />.
-    /// </remarks>
-    private static readonly List<ContentDifficulty> CasualContent =
-    [
-        ContentDifficulty.Normal,
-        ContentDifficulty.Hard,
-    ];
-
-    /// <summary>
-    ///     A string representation of the list of casual content difficulties.
-    /// </summary>
-    /// <seealso cref="CasualContent" />
-    public static readonly string CasualContentList =
-        string.Join(", ", CasualContent.Select(x => x.ToString()));
-
-    /// <summary>
-    ///     A list of content difficulties that are considered not casual.
-    /// </summary>
-    /// <remarks>
-    ///     The rest of the list set would be <see cref="CasualContent" />.
-    /// </remarks>
-    private static readonly List<ContentDifficulty> HardContent =
-    [
-        ContentDifficulty.Unreal,
-        ContentDifficulty.FieldRaidsSavage,
-        ContentDifficulty.Chaotic,
-        ContentDifficulty.Criterion,
-        ContentDifficulty.Extreme,
-        ContentDifficulty.Savage,
-        ContentDifficulty.CriterionSavage,
-        ContentDifficulty.Ultimate
-    ];
-
-    /// <summary>
-    ///     A string representation of the list of hard content difficulties.
-    /// </summary>
-    /// <seealso cref="HardContent" />
-    public static readonly string HardContentList =
-        string.Join(", ", HardContent.Select(x => x.ToString()));
-
-    #endregion
-
-    #region Cored Content Lists
 
     /// <summary>
     ///     A list of content difficulties that are considered soft-core.

--- a/XIVSlothCombo/Data/ContentCheck.cs
+++ b/XIVSlothCombo/Data/ContentCheck.cs
@@ -99,7 +99,7 @@ public class ContentCheck
     /// </summary>
     /// <returns>
     ///     If the
-    ///     <see cref="Content.DetermineContentDifficulty">
+    ///     <see cref="ECommons.GameHelpers.Content.DetermineContentDifficulty">
     ///         determined difficulty
     ///     </see>
     ///     is in the list of <see cref="BottomHalfContent" />.
@@ -120,7 +120,7 @@ public class ContentCheck
     /// </summary>
     /// <returns>
     ///     If the
-    ///     <see cref="Content.DetermineContentDifficulty">
+    ///     <see cref="ECommons.GameHelpers.Content.DetermineContentDifficulty">
     ///         determined difficulty
     ///     </see>
     ///     is in the list of <see cref="TopHalfContent" />.
@@ -190,7 +190,7 @@ public class ContentCheck
     /// </summary>
     /// <returns>
     ///     If the
-    ///     <see cref="Content.DetermineContentDifficulty">
+    ///     <see cref="ECommons.GameHelpers.Content.DetermineContentDifficulty">
     ///         determined difficulty
     ///     </see>
     ///     is in the list of <see cref="CasualContent" />.
@@ -210,7 +210,7 @@ public class ContentCheck
     /// </summary>
     /// <returns>
     ///     If the
-    ///     <see cref="Content.DetermineContentDifficulty">
+    ///     <see cref="ECommons.GameHelpers.Content.DetermineContentDifficulty">
     ///         determined difficulty
     ///     </see>
     ///     is in the list of <see cref="HardContent" />.
@@ -278,7 +278,7 @@ public class ContentCheck
     /// </summary>
     /// <returns>
     ///     If the
-    ///     <see cref="Content.DetermineContentDifficulty">
+    ///     <see cref="ECommons.GameHelpers.Content.DetermineContentDifficulty">
     ///         determined difficulty
     ///     </see>
     ///     is in the list of <see cref="SoftCoreContent" />.
@@ -298,7 +298,7 @@ public class ContentCheck
     /// </summary>
     /// <returns>
     ///     If the
-    ///     <see cref="Content.DetermineContentDifficulty">
+    ///     <see cref="ECommons.GameHelpers.Content.DetermineContentDifficulty">
     ///         determined difficulty
     ///     </see>
     ///     is in the list of <see cref="MidCoreContent" />.
@@ -318,7 +318,7 @@ public class ContentCheck
     /// </summary>
     /// <returns>
     ///     If the
-    ///     <see cref="Content.DetermineContentDifficulty">
+    ///     <see cref="ECommons.GameHelpers.Content.DetermineContentDifficulty">
     ///         determined difficulty
     ///     </see>
     ///     is in the list of <see cref="HardCoreContent" />.

--- a/XIVSlothCombo/Data/ContentCheck.cs
+++ b/XIVSlothCombo/Data/ContentCheck.cs
@@ -10,6 +10,32 @@ namespace XIVSlothCombo.Data;
 
 public class ContentCheck
 {
+    /// <summary>
+    ///     Valid selections for list sets to use.
+    /// </summary>
+    public enum ListSet
+    {
+        /// <seealso cref="ContentCheck.IsInBottomHalfContent" />
+        /// <seealso cref="ContentCheck.IsInTopHalfContent" />
+        /// <seealso cref="ContentCheck.BottomHalfContent" />
+        /// <seealso cref="ContentCheck.TopHalfContent" />
+        Halved,
+
+        /// <seealso cref="ContentCheck.IsInCasualContent" />
+        /// <seealso cref="ContentCheck.IsInHardContent" />
+        /// <seealso cref="ContentCheck.CasualContent" />
+        /// <seealso cref="ContentCheck.HardContent" />
+        CasualVSHard,
+
+        /// <seealso cref="ContentCheck.IsInSoftCoreContent" />
+        /// <seealso cref="ContentCheck.IsInMidCoreContent" />
+        /// <seealso cref="ContentCheck.IsInHardCoreContent" />
+        /// <seealso cref="ContentCheck.SoftCoreContent" />
+        /// <seealso cref="ContentCheck.MidCoreContent" />
+        /// <seealso cref="ContentCheck.HardCoreContent" />
+        Cored,
+    }
+
     #region Halved Content Lists
 
     /// <summary>

--- a/XIVSlothCombo/Data/ContentCheck.cs
+++ b/XIVSlothCombo/Data/ContentCheck.cs
@@ -1,8 +1,10 @@
 ﻿#region
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using ECommons.GameHelpers;
+using XIVSlothCombo.CustomComboNS.Functions;
 
 #endregion
 
@@ -34,6 +36,59 @@ public class ContentCheck
         /// <seealso cref="ContentCheck.MidCoreContent" />
         /// <seealso cref="ContentCheck.HardCoreContent" />
         Cored,
+    }
+
+    /// <summary>
+    ///     Check if the current content the user was in matches the content in the
+    ///     given configuration.
+    /// </summary>
+    /// <param name="configuredContent">
+    ///     The <see cref="UserBoolArray">User Config variable</see> of selected
+    ///     valid content difficulties to check against.
+    /// </param>
+    /// <param name="configListSet">
+    ///     The <see cref="ListSet">List Set</see> that the variable is set to.
+    /// </param>
+    /// <returns>
+    ///     Whether the current content is matches the selected difficulties.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    internal static bool IsInConfiguredContent
+        (UserBoolArray configuredContent, ListSet configListSet)
+    {
+        {
+            switch (configListSet)
+            {
+                case ListSet.Halved:
+                    if (configuredContent[0] && IsInBottomHalfContent())
+                        return true;
+                    if (configuredContent[1] && IsInTopHalfContent())
+                        return true;
+                    break;
+
+                case ListSet.CasualVSHard:
+                    if (configuredContent[0] && IsInCasualContent())
+                        return true;
+                    if (configuredContent[1] && IsInHardContent())
+                        return true;
+                    break;
+
+                case ListSet.Cored:
+                    if (configuredContent[0] && IsInSoftCoreContent())
+                        return true;
+                    if (configuredContent[1] && IsInMidCoreContent())
+                        return true;
+                    if (configuredContent[2] && IsInHardCoreContent())
+                        return true;
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException
+                        (nameof(configListSet), configListSet, null);
+            }
+
+            return false;
+        }
     }
 
     #region Halved Content Lists

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1107,6 +1107,129 @@ namespace XIVSlothCombo.Window.Functions
             ImGui.Spacing();
         }
 
+        /// <summary>
+        ///     Draws a multi choice checkbox in a horizontal configuration,
+        ///     with values for Content Difficulty filtering's Halved Difficulty
+        ///     list set.
+        /// </summary>
+        /// <value>
+        ///     <c>[0]true</c> if <see cref="ContentCheck.BottomHalfContent"/>
+        ///     is enabled.<br/>
+        ///     <c>[1]true</c> if <see cref="ContentCheck.TopHalfContent"/>
+        ///     is enabled.
+        /// </value>
+        /// <param name="config">
+        ///     The <see cref="UserBoolArray"/> config variable for this setting.
+        /// </param>
+        /// <seealso cref="ContentCheck.IsInBottomHalfContent"/>
+        /// <seealso cref="ContentCheck.IsInTopHalfContent"/>
+        public static void DrawHalvedDifficultyMultiChoice(string config)
+        {
+            ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudYellow);
+            ImGui.Indent();
+            ImGui.TextUnformatted("Select what difficulty the above should apply to:");
+            ImGui.PopStyleColor();
+            ImGui.Unindent();
+
+            DrawHorizontalMultiChoice(
+                config, "Easiest Content",
+                ContentCheck.BottomHalfContentList,
+                totalChoices: 2, choice: 0,
+                descriptionColor: ImGuiColors.DalamudYellow
+            );
+            DrawHorizontalMultiChoice(
+                config, "Hardest Content",
+                ContentCheck.TopHalfContentList,
+                totalChoices: 2, choice: 1,
+                descriptionColor: ImGuiColors.DalamudYellow
+            );
+        }
+
+        /// <summary>
+        ///     Draws a multi choice checkbox in a horizontal configuration,
+        ///     with values for Content Difficulty filtering's Casual vs Hard
+        ///     difficulty list set.
+        /// </summary>
+        /// <value>
+        ///     <c>[0]true</c> if <see cref="ContentCheck.CasualContent"/>
+        ///     is enabled.<br/>
+        ///     <c>[1]true</c> if <see cref="ContentCheck.HardContent"/>
+        ///     is enabled.
+        /// </value>
+        /// <param name="config">
+        ///     The <see cref="UserBoolArray"/> config variable for this setting.
+        /// </param>
+        /// <seealso cref="ContentCheck.IsInCasualContent"/>
+        /// <seealso cref="ContentCheck.IsInHardContent"/>
+        public static void DrawCasualVSHardDifficultyMultiChoice(string config)
+        {
+            ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudYellow);
+            ImGui.Indent();
+            ImGui.TextUnformatted("Select what difficulty the above should apply to:");
+            ImGui.PopStyleColor();
+            ImGui.Unindent();
+
+            DrawHorizontalMultiChoice(
+                config, "Casual Content",
+                ContentCheck.CasualContentList,
+                totalChoices: 2, choice: 0,
+                descriptionColor: ImGuiColors.DalamudYellow
+            );
+            DrawHorizontalMultiChoice(
+                config, "'Hard' Content",
+                ContentCheck.HardContentList,
+                totalChoices: 2, choice: 1,
+                descriptionColor: ImGuiColors.DalamudYellow
+            );
+        }
+
+        /// <summary>
+        ///     Draws a multi choice checkbox in a horizontal configuration,
+        ///     with values for Content Difficulty filtering's Cored Difficulty
+        ///     list set.
+        /// </summary>
+        /// <value>
+        ///     <c>[0]true</c> if <see cref="ContentCheck.SoftCoreContent"/>
+        ///     is enabled.<br/>
+        ///     <c>[1]true</c> if <see cref="ContentCheck.MidCoreContent"/>
+        ///     is enabled.<br/>
+        ///     <c>[2]true</c> if <see cref="ContentCheck.HardCoreContent"/>
+        ///     is enabled.
+        /// </value>
+        /// <param name="config">
+        ///     The <see cref="UserBoolArray"/> config variable for this setting.
+        /// </param>
+        /// <seealso cref="ContentCheck.IsInSoftCoreContent"/>
+        /// <seealso cref="ContentCheck.IsInMidCoreContent"/>
+        /// <seealso cref="ContentCheck.IsInHardCoreContent"/>
+        public static void DrawCoredDifficultyMultiChoice(string config)
+        {
+            ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudYellow);
+            ImGui.Indent();
+            ImGui.TextUnformatted("Select what difficulty the above should apply to:");
+            ImGui.PopStyleColor();
+            ImGui.Unindent();
+
+            DrawHorizontalMultiChoice(
+                config, "SoftCore Content",
+                ContentCheck.SoftCoreContentList,
+                totalChoices: 3, choice: 0,
+                descriptionColor: ImGuiColors.DalamudYellow
+            );
+            DrawHorizontalMultiChoice(
+                config, "MidCore Content",
+                ContentCheck.MidCoreContentList,
+                totalChoices: 3, choice: 1,
+                descriptionColor: ImGuiColors.DalamudYellow
+            );
+            DrawHorizontalMultiChoice(
+                config, "HardCore Content",
+                ContentCheck.HardCoreContentList,
+                totalChoices: 3, choice: 2,
+                descriptionColor: ImGuiColors.DalamudYellow
+            );
+        }
+
         internal static void DrawPriorityInput(UserIntArray config, int maxValues, int currentItem, string customLabel = "")
         {
             if (config.Count != maxValues || config.Any(x => x == 0))

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1108,6 +1108,38 @@ namespace XIVSlothCombo.Window.Functions
         }
 
         /// <summary>
+        ///     Draws the correct multi choice checkbox method based on the given
+        ///     <see cref="ContentCheck.ListSet"/>.
+        /// </summary>
+        /// <param name="config">
+        ///     The <see cref="UserBoolArray"/> config variable for this setting.
+        /// </param>
+        /// <param name="configListSet">
+        ///     Which difficulty list set to draw.
+        /// </param>
+        /// <seealso cref="DrawHalvedDifficultyMultiChoice"/>
+        /// <seealso cref="DrawCasualVSHardDifficultyMultiChoice"/>
+        /// <seealso cref="DrawCoredDifficultyMultiChoice"/>
+        public static void DrawDifficultyMultiChoice
+            (string config, ContentCheck.ListSet configListSet)
+        {
+            switch (configListSet)
+            {
+                case ContentCheck.ListSet.Halved:
+                    DrawHalvedDifficultyMultiChoice(config);
+                    break;
+                case ContentCheck.ListSet.CasualVSHard:
+                    DrawCasualVSHardDifficultyMultiChoice(config);
+                    break;
+                case ContentCheck.ListSet.Cored:
+                    DrawCoredDifficultyMultiChoice(config);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(configListSet), configListSet, null);
+            }
+        }
+
+        /// <summary>
         ///     Draws a multi choice checkbox in a horizontal configuration,
         ///     with values for Content Difficulty filtering's Halved Difficulty
         ///     list set.
@@ -1123,7 +1155,7 @@ namespace XIVSlothCombo.Window.Functions
         /// </param>
         /// <seealso cref="ContentCheck.IsInBottomHalfContent"/>
         /// <seealso cref="ContentCheck.IsInTopHalfContent"/>
-        public static void DrawHalvedDifficultyMultiChoice(string config)
+        private static void DrawHalvedDifficultyMultiChoice(string config)
         {
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudYellow);
             ImGui.Indent();
@@ -1161,7 +1193,7 @@ namespace XIVSlothCombo.Window.Functions
         /// </param>
         /// <seealso cref="ContentCheck.IsInCasualContent"/>
         /// <seealso cref="ContentCheck.IsInHardContent"/>
-        public static void DrawCasualVSHardDifficultyMultiChoice(string config)
+        private static void DrawCasualVSHardDifficultyMultiChoice(string config)
         {
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudYellow);
             ImGui.Indent();
@@ -1202,7 +1234,7 @@ namespace XIVSlothCombo.Window.Functions
         /// <seealso cref="ContentCheck.IsInSoftCoreContent"/>
         /// <seealso cref="ContentCheck.IsInMidCoreContent"/>
         /// <seealso cref="ContentCheck.IsInHardCoreContent"/>
-        public static void DrawCoredDifficultyMultiChoice(string config)
+        private static void DrawCoredDifficultyMultiChoice(string config)
         {
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudYellow);
             ImGui.Indent();

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1120,6 +1120,7 @@ namespace XIVSlothCombo.Window.Functions
         /// <seealso cref="DrawHalvedDifficultyMultiChoice"/>
         /// <seealso cref="DrawCasualVSHardDifficultyMultiChoice"/>
         /// <seealso cref="DrawCoredDifficultyMultiChoice"/>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
         public static void DrawDifficultyMultiChoice
             (string config, ContentCheck.ListSet configListSet)
         {

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1117,23 +1117,26 @@ namespace XIVSlothCombo.Window.Functions
         /// <param name="configListSet">
         ///     Which difficulty list set to draw.
         /// </param>
+        /// <param name="overrideText">
+        ///     Optional text to override the default description.
+        /// </param>
         /// <seealso cref="DrawHalvedDifficultyMultiChoice"/>
         /// <seealso cref="DrawCasualVSHardDifficultyMultiChoice"/>
         /// <seealso cref="DrawCoredDifficultyMultiChoice"/>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         public static void DrawDifficultyMultiChoice
-            (string config, ContentCheck.ListSet configListSet)
+            (string config, ContentCheck.ListSet configListSet, string overrideText = "")
         {
             switch (configListSet)
             {
                 case ContentCheck.ListSet.Halved:
-                    DrawHalvedDifficultyMultiChoice(config);
+                    DrawHalvedDifficultyMultiChoice(config, overrideText);
                     break;
                 case ContentCheck.ListSet.CasualVSHard:
-                    DrawCasualVSHardDifficultyMultiChoice(config);
+                    DrawCasualVSHardDifficultyMultiChoice(config, overrideText);
                     break;
                 case ContentCheck.ListSet.Cored:
-                    DrawCoredDifficultyMultiChoice(config);
+                    DrawCoredDifficultyMultiChoice(config, overrideText);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(configListSet), configListSet, null);
@@ -1154,13 +1157,19 @@ namespace XIVSlothCombo.Window.Functions
         /// <param name="config">
         ///     The <see cref="UserBoolArray"/> config variable for this setting.
         /// </param>
+        /// <param name="overrideText">
+        ///     Optional text to override the default description.
+        /// </param>
         /// <seealso cref="ContentCheck.IsInBottomHalfContent"/>
         /// <seealso cref="ContentCheck.IsInTopHalfContent"/>
-        private static void DrawHalvedDifficultyMultiChoice(string config)
+        private static void DrawHalvedDifficultyMultiChoice
+            (string config, string overrideText = "")
         {
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudYellow);
             ImGui.Indent();
-            ImGui.TextUnformatted("Select what difficulty the above should apply to:");
+            ImGui.TextUnformatted(overrideText.IsNullOrEmpty()
+                ? "Select what difficulty the above should apply to:"
+                : overrideText);
             ImGui.PopStyleColor();
             ImGui.Unindent();
 
@@ -1192,13 +1201,19 @@ namespace XIVSlothCombo.Window.Functions
         /// <param name="config">
         ///     The <see cref="UserBoolArray"/> config variable for this setting.
         /// </param>
+        /// <param name="overrideText">
+        ///     Optional text to override the default description.
+        /// </param>
         /// <seealso cref="ContentCheck.IsInCasualContent"/>
         /// <seealso cref="ContentCheck.IsInHardContent"/>
-        private static void DrawCasualVSHardDifficultyMultiChoice(string config)
+        private static void DrawCasualVSHardDifficultyMultiChoice
+            (string config, string overrideText = "")
         {
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudYellow);
             ImGui.Indent();
-            ImGui.TextUnformatted("Select what difficulty the above should apply to:");
+            ImGui.TextUnformatted(overrideText.IsNullOrEmpty()
+                ? "Select what difficulty the above should apply to:"
+                : overrideText);
             ImGui.PopStyleColor();
             ImGui.Unindent();
 
@@ -1232,14 +1247,20 @@ namespace XIVSlothCombo.Window.Functions
         /// <param name="config">
         ///     The <see cref="UserBoolArray"/> config variable for this setting.
         /// </param>
+        /// <param name="overrideText">
+        ///     Optional text to override the default description.
+        /// </param>
         /// <seealso cref="ContentCheck.IsInSoftCoreContent"/>
         /// <seealso cref="ContentCheck.IsInMidCoreContent"/>
         /// <seealso cref="ContentCheck.IsInHardCoreContent"/>
-        private static void DrawCoredDifficultyMultiChoice(string config)
+        private static void DrawCoredDifficultyMultiChoice
+            (string config, string overrideText = "")
         {
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudYellow);
             ImGui.Indent();
-            ImGui.TextUnformatted("Select what difficulty the above should apply to:");
+            ImGui.TextUnformatted(overrideText.IsNullOrEmpty()
+                ? "Select what difficulty the above should apply to:"
+                : overrideText);
             ImGui.PopStyleColor();
             ImGui.Unindent();
 


### PR DESCRIPTION
Same as #35.

This adds brand new filtering capabilities based on Content Difficulty with `ContentCheck` and UI elements to add to your settings to add difficulty filtering to your options.

The biggest use-case for this is more restrictive settings in Advanced Mode that don't necessarily make sense for all types of content; for example DRK has options to stop using abilities at set HP% thresholds - these options make way more sense in more casual content. So I can add the `DrawDifficultyMultiChoice` UI element under that HP% slider, hook up `IsInConfiguredContent` in my actual job code and now the setting makes more sense.

There are multiple setups for Content Difficulty filtering called list sets. These are the current values of those list sets - I am very open to feedback on how the lists should be adjusted:

<table align="left">
  <tr><th colspan="2">Halved Content List Set</th></tr>
  <tr><th>Bottom Half</th><th>Top Half</th></tr>
  <tr><td>Normal</td><td>Chaotic</td></tr>
  <tr><td>Hard</td><td>Criterion</td></tr>
  <tr><td>Unreal</td><td>Extreme</td></tr>
  <tr><td>FieldRaidsSavage</td><td>Savage</td></tr>
  <tr><td></td><td>CriterionSavage</td></tr>
  <tr><td></td><td>Ultimate</td></tr>
</table>

<table>
  <tr><th colspan="2">Casual VS Hard Content List Set</th></tr>
  <tr><th>Casual</th><th>Hard</th></tr>
  <tr><td>Normal</td><td>Unreal</td></tr>
  <tr><td>Hard</td><td>FieldRaidsSavage</td></tr>
  <tr><td></td><td>Chaotic</td></tr>
  <tr><td></td><td>Criterion</td></tr>
  <tr><td></td><td>Extreme</td></tr>
  <tr><td></td><td>Savage</td></tr>
  <tr><td></td><td>CriterionSavage</td></tr>
  <tr><td></td><td>Ultimate</td></tr>
</table>

<table>
  <tr><th colspan="3">Cored Content List Set</th></tr>
  <tr><th>SoftCore</th><th>MidCore</th><th>HardCore</th></tr>
  <tr><td>Normal</td><td>Unreal</td><td>Criterion</td></tr>
  <tr><td>Hard</td><td>FieldRaidsSavage</td><td>Savage</td></tr>
  <tr><td></td><td>Extreme</td><td>CriterionSavage</td></tr>
  <tr><td></td><td>Chaotic</td><td>Ultimate</td></tr>
</table>


Additionally, this does also update `UserBoolArray`s to support default values.

> Relies on NightmareXIV/ECommons#79 to provide the Content Difficulty detection, thus the ECommons bump.