### PR TITLE
SCH Fairy Reminder, Warning Squash

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -4279,7 +4279,7 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Swiftcast Raise Combo Feature", "Changes Swiftcast to Resurrection while Swiftcast is on cooldown.", SCH.JobID, 10)]
         SCH_Raise = 16032,
 
-        [ReplaceSkill(SCH.WhisperingDawn, SCH.FeyBlessing, SCH.FeyBlessing, SCH.Aetherpact, SCH.Dissipation)]
+        [ReplaceSkill(SCH.WhisperingDawn, SCH.FeyIllumination, SCH.FeyBlessing, SCH.Aetherpact, SCH.Dissipation, SCH.SummonSeraph)]
         [CustomComboInfo("Fairy Feature", "Change all fairy actions into Summon Eos when the Fairy is not summoned.", SCH.JobID, 11)]
         SCH_FairyReminder = 16033,
 

--- a/XIVSlothCombo/Combos/PvE/ADV/ADV_Config.cs
+++ b/XIVSlothCombo/Combos/PvE/ADV/ADV_Config.cs
@@ -8,10 +8,10 @@ internal partial class ADV
 
         internal static void Draw(CustomComboPreset preset)
         {
-            switch (preset)
-            {
-                //Presets
-            }
+            //switch (preset)
+            //{
+            //    //Presets
+            //}
         }
     }
 }

--- a/XIVSlothCombo/Combos/PvE/ALL/ALL_Config.cs
+++ b/XIVSlothCombo/Combos/PvE/ALL/ALL_Config.cs
@@ -8,10 +8,10 @@ internal partial class ALL
 
         internal static void Draw(CustomComboPreset preset)
         {
-            switch (preset)
-            {
-                //Presets
-            }
+            //switch (preset)
+            //{
+            //    //Presets
+            //}
         }
     }
 }

--- a/XIVSlothCombo/Combos/PvE/BLU/BLU_Config.cs
+++ b/XIVSlothCombo/Combos/PvE/BLU/BLU_Config.cs
@@ -8,10 +8,10 @@ internal partial class BLU
 
         internal static void Draw(CustomComboPreset preset)
         {
-            switch (preset)
-            {
-                //Presets
-            }
+            //switch (preset)
+            //{
+            //    //Presets
+            //}
         }
     }
 }

--- a/XIVSlothCombo/Combos/PvE/DOH/DOH_Config.cs
+++ b/XIVSlothCombo/Combos/PvE/DOH/DOH_Config.cs
@@ -8,10 +8,10 @@ internal partial class DOH
 
         internal static void Draw(CustomComboPreset preset)
         {
-            switch (preset)
-            {
-                //Presets
-            }
+            //switch (preset)
+            //{
+            //    //Presets
+            //}
         }
     }
 }

--- a/XIVSlothCombo/Combos/PvE/DOL/DOL_Config.cs
+++ b/XIVSlothCombo/Combos/PvE/DOL/DOL_Config.cs
@@ -8,10 +8,10 @@ internal partial class DOL
 
         internal static void Draw(CustomComboPreset preset)
         {
-            switch (preset)
-            {
-                //Presets
-            }
+            //switch (preset)
+            //{
+            //    //Presets
+            //}
         }
     }
 }

--- a/XIVSlothCombo/Combos/PvE/SCH/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH/SCH.cs
@@ -64,7 +64,7 @@ namespace XIVSlothCombo.Combos.PvE
         internal static readonly List<uint>
             BroilList = [Ruin, Broil, Broil2, Broil3, Broil4],
             AetherflowList = [EnergyDrain, Lustrate, SacredSoil, Indomitability, Excogitation],
-            FairyList = [WhisperingDawn, FeyBlessing, FeyIllumination, Dissipation, Aetherpact];
+            FairyList = [WhisperingDawn, FeyBlessing, FeyIllumination, Dissipation, Aetherpact, SummonSeraph];
 
         internal static class Buffs
         {


### PR DESCRIPTION
- SCH Fairy Reminder now includes Summon Seraph. Fixed ReplaceSkill attribute
- Commented out multiple empty config switches to shut up compile warnings