### PR TITLE
[PvP] 7.1 PvP update

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -5845,6 +5845,10 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(SAMPvP_BurstMode)]
         [CustomComboInfo("Burst Mode on Kasha Combo Option", "Adds Burst Mode to Kasha Combo instead.", SAM.JobID, 1)]
         SAMPvP_BurstMode_MainCombo = 125003,
+
+        [ParentCombo(SAMPvP_BurstMode)]
+        [CustomComboInfo("Zanshin Option", "Adds Zanshin to Burst Mode.", SAM.JobID)]
+        SAMPvP_BurstMode_Zanshin = 125007,
         #endregion
 
         #region Kasha Features
@@ -5863,7 +5867,7 @@ namespace XIVSlothCombo.Combos
         SAMPvP_KashaFeatures_AoEMeleeProtection = 125006,
         #endregion
 
-        // Last value = 125006
+        // Last value = 125007
 
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -5186,11 +5186,23 @@ namespace XIVSlothCombo.Combos
 
         [ParentCombo(ASTPvP_Burst)]
         [CustomComboInfo("Card Option", "Adds Drawing and Playing Cards to Burst Mode.", AST.JobID)]
-        ASTPvP_Card = 111002,
+        ASTPvP_Burst_MinorArcana = 111002,
 
         [PvPCustomCombo]
         [CustomComboInfo("Double Cast Heal Feature", "Adds Double Cast to Aspected Benefic.", AST.JobID)]
         ASTPvP_Heal = 111003,
+
+        [ParentCombo(ASTPvP_DoubleCast)]
+        [CustomComboInfo("Double Malefic Cast Option", "Adds Double Malefic Cast to Burst Mode.", AST.JobID)]
+        ASTPvP_Burst_DoubleMalefic = 111004,
+
+        [ParentCombo(ASTPvP_DoubleCast)]
+        [CustomComboInfo("Double Gravity Cast Option", "Adds Double Gravity Cast to Burst Mode.", AST.JobID)]
+        ASTPvP_Burst_Gravity = 111005,
+
+        [ParentCombo(ASTPvP_Burst)]
+        [CustomComboInfo("Macrocosmos Option", "Adds Macrocosmos to Burst Mode.", AST.JobID)]
+        ASTPvP_Burst_Macrocosmos = 111006,
 
         // Last value = 111003
         #endregion
@@ -5202,15 +5214,50 @@ namespace XIVSlothCombo.Combos
 
         [ParentCombo(BLMPvP_BurstMode)]
         [PvPCustomCombo]
-        [CustomComboInfo("Night Wing Option", "Adds Night Wing to Burst Mode.", BLM.JobID)]
-        BLMPvP_BurstMode_NightWing = 112001,
+        [CustomComboInfo("Aetherial Manipulation Option", "Uses Aetherial Manipulation to gap close if Burst is off cooldown.", BLM.JobID)]
+        BLMPvP_BurstMode_AetherialManip = 112001,
 
         [ParentCombo(BLMPvP_BurstMode)]
         [PvPCustomCombo]
-        [CustomComboInfo("Aetherial Manipulation Option", "Uses Aetherial Manipulation to gap close if Burst is off cooldown.", BLM.JobID)]
-        BLMPvP_BurstMode_AetherialManip = 112002,
+        [CustomComboInfo("Burst cast Option", "Adds Burst to Burst Mode.", BLM.JobID)]
+        BLMPvP_BurstMode_Burst = 112002,
 
-        // Last value = 112002
+        [ParentCombo(BLMPvP_BurstMode)]
+        [PvPCustomCombo]
+        [CustomComboInfo("Paradox Option", "Adds Paradox to Burst Mode.", BLM.JobID)]
+        BLMPvP_BurstMode_Paradox = 112003,
+
+        [ParentCombo(BLMPvP_BurstMode)]
+        [PvPCustomCombo]
+        [CustomComboInfo("Xenoglossy Option", "Adds Xenoglossy to Burst Mode.", BLM.JobID)]
+        BLMPvP_BurstMode_Xenoglossy = 112004,
+
+        [ParentCombo(BLMPvP_BurstMode)]
+        [PvPCustomCombo]
+        [CustomComboInfo("Lethargy Option", "Adds Lethargy to Burst Mode.", BLM.JobID)]
+        BLMPvP_BurstMode_Lethargy = 112005,
+
+        [ParentCombo(BLMPvP_BurstMode)]
+        [PvPCustomCombo]
+        [CustomComboInfo("Wreath of Fire (Elemental Weave) Option", "Adds Wreath of Fire to Burst Mode when the target is under Guard status.", BLM.JobID)]
+        BLMPvP_BurstMode_WreathOfFire = 112006,
+
+        [ParentCombo(BLMPvP_BurstMode)]
+        [PvPCustomCombo]
+        [CustomComboInfo("Wreath of Ice (Elemental Weave) Option", "Adds Wreath of Fire to Burst Mode when the target is under Guard status.", BLM.JobID)]
+        BLMPvP_BurstMode_WreathOfIce = 112007,
+
+        [ParentCombo(BLMPvP_BurstMode)]
+        [PvPCustomCombo]
+        [CustomComboInfo("Flare Star Option", "Adds Flare Star to Burst Mode.", BLM.JobID)]
+        BLMPvP_BurstMode_FlareStar = 112008,
+
+        [ParentCombo(BLMPvP_BurstMode)]
+        [PvPCustomCombo]
+        [CustomComboInfo("Frost Star Option", "Adds Frost Star to Burst Mode.", BLM.JobID)]
+        BLMPvP_BurstMode_FrostStar = 112009,
+
+        // Last value = 112009
 
         #endregion
 
@@ -5224,9 +5271,30 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Silent Nocturne Option", "Adds Silent Nocturne to Burst Mode.", BRD.JobID)]
         BRDPvP_SilentNocturne = 113001,
 
-        // Last value = 113001
+        [PvPCustomCombo]
+        [ParentCombo(BRDPvP_BurstMode)]
+        [CustomComboInfo("Apex Arrow Option", "Adds Apex Arrow to Burst Mode.", BRD.JobID)]
+        BRDPvP_ApexArrow = 113002,
+
+        [PvPCustomCombo]
+        [ParentCombo(BRDPvP_BurstMode)]
+        [CustomComboInfo("Blast Arrow Option", "Adds Blast Arrow to Burst Mode.", BRD.JobID)]
+        BRDPvP_BlastArrow = 113003,
+
+        [PvPCustomCombo]
+        [ParentCombo(BRDPvP_BurstMode)]
+        [CustomComboInfo("Harmonic Arrow Option", "Adds Harmonic Arrow to Burst Mode.", BRD.JobID)]
+        BRDPvP_HarmonicArrow = 113004,
+
+        [PvPCustomCombo]
+        [ParentCombo(BRDPvP_BurstMode)]
+        [CustomComboInfo("Encore of Light Option", "Adds Encore of Light to Burst Mode.", BRD.JobID)]
+        BRDPvP_EncoreOfLight = 113005,
+
+        // Last value = 113005
 
         #endregion
+
 
         #region DANCER
         [PvPCustomCombo]
@@ -5267,7 +5335,32 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Salted Earth Option", "Adds Salted Earth to Burst mode.", DRK.JobID)]
         DRKPvP_SaltedEarth = 115003,
 
-        // Last value = 115002
+        [PvPCustomCombo]
+        [ParentCombo(DRKPvP_Burst)]
+        [CustomComboInfo("Salt and Darkness Option", "Adds Salt and Darkness to Burst mode.", DRK.JobID)]
+        DRKPvP_SaltAndDarkness = 115004,
+
+        [PvPCustomCombo]
+        [ParentCombo(DRKPvP_Burst)]
+        [CustomComboInfo("Impalement Option", "Adds Impalement to Burst mode.", DRK.JobID)]
+        DRKPvP_Impalement = 115005,
+
+        [PvPCustomCombo]
+        [ParentCombo(DRKPvP_Burst)]
+        [CustomComboInfo("Shadowbringer Option", "Adds Shadowbringer to Burst mode.", DRK.JobID)]
+        DRKPvP_Shadowbringer = 115006,
+
+        [PvPCustomCombo]
+        [ParentCombo(DRKPvP_Burst)]
+        [CustomComboInfo("Blackest Night Option", "Adds Blackest Night to Burst mode.", DRK.JobID)]
+        DRKPvP_BlackestNight = 115007,
+
+        [PvPCustomCombo]
+        [ParentCombo(DRKPvP_Burst)]
+        [CustomComboInfo("Scorn Option", "Adds Scorn to Burst mode.", DRK.JobID)]
+        DRKPvP_Scorn = 115008,
+
+        // Last value = 115008
 
         #endregion
 
@@ -5316,23 +5409,19 @@ namespace XIVSlothCombo.Combos
         GNBPvP_Burst = 117000,
 
         [ParentCombo(GNBPvP_Burst)]
-        [CustomComboInfo("Double Down Option", "Adds Double Down to rotation when appropriate.", GNB.JobID)]
-        GNBPvP_DoubleDown = 117001,
+        [CustomComboInfo("Fated Circle Option", "Adds Fated Circle to rotation under No Mercy status.", GNB.JobID)]
+        GNBPvP_FatedCircle = 117001,
 
         [ParentCombo(GNBPvP_Burst)]
         [CustomComboInfo("Burst Strike Option", "Adds Burst Strike to rotation when appropriate.", GNB.JobID)]
         GNBPvP_BurstStrike = 117002,
 
         [ParentCombo(GNBPvP_Burst)]
-        [CustomComboInfo("Draw & Junction Option", "Adds Draw And Junction to rotation when appropriate.", GNB.JobID)]
-        GNBPvP_ST_DrawAndJunction = 117003,
-
-        [ParentCombo(GNBPvP_Burst)]
-        [CustomComboInfo("Gnashing Fang Option", "Adds Gnashing Fang to to rotation when appropriate.", GNB.JobID)]
+        [CustomComboInfo("Gnashing Fang Option", "Adds Gnashing Fang to Burst Mode.", GNB.JobID)]
         GNBPvP_ST_GnashingFang = 117004,
 
         [ParentCombo(GNBPvP_Burst)]
-        [CustomComboInfo("Continuation Option", "Adds Continuation to rotation when appropriate.", GNB.JobID)]
+        [CustomComboInfo("Continuation Option", "Adds Continuation to Burst Mode.", GNB.JobID)]
         GNBPvP_ST_Continuation = 117005,
 
         [ParentCombo(GNBPvP_Burst)]
@@ -5340,16 +5429,9 @@ namespace XIVSlothCombo.Combos
         GNBPvP_RoughDivide = 117006,
 
         [ParentCombo(GNBPvP_Burst)]
-        [CustomComboInfo("Junction Cast DPS Option", "Adds Junction Cast (DPS) to rotation.", GNB.JobID)]
-        GNBPvP_JunctionDPS = 117007,
+        [CustomComboInfo("Blasting Zone Option", "Adds Blasting Zone to Burst Mode under No Mercy status.", GNB.JobID)]
+        GNBPvP_BlastingZone = 117007,
 
-        [ParentCombo(GNBPvP_Burst)]
-        [CustomComboInfo("Junction Cast Healer Option", "Adds Junction Cast (Healer) to rotation.", GNB.JobID)]
-        GNBPvP_JunctionHealer = 117008,
-
-        [ParentCombo(GNBPvP_Burst)]
-        [CustomComboInfo("Junction Cast Tank Option", "Adds Junction Cast (Tank) to rotation.", GNB.JobID)]
-        GNBPvP_JunctionTank = 117009,
 
         #endregion
 
@@ -5359,12 +5441,7 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Continuation Feature", "Adds Continuation to Gnashing Fang.", GNB.JobID)]
         GNBPvP_GnashingFang = 117010,
 
-        [ConflictingCombos(GNBPvP_ST_DrawAndJunction)]
-        [PvPCustomCombo]
-        [CustomComboInfo("Junctioned Cast Feature", "Adds Junctioned Cast to Draw and Junction.", GNB.JobID)]
-        GNBPvP_DrawAndJunction = 117011,
-
-        // Last value = 117011
+        // Last value = 117010
 
         #endregion
 
@@ -5377,15 +5454,60 @@ namespace XIVSlothCombo.Combos
 
         [PvPCustomCombo]
         [ParentCombo(MCHPvP_BurstMode)]
