### PR TITLE
[PLD] Sheltron Overcap Health Check optional

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2895,6 +2895,10 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only when taking damage.\n- Will not interrupt burst phase.\n- Required gauge threshold:", PLD.JobID, 4)]
         PLD_ST_AdvancedMode_Sheltron = 11007,
 
+        [ParentCombo(PLD_ST_AdvancedMode_Sheltron)]
+        [CustomComboInfo("Sheltron Health Ignore Option", "Ignore health check\n- Useful for offtank setup with reaction to intervention the target's target", PLD.JobID, 4)]
+        PLD_ST_AdvancedMode_SheltronHealth = 11038,
+
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Goring Blade Option", "Adds Goring Blade to Advanced Mode.\n- Prefers to use after Requiescat.", PLD.JobID, 6)]
         PLD_ST_AdvancedMode_GoringBlade = 11008,

--- a/XIVSlothCombo/Combos/PvE/PLD/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD/PLD.cs
@@ -421,7 +421,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                             // Sheltron Overcap Protection
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Sheltron) && LevelChecked(Sheltron) &&
-                                Gauge.OathGauge >= Config.PLD_ST_SheltronOption && PlayerHealthPercentageHp() < 100 &&
+                                Gauge.OathGauge >= Config.PLD_ST_SheltronOption && (PlayerHealthPercentageHp() < 100 || IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_SheltronHealth)) &&
                                 InCombat() && !HasEffect(Buffs.Sheltron) && !HasEffect(Buffs.HolySheltron))
                                 return OriginalHook(Sheltron);
                         }


### PR DESCRIPTION
A forced health check was added to overcap shelltron a few months back. Simply made it an option for 2 reasons. 

Shelltron is a mit more than a heal. I would rather it prevent the hit than be used right after it 

Forcing a health check prevents something like the below reaction for using overcap as an offtank. 

![image](https://github.com/user-attachments/assets/a9e9afea-200b-4ede-a2b0-1a537e83cd52)
