### PR TITLE
[Core] Conflicting Plugins

### DIFF
--- a/XIVSlothCombo/Data/ConflictingPluginsCheck.cs
+++ b/XIVSlothCombo/Data/ConflictingPluginsCheck.cs
@@ -1,0 +1,42 @@
+﻿using System.Linq;
+using ECommons.DalamudServices;
+
+namespace XIVSlothCombo.Data;
+
+public static class ConflictingPluginsCheck
+{
+    /// <summary>
+    /// List of the most popular conflicting plugins.
+    /// </summary>
+    /// <remarks>
+    /// The list is case-sensitive, and needs to be lowercase.
+    /// </remarks>
+    private static string[] conflictingPluginsNames = new string[]
+    {
+        "xivcombo",
+        "xivcomboexpanded",
+        "xivcomboexpandedest",
+        "xivcombovx",
+        "xivslothcombo",
+    };
+
+    /// <summary>
+    /// Searches for any enabled conflicting plugins.
+    /// </summary>
+    /// <returns>
+    /// <c>null</c> if no conflicts were found.<br/>
+    /// <c>string[]</c> of conflicting plugins otherwise.<br/>
+    /// </returns>
+    /// <remarks>
+    /// Each <c>string</c> would be <c>InternalName(Version)</c>
+    /// </remarks>
+    public static string[]? TryGetConflictingPlugins()
+    {
+        var conflictingPlugins = Svc.PluginInterface.InstalledPlugins
+            .Where(x => conflictingPluginsNames.Contains(x.InternalName.ToLower()) && x.IsLoaded)
+            .Select(x => $"{x.InternalName}({x.Version})")
+            .ToArray();
+
+        return conflictingPlugins.Length == 0 ? null : conflictingPlugins;
+    }
+}

--- a/XIVSlothCombo/Data/RepoCheck.cs
+++ b/XIVSlothCombo/Data/RepoCheck.cs
@@ -14,18 +14,31 @@ namespace XIVSlothCombo.Data
         public static RepoCheck? FetchCurrentRepo()
         {
             FileInfo? f = Svc.PluginInterface.AssemblyLocation;
-            var manifest = Path.Join(f.DirectoryName, "XIVSlothCombo.json");
 
-            if (File.Exists(manifest))
+            // Flag as self-built if in dev mode
+            if (Svc.PluginInterface.IsDev)
+            {
+                return new RepoCheck
+                {
+                    InstalledFromUrl = "!! Self-Built !!"
+                };
+            }
+            var manifest = Path.Join(f.DirectoryName, "WrathCombo.json");
+
+            // Load the manifest
+            try
             {
                 RepoCheck? repo = JsonConvert.DeserializeObject<RepoCheck>(File.ReadAllText(manifest));
-                return repo;
+
+                // Check if we were able to read the manifest and its repo URL
+                return repo?.InstalledFromUrl is null ? null : repo;
             }
-            else
+            catch
             {
-                return null;
+                // ignored
             }
 
+            return null;
         }
 
         public static bool IsFromSlothRepo()
@@ -35,7 +48,7 @@ namespace XIVSlothCombo.Data
 
             if (repo.InstalledFromUrl is null) return false;
 
-            if (repo.InstalledFromUrl == "https://raw.githubusercontent.com/Nik-Potokar/MyDalamudPlugins/main/pluginmaster.json")
+            if (repo.InstalledFromUrl == "https://love.puni.sh/ment.json")
                 return true;
             else
                 return false;

--- a/XIVSlothCombo/Window/ConfigWindow.cs
+++ b/XIVSlothCombo/Window/ConfigWindow.cs
@@ -10,10 +10,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using Dalamud.Interface.Colors;
 using XIVSlothCombo.Attributes;
 using XIVSlothCombo.Combos;
 using XIVSlothCombo.Combos.PvE;
 using XIVSlothCombo.Core;