-        [CustomComboInfo("Alternate Drill Option", "Saves Drill for use after Wildfire.", MCHPvP.JobID)]
-        MCHPvP_BurstMode_AltDrill = 118001,
+        [CustomComboInfo("Air Anchor Option", "Adds Air Anchor to Burst Mode.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_AirAnchor = 118001,
 
         [PvPCustomCombo]
         [ParentCombo(MCHPvP_BurstMode)]
-        [CustomComboInfo("Alternate Analysis Option", "Uses Analysis with Air Anchor instead of Chain Saw.", MCHPvP.JobID)]
-        MCHPvP_BurstMode_AltAnalysis = 118002,
+        [CustomComboInfo("Analysis Option", "Adds Analysis to Burst Mode.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_Analysis = 118002,
 
-        // Last value = 118002
+        [PvPCustomCombo]
+        [ParentCombo(MCHPvP_BurstMode_Analysis)]
+        [CustomComboInfo("Alternate Analysis Option", "Uses Analysis with Air Anchor instead of Chain Saw.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_AltAnalysis = 118003,
+
+        [PvPCustomCombo]
+        [ParentCombo(MCHPvP_BurstMode)]
+        [CustomComboInfo("Drill Option", "Adds Drill to Burst Mode.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_Drill = 118004,
+
+        [PvPCustomCombo]
+        [ParentCombo(MCHPvP_BurstMode_Drill)]
+        [CustomComboInfo("Alternate Drill Option", "Saves Drill for use after Wildfire.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_AltDrill = 118005,
+
+        [PvPCustomCombo]
+        [ParentCombo(MCHPvP_BurstMode)]
+        [CustomComboInfo("Bio Blaster Option", "Adds Bio Blaster to Burst Mode.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_BioBlaster = 118006,
+
+        [PvPCustomCombo]
+        [ParentCombo(MCHPvP_BurstMode)]
+        [CustomComboInfo("Chain Saw Option", "Adds Chain Saw to Burst Mode.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_ChainSaw = 118007,
+
+        [PvPCustomCombo]
+        [ParentCombo(MCHPvP_BurstMode)]
+        [CustomComboInfo("Full Metal Field Option", "Adds Full Metal Field to Burst Mode.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_FullMetalField = 118008,
+
+        [PvPCustomCombo]
+        [ParentCombo(MCHPvP_BurstMode)]
+        [CustomComboInfo("Wildfire Option", "Adds Wildfire to Burst Mode.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_Wildfire = 118009,
+
+        [PvPCustomCombo]
+        [ParentCombo(MCHPvP_BurstMode)]
+        [CustomComboInfo("Blazing Shot Option", "Adds Blazing Shot to Burst Mode.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_BlazingShot = 118010,
+
+        [PvPCustomCombo]
+        [ParentCombo(MCHPvP_BurstMode)]
+        [CustomComboInfo("Marksmans Spite Option", "Adds Marksmans Spite to Burst Mode when the target is below specified HP.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_MarksmanSpite = 118011,
+
+        // Last value = 118011
 
         #endregion
 
@@ -5406,10 +5528,20 @@ namespace XIVSlothCombo.Combos
 
         [ParentCombo(MNKPvP_Burst)]
         [PvPCustomCombo]
-        [CustomComboInfo("Six-sided Star Option", "Adds Six-sided Star to Burst Mode.", MNK.JobID)]
-        MNKPvP_Burst_SixSidedStar = 119003,
+        [CustomComboInfo("Flints Reply Option", "Adds Flints Reply to Burst Mode.", MNK.JobID)]
+        MNKPvP_Burst_FlintsReply = 119003,
 
-        // Last value = 119003
+        [ParentCombo(MNKPvP_Burst)]
+        [PvPCustomCombo]
+        [CustomComboInfo("Rising Phoenix Option", "Adds Rising Phoenix to Burst Mode.", MNK.JobID)]
+        MNKPvP_Burst_RisingPhoenix = 119004,
+
+        [ParentCombo(MNKPvP_Burst)]
+        [PvPCustomCombo]
+        [CustomComboInfo("Wind's Reply Option", "Adds Wind's Reply to Burst Mode.", MNK.JobID)]
+        MNKPvP_Burst_WindsReply = 119005,
+
+        // Last value = 119004
 
         #endregion
 
@@ -5427,10 +5559,55 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Meisui Option", "Uses Three Mudra on Meisui when HP is under the set threshold.", NINPvP.JobID)]
         NINPvP_ST_Meisui = 120002,
 
+        [ParentCombo(NINPvP_ST_BurstMode)]
+        [PvPCustomCombo]
+        [CustomComboInfo("Fuma Shuriken Option", "Adds Fuma Shuriken to Burst Mode.", NINPvP.JobID)]
+        NINPvP_ST_FumaShuriken = 120003,
+
+        [ParentCombo(NINPvP_ST_BurstMode)]
+        [PvPCustomCombo]
+        [CustomComboInfo("Three Mudra Option", "Adds Three Mudra to Burst Mode.", NINPvP.JobID)]
+        NINPvP_ST_ThreeMudra = 120004,
+
+        [ParentCombo(NINPvP_ST_BurstMode)]
+        [PvPCustomCombo]
+        [CustomComboInfo("Dokumori Option", "Adds Dokumori to Burst Mode.", NINPvP.JobID)]
+        NINPvP_ST_Dokumori = 120005,
+
+        [ParentCombo(NINPvP_ST_BurstMode)]
+        [PvPCustomCombo]
+        [CustomComboInfo("Bunshin Option", "Adds Bunshin to Burst Mode.", NINPvP.JobID)]
+        NINPvP_ST_Bunshin = 120006,
+
+        [ParentCombo(NINPvP_ST_BurstMode)]
+        [PvPCustomCombo]
+        [CustomComboInfo("Seiton Tenchu Option", "Adds SeitonTenchu to Burst Mode when the target is below threshold HP%.", NINPvP.JobID)]
+        NINPvP_ST_SeitonTenchu = 120007,
+
         [ParentCombo(NINPvP_AoE_BurstMode)]
         [PvPCustomCombo]
         [CustomComboInfo("Meisui Option", "Uses Three Mudra on Meisui when HP is under the set threshold.", NINPvP.JobID)]
-        NINPvP_AoE_Meisui = 120003,
+        NINPvP_AoE_Meisui = 120008,
+
+        [ParentCombo(NINPvP_AoE_BurstMode)]
+        [PvPCustomCombo]
+        [CustomComboInfo("Fuma Shuriken Option", "Adds Fuma Shuriken to Burst Mode.", NINPvP.JobID)]
+        NINPvP_AoE_FumaShuriken = 120009,
+
+        [ParentCombo(NINPvP_AoE_BurstMode)]
+        [PvPCustomCombo]
+        [CustomComboInfo("Three Mudra Option", "Adds Three Mudra to Burst Mode.", NINPvP.JobID)]
+        NINPvP_AoE_ThreeMudra = 120010,
+
+        [ParentCombo(NINPvP_AoE_BurstMode)]
+        [PvPCustomCombo]
+        [CustomComboInfo("Dokumori Option", "Adds Dokumori to Burst Mode.", NINPvP.JobID)]
+        NINPvP_AoE_Dokumori = 120011,
+
+        [ParentCombo(NINPvP_AoE_BurstMode)]
+        [PvPCustomCombo]
+        [CustomComboInfo("Bunshin Option", "Adds Bunshin to Burst Mode.", NINPvP.JobID)]
+        NINPvP_AoE_Bunshin = 120012,
 
         // Last value = 120003
 
@@ -5442,14 +5619,34 @@ namespace XIVSlothCombo.Combos
         PLDPvP_Burst = 121000,
 
         [ParentCombo(PLDPvP_Burst)]
-        [CustomComboInfo("Shield Bash Option", "Adds Shield Bash to Burst Mode.", PLD.JobID)]
-        PLDPvP_ShieldBash = 121001,
+        [CustomComboInfo("Shield Smite Option", "Adds Shield Smite to Burst Mode.", PLD.JobID)]
+        PLDPvP_ShieldSmite = 121001,
+
+        [ParentCombo(PLDPvP_Burst)]
+        [CustomComboInfo("Imperator Option", "Adds Imperator to Burst Mode.", PLD.JobID)]
+        PLDPvP_Imperator = 121002,
 
         [ParentCombo(PLDPvP_Burst)]
         [CustomComboInfo("Confiteor Option", "Adds Confiteor to Burst Mode.", PLD.JobID)]
-        PLDPvP_Confiteor = 121002,
+        PLDPvP_Confiteor = 121003,
 
-        // Last value = 121002
+        [ParentCombo(PLDPvP_Burst)]
+        [CustomComboInfo("Holy Spirit Option", "Adds Holy Spirit to Burst Mode.", PLD.JobID)]
+        PLDPvP_HolySpirit = 121004,
+
+        [ParentCombo(PLDPvP_Burst)]
+        [CustomComboInfo("Intervene Option", "Adds Intervene to Burst Mode.", PLD.JobID)]
+        PLDPvP_Intervene = 121005,
+
+        [ParentCombo(PLDPvP_Burst)]
+        [CustomComboInfo("Melee Intervene Option", "Adds Intervene to Burst Mode when in melee range.", PLD.JobID)]
+        PLDPvP_Intervene_Melee = 121006,
+
+        [ParentCombo(PLDPvP_Burst)]
+        [CustomComboInfo("Phalanx Combo Option", "Adds Phalanx Combo to Burst Mode.", PLD.JobID)]
+        PLDPvP_PhalanxCombo = 121007,
+
+        // Last value = 121007
 
         #endregion
 
@@ -5471,7 +5668,27 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Smart Palette Option", "Uses Subtractive Palette when standing still and releases it when moving.", PCTPvP.JobID)]
         PCTPvP_SubtractivePalette = 140003,
 
-        // Last value = 140003
+        [ParentCombo(PCTPvP_Burst)]
+        [CustomComboInfo("Creature Motif Option", "Adds Creature Motif to Burst Mode.", PCTPvP.JobID)]
+        PCTPvP_CreatureMotif = 140004,
+
+        [ParentCombo(PCTPvP_Burst)]
+        [CustomComboInfo("Living Muse Option", "Adds Living Muse to Burst Mode.", PCTPvP.JobID)]
+        PCTPvP_LivingMuse = 140005,
+
+        [ParentCombo(PCTPvP_Burst)]
+        [CustomComboInfo("Mog Of The Ages Option", "Adds Mog Of The Ages to Burst Mode.", PCTPvP.JobID)]
+        PCTPvP_MogOfTheAges = 140006,
+
+        [ParentCombo(PCTPvP_Burst)]
+        [CustomComboInfo("Holy In White Option", "Adds Holy In White to Burst Mode.", PCTPvP.JobID)]
+        PCTPvP_HolyInWhite = 140007,
+
+        [ParentCombo(PCTPvP_Burst)]
+        [CustomComboInfo("Star Prism Option", "Adds Star Prism to Burst Mode.", PCTPvP.JobID)]
+        PCTPvP_StarPrism = 140008,
+
+        // Last value = 140008
         #endregion
 
         #region REAPER
@@ -5527,15 +5744,37 @@ namespace XIVSlothCombo.Combos
 
         #region RED MAGE
         [PvPCustomCombo]
-        [CustomComboInfo("Burst Mode", "Turns Verstone/Verfire into an all-in-one damage button.", RDMPvP.JobID)]
+        [CustomComboInfo("Burst Mode", "Turns Jolt3 into an all-in-one damage button.", RDMPvP.JobID)]
         RDMPvP_BurstMode = 123000,
 
         [PvPCustomCombo]
         [ParentCombo(RDMPvP_BurstMode)]
-        [CustomComboInfo("No Frazzle Option", "Prevents Frazzle from being used in Burst Mode.", RDMPvP.JobID)]
-        RDMPvP_FrazzleOption = 123001,
+        [CustomComboInfo("Corps-a-Corps Option", "Adds Corps-a-Corps to Burst Mode.", RDMPvP.JobID)]
+        RDMPvP_Burst_CorpsACorps = 123001,
 
-        // Last value = 123001
+        [PvPCustomCombo]
+        [ParentCombo(RDMPvP_BurstMode)]
+        [CustomComboInfo("Displacement Option", "Adds Displacement to Burst Mode.", RDMPvP.JobID)]
+        RDMPvP_Burst_Displacement = 123002,
+
+        [PvPCustomCombo]
+        [ParentCombo(RDMPvP_BurstMode)]
+        [CustomComboInfo("Embolden Option", "Adds Embolden to Burst Mode.", RDMPvP.JobID)]
+        RDMPvP_Burst_Embolden = 123003,
+
+        [PvPCustomCombo]
+        [ParentCombo(RDMPvP_BurstMode)]
+        [CustomComboInfo("Resolution Option", "Adds Resolution to Burst Mode.", RDMPvP.JobID)]
+        RDMPvP_Burst_Resolution = 123004,
+
+        [PvPCustomCombo]
+        [ParentCombo(RDMPvP_BurstMode)]
+        [CustomComboInfo("Enchanted Riposte Option", "Adds Enchanted Riposte to Burst Mode.", RDMPvP.JobID)]
+        RDMPvP_Burst_EnchantedRiposte = 123005,
+
+        // Last value = 123005
+
+        #endregion
 
         #endregion
 
@@ -5548,7 +5787,31 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Pneuma Option", "Adds Pneuma to Burst Mode.", SGE.JobID)]
         SGEPvP_BurstMode_Pneuma = 124001,
 
-        // Last value = 124001
+        [ParentCombo(SGEPvP_BurstMode)]
+        [CustomComboInfo("Eukrasia Option", "Adds Eukrasia to Burst Mode.", SGE.JobID)]
+        SGEPvP_BurstMode_Eukrasia = 124002,
+
+        [ParentCombo(SGEPvP_BurstMode)]
+        [CustomComboInfo("Phlegma Option", "Adds Phlegma to Burst Mode.", SGE.JobID)]
+        SGEPvP_BurstMode_Phlegma = 124003,
+
+        [ParentCombo(SGEPvP_BurstMode)]
+        [CustomComboInfo("Psyche Option", "Adds Psyche to Burst Mode.", SGE.JobID)]
+        SGEPvP_BurstMode_Psyche = 124004,
+
+        [ParentCombo(SGEPvP_BurstMode)]
+        [CustomComboInfo("Toxikon Option", "Adds Toxikon to Burst Mode.", SGE.JobID)]
+        SGEPvP_BurstMode_Toxikon = 124005,
+
+        [ParentCombo(SGEPvP_BurstMode)]
+        [CustomComboInfo("Toxikon II Option", "Adds Toxikon II to Burst Mode.", SGE.JobID)]
+        SGEPvP_BurstMode_Toxikon2 = 124006,
+
+        [ParentCombo(SGEPvP_BurstMode)]
+        [CustomComboInfo("Kardia Reminder Option", "Adds Kardia to Burst Mode.", SGE.JobID)]
+        SGEPvP_BurstMode_KardiaReminder = 124007,
+
+        // Last value = 124007
 
         #endregion
 
@@ -5612,7 +5875,11 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Deployment Tactics Option", "Adds Deployment Tactics to Burst Mode when available.", SCH.JobID)]
         SCHPvP_DeploymentTactics = 126003,
 
-        // Last value = 126003
+        [ParentCombo(SCHPvP_Burst)]
+        [CustomComboInfo("Chain Stratagem Option", "Adds Chain Stratagem to Burst Mode when available.", SCH.JobID)]
+        SCHPvP_ChainStratagem = 126004,
+
+        // Last value = 126004
 
         #endregion
 
@@ -5626,7 +5893,42 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Radiant Aegis Option", "Adds Radiant Aegis to Burst Mode when available, and your HP is at or below the set percentage.", SMNPvP.JobID)]
         SMNPvP_BurstMode_RadiantAegis = 127001,
 
-        // Last value = 127001
+        [PvPCustomCombo]
+        [ParentCombo(SMNPvP_BurstMode)]
+        [CustomComboInfo("Crimson Cyclone Option", "Adds Crimson Cyclone to Burst Mode.", SMNPvP.JobID)]
+        SMNPvP_BurstMode_CrimsonCyclone = 127002,
+
+        [PvPCustomCombo]
+        [ParentCombo(SMNPvP_BurstMode)]
+        [CustomComboInfo("Crimson Strike Option", "Adds Crimson Strike to Burst Mode.", SMNPvP.JobID)]
+        SMNPvP_BurstMode_CrimsonStrike = 127003,
+
+        [PvPCustomCombo]
+        [ParentCombo(SMNPvP_BurstMode)]
+        [CustomComboInfo("Mountain Buster Option", "Adds Mountain Buster to Burst Mode.", SMNPvP.JobID)]
+        SMNPvP_BurstMode_MountainBuster = 127004,
+
+        [PvPCustomCombo]
+        [ParentCombo(SMNPvP_BurstMode)]
+        [CustomComboInfo("Slipstream Option", "Adds Slipstream to Burst Mode.", SMNPvP.JobID)]
+        SMNPvP_BurstMode_Slipstream = 127005,
+
+        [PvPCustomCombo]
+        [ParentCombo(SMNPvP_BurstMode)]
+        [CustomComboInfo("Necrotize Option", "Adds Necrotize to Burst Mode.", SMNPvP.JobID)]
+        SMNPvP_BurstMode_Necrotize = 127006,
+
+        [PvPCustomCombo]
+        [ParentCombo(SMNPvP_BurstMode)]
+        [CustomComboInfo("DeathFlare Option", "Adds DeathFlare to Burst Mode.", SMNPvP.JobID)]
+        SMNPvP_BurstMode_DeathFlare = 127007,
+
+        [PvPCustomCombo]
+        [ParentCombo(SMNPvP_BurstMode)]
+        [CustomComboInfo("Brand of Purgatory Option", "Adds Brand of Purgatory to Burst Mode.", SMNPvP.JobID)]
+        SMNPvP_BurstMode_BrandofPurgatory = 127008,
+
+        // Last value = 127008
 
         #endregion
 
@@ -5659,7 +5961,27 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Primal Rend Option", "Adds Primal Rend to Burst Mode.", WARPvP.JobID)]
         WARPvP_BurstMode_PrimalRend = 128004,
 
-        // Last value = 128002
+        [PvPCustomCombo]
+        [ParentCombo(WARPvP_BurstMode)]
+        [CustomComboInfo("Inner Chaos Option", "Adds Inner Chaos to Burst Mode.", WARPvP.JobID)]
+        WARPvP_BurstMode_InnerChaos = 128005,
+
+        [PvPCustomCombo]
+        [ParentCombo(WARPvP_BurstMode)]
+        [CustomComboInfo("Orogeny Option", "Adds Orogeny to Burst Mode.", WARPvP.JobID)]
+        WARPvP_BurstMode_Orogeny = 128006,
+
+        [PvPCustomCombo]
+        [ParentCombo(WARPvP_BurstMode)]
+        [CustomComboInfo("Onslaught Option", "Adds Onslaught to Burst Mode.", WARPvP.JobID)]
+        WARPvP_BurstMode_Onslaught = 128007,
+
+        [PvPCustomCombo]
+        [ParentCombo(WARPvP_BurstMode)]
+        [CustomComboInfo("PrimalScream Option", "Adds Primal Scream to Burst Mode.", WARPvP.JobID)]
+        WARPvP_BurstMode_PrimalScream = 128008,
+
+        // Last value = 128008
 
         #endregion
 
@@ -5688,10 +6010,13 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Cure III Feature", "Adds Cure III to Cure II when available.", WHM.JobID)]
         WHMPvP_Cure3 = 129005,
 
-        // Last value = 129005
+        [ParentCombo(WHMPvP_Burst)]
+        [CustomComboInfo("Glare IV Option", "Adds Glare IV to Burst Mode.", WHM.JobID)]
+        WHMPvP_Glare4 = 129006,
+
+        // Last value = 129006
 
         #endregion
 
-        #endregion
     }
 }

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -5185,24 +5185,33 @@ namespace XIVSlothCombo.Combos
         ASTPvP_DoubleCast = 111001,
 
         [ParentCombo(ASTPvP_Burst)]
-        [CustomComboInfo("Card Option", "Adds Drawing and Playing Cards to Burst Mode.", AST.JobID)]
-        ASTPvP_Burst_MinorArcana = 111002,
+        [CustomComboInfo("Card Draw Option", "Adds Drawing Cards to Burst Mode.", AST.JobID)]
+        ASTPvP_Burst_DrawCard = 111002,
+
+        [ParentCombo(ASTPvP_Burst)]
+        [CustomComboInfo("Card Play Option", "Adds Playing Cards to Burst Mode.", AST.JobID)]
+        ASTPvP_Burst_PlayCard = 111003,
 
         [PvPCustomCombo]
         [CustomComboInfo("Double Cast Heal Feature", "Adds Double Cast to Aspected Benefic.", AST.JobID)]
-        ASTPvP_Heal = 111003,
+        ASTPvP_Heal = 111004,
 
         [ParentCombo(ASTPvP_DoubleCast)]
         [CustomComboInfo("Double Malefic Cast Option", "Adds Double Malefic Cast to Burst Mode.", AST.JobID)]
-        ASTPvP_Burst_DoubleMalefic = 111004,
+        ASTPvP_Burst_DoubleMalefic = 111005,
 
         [ParentCombo(ASTPvP_DoubleCast)]
         [CustomComboInfo("Double Gravity Cast Option", "Adds Double Gravity Cast to Burst Mode.", AST.JobID)]
-        ASTPvP_Burst_Gravity = 111005,
+        ASTPvP_Burst_Gravity = 111006,
 
         [ParentCombo(ASTPvP_Burst)]
         [CustomComboInfo("Macrocosmos Option", "Adds Macrocosmos to Burst Mode.", AST.JobID)]
-        ASTPvP_Burst_Macrocosmos = 111006,
+        ASTPvP_Burst_Macrocosmos = 111007,
+
+        [PvPCustomCombo]
+        [CustomComboInfo("Epicycle Burst Feature", "Turns Epicycle into burst combo.", AST.JobID)]
+        ASTPvP_Epicycle = 111008,
+
 
         // Last value = 111003
         #endregion

--- a/XIVSlothCombo/Combos/PvE/AST/AST_Config.cs
+++ b/XIVSlothCombo/Combos/PvE/AST/AST_Config.cs
@@ -4,6 +4,8 @@ using static XIVSlothCombo.CustomComboNS.Functions.CustomComboFunctions;
 using static XIVSlothCombo.Extensions.UIntExtensions;
 using static XIVSlothCombo.Window.Functions.UserConfig;
 using static XIVSlothCombo.Window.Functions.SliderIncrements;
+using XIVSlothCombo.Combos.PvP;
+using XIVSlothCombo.Window.Functions;
 
 namespace XIVSlothCombo.Combos.PvE
 {
@@ -27,7 +29,9 @@ namespace XIVSlothCombo.Combos.PvE
                 AST_AOE_LightSpeedOption = new("AST_AOE_LightSpeedOption"),
                 AST_DPS_CombustOption = new("AST_DPS_CombustOption"),
                 AST_QuickTarget_Override = new("AST_QuickTarget_Override"),
-                AST_ST_DPS_Play_SpeedSetting = new("AST_ST_DPS_Play_SpeedSetting");
+                AST_ST_DPS_Play_SpeedSetting = new("AST_ST_DPS_Play_SpeedSetting"),
+                //PVP
+                ASTPvP_Burst_PlayCardOption = new("ASTPvP_Burst_PlayCardOption");
             public static UserBool
                 AST_QuickTarget_SkipDamageDown = new("AST_QuickTarget_SkipDamageDown"),
                 AST_QuickTarget_SkipRezWeakness = new("AST_QuickTarget_SkipRezWeakness"),
@@ -191,6 +195,21 @@ namespace XIVSlothCombo.Combos.PvE
                     case CustomComboPreset.AST_DPS_AutoDraw:
                         DrawAdditionalBoolChoice(AST_ST_DPS_OverwriteCards, "Overwrite Non-DPS Cards", "Will draw even if you have healing cards remaining.");
                         break;
+
+                    //PVP
+                    case CustomComboPreset.ASTPvP_Burst_PlayCard:
+                        UserConfig.DrawHorizontalRadioButton(ASTPvP_Burst_PlayCardOption, "Lord and Lady card play",
+                            "Uses Lord and Lady of Crowns when available.", 1);
+
+                        UserConfig.DrawHorizontalRadioButton(ASTPvP_Burst_PlayCardOption, "Lord of Crowns card play",
+                            "Only uses Lord of Crowns when available.", 2);
+
+                        UserConfig.DrawHorizontalRadioButton(ASTPvP_Burst_PlayCardOption, "Lady of Crowns card play",
+                            "Only uses Lady of Crowns when available.", 3);
+
+                        break;
+
+
                 }
             }
         }

--- a/XIVSlothCombo/Combos/PvE/MCH/MCH_Config.cs
+++ b/XIVSlothCombo/Combos/PvE/MCH/MCH_Config.cs
@@ -1,5 +1,7 @@
+using XIVSlothCombo.Combos.PvP;
 using XIVSlothCombo.CustomComboNS.Functions;
 using XIVSlothCombo.Data;
+using XIVSlothCombo.Window.Functions;
 using static XIVSlothCombo.Window.Functions.UserConfig;
 
 namespace XIVSlothCombo.Combos.PvE;
@@ -114,6 +116,22 @@ internal partial class MCH
                         "Stop Using When Target HP% is at or Below (Set to 0 to Disable This Check)");
 
                     break;
+
+                //PVP
+                case CustomComboPreset.MCHPvP_BurstMode_MarksmanSpite:
+                    DrawSliderInt(0, 36000, MCHPvP.Config.MCHPVP_MarksmanSpite,
+                        "Use Marksman's Spite when the target is below set HP");
+                    break;
+
+                case CustomComboPreset.MCHPvP_BurstMode_FullMetalField:
+                    UserConfig.DrawHorizontalRadioButton(MCHPvP.Config.MCHPVP_FMFOption, "Full Metal Field Wildfire combo",
+                        "Uses Full Metal Field when Wildfire is ready.", 1);
+
+                    UserConfig.DrawHorizontalRadioButton(MCHPvP.Config.MCHPVP_FMFOption, "Full Metal Field only when Overheated",
+                        "Only uses Full Metal Field while Overheated.", 2);
+
+                    break;
+
             }
         }
     }

--- a/XIVSlothCombo/Combos/PvE/NIN/NIN_Config.cs
+++ b/XIVSlothCombo/Combos/PvE/NIN/NIN_Config.cs
@@ -1,3 +1,4 @@
+using XIVSlothCombo.Combos.PvP;
 using XIVSlothCombo.Window.Functions;
 
 namespace XIVSlothCombo.Combos.PvE;
@@ -148,6 +149,11 @@ internal partial class NIN
                 case CustomComboPreset.NIN_Variant_Cure:
                     UserConfig.DrawSliderInt(1, 100, NIN_VariantCure, "HP% to be at or under", 200);
 
+                    break;
+
+                //PVP
+                case CustomComboPreset.NINPvP_ST_SeitonTenchu:
+                    UserConfig.DrawSliderInt(1, 50, NINPvP.Config.NINPVP_SeitonTenchu, "Target's HP% to be at or under", 200);
                     break;
             }
         }

--- a/XIVSlothCombo/Combos/PvP/ASTPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/ASTPVP.cs
@@ -16,17 +16,15 @@ namespace XIVSlothCombo.Combos.PvP
             DoubleGravity = 29248,
             Draw = 29249,
             Macrocosmos = 29253,
-            Microcosmos = 29254;
+            Microcosmos = 29254,
+            MinorArcana = 41503;
 
         internal class Buffs
         {
             internal const ushort
-                BalanceDrawn = 3101,
-                BoleDrawn = 3403,
-                ArrowDrawn = 3404,
-                Arrow = 3402,
-                Balance = 1338,
-                Bole = 1339;
+                    LadyOfCrowns = 4328,
+                    LordOfCrowns = 4329;
+
         }
 
         internal class ASTPvP_Burst : CustomCombo
@@ -37,54 +35,33 @@ namespace XIVSlothCombo.Combos.PvP
             {
                 if (actionID is Malefic)
                 {
-                    // Out of combat Draw
-                    if (IsOffCooldown(Draw) && !InCombat() && IsEnabled(CustomComboPreset.ASTPvP_Card))
-                        return Draw;
-
-                    // Malefic to initiate combat
-                    if (!InCombat() &&
-                        (IsOffCooldown(Draw) || HasEffect(Buffs.BoleDrawn) || HasEffect(Buffs.ArrowDrawn)))
-                        return Malefic;
-
-                    // Post-Draw Malefic
-                    if (lastComboMove == Draw && !CanWeave(actionID))
-                        return Malefic;
-
-                    // Play "The Balance" before a Gravity/Double + Macro burst
-                    if (HasCharges(DoubleCast) && IsOffCooldown(Gravity) && IsOffCooldown(Macrocosmos) && HasEffect(Buffs.BalanceDrawn) && IsEnabled(CustomComboPreset.ASTPvP_Card))
-                        return OriginalHook(Draw);
-
-                    if (!TargetHasEffectAny(PvPCommon.Buffs.Guard))
+                    if (!PvPCommon.IsImmuneToDamage())
                     {
-                        if (lastComboMove == DoubleGravity && IsOffCooldown(Macrocosmos))
+                        if (IsEnabled(CustomComboPreset.ASTPvP_Burst_MinorArcana))
+                        {
+
+                            if (IsOffCooldown(MinorArcana) || HasEffect(Buffs.LadyOfCrowns) && IsOffCooldown(MinorArcana) || HasEffect(Buffs.LordOfCrowns) && CanWeave(actionID))
+                                return OriginalHook(MinorArcana);
+                        }
+
+                        if (IsEnabled(CustomComboPreset.ASTPvP_Burst_Macrocosmos) && lastComboMove == DoubleGravity && IsOffCooldown(Macrocosmos))
                             return Macrocosmos;
 
-                        if (lastComboMove == Gravity && HasCharges(DoubleCast) && IsEnabled(CustomComboPreset.ASTPvP_DoubleCast))
+                        if (IsEnabled(CustomComboPreset.ASTPvP_DoubleCast) && lastComboMove == Gravity && HasCharges(DoubleCast))
                             return DoubleGravity;
 
-                        if (IsOffCooldown(Gravity))
+                        if (IsEnabled(CustomComboPreset.ASTPvP_Burst_Gravity) && IsOffCooldown(Gravity))
                             return Gravity;
 
-                        if (lastComboMove == Malefic && (GetRemainingCharges(DoubleCast) > 1 ||
-                            GetCooldownRemainingTime(Gravity) > 7.5f) && CanWeave(actionID) && IsEnabled(CustomComboPreset.ASTPvP_DoubleCast))
-                            return DoubleMalefic;
+                        if (IsEnabled(CustomComboPreset.ASTPvP_Burst_DoubleMalefic))
+                        {
+                            if (lastComboMove == Malefic && (GetRemainingCharges(DoubleCast) > 1 ||
+                                GetCooldownRemainingTime(Gravity) > 7.5f) && CanWeave(actionID) && IsEnabled(CustomComboPreset.ASTPvP_DoubleCast))
+                                return DoubleMalefic;
+                        }
+
                     }
 
-                    // Card waste prevention
-                    if (((GetBuffRemainingTime(Buffs.BalanceDrawn) < 3) ||
-                        (GetBuffRemainingTime(Buffs.BoleDrawn) < 3) ||
-                        (GetBuffRemainingTime(Buffs.ArrowDrawn) < 3)) &&
-                        CanWeave(actionID) && IsEnabled(CustomComboPreset.ASTPvP_Card))
-                        return OriginalHook(Draw);
-
-                    // Generic Draw
-                    if (IsOffCooldown(Draw) && CanWeave(actionID) && IsEnabled(CustomComboPreset.ASTPvP_Card))
-                        return Draw;
-
-                    // Generic Play outside of necessary holding
-                    if (CanWeave(actionID) && GetCooldownRemainingTime(Macrocosmos) > 7.5f && (IsOffCooldown(Draw) ||
-                        HasEffect(Buffs.BalanceDrawn) || HasEffect(Buffs.BoleDrawn) || HasEffect(Buffs.ArrowDrawn)) && IsEnabled(CustomComboPreset.ASTPvP_Card))
-                        return OriginalHook(Draw);
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvP/BLMPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/BLMPVP.cs
@@ -16,18 +16,25 @@ namespace XIVSlothCombo.Combos.PvP
             Flare = 29651,
             Blizzard4 = 29654,
             Freeze = 29655,
-            Foul = 29371;
+            Foul = 29371,
+            Lethargy = 41510,
+            ElementalWeave = 41475,
+            SoulResonance = 29662,
+            Xenoglossy = 29658;
 
         public static class Buffs
         {
             public const ushort
-                AstralFire2 = 3212,
-                AstralFire3 = 3213,
+                AstralFire1 = 3212,
+                AstralFire2 = 3213,
+                AstralFire3 = 3381,
                 UmbralIce2 = 3214,
                 UmbralIce3 = 3215,
                 Burst = 3221,
                 SoulResonance = 3222,
-                Polyglot = 3169;
+                Polyglot = 3169,
+                ElementalStar = 4317,
+                Paradox = 3223;
         }
 
         public static class Debuffs
@@ -39,79 +46,88 @@ namespace XIVSlothCombo.Combos.PvP
                 DeepFreeze = 3219;
         }
 
+        public static class Config
+        {
+            public const string
+                BLMPvP_WreathOfIce = "BLMPvP_WreathOfIce";
+
+        }
+
         internal class BLMPvP_BurstMode : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BLMPvP_BurstMode;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
+                bool canWeave = CanSpellWeave(actionID);
+
                 if (actionID is Fire or Fire4 or Flare)
                 {
-                    bool canWeave = CanSpellWeave(actionID);
 
-                    if (HasEffect(Buffs.Polyglot))
-                        return Foul;
+                    if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_WreathOfFire))
+                    {
+                        if (IsOffCooldown(ElementalWeave) && TargetHasEffectAny(PvPCommon.Buffs.Guard) && canWeave && (HasEffect(Buffs.AstralFire1) || HasEffect(Buffs.AstralFire2) || HasEffect(Buffs.AstralFire3)))
+                            return OriginalHook(ElementalWeave);
+                    }
 
-                    if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_AetherialManip) &&
-                        GetCooldown(AetherialManipulation).RemainingCharges > 0 &&
-                        !InMeleeRange() && IsOffCooldown(Burst) && canWeave)
-                        return AetherialManipulation;
+                    if (!PvPCommon.IsImmuneToDamage())
+                    {
+                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_FlareStar) && HasEffect(Buffs.ElementalStar))
+                            return OriginalHook(SoulResonance);
 
-                    if (InMeleeRange() &&
-                        IsOffCooldown(Burst))
-                        return Burst;
+                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_Xenoglossy) && HasCharges(Xenoglossy))
+                            return Xenoglossy;
 
-                    if (!TargetHasEffect(Debuffs.AstralWarmth))
-                        return OriginalHook(Fire);
+                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_AetherialManip) &&
+                            GetCooldown(AetherialManipulation).RemainingCharges > 0 &&
+                            !InMeleeRange() && IsOffCooldown(Burst) && canWeave)
+                            return AetherialManipulation;
 
-                    if (FindTargetEffect(Debuffs.AstralWarmth).StackCount < 3 &&
-                        IsOffCooldown(Paradox))
-                        return Paradox;
+                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_Burst) && InMeleeRange() &&
+                            IsOffCooldown(Burst))
+                            return Burst;
 
-                    if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_NightWing) &&
-                        IsOffCooldown(NightWing))
-                        return NightWing;
+                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_Lethargy) && IsOffCooldown(Lethargy) && canWeave)
+                            return Lethargy;
 
