### PR TITLE
[RDM] Reordered priority of oGCDs in weave window (Fleche > Contre Six > Engagement > Corps-a-corps > ...

### DIFF
--- a/XIVSlothCombo/Combos/PvE/RDM/RDM_Helper.cs
+++ b/XIVSlothCombo/Combos/PvE/RDM/RDM_Helper.cs
@@ -70,6 +70,16 @@ namespace XIVSlothCombo.Combos.PvE
             //Grabs an oGCD to return based on radio options
 
             if (placeOGCD == 0
+                && fleche
+                && ActionReady(Fleche))
+                placeOGCD = Fleche;
+
+            if (placeOGCD == 0
+                && contre
+                && ActionReady(ContreSixte))
+                placeOGCD = ContreSixte;
+            
+            if (placeOGCD == 0
                 && engagement
                 && (GetRemainingCharges(Engagement) > engagementPool
                     || (GetRemainingCharges(Engagement) == 1 && GetCooldownRemainingTime(Engagement) < 3))
@@ -85,16 +95,6 @@ namespace XIVSlothCombo.Combos.PvE
                 && LevelChecked(Corpsacorps)
                 && distance <= corpacorpsRange)
                 placeOGCD = Corpsacorps;
-
-            if (placeOGCD == 0
-                && contre
-                && ActionReady(ContreSixte))
-                placeOGCD = ContreSixte;
-
-            if (placeOGCD == 0
-                && fleche
-                && ActionReady(Fleche))
-                placeOGCD = Fleche;
 
             if (placeOGCD == 0
                 && vice


### PR DESCRIPTION
Changed around the order of oGCDs so that Fleche > Contre Six > Engagement > Corps-a-corps