+using XIVSlothCombo.Data;
 using XIVSlothCombo.Window.Tabs;
 
 namespace XIVSlothCombo.Window
@@ -156,6 +158,38 @@ namespace XIVSlothCombo.Window
                 }
                 ImGui.Spacing();
 #endif
+
+                var conflictingPlugins = ConflictingPluginsCheck.TryGetConflictingPlugins();
+                if (conflictingPlugins != null)
+                {
+                    ImGui.Spacing();
+                    ImGui.Spacing();
+                    const string conflictStringStart = "Conflicting Combo";
+                    const string conflictStringEnd = "Plugins Detected!";
+
+                    // Chop the text in half if it doesn't fit
+                    ImGuiEx.LineCentered("###ConflictingPlugins", () =>
+                    {
+                        if (ImGui.GetColumnWidth() < ImGui.CalcTextSize(conflictStringStart + " " + conflictStringEnd).X.Scale())
+                            ImGui.TextColored(ImGuiColors.DalamudYellow, conflictStringStart + "\n" + conflictStringEnd);
+                        else
+                            ImGui.TextColored(ImGuiColors.DalamudYellow, conflictStringStart + " " + conflictStringEnd);
+
+                        // Tooltip with explanation
+                        if (ImGui.IsItemHovered())
+                        {
+                            var conflictingPluginsText = "- " + string.Join("\n- ", conflictingPlugins);
+                            var tooltipText =
+                                "The following plugins are known to conflict " +
+                                $"with {Svc.PluginInterface.InternalName}:\n" +
+                                conflictingPluginsText +
+                                "\n\nIt is recommended you disable these plugins to prevent\n" +
+                                "unexpected behavior and bugs.";
+
+                            ImGui.SetTooltip(tooltipText);
+                        }
+                    });
+                }
 
             }
 

--- a/XIVSlothCombo/XIVSlothCombo.cs
+++ b/XIVSlothCombo/XIVSlothCombo.cs
@@ -427,23 +427,37 @@ namespace XIVSlothCombo
 
                             string desktopPath = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
 
+                            string[]? conflictingPlugins = ConflictingPluginsCheck.TryGetConflictingPlugins();
+                            int conflictingPluginsCount = conflictingPlugins?.Length ?? 0;
+
+                            string repoURL = RepoCheckFunctions.FetchCurrentRepo()?.InstalledFromUrl ?? "Unknown";
+                            string currentZone = Svc.Data.GetExcelSheet<TerritoryType>()?
+                                .FirstOrDefault(x => x.RowId == Svc.ClientState.TerritoryType)
+                                .PlaceName.Value.Name.ToString() ?? "Unknown";
+
                             using StreamWriter file = new($"{desktopPath}/WrathDebug.txt", append: false);  // Output path
 
                             file.WriteLine("START DEBUG LOG");
                             file.WriteLine("");
-                            file.WriteLine($"Plugin Version: {GetType().Assembly.GetName().Version}");                          // Plugin version
+                            file.WriteLine($"Plugin Version: {GetType().Assembly.GetName().Version}");                   // Plugin version
                             file.WriteLine("");
-                            file.WriteLine($"Installation Repo: {RepoCheckFunctions.FetchCurrentRepo()?.InstalledFromUrl}");    // Installation Repo
+                            file.WriteLine($"Installation Repo: {repoURL}");                                             // Installation Repo
                             file.WriteLine("");