-                    if (FindTargetEffect(Debuffs.AstralWarmth).StackCount == 3 &&
-                        GetCooldown(Superflare).RemainingCharges > 0 &&
-                        !TargetHasEffect(Debuffs.Burns))
-                        return Superflare;
+                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_Paradox) && HasEffect(Buffs.Paradox))
+                            return Paradox;
+                    }
 
                 }
 
                 if (actionID is Blizzard or Blizzard4 or Freeze)
                 {
-                    bool canWeave = CanSpellWeave(actionID);
 
-                    if (HasEffect(Buffs.Polyglot))
-                        return Foul;
+                    if (!PvPCommon.IsImmuneToDamage())
+                    {
+                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_FrostStar) && HasEffect(Buffs.ElementalStar))
+                            return OriginalHook(SoulResonance);
 
-                    if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_AetherialManip) &&
-                        GetCooldown(AetherialManipulation).RemainingCharges > 0 &&
-                        !InMeleeRange() &&
-                        IsOffCooldown(Burst) &&
-                        canWeave)
-                        return AetherialManipulation;
+                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_WreathOfIce) && IsOffCooldown(ElementalWeave) && canWeave && PlayerHealthPercentageHp() <= GetOptionValue(Config.BLMPvP_WreathOfIce))
+                            return OriginalHook(ElementalWeave);
 
-                    if (InMeleeRange() &&
-                        IsOffCooldown(Burst))
-                        return Burst;
+                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_Xenoglossy) && HasCharges(Xenoglossy))
+                            return Foul;
 
-                    if (!TargetHasEffect(Debuffs.UmbralFreeze))
-                        return OriginalHook(Blizzard);
+                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_AetherialManip) &&
+                            GetCooldown(AetherialManipulation).RemainingCharges > 0 &&
+                            !InMeleeRange() &&
+                            IsOffCooldown(Burst) &&
+                            canWeave)
+                            return AetherialManipulation;
 
-                    if (FindTargetEffect(Debuffs.UmbralFreeze).StackCount < 3 &&
-                        IsOffCooldown(Paradox))
-                        return Paradox;
+                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_Burst) && InMeleeRange() &&
+                            IsOffCooldown(Burst))
+                            return Burst;
 
-                    if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_NightWing) &&
-                        IsOffCooldown(NightWing))
-                        return NightWing;
+                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_Lethargy) && IsOffCooldown(Lethargy) && canWeave)
+                            return Lethargy;
 
-                    if (FindTargetEffect(Debuffs.UmbralFreeze).StackCount == 3 &&
-                        GetCooldown(Superflare).RemainingCharges > 0 &&
-                        !TargetHasEffect(Debuffs.DeepFreeze))
-                        return Superflare;
+                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_Paradox) && HasEffect(Buffs.Paradox))
+                            return Paradox;
+                    }
+
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvP/BRDPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/BRDPVP.cs
@@ -11,11 +11,12 @@ namespace XIVSlothCombo.Combos.PvP
             PowerfulShot = 29391,
             ApexArrow = 29393,
             SilentNocturne = 29395,
-            EmpyrealArrow = 29398,
             RepellingShot = 29399,
             WardensPaean = 29400,
             PitchPerfect = 29392,
-            BlastArrow = 29394;
+            BlastArrow = 29394,
+            HarmonicArrow = 41464,
+            FinalFantasia = 29401;
 
         public static class Buffs
         {
@@ -23,7 +24,16 @@ namespace XIVSlothCombo.Combos.PvP
                 FrontlinersMarch = 3138,
                 FrontlinersForte = 3140,
                 Repertoire = 3137,
-                BlastArrowReady = 3142;
+                BlastArrowReady = 3142,
+                EncoreofLightReady = 4312,
+                FrontlineMarch = 3139;
+        }
+
+        public static class Config
+        {
+            public const string
+                BRDPvP_HarmonicArrowsCharges = "BRDPvP_HarmonicArrowsCharges";
+
         }
 
         internal class BRDPvP_BurstMode : CustomCombo