-                            file.WriteLine($"Current Job: " +                                                                   // Current Job
+                            file.WriteLine($"Conflicting Plugins: {conflictingPluginsCount}");                           // Conflicting Plugins
+                            if (conflictingPlugins != null) {
+                                foreach (var plugin in conflictingPlugins)
+                                    file.WriteLine($"- {plugin}");                                                       // Listing Conflicting Plugin
+                                file.WriteLine("");
+                            }
+                            file.WriteLine($"Current Job: " +                                                            // Current Job
                                 $"{Svc.ClientState.LocalPlayer.ClassJob.Value.Name} / " +                                // - Client Name
                                 $"{Svc.ClientState.LocalPlayer.ClassJob.Value.NameEnglish} / " +                         // - EN Name
                                 $"{Svc.ClientState.LocalPlayer.ClassJob.Value.Abbreviation}");                           // - Abbreviation
-                            file.WriteLine($"Current Job Index: {Svc.ClientState.LocalPlayer.ClassJob.RowId}");                // Job Index
-                            file.WriteLine($"Current Job Level: {Svc.ClientState.LocalPlayer.Level}");                      // Job Level
+                            file.WriteLine($"Current Job Index: {Svc.ClientState.LocalPlayer.ClassJob.RowId}");          // Job Index
+                            file.WriteLine($"Current Job Level: {Svc.ClientState.LocalPlayer.Level}");                   // Job Level
                             file.WriteLine("");
-                            file.WriteLine($"Current Zone: {Svc.Data.GetExcelSheet<TerritoryType>()?.FirstOrDefault(x => x.RowId == Svc.ClientState.TerritoryType).PlaceName.Value.Name}");   // Current zone location
-                            file.WriteLine($"Current Party Size: {Svc.Party.Length}");                                  // Current party size
+                            file.WriteLine($"Current Zone: {currentZone}");                                              // Current zone location
+                            file.WriteLine($"Current Party Size: {Svc.Party.Length}");                                   // Current party size
                             file.WriteLine("");
                             file.WriteLine($"START ENABLED FEATURES");
 
@@ -593,7 +607,7 @@ namespace XIVSlothCombo
                             }
 
                             file.WriteLine("END DEBUG LOG");
-                            Svc.Chat.Print("Please check your desktop for SlothDebug.txt and upload this file where requested.");
+                            Svc.Chat.Print("Please check your desktop for WrathDebug.txt and upload this file where requested.");
 
                             break;
                         }

--- a/XIVSlothCombo/XIVSlothCombo.cs
+++ b/XIVSlothCombo/XIVSlothCombo.cs
@@ -440,7 +440,6 @@ namespace XIVSlothCombo
                             file.WriteLine("START DEBUG LOG");
                             file.WriteLine("");
                             file.WriteLine($"Plugin Version: {GetType().Assembly.GetName().Version}");                   // Plugin version
-                            file.WriteLine("");
                             file.WriteLine($"Installation Repo: {repoURL}");                                             // Installation Repo
                             file.WriteLine("");
                             file.WriteLine($"Conflicting Plugins: {conflictingPluginsCount}");                           // Conflicting Plugins


### PR DESCRIPTION
Same as #6.

This adds reminder text for users about conflicting plugins, and a tooltip advising them to disable the plugins.
It is just a simple check for the most common combo plugins, so it can help every-day users without substantial code to try to account for dev plugins, etc.

![image](https://github.com/user-attachments/assets/6374d5d2-c37c-4f54-9442-f5c37600c80c)

Additionally, it adds the conflict count and list of conflicting plugins to debug logs.

<table><tr><td>

```
START DEBUG LOG

Plugin Version: 1.0.0.0
Installation Repo: !! Self-Built !!

Conflicting Plugins: 2
- XIVCombo(1.8.5.0)
- XIVComboExpanded(2.0.0.12)
```

</td><td>

```
START DEBUG LOG

Plugin Version: 1.0.0.0
Installation Repo: !! Self-Built !!

Conflicting Plugins: 0


```

</td></tr></table>

> Additionally, this also includes:
> - A little bit of cleanup for `RepoCheck`
> - Support for grabbing URL from plugins not from us (since we would already be seeing URLs that were updated when the `InternalName` was not - just for consistency)
> - Support for when our manifest is `Wrath Combo`
> - A callout for dev plugins (since the manifest would give `null` anyway)