@@ -37,25 +47,36 @@ namespace XIVSlothCombo.Combos.PvP
                 {
                     var canWeave = CanWeave(actionID, 0.5);
 
-                    if (canWeave)
+                    if (!PvPCommon.IsImmuneToDamage())
                     {
-                        if (GetCooldown(EmpyrealArrow).RemainingCharges == 3)
-                            return OriginalHook(EmpyrealArrow);
+                        if (canWeave)
+                        {
+                            if (IsEnabled(CustomComboPreset.BRDPvP_SilentNocturne) && !GetCooldown(SilentNocturne).IsCooldown)
+                                return OriginalHook(SilentNocturne);
 
-                        if (IsEnabled(CustomComboPreset.BRDPvP_SilentNocturne) && !GetCooldown(SilentNocturne).IsCooldown)
-                            return OriginalHook(SilentNocturne);
+                            if (IsEnabled(CustomComboPreset.BRDPvP_EncoreOfLight) && HasEffect(Buffs.EncoreofLightReady))
+                                return OriginalHook(FinalFantasia);
+                        }
+
+                        if (IsEnabled(CustomComboPreset.BRDPvP_ApexArrow) && !GetCooldown(ApexArrow).IsCooldown)
+                            return OriginalHook(ApexArrow);
+
+                        if (HasEffect(Buffs.FrontlineMarch))
+                        {
+                            if (IsEnabled(CustomComboPreset.BRDPvP_HarmonicArrow) && GetRemainingCharges(HarmonicArrow) >= GetOptionValue(Config.BRDPvP_HarmonicArrowsCharges))
+                                return OriginalHook(HarmonicArrow);
+
+                            if (IsEnabled(CustomComboPreset.BRDPvP_BlastArrow) && HasEffect(Buffs.BlastArrowReady))
+                                return OriginalHook(BlastArrow);
+
+                            if (HasEffect(Buffs.Repertoire))
+                                return OriginalHook(PowerfulShot);
+
+                        }
+
+                        return OriginalHook(PowerfulShot);
                     }
 
-                    if (HasEffect(Buffs.BlastArrowReady))
-                        return OriginalHook(BlastArrow);
-
-                    if (HasEffect(Buffs.Repertoire))
-                        return OriginalHook(PowerfulShot);
-
-                    if (!GetCooldown(ApexArrow).IsCooldown)
-                        return OriginalHook(ApexArrow);
-
-                    return OriginalHook(PowerfulShot);
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvP/DRKPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/DRKPVP.cs
@@ -8,13 +8,14 @@ namespace XIVSlothCombo.Combos.PvP
             HardSlash = 29085,
             SyphonStrike = 29086,
             Souleater = 29087,
-            Quietus = 29737,
             Shadowbringer = 29091,
             Plunge = 29092,
             BlackestNight = 29093,
             SaltedEarth = 29094,
             Bloodspiller = 29088,
-            SaltAndDarkness = 29095;
+            SaltAndDarkness = 29095,
+            Impalement = 41438,
+            Eventide = 29097;
 
         public class Buffs
         {
@@ -24,7 +25,8 @@ namespace XIVSlothCombo.Combos.PvP
                 SaltedEarthDMG = 3036,
                 SaltedEarthDEF = 3037,
                 DarkArts = 3034,
-                UndeadRedemption = 3039;
+                UndeadRedemption = 3039,
+                Scorn = 4290;
         }
 
         public class Config
@@ -45,40 +47,48 @@ namespace XIVSlothCombo.Combos.PvP
                     bool canWeave = CanWeave(HardSlash);
                     int shadowBringerThreshold = GetOptionValue(Config.ShadowbringerThreshold);
 
-
-                    if (IsEnabled(CustomComboPreset.DRKPvP_Plunge) && HasTarget() && ((!InMeleeRange()) || (InMeleeRange() && IsEnabled(CustomComboPreset.DRKPvP_PlungeMelee))) && ActionReady(Plunge))
-                        return OriginalHook(Plunge);
-
-                    if (canWeave)
+                    if (!PvPCommon.IsImmuneToDamage())
                     {
-                        if (ActionReady(BlackestNight))
-                            return OriginalHook(BlackestNight);
-
-                        if (ActionReady(SaltedEarth) && IsEnabled(CustomComboPreset.DRKPvP_SaltedEarth))
-                            return OriginalHook(SaltedEarth);
-
-                        if (HasEffect(Buffs.SaltedEarthDMG) && ActionReady(SaltAndDarkness))
-                            return OriginalHook(SaltAndDarkness);
-
-                        if (!HasEffect(Buffs.Blackblood) && (HasEffect(Buffs.DarkArts) || PlayerHealthPercentageHp() >= shadowBringerThreshold))
-                            return OriginalHook(Shadowbringer);
-                    }
-
-                    if (InMeleeRange())
-                    {
-                        if (ActionReady(Quietus))
-                            return OriginalHook(Quietus);
-
-                        if (comboTime > 1f)
+                        if (IsEnabled(CustomComboPreset.DRKPvP_Plunge))
                         {
-                            if (lastComboActionID == HardSlash)
-                                return OriginalHook(SyphonStrike);
-
-                            if (lastComboActionID == SyphonStrike)
-                                return OriginalHook(Souleater);
+                            if (HasTarget() && (!InMeleeRange()) || (InMeleeRange() && ActionReady(Plunge) && IsEnabled(CustomComboPreset.DRKPvP_PlungeMelee)))
+                                return OriginalHook(Plunge);
                         }
 
-                        return OriginalHook(HardSlash);
+                        if (IsEnabled(CustomComboPreset.DRKPvP_Scorn) && HasEffect(Buffs.Scorn))
+                            return OriginalHook(Eventide);
+
+                        if (canWeave)
+                        {
+                            if (IsEnabled(CustomComboPreset.DRKPvP_BlackestNight) && ActionReady(BlackestNight) && !HasEffect(Buffs.BlackestNight))
+                                return OriginalHook(BlackestNight);
+
+                            if (IsEnabled(CustomComboPreset.DRKPvP_SaltedEarth) && ActionReady(SaltedEarth) && IsEnabled(CustomComboPreset.DRKPvP_SaltedEarth))
+                                return OriginalHook(SaltedEarth);
+
+                            if (IsEnabled(CustomComboPreset.DRKPvP_SaltAndDarkness) && HasEffect(Buffs.SaltedEarthDMG) && ActionReady(SaltAndDarkness))
+                                return OriginalHook(SaltAndDarkness);
+
+                            if (IsEnabled(CustomComboPreset.DRKPvP_Shadowbringer) && !HasEffect(Buffs.Blackblood) && (HasEffect(Buffs.DarkArts) || PlayerHealthPercentageHp() >= shadowBringerThreshold))
+                                return OriginalHook(Shadowbringer);
+                        }
+
+                        if (InMeleeRange())
+                        {
+                            if (IsEnabled(CustomComboPreset.DRKPvP_Impalement) && ActionReady(Impalement))
+                                return OriginalHook(Impalement);
+
+                            if (comboTime > 1f)
+                            {
+                                if (lastComboActionID == HardSlash)
+                                    return OriginalHook(SyphonStrike);
+
+                                if (lastComboActionID == SyphonStrike)
+                                    return OriginalHook(Souleater);
+                            }
+
+                            return OriginalHook(HardSlash);
+                        }
                     }
                 }
 

--- a/XIVSlothCombo/Combos/PvP/MCHPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/MCHPVP.cs
@@ -1,3 +1,4 @@
+using XIVSlothCombo.Core;
 using XIVSlothCombo.CustomComboNS;
 
 namespace XIVSlothCombo.Combos.PvP
@@ -8,7 +9,7 @@ namespace XIVSlothCombo.Combos.PvP
 
         public const uint
             BlastCharge = 29402,
-            HeatBlast = 29403,
+            BlazingShot = 41468,
             Scattergun = 29404,
             Drill = 29405,
             BioBlaster = 29406,
@@ -18,7 +19,8 @@ namespace XIVSlothCombo.Combos.PvP
             BishopTurret = 29412,
             AetherMortar = 29413,
             Analysis = 29414,
-            MarksmanSpite = 29415;
+            MarksmanSpite = 29415,
+            FullMetalField = 41469;
 
         public static class Buffs
         {
@@ -38,6 +40,15 @@ namespace XIVSlothCombo.Combos.PvP
                 Wildfire = 1323;
         }
 
+        public static class Config
+        {
+            public const string
+                MCHPVP_MarksmanSpite = "MCHPVP_MarksmanSpite",
+                MCHPVP_FMFOption = "MCHPVP_FMFOption",
+                MCHPVP_Heat = "MCHPVP_Heat";
+
+        }
+
         internal class MCHPvP_BurstMode : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MCHPvP_BurstMode;
@@ -50,34 +61,68 @@ namespace XIVSlothCombo.Combos.PvP
                     var analysisStacks = GetRemainingCharges(Analysis);
                     var bigDamageStacks = GetRemainingCharges(OriginalHook(Drill));
                     var overheated = HasEffect(Buffs.Overheated);
+                    var FMFOption = PluginConfiguration.GetCustomIntValue(Config.MCHPVP_FMFOption);
 
-                    if (canWeave && HasEffect(Buffs.Overheated) && IsOffCooldown(Wildfire))
-                        return OriginalHook(Wildfire);
-
-                    if (overheated)
-                        return OriginalHook(HeatBlast);
-
-                    if ((HasEffect(Buffs.DrillPrimed) ||
-                        (HasEffect(Buffs.ChainSawPrimed) && !IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AltAnalysis)) ||
-                        (HasEffect(Buffs.AirAnchorPrimed) && IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AltAnalysis))) &&
-                        !HasEffect(Buffs.Analysis) && analysisStacks > 0 && (!IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AltDrill)
-                        || IsOnCooldown(Wildfire)) && !canWeave && !overheated && bigDamageStacks > 0)
-                        return OriginalHook(Analysis);
-
-                    if (bigDamageStacks > 0)
+                    if (!PvPCommon.IsImmuneToDamage())
                     {
-                        if (HasEffect(Buffs.DrillPrimed))
-                            return OriginalHook(Drill);
+                        // MarksmanSpite execute condition - todo add config
+                        if (IsEnabled(CustomComboPreset.MCHPvP_BurstMode_MarksmanSpite) && EnemyHealthCurrentHp() < GetOptionValue(Config.MCHPVP_MarksmanSpite) && IsLB1Ready)
+                            return MarksmanSpite;
 
-                        if (HasEffect(Buffs.BioblasterPrimed) && GetTargetDistance() <= 12)
-                            return OriginalHook(BioBlaster);
+                        if (IsEnabled(CustomComboPreset.MCHPvP_BurstMode_Wildfire) && canWeave && overheated && IsOffCooldown(Wildfire))
+                            return OriginalHook(Wildfire);
 
-                        if (HasEffect(Buffs.AirAnchorPrimed))
-                            return OriginalHook(AirAnchor);
+                        // FullMetalField condition when not overheated or if overheated and FullMetalField is off cooldown
+                        if(IsEnabled(CustomComboPreset.MCHPvP_BurstMode_FullMetalField) && IsOffCooldown(FullMetalField))
+                        {
+                            if (FMFOption == 1)
+                            {
+                                if (!overheated && IsOffCooldown(Wildfire))
+                                    return FullMetalField;
+                            }
+                            if (FMFOption == 2)
+                            {
+                                if (overheated)
+                                    return FullMetalField;
+                            }
+                        }
 
-                        if (HasEffect(Buffs.ChainSawPrimed))
-                            return OriginalHook(ChainSaw);
+                        // If overheated, BlazingShot is the next action
+                        if (IsEnabled(CustomComboPreset.MCHPvP_BurstMode_BlazingShot) && overheated)
+                            return OriginalHook(BlazingShot);
+
+                        // Check if primed buffs and analysis conditions are met
+                        bool hasPrimedBuffs = HasEffect(Buffs.DrillPrimed) ||
+                                              (HasEffect(Buffs.ChainSawPrimed) && !IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AltAnalysis)) ||
+                                              (HasEffect(Buffs.AirAnchorPrimed) && IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AltAnalysis));
+
+                        if (IsEnabled(CustomComboPreset.MCHPvP_BurstMode_Analysis))
+                        {
+                            if (hasPrimedBuffs && !HasEffect(Buffs.Analysis) && analysisStacks > 0 &&
+                                (!IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AltDrill) || IsOnCooldown(Wildfire)) &&
+                                !canWeave && !overheated && bigDamageStacks > 0)
+                            {
+                                return OriginalHook(Analysis);
+                            }
+                        }
+
+                        // BigDamageStacks logic with checks for primed buffs
+                        if (bigDamageStacks > 0)
+                        {
+                            if (IsEnabled(CustomComboPreset.MCHPvP_BurstMode_Drill) && HasEffect(Buffs.DrillPrimed))
+                                return OriginalHook(Drill);
+
+                            if (IsEnabled(CustomComboPreset.MCHPvP_BurstMode_BioBlaster) && HasEffect(Buffs.BioblasterPrimed) && GetTargetDistance() <= 12)
+                                return OriginalHook(BioBlaster);
+
+                            if (IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AirAnchor) && HasEffect(Buffs.AirAnchorPrimed))
+                                return OriginalHook(AirAnchor);
+
+                            if (IsEnabled(CustomComboPreset.MCHPvP_BurstMode_ChainSaw) && HasEffect(Buffs.ChainSawPrimed))
+                                return OriginalHook(ChainSaw);
+                        }
                     }
+
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvP/MNKPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/MNKPVP.cs
@@ -9,27 +9,28 @@ namespace XIVSlothCombo.Combos.PvP
 
         public const uint
             PhantomRushCombo = 55,
-            Bootshine = 29472,
-            TrueStrike = 29473,
-            SnapPunch = 29474,
             DragonKick = 29475,
             TwinSnakes = 29476,
             Demolish = 29477,
             PhantomRush = 29478,
-            SixSidedStar = 29479,
-            Enlightenment = 29480,
             RisingPhoenix = 29481,
             RiddleOfEarth = 29482,
             ThunderClap = 29484,
             EarthsReply = 29483,
-            Meteordrive = 29485;
+            Meteordrive = 29485,
+            WindsReply = 41509,
+            FlintsReply = 41447,
+            LeapingOpo = 41444,
+            RisingRaptor = 41445,
+            PouncingCoeurl = 41446;
 
         public static class Buffs
         {
             public const ushort
-                WindResonance = 2007,
+                FiresRumination = 4301,
                 FireResonance = 3170,
                 EarthResonance = 3171;
+
         }
 
         public static class Debuffs
@@ -44,36 +45,38 @@ namespace XIVSlothCombo.Combos.PvP
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is Bootshine or TrueStrike or SnapPunch or DragonKick or TwinSnakes or Demolish or PhantomRush)
+                if (actionID is DragonKick or TwinSnakes or Demolish or LeapingOpo or RisingRaptor or PouncingCoeurl or PhantomRush)
                 {
 
-                    if (!TargetHasEffectAny(PvPCommon.Buffs.Guard))
+                    if (!PvPCommon.IsImmuneToDamage())
                     {
                         if (IsEnabled(CustomComboPreset.MNKPvP_Burst_RiddleOfEarth) && IsOffCooldown(RiddleOfEarth) && PlayerHealthPercentageHp() <= 95)
                             return OriginalHook(RiddleOfEarth);
 
-                        if (IsEnabled(CustomComboPreset.MNKPvP_Burst_Thunderclap) && !HasEffect(Buffs.WindResonance) && GetRemainingCharges(ThunderClap) > 0)
+                        if (IsEnabled(CustomComboPreset.MNKPvP_Burst_Thunderclap) && GetRemainingCharges(ThunderClap) > 0 && !InMeleeRange())
                             return OriginalHook(ThunderClap);
+
+                        if (IsEnabled(CustomComboPreset.MNKPvP_Burst_WindsReply) && InActionRange(WindsReply) && IsOffCooldown(WindsReply))
+                            return WindsReply;
 
                         if (CanWeave(actionID))
                         {
-                            if (IsEnabled(CustomComboPreset.MNKPvP_Burst_SixSidedStar) && IsOffCooldown(SixSidedStar))
-                                return OriginalHook(SixSidedStar);
 
                             if (IsEnabled(CustomComboPreset.MNKPvP_Burst_RiddleOfEarth) && HasEffect(Buffs.EarthResonance) && GetBuffRemainingTime(Buffs.EarthResonance) < 6)
                                 return OriginalHook(EarthsReply);
+                        }
 
-                            if (GetRemainingCharges(RisingPhoenix) > 0 && !HasEffect(Buffs.FireResonance) && (lastComboMove is Demolish || IsOffCooldown(Enlightenment)))
+
+                        if (IsEnabled(CustomComboPreset.MNKPvP_Burst_RisingPhoenix))
+                        {
+                            if (!HasEffect(Buffs.FireResonance) && GetRemainingCharges(RisingPhoenix) > 1 || WasLastWeaponskill(PouncingCoeurl) && GetRemainingCharges(RisingPhoenix) > 0)
                                 return OriginalHook(RisingPhoenix);
                         }
 
-                        if (HasEffect(Buffs.FireResonance))
+                        if (IsEnabled(CustomComboPreset.MNKPvP_Burst_FlintsReply))
                         {
-                            if (lastComboMove is Demolish)
-                                return OriginalHook(PhantomRush);
-
-                            if (IsOffCooldown(Enlightenment))
-                                return OriginalHook(Enlightenment);
+                            if (GetRemainingCharges(FlintsReply) > 0 && (!WasLastAction(LeapingOpo) || !WasLastAction(RisingRaptor) || !WasLastAction(PouncingCoeurl)) || HasEffect(Buffs.FiresRumination) && !WasLastAction(PouncingCoeurl))
+                                return OriginalHook(FlintsReply);
                         }
                     }
                 }

--- a/XIVSlothCombo/Combos/PvP/PCTPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/PCTPVP.cs
@@ -49,7 +49,6 @@ namespace XIVSlothCombo.Combos.PvP
                 bool isMoving = IsMoving;
                 bool hasTarget = HasTarget();
                 bool hasStarPrism = HasEffect(Buffs.Starstruck);
-                bool targetHasGuard = TargetHasEffectAny(PvPCommon.Buffs.Guard);
                 bool hasSubtractivePalette = HasEffect(Buffs.SubtractivePalette);
                 bool hasPortrait = HasEffect(Buffs.MooglePortrait) || HasEffect(Buffs.MadeenPortrait);
                 bool isStarPrismExpiring = HasEffect(Buffs.Starstruck) && GetBuffRemainingTime(Buffs.Starstruck) <= 3;
@@ -61,37 +60,46 @@ namespace XIVSlothCombo.Combos.PvP
                 if (actionID is FireInRed or AeroInGreen or WaterInBlue)
                 {
                     // Tempera Coat / Tempera Grassa
-                    if (IsEnabled(CustomComboPreset.PCTPvP_TemperaCoat) && ((IsOffCooldown(TemperaCoat) &&
-                        InCombat() && PlayerHealthPercentageHp() < Config.PCTPvP_TemperaHP) || isTemperaCoatExpiring))
-                        return OriginalHook(TemperaCoat);
+                    if (IsEnabled(CustomComboPreset.PCTPvP_TemperaCoat))
+                    {
+                        if ((IsOffCooldown(TemperaCoat) &&
+                        InCombat() && PlayerHealthPercentageHp() < Config.PCTPvP_TemperaHP) || isTemperaCoatExpiring)
+                            return OriginalHook(TemperaCoat);
+                    }
 
-                    if (hasTarget && !targetHasGuard)
+                    if (hasTarget && !PvPCommon.IsImmuneToDamage())
                     {
                         // Star Prism
-                        if (hasStarPrism && (isBurstControlled || isStarPrismExpiring))
-                            return StarPrism;
+                        if (IsEnabled(CustomComboPreset.PCTPvP_StarPrism))
+                        {
+                            if (hasStarPrism && (isBurstControlled || isStarPrismExpiring))
+                                return StarPrism;
+                        }
 
                         // Moogle / Madeen Portrait
-                        if (hasPortrait && isBurstControlled)
+                        if (IsEnabled(CustomComboPreset.PCTPvP_MogOfTheAges) && hasPortrait && isBurstControlled)
                             return OriginalHook(MogOfTheAges);
 
                         // Living Muse
-                        if (hasMotifDrawn && HasCharges(OriginalHook(LivingMuse)) && isBurstControlled)
+                        if (IsEnabled(CustomComboPreset.PCTPvP_LivingMuse) && hasMotifDrawn && HasCharges(OriginalHook(LivingMuse)) && isBurstControlled)
                             return OriginalHook(LivingMuse);
 
                         // Holy in White / Comet in Black
-                        if (HasCharges(OriginalHook(HolyInWhite)) && isBurstControlled)
+                        if (IsEnabled(CustomComboPreset.PCTPvP_HolyInWhite) && HasCharges(OriginalHook(HolyInWhite)) && isBurstControlled)
                             return OriginalHook(HolyInWhite);
                     }
 
                     // Creature Motif
-                    if (!hasMotifDrawn && !isMoving)
+                    if (IsEnabled(CustomComboPreset.PCTPvP_CreatureMotif) && !hasMotifDrawn && !isMoving)
                         return OriginalHook(CreatureMotif);
 
                     // Subtractive Palette
-                    if (IsEnabled(CustomComboPreset.PCTPvP_SubtractivePalette) && IsOffCooldown(OriginalHook(SubtractivePalette)) &&
-                        hasTarget && ((isMoving && hasSubtractivePalette) || (!isMoving && !hasSubtractivePalette)))
-                        return OriginalHook(SubtractivePalette);
+                    if (IsEnabled(CustomComboPreset.PCTPvP_SubtractivePalette))
+                    {
+                        if (IsOffCooldown(OriginalHook(SubtractivePalette)) &&
+                            hasTarget && ((isMoving && hasSubtractivePalette) || (!isMoving && !hasSubtractivePalette)))
+                            return OriginalHook(SubtractivePalette);
+                    }
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvP/PLDPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/PLDPVP.cs
@@ -10,13 +10,35 @@ namespace XIVSlothCombo.Combos.PvP
             FastBlade = 29058,
             RiotBlade = 29059,
             RoyalAuthority = 29060,
-            ShieldBash = 29064,
-            Confiteor = 29070;
+            ShieldSmite = 41430,
+            HolySpirit = 29062,
+            Imperator = 41431,
+            Intervene = 29065,
+            HolySheltron = 29067,
+            Guardian = 29066,
+            Phalanx = 29069,
+            BladeOfFaith = 29071,
+            BladeOfTruth = 29072,
+            BladeOfValor = 29073;
+
+
+        internal class Buffs
+        {
+            internal const ushort
+                ConfiteorReady = 3028,
+                HallowedGround = 1302,
+                AttonementReady = 2015,
+                SupplicationReady = 4281,
+                SepulchreReady = 4282,
+                BladeOfFaithReady = 3250;
+
+        }
 
         internal class Debuffs
         {
             internal const ushort
-                Stun = 1343;
+                Stun = 1343,
+                ShieldSmite = 4283;
         }
 
         internal class PLDPvP_Burst : CustomCombo
@@ -27,15 +49,34 @@ namespace XIVSlothCombo.Combos.PvP
             {
                 if (actionID is FastBlade or RiotBlade or RoyalAuthority)
                 {
-                    if (IsEnabled(CustomComboPreset.PLDPvP_ShieldBash) &&
-                        InCombat() && IsOffCooldown(ShieldBash) && CanWeave(actionID))
-                        return ShieldBash;
+                    if (IsEnabled(CustomComboPreset.PLDPvP_Intervene) && !InMeleeRange() && IsOffCooldown(Intervene) || IsEnabled(CustomComboPreset.PLDPvP_Intervene_Melee) && InMeleeRange() && IsOffCooldown(Intervene))
+                        return Intervene;
 
-                    if (IsEnabled(CustomComboPreset.PLDPvP_Confiteor))
+                    // Check conditions for ShieldSmite
+                    if (IsEnabled(CustomComboPreset.PLDPvP_ShieldSmite) && IsOffCooldown(ShieldSmite) && InCombat() && InMeleeRange())
+                        return ShieldSmite;
+
+                    // Prioritize Imperator
+                    if (IsEnabled(CustomComboPreset.PLDPvP_Imperator) && IsOffCooldown(Imperator) && InMeleeRange() && CanWeave(actionID))
+                        return Imperator;
+
+                    if (IsEnabled(CustomComboPreset.PLDPvP_PhalanxCombo))
                     {
-                        if (IsOffCooldown(Confiteor))
-                            return Confiteor;
+                        if (HasEffect(Buffs.BladeOfFaithReady) || WasLastSpell(BladeOfTruth) || WasLastSpell(BladeOfFaith))
+                            return OriginalHook(Phalanx);
                     }
+
+                    // Check if the custom combo preset is enabled and ConfiteorReady is active
+                    if (IsEnabled(CustomComboPreset.PLDPvP_Confiteor) && HasEffect(Buffs.ConfiteorReady))
+                        return OriginalHook(Imperator);
+
+
+                    if (IsEnabled(CustomComboPreset.PLDPvP_HolySpirit))
+                    {
+                        if (IsOffCooldown(HolySpirit) && !InMeleeRange() || IsOffCooldown(HolySpirit) && (!HasEffect(Buffs.AttonementReady) && !HasEffect(Buffs.SupplicationReady) && !HasEffect(Buffs.SepulchreReady)))
+                            return HolySpirit;
+                    }
+
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvP/PVPCommon.cs
+++ b/XIVSlothCombo/Combos/PvP/PVPCommon.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using XIVSlothCombo.Core;
 using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.CustomComboNS.Functions;
 
 namespace XIVSlothCombo.Combos.PvP
 {
@@ -41,6 +42,11 @@ namespace XIVSlothCombo.Combos.PvP
             public const ushort
                 Sprint = 1342,
                 Guard = 3054;
+        }
+
+        public static bool IsImmuneToDamage()
+        {
+            return CustomComboFunctions.TargetHasEffectAny(PvPCommon.Buffs.Guard) || CustomComboFunctions.TargetHasEffectAny(DRKPvP.Buffs.UndeadRedemption) || CustomComboFunctions.TargetHasEffectAny(PLDPvP.Buffs.HallowedGround) || CustomComboFunctions.TargetHasEffectAny(VPRPvP.Buffs.HardenedScales);
         }
 
         // Lists of Excluded skills 

--- a/XIVSlothCombo/Combos/PvP/RDMPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/RDMPVP.cs
@@ -8,22 +8,19 @@ namespace XIVSlothCombo.Combos.PvP
 
         public const uint
             Verstone = 29683,
-            EnchantedRiposte = 29689,
-            Resolution = 29695,
+            EnchantedRiposte = 41488,
+            Resolution = 41492,
             MagickBarrier = 29697,
             CorpsACorps = 29699,
             Displacement = 29700,
-            Veraero3 = 29684,
-            Verholy = 29685,
-            Verfire = 29686,
-            Verthunder3 = 29687,
-            Verflare = 29688,
-            EnchantedZwerchhau = 29690,
-            EnchantedRedoublement = 29691,
+            EnchantedZwerchhau = 41489,
+            EnchantedRedoublement = 41490,
             Frazzle = 29698,
-            WhiteShift = 29703,
-            BlackShift = 29702,
-            SouthernCross = 29704;
+            SouthernCross = 29704,
+            Embolden = 41494,
+            Forte = 41496,
+            Jolt3 = 41486,
+            ViceofThorns = 41493;
 
         public static class Buffs
         {
@@ -35,7 +32,17 @@ namespace XIVSlothCombo.Combos.PvP
                 EnchantedRedoublement = 3236,
                 EnchantedZwerchhau = 3235,
                 VermilionRadiance = 3233,
-                MagickBarrier = 3240;
+                MagickBarrier = 3240,
+                Embolden = 2282,
+                Forte = 4320,
+                PrefulgenceReady = 4322,
+                ThornedFlourish = 0;
+        }
+
+        public static class Debuffs
+        {
+            public const ushort
+                Monomachy = 3242;
         }
 
         internal class RDMPvP_BurstMode : CustomCombo
@@ -44,31 +51,46 @@ namespace XIVSlothCombo.Combos.PvP
 
             protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
-                if (actionID is Verstone or Verfire)
+                if (actionID is Jolt3)
                 {
+                    if (IsOffCooldown(Forte) && CanWeave(actionID))
+                        return Forte;
 
-                    if (!GetCooldown(Frazzle).IsCooldown && HasEffect(Buffs.BlackShift) && IsNotEnabled(CustomComboPreset.RDMPvP_FrazzleOption))
-                        return OriginalHook(Frazzle);
-
-                    if (!GetCooldown(Resolution).IsCooldown)
-                        return OriginalHook(Resolution);
-
-                    if (!InMeleeRange() && GetCooldown(CorpsACorps).RemainingCharges > 0 && !GetCooldown(EnchantedRiposte).IsCooldown)
-                        return OriginalHook(CorpsACorps);
-
-                    if (InMeleeRange())
+                    if (!PvPCommon.IsImmuneToDamage())
                     {
-                        if (!GetCooldown(EnchantedRiposte).IsCooldown || lastComboActionID == EnchantedRiposte || lastComboActionID == EnchantedZwerchhau)
+                        if (IsEnabled(CustomComboPreset.RDMPvP_Burst_Resolution) && !GetCooldown(Resolution).IsCooldown)
+                            return OriginalHook(Resolution);
+
+                        if (IsEnabled(CustomComboPreset.RDMPvP_Burst_CorpsACorps) && !InMeleeRange() && GetCooldown(CorpsACorps).RemainingCharges > 0 && !GetCooldown(EnchantedRiposte).IsCooldown)
+                            return OriginalHook(CorpsACorps);
+
+                        if (InMeleeRange())
+                        {
+                            if (IsEnabled(CustomComboPreset.RDMPvP_Burst_Embolden))
+                            {
+                                if (IsOffCooldown(Embolden) && (WasLastAbility(CorpsACorps) || TargetHasEffect(Debuffs.Monomachy)) || HasEffect(Buffs.PrefulgenceReady))
+                                    return OriginalHook(Embolden);
+
+                            }
+
+                            if (IsEnabled(CustomComboPreset.RDMPvP_Burst_EnchantedRiposte))
+                            {
+                                if (!GetCooldown(EnchantedRiposte).IsCooldown || lastComboActionID == EnchantedRiposte || lastComboActionID == EnchantedZwerchhau || lastComboActionID == EnchantedRedoublement)
+                                    return OriginalHook(EnchantedRiposte);
+                            }
+
+
+                            if (IsEnabled(CustomComboPreset.RDMPvP_Burst_Displacement) && lastComboActionID == EnchantedRedoublement && GetCooldown(Displacement).RemainingCharges > 0)
+                                return OriginalHook(Displacement);
+                        }
+
+                        if (lastComboActionID == EnchantedRedoublement)
                             return OriginalHook(EnchantedRiposte);
 
-                        if (lastComboActionID == EnchantedRedoublement && GetCooldown(Displacement).RemainingCharges > 0)
-                            return OriginalHook(Displacement);
+                        if (HasEffect(Buffs.VermilionRadiance))
+                            return OriginalHook(EnchantedRiposte);
                     }
 
-                    if (HasEffect(Buffs.VermilionRadiance))
-                        return OriginalHook(EnchantedRiposte);
-
-                    return OriginalHook(Verstone);
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvP/SAMPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/SAMPVP.cs
@@ -32,7 +32,8 @@ namespace XIVSlothCombo.Combos.PvP
             public const ushort
                 Kaiten = 3201,
                 Midare = 3203,
-                TendoSetsugekkaReady = 3203;
+                TendoSetsugekkaReady = 3203,
+                ZanshinReady = 1318;
         }
 
         public static class Debuffs
@@ -62,6 +63,9 @@ namespace XIVSlothCombo.Combos.PvP
                 {
                     if (!TargetHasEffectAny(PvPCommon.Buffs.Guard))
                     {
+                        if (IsEnabled(CustomComboPreset.SAMPvP_BurstMode_Zanshin) && CanWeave(actionID) && HasEffect(Buffs.ZanshinReady))
+                            return OriginalHook(Chiten);
+
                         if (IsOffCooldown(MeikyoShisui) || HasEffect(Buffs.TendoSetsugekkaReady))
                             return OriginalHook(MeikyoShisui);
 

--- a/XIVSlothCombo/Combos/PvP/SAMPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/SAMPVP.cs
@@ -23,13 +23,16 @@ namespace XIVSlothCombo.Combos.PvP
             MeikyoShisui = 29536,
             Midare = 29529,
             Kaeshi = 29531,
-            Zantetsuken = 29537;
+            Zantetsuken = 29537,
+            TendoSetsugekka = 41454,
+            TendoKaeshiSetsugekka = 41455;
 
         public static class Buffs
         {
             public const ushort
                 Kaiten = 3201,
-                Midare = 3203;
+                Midare = 3203,
+                TendoSetsugekkaReady = 3203;
         }
 
         public static class Debuffs
@@ -57,10 +60,9 @@ namespace XIVSlothCombo.Combos.PvP
                 if ((IsNotEnabled(CustomComboPreset.SAMPvP_BurstMode_MainCombo) && actionID == MeikyoShisui) ||
                     (IsEnabled(CustomComboPreset.SAMPvP_BurstMode_MainCombo) && actionID is Yukikaze or Gekko or Kasha or Hyosetsu or Oka or Mangetsu))
                 {
-
                     if (!TargetHasEffectAny(PvPCommon.Buffs.Guard))
                     {
-                        if (IsOffCooldown(MeikyoShisui))
+                        if (IsOffCooldown(MeikyoShisui) || HasEffect(Buffs.TendoSetsugekkaReady))
                             return OriginalHook(MeikyoShisui);
 
                         if (IsEnabled(CustomComboPreset.SAMPvP_BurstMode_Chiten) && IsOffCooldown(Chiten) && InCombat() && PlayerHealthPercentageHp() <= 95)
@@ -69,7 +71,7 @@ namespace XIVSlothCombo.Combos.PvP
                         if (GetCooldownRemainingTime(Soten) < 1 && CanWeave(Yukikaze))
                             return OriginalHook(Soten);
 
-                        if (OriginalHook(MeikyoShisui) == Midare && !IsMoving)
+                        if ((OriginalHook(MeikyoShisui) == TendoSetsugekka || OriginalHook(MeikyoShisui) == TendoKaeshiSetsugekka) && !IsMoving)
                             return OriginalHook(MeikyoShisui);
 
                         if (IsEnabled(CustomComboPreset.SAMPvP_BurstMode_Stun) && IsOffCooldown(Mineuchi))

--- a/XIVSlothCombo/Combos/PvP/SCHPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/SCHPVP.cs
@@ -11,7 +11,9 @@ namespace XIVSlothCombo.Combos.PvP
             Aqloquilum = 29232,
             Biolysis = 29233,
             DeploymentTactics = 29234,
-            Expedient = 29236;
+            Expedient = 29236,
+            ChainStratagem = 29716;
+
 
         internal class Buffs
         {
@@ -33,13 +35,20 @@ namespace XIVSlothCombo.Combos.PvP
             {
                 if (actionID is Broil && InCombat())
                 {
+                    // Uses Chain Stratagem when available
+                    if (IsEnabled(CustomComboPreset.SCHPvP_ChainStratagem) && IsOffCooldown(ChainStratagem))
+                        return ChainStratagem;
+
                     // Uses Expedient when available and target isn't affected with Biolysis
                     if (IsEnabled(CustomComboPreset.SCHPvP_Expedient) && IsOffCooldown(Expedient) && !TargetHasEffect(Debuffs.Biolysis))
                         return Expedient;
 
                     // Uses Biolysis under Recitation, or on cooldown when option active
-                    if ((IsEnabled(CustomComboPreset.SCHPvP_Biolysis) && IsOffCooldown(Biolysis)) || (HasEffect(Buffs.Recitation) && IsOffCooldown(Biolysis)))
-                        return Biolysis;
+                    if (IsEnabled(CustomComboPreset.SCHPvP_Biolysis))
+                    {
+                        if (IsOffCooldown(Biolysis) || (HasEffect(Buffs.Recitation) && IsOffCooldown(Biolysis)))
+                            return Biolysis;
+                    }
 
                     // Uses Deployment Tactics when available
                     if (IsEnabled(CustomComboPreset.SCHPvP_DeploymentTactics) && GetRemainingCharges(DeploymentTactics) > 1)

--- a/XIVSlothCombo/Combos/PvP/SGEPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/SGEPVP.cs
@@ -13,7 +13,8 @@ namespace XIVSlothCombo.Combos.PvP
             Toxikon = 29262,
             Kardia = 29264,
             EukrasianDosis = 29257,
-            Toxicon2 = 29263;
+            Toxicon2 = 29263,
+            Psyche = 41658;
 
         internal class Debuffs
         {
@@ -41,27 +42,33 @@ namespace XIVSlothCombo.Combos.PvP
             {
                 if (actionID == Dosis)
                 {
-
-                    if (!HasEffectAny(Buffs.Kardia))
+                    if (IsEnabled(CustomComboPreset.SGEPvP_BurstMode_KardiaReminder) && !HasEffectAny(Buffs.Kardia))
                         return Kardia;
 
-                    if (IsEnabled(CustomComboPreset.SGEPvP_BurstMode_Pneuma) && !GetCooldown(Pneuma).IsCooldown)
-                        return Pneuma;
+                    if (!PvPCommon.IsImmuneToDamage())
+                    {
+                        // Psyche after Phlegma
+                        if (IsEnabled(CustomComboPreset.SGEPvP_BurstMode_Psyche) && WasLastSpell(Phlegma))
+                            return Psyche;
 
-                    if (InMeleeRange() && !HasEffect(Buffs.Eukrasia) && GetCooldown(Phlegma).RemainingCharges > 0)
-                        return Phlegma;
+                        if (IsEnabled(CustomComboPreset.SGEPvP_BurstMode_Pneuma) && !GetCooldown(Pneuma).IsCooldown)
+                            return Pneuma;
 
-                    if (HasEffect(Buffs.Addersting) && !HasEffect(Buffs.Eukrasia))
-                        return Toxicon2;
+                        if (IsEnabled(CustomComboPreset.SGEPvP_BurstMode_Phlegma) && InMeleeRange() && !HasEffect(Buffs.Eukrasia) && GetCooldown(Phlegma).RemainingCharges > 0)
+                            return Phlegma;
 
-                    if (!TargetHasEffectAny(Debuffs.EukrasianDosis) && GetCooldown(Eukrasia).RemainingCharges > 0 && !HasEffect(Buffs.Eukrasia))
-                        return Eukrasia;
+                        if (IsEnabled(CustomComboPreset.SGEPvP_BurstMode_Toxikon2) && HasEffect(Buffs.Addersting) && !HasEffect(Buffs.Eukrasia))
+                            return Toxicon2;
 
-                    if (HasEffect(Buffs.Eukrasia))
-                        return OriginalHook(Dosis);
+                        if (IsEnabled(CustomComboPreset.SGEPvP_BurstMode_Eukrasia) && !TargetHasEffectAny(Debuffs.EukrasianDosis) && GetCooldown(Eukrasia).RemainingCharges > 0 && !HasEffect(Buffs.Eukrasia))
+                            return Eukrasia;
 
-                    if (!TargetHasEffect(Debuffs.Toxicon) && GetCooldown(Toxikon).RemainingCharges > 0)
-                        return OriginalHook(Toxikon);
+                        if (HasEffect(Buffs.Eukrasia))
+                            return OriginalHook(Dosis);
+
+                        if (IsEnabled(CustomComboPreset.SGEPvP_BurstMode_Toxikon) && !TargetHasEffect(Debuffs.Toxicon) && GetCooldown(Toxikon).RemainingCharges > 0)
+                            return OriginalHook(Toxikon);
+                    }
 
                 }
                 return actionID;

--- a/XIVSlothCombo/Combos/PvP/SMNPvP.cs
+++ b/XIVSlothCombo/Combos/PvP/SMNPvP.cs
@@ -17,14 +17,23 @@ namespace XIVSlothCombo.Combos.PvP
             Slipstream = 29669,
             RadiantAegis = 29670,
             MountainBuster = 29671,
-            Fester = 29672,
-            EnkindleBahamut = 29674,
+            Necrotize = 41483,
+            DeathFlare = 41484,
             Megaflare = 29675,          // unused
             Wyrmwave = 29676,           // unused
             AkhMorn = 29677,            // unused
             EnkindlePhoenix = 29679,
             ScarletFlame = 29681,       // unused
-            Revelation = 29682;         // unused
+            Revelation = 29682,         // unused
+            Ruin4 = 41482,
+            BrandofPurgatory = 41485;
+
+        internal class Buffs
+        {
+            internal const ushort
+                FurtherRuin = 4399;
+
+        }
 
         public static class Config
         {
@@ -47,58 +56,45 @@ namespace XIVSlothCombo.Combos.PvP
                     bool bahamutBurst = OriginalHook(Ruin3) is AstralImpulse;
                     bool phoenixBurst = OriginalHook(Ruin3) is FountainOfFire;
                     double playerHP = PlayerHealthPercentageHp();
-                    double targetHP = GetTargetHPPercent();
-                    bool enemyGuarded = TargetHasEffectAny(PvPCommon.Buffs.Guard);
                     bool canBind = !TargetHasEffectAny(PvPCommon.Debuffs.Bind);
                     int radiantThreshold = PluginConfiguration.GetCustomIntValue(Config.SMNPvP_RadiantAegisThreshold);
-                    int festerThreshold = PluginConfiguration.GetCustomIntValue(Config.SMNPvP_FesterThreshold);
                     #endregion
 
-                    if (canWeave)
+                    if (!PvPCommon.IsImmuneToDamage())
                     {
-                        // Radiant Aegis
-                        if (IsEnabled(CustomComboPreset.SMNPvP_BurstMode_RadiantAegis) &&
-                            IsOffCooldown(RadiantAegis) && playerHP <= radiantThreshold)
-                            return RadiantAegis;
-
-                        // Fester
-                        if (HasCharges(Fester) && targetHP <= festerThreshold && !enemyGuarded &&
-                            !(phoenixBurst || bahamutBurst)) // Lazy method for correct (?) priority
-                            return Fester;
-                    }
-
-                    // Phoenix & Bahamut bursts
-                    if (phoenixBurst || bahamutBurst)
-                    {
-                        if (!enemyGuarded && canWeave)
+                        if (canWeave)
                         {
-                            if (IsOffCooldown(EnkindlePhoenix) && phoenixBurst)
-                                return EnkindlePhoenix;
-                            if (IsOffCooldown(EnkindleBahamut) && bahamutBurst)
-                                return EnkindleBahamut;
-                            if (HasCharges(Fester) && targetHP <= festerThreshold)
-                                return Fester;
-                            if (IsOffCooldown(MountainBuster))
-                                return MountainBuster;
+                            // Radiant Aegis
+                            if (IsEnabled(CustomComboPreset.SMNPvP_BurstMode_RadiantAegis) &&
+                                IsOffCooldown(RadiantAegis) && playerHP <= radiantThreshold)
+                                return RadiantAegis;
+
+                            // Phoenix & Bahamut bursts
+                            if (IsEnabled(CustomComboPreset.SMNPvP_BurstMode_BrandofPurgatory) && phoenixBurst && IsOffCooldown(BrandofPurgatory))
+                                return BrandofPurgatory;
+
+                            if (IsEnabled(CustomComboPreset.SMNPvP_BurstMode_DeathFlare) && bahamutBurst && IsOffCooldown(DeathFlare))
+                                return DeathFlare;
+
+                            if (IsEnabled(CustomComboPreset.SMNPvP_BurstMode_Necrotize) && GetRemainingCharges(Necrotize) > 0 && !HasEffect(Buffs.FurtherRuin))
+                                return Necrotize;
                         }
-                    }
 
-                    // Titan
-                    if (IsOffCooldown(MountainBuster) && canWeave && canBind && !enemyGuarded)
-                        return MountainBuster;
-
-                    // Ifrit
-                    if (!enemyGuarded)
-                    {
-                        if (OriginalHook(CrimsonCyclone) is CrimsonStrike)
+                        // Ifrit (check CrimsonCyclone conditions)
+                        if (IsEnabled(CustomComboPreset.SMNPvP_BurstMode_CrimsonStrike) && OriginalHook(CrimsonCyclone) is CrimsonStrike)
                             return CrimsonStrike;
-                        if (IsOffCooldown(CrimsonCyclone) && InMeleeRange())
-                            return CrimsonCyclone;
-                    }
 
-                    // Garuda
-                    if (IsOffCooldown(Slipstream))
-                        return Slipstream;
+                        if (IsEnabled(CustomComboPreset.SMNPvP_BurstMode_CrimsonCyclone) && IsOffCooldown(CrimsonCyclone))
+                            return CrimsonCyclone;
+
+                        // Titan
+                        if (IsEnabled(CustomComboPreset.SMNPvP_BurstMode_MountainBuster) && IsOffCooldown(MountainBuster) && InActionRange(MountainBuster))
+                            return MountainBuster;
+
+                        // Garuda (check Slipstream cooldown)
+                        if (IsEnabled(CustomComboPreset.SMNPvP_BurstMode_Slipstream) && IsOffCooldown(Slipstream) && !IsMoving)
+                            return Slipstream;
+                    }
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvP/VPRPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/VPRPVP.cs
@@ -23,6 +23,12 @@ namespace XIVSlothCombo.Combos.PvP
             FourthGeneration = 39172,
             Ouroboros = 39173;
 
+        internal class Buffs
+        {
+            internal const ushort
+                HardenedScales = 4096;
+        }
+
         internal class VPRPvP_Burst : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.VPRPvP_Burst;
@@ -37,7 +43,7 @@ namespace XIVSlothCombo.Combos.PvP
 
                 if (actionID is SteelFangs or HuntersSting or BarbarousSlice or PiercingFangs or SwiftskinsSting or RavenousBite)
                 {
-                    if (HasTarget())
+                    if (!PvPCommon.IsImmuneToDamage() && HasTarget())
                     {
                         // Serpent's Tail
                         if (isSerpentsTailPrimed && canWeave)

--- a/XIVSlothCombo/Combos/PvP/WARPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/WARPVP.cs
@@ -15,13 +15,19 @@ namespace XIVSlothCombo.Combos.PvP
             Onslaught = 29079,
             Orogeny = 29080,
             Blota = 29081,
-            Bloodwhetting = 29082;
+            Bloodwhetting = 29082,
+            PrimalScream = 29083,
+            PrimalWrath = 41433;
+
 
         internal class Buffs
         {
             internal const ushort
+                InnerRelease = 1303,
                 NascentChaos = 1992,
-                InnerRelease = 1303;
+                InnerChaosReady = 4284,
+                PrimalRuinationReady = 4285,
+                Wrathfull = 4286;
         }
 
         public static class Config
@@ -38,30 +44,76 @@ namespace XIVSlothCombo.Combos.PvP
             {
                 if (actionID is HeavySwing or Maim or StormsPath)
                 {
-                    var canWeave = CanWeave(actionID);
-
-                    if (!GetCooldown(Bloodwhetting).IsCooldown && (IsEnabled(CustomComboPreset.WARPvP_BurstMode_Bloodwhetting) || canWeave))
-                        return OriginalHook(Bloodwhetting);
-
-                    if (!InMeleeRange() && IsOffCooldown(Blota) && !TargetHasEffectAny(PvPCommon.Debuffs.Stun) && IsEnabled(CustomComboPreset.WARPvP_BurstMode_Blota) && Config.WARPVP_BlotaTiming == 0 && IsOffCooldown(PrimalRend))
-                        return OriginalHook(Blota);
-
-                    if (IsEnabled(CustomComboPreset.WARPvP_BurstMode_PrimalRend) && IsOffCooldown(PrimalRend))
-                        return OriginalHook(PrimalRend);
-
-                    if (!InMeleeRange() && IsOffCooldown(Blota) && !TargetHasEffectAny(PvPCommon.Debuffs.Stun) && IsEnabled(CustomComboPreset.WARPvP_BurstMode_Blota) && Config.WARPVP_BlotaTiming == 1 && IsOnCooldown(PrimalRend))
-                        return OriginalHook(Blota);
-
-                    if (!GetCooldown(Onslaught).IsCooldown && canWeave)
-                        return OriginalHook(Onslaught);
-
-                    if (InMeleeRange())
+                    if (!PvPCommon.IsImmuneToDamage())
                     {
-                        if (HasEffect(Buffs.NascentChaos))
-                            return OriginalHook(Bloodwhetting);
+                        var canWeave = CanWeave(actionID);
 
-                        if (!GetCooldown(Orogeny).IsCooldown && canWeave)
-                            return OriginalHook(Orogeny);
+                        // Bloodwhetting condition (both WARPvP BurstMode and CanWeave)
+                        if (IsEnabled(CustomComboPreset.WARPvP_BurstMode_Bloodwhetting))
+                        {
+                            if (!GetCooldown(Bloodwhetting).IsCooldown || canWeave && IsOffCooldown(Bloodwhetting))
+                                return OriginalHook(Bloodwhetting);
+                        }
+
+                        // Primal Wrath if in melee range and Wrathfull effect is active
+                        if (IsEnabled(CustomComboPreset.WARPvP_BurstMode_PrimalScream) && InMeleeRange() && canWeave && HasEffect(Buffs.Wrathfull))
+                            return OriginalHook(PrimalScream);
+
+                        // Blota and PrimalRend conditions based on range and cooldowns
+                        if (!InMeleeRange())
+                        {
+                            // Blota with specific conditions and burst mode enabled
+                            if (IsOffCooldown(Blota) && !TargetHasEffectAny(PvPCommon.Debuffs.Stun) && IsEnabled(CustomComboPreset.WARPvP_BurstMode_Blota))
+                            {
+                                if (Config.WARPVP_BlotaTiming == 0 && IsOffCooldown(PrimalRend))
+                                    return OriginalHook(Blota);
+                                if (Config.WARPVP_BlotaTiming == 1 && IsOnCooldown(PrimalRend))
+                                    return OriginalHook(Blota);
+                            }
+
+                            // PrimalRend if ready or BurstMode enabled
+                            if (IsEnabled(CustomComboPreset.WARPvP_BurstMode_PrimalRend))
+                            {
+                                if ((IsOffCooldown(PrimalRend) || HasEffect(Buffs.PrimalRuinationReady)))
+                                    return OriginalHook(PrimalRend);
+                            }
+
+                        }
+
+                        // In melee range logic
+                        if (InMeleeRange())
+                        {
+                            // Inner Chaos effect logic
+                            if (IsEnabled(CustomComboPreset.WARPvP_BurstMode_InnerChaos) && HasEffect(Buffs.InnerChaosReady))
+                                return OriginalHook(Blota);
+
+                            // Onslaught and Orogeny conditions for melee
+                            if (IsEnabled(CustomComboPreset.WARPvP_BurstMode_Onslaught) && !GetCooldown(Onslaught).IsCooldown && canWeave)
+                                return OriginalHook(Onslaught);
+
+                            // Nascent Chaos and Orogeny conditions
+                            if (IsEnabled(CustomComboPreset.WARPvP_BurstMode_Bloodwhetting) && HasEffect(Buffs.NascentChaos))
+                                return OriginalHook(Bloodwhetting);
+
+                            if (IsEnabled(CustomComboPreset.WARPvP_BurstMode_Orogeny) && !GetCooldown(Orogeny).IsCooldown && canWeave)
+                                return OriginalHook(Orogeny);
+
+                            // PrimalRend if ready or BurstMode enabled
+                            if (IsEnabled(CustomComboPreset.WARPvP_BurstMode_PrimalRend))
+                            {
+                                if (IsOffCooldown(PrimalRend) || HasEffect(Buffs.PrimalRuinationReady))
+                                    return OriginalHook(PrimalRend);
+                            }
+
+                            // Blota with specific conditions and burst mode enabled in meleerange
+                            if (IsOffCooldown(Blota) && !TargetHasEffectAny(PvPCommon.Debuffs.Stun) && IsEnabled(CustomComboPreset.WARPvP_BurstMode_Blota))
+                            {
+                                if (Config.WARPVP_BlotaTiming == 0 && IsOffCooldown(PrimalRend))
+                                    return OriginalHook(Blota);
+                                if (Config.WARPVP_BlotaTiming == 1 && IsOnCooldown(PrimalRend))
+                                    return OriginalHook(Blota);
+                            }
+                        }
                     }
                 }
                 return actionID;

--- a/XIVSlothCombo/Combos/PvP/WHMPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/WHMPVP.cs
@@ -18,7 +18,8 @@ namespace XIVSlothCombo.Combos.PvP
         internal class Buffs
         {
             internal const ushort
-                Cure3Ready = 3083;
+                Cure3Ready = 3083,
+                SacredSight = 4326;
         }
 
         internal class WHMPvP_Burst : CustomCombo
@@ -29,16 +30,24 @@ namespace XIVSlothCombo.Combos.PvP
             {
                 if (actionID is Glare)
                 {
-                    if (!TargetHasEffectAny(PvPCommon.Buffs.Guard))
+                    if (!PvPCommon.IsImmuneToDamage())
                     {
+                        // Afflatus Misery if enabled and off cooldown
                         if (IsEnabled(CustomComboPreset.WHMPvP_Afflatus_Misery) && IsOffCooldown(AfflatusMisery))
                             return AfflatusMisery;
 
+                        // Seraph Strike if Sacred Sight is active
+                        if (IsEnabled(CustomComboPreset.WHMPvP_Glare4) && HasEffect(Buffs.SacredSight))
+                            return OriginalHook(SeraphStrike);
+
+                        // Weave conditions
                         if (CanWeave(actionID))
                         {
-                            if (IsEnabled(CustomComboPreset.WHMPvP_Mirace_of_Nature) && IsOffCooldown(MiracleOfNature))
+                            // Miracle of Nature if enabled and off cooldown and inrange 
+                            if (IsEnabled(CustomComboPreset.WHMPvP_Mirace_of_Nature) && IsOffCooldown(MiracleOfNature) && InActionRange(MiracleOfNature))
                                 return MiracleOfNature;
 
+                            // Seraph Strike if enabled and off cooldown
                             if (IsEnabled(CustomComboPreset.WHMPvP_Seraph_Strike) && IsOffCooldown(SeraphStrike))
                                 return SeraphStrike;
                         }


### PR DESCRIPTION
7.1 PvP Updates

Updated to reflect the latest changes introduced in patch 7.1 for PvP.

- [x] Added `IsImmuneToDamage` Check
Implemented a check to avoid wasting burst skills on targets that are immune to or cannot take significant damage.
- [x] Enhanced Customization Options
 Expanded on the customization options
- [x] Introduced additional customization options for nearly every class (excluding VPR).
- [x] Burst Mode Enhancements
Added Limit Break (LB) usage in burst mode for select jobs, with plans to expand this functionality further in future updates.