### PR TITLE
[BRD & MCH] Aoe Interrupts + Bard changes

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -309,7 +309,7 @@ namespace XIVSlothCombo.Combos
 
         [AutoAction(true,true)]
         [ReplaceSkill(AST.Helios, AST.AspectedHelios, AST.HeliosConjuction)]
-        [CustomComboInfo("Simple Heals (AoE)", "Replaces Aspected Helios or Helios with a one button healing replacement.", AST.JobID, 4)]
+        [CustomComboInfo("Simple Heals (AoE)", "Replaces Aspected Helios/Helios Conjunction or Helios with a one button healing replacement.", AST.JobID, 4)]
         AST_AoE_SimpleHeals_AspectedHelios = 1010,
 
         [ParentCombo(AST_AoE_SimpleHeals_AspectedHelios)]
@@ -325,7 +325,7 @@ namespace XIVSlothCombo.Combos
         AST_AoE_SimpleHeals_Horoscope = 1026,
                
         [ParentCombo(AST_AoE_SimpleHeals_AspectedHelios)]
-        [CustomComboInfo("Aspected Helios Option", "In Helios mode: Will Cast Aspected Helios when the HoT is missing on yourself."
+        [CustomComboInfo("Aspected Helios Option", "In Helios mode: Will Cast Aspected Helios/Helios Conjunction when the HoT is missing on yourself."
                                                    + "\nIn Aspected Helios mode: Is considered enabled regardless.", AST.JobID)]
         AST_AoE_SimpleHeals_Aspected = 1053,
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -765,6 +765,10 @@ namespace XIVSlothCombo.Combos
         BRD_AoE_Adv_Songs = 3016,
 
         [ParentCombo(BRD_AoE_AdvMode)]
+        [CustomComboInfo("Interrupt Option", "Uses interrupt during the rotation if applicable.", BRD.JobID)]
+        BRD_AoE_Adv_Interrupt = 3043,
+
+        [ParentCombo(BRD_AoE_AdvMode)]
         [CustomComboInfo("oGcd Option", "Weave Sidewinder, Empyreal arrow, Rain of death, and Pitch perfect when available.", BRD.JobID)]
         BRD_AoE_Adv_oGCD = 3037,
 
@@ -2082,6 +2086,10 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(MCH_AoE_AdvancedMode)]
         [CustomComboInfo("Second Wind Option", "Use Second Wind when below the set HP percentage.", MCH.JobID)]
         MCH_AoE_Adv_SecondWind = 8399,
+
+        [ParentCombo(MCH_AoE_AdvancedMode)]
+        [CustomComboInfo("Head Graze Option", "Uses Head Graze to interrupt during the rotation, where applicable.", MCH.JobID)]
+        MCH_AoE_Adv_Interrupt = 8311,
 
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -732,12 +732,20 @@ namespace XIVSlothCombo.Combos
         BRD_Apex = 3005,
 
         [ReplaceSkill(BRD.Bloodletter)]
-        [CustomComboInfo("Single Target oGCD Feature", "All oGCD's on Bloodletter/Heartbreakshot (+ Songs rotation) depending on their CD.", BRD.JobID)]
+        [CustomComboInfo("Single Target oGCD Feature", "All oGCD's on Bloodletter/Heartbreakshot", BRD.JobID)]
         BRD_ST_oGCD = 3006,
+
+        [ParentCombo(BRD_ST_oGCD)]
+        [CustomComboInfo("Quick song option", "Adds the songs to the oGCD feature. Wanderers > Mages > Armys", BRD.JobID)]
+        BRD_ST_oGCD_Songs = 3044,
 
         [ReplaceSkill(BRD.RainOfDeath)]       
         [CustomComboInfo("AoE oGCD Feature", "All AoE oGCD's on Rain of Death depending on their CD.", BRD.JobID)]
         BRD_AoE_oGCD = 3007,
+
+        [ParentCombo(BRD_AoE_oGCD)]
+        [CustomComboInfo("Quick song option", "Adds the songs to the AoE oGCD feature. Wanderers > Mages > Armys", BRD.JobID)]
+        BRD_AoE_oGCD_Songs = 3045,
 
         [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
         [ConflictingCombos(BRD_AoE_AdvMode, BRD_AoE_SimpleMode)]
@@ -858,7 +866,7 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(BRD_AoE_AdvMode)]
         [CustomComboInfo("AoE No Waste Option", "Adds enemy health checking on targetted mob for songs.\nThey will not be reapplied if less than specified.", BRD.JobID)]
         BRD_AoE_Adv_NoWaste = 3033,
-        // Last value = 3042
+        // Last value = 3045
 
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -845,9 +845,17 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Second Wind Option", "Uses Second Wind when below set HP percentage.", BRD.JobID)]
         BRD_ST_SecondWind = 3028,
 
+        [ParentCombo(BRD_ST_AdvMode)]
+        [CustomComboInfo("Self Cleanse Option", "Uses Wardens Paeon when you have a cleansable debuff.", BRD.JobID)]
+        BRD_ST_Wardens = 3047,
+
         [ParentCombo(BRD_AoE_AdvMode)]
         [CustomComboInfo("Second Wind Option", "Uses Second Wind when below set HP percentage.", BRD.JobID)]
         BRD_AoE_SecondWind = 3029,
+
+        [ParentCombo(BRD_AoE_AdvMode)]
+        [CustomComboInfo("Self Cleanse Option", "Uses Wardens Paeon when you have a cleansable debuff.", BRD.JobID)]
+        BRD_AoE_Wardens = 3046,
 
         [Variant]
         [VariantParent(BRD_ST_AdvMode, BRD_AoE_AdvMode)]
@@ -866,7 +874,7 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(BRD_AoE_AdvMode)]
         [CustomComboInfo("AoE No Waste Option", "Adds enemy health checking on targetted mob for songs.\nThey will not be reapplied if less than specified.", BRD.JobID)]
         BRD_AoE_Adv_NoWaste = 3033,
-        // Last value = 3045
+        // Last value = 3047
 
         #endregion
 

--- a/XIVSlothCombo/Combos/PvE/BRD/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD/BRD.cs
@@ -30,6 +30,7 @@ namespace XIVSlothCombo.Combos.PvE
             EmpyrealArrow = 3558,
             WanderersMinuet = 3559,
             IronJaws = 3560,
+            TheWardensPaeon = 3561,
             Sidewinder = 3562,
             PitchPerfect = 7404,
             Troubadour = 7405,
@@ -425,16 +426,21 @@ namespace XIVSlothCombo.Combos.PvE
                             else if (rainOfDeathCharges > 0)
                                 return OriginalHook(RainOfDeath);
                         }
-                        //Moved Below ogcds as it was preventing them from happening. 
-                        if (HasEffect(Buffs.RadiantEncoreReady) && !JustUsed(RadiantFinale) && GetCooldownElapsed(BattleVoice) >= 4.2f && IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs))
-                            return OriginalHook(RadiantEncore);
-
+                    }
+                     
+                    if (HasEffect(Buffs.RadiantEncoreReady) && !JustUsed(RadiantFinale) && GetCooldownElapsed(BattleVoice) >= 4.2f && IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs))
+                        return OriginalHook(RadiantEncore);
+                    
+                    if (canWeave)
+                    { 
                         // healing - please move if not appropriate priority
                         if (IsEnabled(CustomComboPreset.BRD_AoE_SecondWind))
                         {
                             if (PlayerHealthPercentageHp() <= PluginConfiguration.GetCustomIntValue(Config.BRD_AoESecondWindThreshold) && ActionReady(All.SecondWind))
                                 return All.SecondWind;
                         }
+                        if (IsEnabled(CustomComboPreset.BRD_AoE_Wardens) && HasCleansableDebuff(LocalPlayer))
+                            return OriginalHook(TheWardensPaeon);
                     }
 
                     bool wideVolleyReady = LevelChecked(WideVolley) && (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage));
@@ -726,15 +732,18 @@ namespace XIVSlothCombo.Combos.PvE
                             else if (bloodletterCharges > 0)
                                 return OriginalHook(Bloodletter);
                         }
-
-                        // healing - please move if not appropriate priority
+                    }
+                    if (canWeave)
+                    {
                         if (IsEnabled(CustomComboPreset.BRD_ST_SecondWind))
                         {
                             if (PlayerHealthPercentageHp() <= PluginConfiguration.GetCustomIntValue(Config.BRD_STSecondWindThreshold) && ActionReady(All.SecondWind))
                                 return All.SecondWind;
                         }
+                        if (IsEnabled(CustomComboPreset.BRD_ST_Wardens) && HasCleansableDebuff(LocalPlayer))
+                            return OriginalHook(TheWardensPaeon);
                     }
-                    //Moved below weaves bc roobert says it is blocking his weaves from happening
+
                     if (HasEffect(Buffs.RadiantEncoreReady) && !JustUsed(RadiantFinale) && GetCooldownElapsed(RadiantFinale) >= 4.2f && IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore))
                         return OriginalHook(RadiantEncore);
 
@@ -1051,16 +1060,15 @@ namespace XIVSlothCombo.Combos.PvE
                             else if (rainOfDeathCharges > 0)
                                 return OriginalHook(RainOfDeath);
                         }
-                        //Moved Below ogcds as it was preventing them from happening. 
-                        if (HasEffect(Buffs.RadiantEncoreReady) && !JustUsed(RadiantFinale) && GetCooldownElapsed(BattleVoice) >= 4.2f)
-                            return OriginalHook(RadiantEncore);
-
-                        // healing - please move if not appropriate priority
-
+                        
                         if (PlayerHealthPercentageHp() <= 40 && ActionReady(All.SecondWind))
                             return All.SecondWind;
 
+                        if (HasCleansableDebuff(LocalPlayer))
+                            return OriginalHook(TheWardensPaeon);
                     }
+                    if (HasEffect(Buffs.RadiantEncoreReady) && !JustUsed(RadiantFinale) && GetCooldownElapsed(BattleVoice) >= 4.2f)
+                        return OriginalHook(RadiantEncore);
 
                     bool wideVolleyReady = LevelChecked(WideVolley) && (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage));
                     bool blastArrowReady = LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady);
@@ -1286,11 +1294,14 @@ namespace XIVSlothCombo.Combos.PvE
                         if (PlayerHealthPercentageHp() <= 40 && ActionReady(All.SecondWind))
                             return All.SecondWind;
 
+                        if (HasCleansableDebuff(LocalPlayer))
+                            return OriginalHook(TheWardensPaeon);
                     }
 
                     //Moved below weaves bc roobert says it is blocking his weaves from happening
                     if (HasEffect(Buffs.RadiantEncoreReady) && !JustUsed(RadiantFinale) && GetCooldownElapsed(BattleVoice) >= 4.2f)
                         return OriginalHook(RadiantEncore);
+
 
                     if (isEnemyHealthHigh)
                     {

--- a/XIVSlothCombo/Combos/PvE/BRD/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD/BRD.cs
@@ -294,8 +294,8 @@ namespace XIVSlothCombo.Combos.PvE
                             return ArmysPaeon;
                     }
 
-                    if (LevelChecked(WanderersMinuet) && songWanderer && gauge.Repertoire == 3)
-                        return OriginalHook(WanderersMinuet);
+                    if (songWanderer && gauge.Repertoire == 3)
+                        return OriginalHook(PitchPerfect);
                     if (ActionReady(EmpyrealArrow))
                         return EmpyrealArrow;
                     if (ActionReady(RainOfDeath))

--- a/XIVSlothCombo/Combos/PvE/BRD/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD/BRD.cs
@@ -439,7 +439,7 @@ namespace XIVSlothCombo.Combos.PvE
                             if (PlayerHealthPercentageHp() <= PluginConfiguration.GetCustomIntValue(Config.BRD_AoESecondWindThreshold) && ActionReady(All.SecondWind))
                                 return All.SecondWind;
                         }
-                        if (IsEnabled(CustomComboPreset.BRD_AoE_Wardens) && HasCleansableDebuff(LocalPlayer))
+                        if (IsEnabled(CustomComboPreset.BRD_AoE_Wardens) && ActionReady(TheWardensPaeon) && HasCleansableDebuff(LocalPlayer))
                             return OriginalHook(TheWardensPaeon);
                     }
 
@@ -740,7 +740,7 @@ namespace XIVSlothCombo.Combos.PvE
                             if (PlayerHealthPercentageHp() <= PluginConfiguration.GetCustomIntValue(Config.BRD_STSecondWindThreshold) && ActionReady(All.SecondWind))
                                 return All.SecondWind;
                         }
-                        if (IsEnabled(CustomComboPreset.BRD_ST_Wardens) && HasCleansableDebuff(LocalPlayer))
+                        if (IsEnabled(CustomComboPreset.BRD_ST_Wardens) && ActionReady(TheWardensPaeon) && HasCleansableDebuff(LocalPlayer))
                             return OriginalHook(TheWardensPaeon);
                     }
 
@@ -1064,7 +1064,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (PlayerHealthPercentageHp() <= 40 && ActionReady(All.SecondWind))
                             return All.SecondWind;
 
-                        if (HasCleansableDebuff(LocalPlayer))
+                        if (ActionReady(TheWardensPaeon) && HasCleansableDebuff(LocalPlayer))
                             return OriginalHook(TheWardensPaeon);
                     }
                     if (HasEffect(Buffs.RadiantEncoreReady) && !JustUsed(RadiantFinale) && GetCooldownElapsed(BattleVoice) >= 4.2f)
@@ -1294,7 +1294,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (PlayerHealthPercentageHp() <= 40 && ActionReady(All.SecondWind))
                             return All.SecondWind;
 
-                        if (HasCleansableDebuff(LocalPlayer))
+                        if (ActionReady(TheWardensPaeon) && HasCleansableDebuff(LocalPlayer))
                             return OriginalHook(TheWardensPaeon);
                     }
 

--- a/XIVSlothCombo/Combos/PvE/BRD/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD/BRD.cs
@@ -278,7 +278,21 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is RainOfDeath)
                 {
                     BRDGauge? gauge = GetJobGauge<BRDGauge>();
+                    bool songArmy = gauge.Song == Song.ARMY;
                     bool songWanderer = gauge.Song == Song.WANDERER;
+                    bool minuetReady = LevelChecked(WanderersMinuet) && IsOffCooldown(WanderersMinuet);
+                    bool balladReady = LevelChecked(MagesBallad) && IsOffCooldown(MagesBallad);
+                    bool paeonReady = LevelChecked(ArmysPaeon) && IsOffCooldown(ArmysPaeon);
+
+                    if (IsEnabled(CustomComboPreset.BRD_AoE_oGCD_Songs) && (gauge.SongTimer < 1 || songArmy))
+                    {
+                        if (minuetReady)
+                            return WanderersMinuet;
+                        if (balladReady)
+                            return MagesBallad;
+                        if (paeonReady)
+                            return ArmysPaeon;
+                    }
 
                     if (LevelChecked(WanderersMinuet) && songWanderer && gauge.Repertoire == 3)
                         return OriginalHook(WanderersMinuet);
@@ -520,7 +534,7 @@ namespace XIVSlothCombo.Combos.PvE
                     bool balladReady = LevelChecked(MagesBallad) && IsOffCooldown(MagesBallad);
                     bool paeonReady = LevelChecked(ArmysPaeon) && IsOffCooldown(ArmysPaeon);
 
-                    if (gauge.SongTimer < 1 || songArmy)
+                    if (IsEnabled(CustomComboPreset.BRD_ST_oGCD_Songs) && (gauge.SongTimer < 1 || songArmy))
                     {
                         if (minuetReady)
                             return WanderersMinuet;

--- a/XIVSlothCombo/Combos/PvE/BRD/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD/BRD.cs
@@ -108,14 +108,16 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (InCombat())
                         {
-                            if (LevelChecked(IronJaws) &&
-                                ((venomous && venomRemaining < 4) || (caustic && causticRemaining < 4)) ||
-                                (windbite && windRemaining < 4) || (stormbite && stormRemaining < 4))
-                                return IronJaws;
-                            if (!LevelChecked(IronJaws) && venomous && venomRemaining < 4)
-                                return VenomousBite;
-                            if (!LevelChecked(IronJaws) && windbite && windRemaining < 4)
-                                return Windbite;
+                            bool canIronJaws = LevelChecked(IronJaws);
+                            Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
+                            Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
+                            float purpleRemaining = purple?.RemainingTime ?? 0;
+                            float blueRemaining = blue?.RemainingTime ?? 0;
+
+                            if (purple is not null && purpleRemaining < 4)
+                                return canIronJaws ? IronJaws : VenomousBite;
+                            if (blue is not null && blueRemaining < 4)
+                                return canIronJaws ? IronJaws : Windbite;
                         }
                     }
 
@@ -123,9 +125,9 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         BRDGauge? gauge = GetJobGauge<BRDGauge>();
 
-                        if (LevelChecked(ApexArrow) && gauge.SoulVoice == 100)
+                        if (gauge.SoulVoice == 100)
                             return ApexArrow;
-                        if (LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady))
+                        if (HasEffect(Buffs.BlastArrowReady))
                             return BlastArrow;
                     }
 
@@ -145,62 +147,38 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is IronJaws)
                 {
+                    Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
+                    Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
+                    float purpleRemaining = purple?.RemainingTime ?? 0;
+                    float blueRemaining = blue?.RemainingTime ?? 0;
 
+                    // Before Iron Jaws: Alternate between DoTs
                     if (!LevelChecked(IronJaws))
-                    {
-                        Status? venomous = FindTargetEffect(Debuffs.VenomousBite);
-                        Status? windbite = FindTargetEffect(Debuffs.Windbite);
-                        float venomRemaining = GetDebuffRemainingTime(Debuffs.VenomousBite);
-                        float windRemaining = GetDebuffRemainingTime(Debuffs.Windbite);
+                        return LevelChecked(Windbite) && blueRemaining <= purpleRemaining ? Windbite : VenomousBite;
 
-                        if (venomous is not null && windbite is not null)
-                        {
-                            if (LevelChecked(VenomousBite) && venomRemaining < windRemaining)
-                                return VenomousBite;
-                            if (LevelChecked(Windbite))
-                                return Windbite;
-                        }
+                    // At least Lv56 (Iron Jaws) from here on...
 
-                        if (LevelChecked(VenomousBite) && (!LevelChecked(Windbite) || windbite is not null))
-                            return VenomousBite;
-                        if (LevelChecked(Windbite))
-                            return Windbite;
-                    }
+                    // DoT application takes priority, as Iron Jaws always cuts ticks
+                    if (blue is null)
+                        return OriginalHook(Windbite);
+                    if (purple is null)
+                        return OriginalHook(VenomousBite);
 
-                    if (!LevelChecked(Stormbite))
-                    {
-                        bool venomous = TargetHasEffect(Debuffs.VenomousBite);
-                        bool windbite = TargetHasEffect(Debuffs.Windbite);
-
-                        if (LevelChecked(IronJaws) && venomous && windbite)
-                            return IronJaws;
-                        if (LevelChecked(VenomousBite) && windbite)
-                            return VenomousBite;
-                        if (LevelChecked(Windbite))
-                            return Windbite;
-                    }
-
-                    bool caustic = TargetHasEffect(Debuffs.CausticBite);
-                    bool stormbite = TargetHasEffect(Debuffs.Stormbite);
-
-                    if (LevelChecked(IronJaws) && caustic && stormbite)
+                    // DoT refresh over Apex Option
+                    if (purpleRemaining < 4 || blueRemaining < 4)
                         return IronJaws;
-                    if (LevelChecked(CausticBite) && stormbite)
-                        return CausticBite;
-                    if (LevelChecked(Stormbite))
-                        return Stormbite;
 
-                    if (IsEnabled(CustomComboPreset.BRD_IronJawsApex) && LevelChecked(ApexArrow))
+                    // Apex Option
+                    if (IsEnabled(CustomComboPreset.BRD_IronJawsApex))
                     {
                         BRDGauge? gauge = GetJobGauge<BRDGauge>();
 
                         if (LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady))
                             return BlastArrow;
-                        if (gauge.SoulVoice == 100 && IsOffCooldown(ApexArrow))
+                        if (gauge.SoulVoice == 100)
                             return ApexArrow;
                     }
                 }
-
                 return actionID;
             }
         }
@@ -213,58 +191,22 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is IronJaws)
                 {
-                    if (!LevelChecked(IronJaws))
-                    {
-                        Status? venomous = FindTargetEffect(Debuffs.VenomousBite);
-                        Status? windbite = FindTargetEffect(Debuffs.Windbite);
+                    Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
+                    Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
+                    float purpleRemaining = purple?.RemainingTime ?? 0;
+                    float blueRemaining = blue?.RemainingTime ?? 0;
 
-                        if (venomous is not null && windbite is not null)
-                        {
-                            float venomRemaining = GetDebuffRemainingTime(Debuffs.VenomousBite);
-                            float windRemaining = GetDebuffRemainingTime(Debuffs.Windbite);
-
-                            if (LevelChecked(VenomousBite) && venomRemaining < windRemaining)
-                                return VenomousBite;
-                            if (LevelChecked(Windbite))
-                                return Windbite;
-                        }
-
-                        if (LevelChecked(VenomousBite) && (!LevelChecked(Windbite) || windbite is not null))
-                            return VenomousBite;
-                        if (LevelChecked(Windbite))
-                            return Windbite;
-                    }
-
-                    if (!LevelChecked(Stormbite))
-                    {
-                        bool venomous = TargetHasEffect(Debuffs.VenomousBite);
-                        bool windbite = TargetHasEffect(Debuffs.Windbite);
-                        float venomRemaining = GetDebuffRemainingTime(Debuffs.VenomousBite);
-                        float windRemaining = GetDebuffRemainingTime(Debuffs.Windbite);
-
-                        if (LevelChecked(IronJaws) && venomous && windbite &&
-                            (venomRemaining < 4 || windRemaining < 4))
-                            return IronJaws;
-                        if (LevelChecked(VenomousBite) && windbite)
-                            return VenomousBite;
-                        if (LevelChecked(Windbite))
-                            return Windbite;
-                    }
-
-                    bool caustic = TargetHasEffect(Debuffs.CausticBite);
-                    bool stormbite = TargetHasEffect(Debuffs.Stormbite);
-                    float causticRemaining = GetDebuffRemainingTime(Debuffs.CausticBite);
-                    float stormRemaining = GetDebuffRemainingTime(Debuffs.Stormbite);
-
-                    if (LevelChecked(IronJaws) && caustic && stormbite &&
-                        (causticRemaining < 4 || stormRemaining < 4))
+                    // Iron Jaws only if it is applicable
+                    if (LevelChecked(IronJaws) && (
+                        (purple is not null && purpleRemaining < 4) ||
+                        (blue is not null && blueRemaining < 4)))
                         return IronJaws;
-                    if (LevelChecked(CausticBite) && stormbite)
-                        return CausticBite;
-                    if (LevelChecked(Stormbite))
-                        return Stormbite;
-                }
 
+                    // Otherwise alternate between DoTs as needed
+                    return LevelChecked(Windbite) && blueRemaining <= purpleRemaining ?
+                        OriginalHook(Windbite) :
+                        OriginalHook(VenomousBite);
+                }
                 return actionID;
             }
         }
@@ -280,17 +222,14 @@ namespace XIVSlothCombo.Combos.PvE
                     BRDGauge? gauge = GetJobGauge<BRDGauge>();
                     bool songArmy = gauge.Song == Song.ARMY;
                     bool songWanderer = gauge.Song == Song.WANDERER;
-                    bool minuetReady = LevelChecked(WanderersMinuet) && IsOffCooldown(WanderersMinuet);
-                    bool balladReady = LevelChecked(MagesBallad) && IsOffCooldown(MagesBallad);
-                    bool paeonReady = LevelChecked(ArmysPaeon) && IsOffCooldown(ArmysPaeon);
-
+                    
                     if (IsEnabled(CustomComboPreset.BRD_AoE_oGCD_Songs) && (gauge.SongTimer < 1 || songArmy))
                     {
-                        if (minuetReady)
+                        if (ActionReady(WanderersMinuet))
                             return WanderersMinuet;
-                        if (balladReady)
+                        if (ActionReady(MagesBallad))
                             return MagesBallad;
-                        if (paeonReady)
+                        if (ActionReady(ArmysPaeon))
                             return ArmysPaeon;
                     }
 
@@ -536,11 +475,11 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (IsEnabled(CustomComboPreset.BRD_ST_oGCD_Songs) && (gauge.SongTimer < 1 || songArmy))
                     {
-                        if (minuetReady)
+                        if (ActionReady(WanderersMinuet))
                             return WanderersMinuet;
-                        if (balladReady)
+                        if (ActionReady(MagesBallad))
                             return MagesBallad;
-                        if (paeonReady)
+                        if (ActionReady(ArmysPaeon))
                             return ArmysPaeon;
                     }
 
@@ -569,18 +508,15 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.BRD_Apex))
                     {
                         BRDGauge? gauge = GetJobGauge<BRDGauge>();
-                        bool blastReady = LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady);
-
-                        if (LevelChecked(ApexArrow) && gauge.SoulVoice == 100)
+                        
+                        if (gauge.SoulVoice == 100)
                             return ApexArrow;
-                        if (blastReady)
+                        if (HasEffect(Buffs.BlastArrowReady))
                             return BlastArrow;
                     }
 
-                    bool wideVolleyReady = LevelChecked(WideVolley) && HasEffect(Buffs.HawksEye);
-
-                    if (IsEnabled(CustomComboPreset.BRD_AoE_Combo) && wideVolleyReady)
-                        return OriginalHook(WideVolley);
+                    if (IsEnabled(CustomComboPreset.BRD_AoE_Combo) && ActionReady(WideVolley) && HasEffect(Buffs.HawksEye))
+                    return OriginalHook(WideVolley);
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvE/BRD/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD/BRD.cs
@@ -314,6 +314,7 @@ namespace XIVSlothCombo.Combos.PvE
                     bool songWanderer = gauge.Song == Song.WANDERER;
                     bool songMage = gauge.Song == Song.MAGE;
                     bool songArmy = gauge.Song == Song.ARMY;
+                    bool canInterrupt = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze);
                     int targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_AoENoWasteHPPercentage);
                     bool isEnemyHealthHigh = !IsEnabled(CustomComboPreset.BRD_AoE_Adv_NoWaste) || GetTargetHPPercent() > targetHPThreshold;
 
@@ -325,6 +326,9 @@ namespace XIVSlothCombo.Combos.PvE
                         IsOffCooldown(Variant.VariantRampart) &&
                         canWeave)
                         return Variant.VariantRampart;
+
+                    if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Interrupt) && canInterrupt)
+                        return All.HeadGraze;
 
                     if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Songs) && canWeave)
                     {
@@ -942,6 +946,7 @@ namespace XIVSlothCombo.Combos.PvE
                     bool songWanderer = gauge.Song == Song.WANDERER;
                     bool songMage = gauge.Song == Song.MAGE;
                     bool songArmy = gauge.Song == Song.ARMY;
+                    bool canInterrupt = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze);
                     int targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_AoENoWasteHPPercentage);
                     bool isEnemyHealthHigh = GetTargetHPPercent() > 1;
 
@@ -952,6 +957,9 @@ namespace XIVSlothCombo.Combos.PvE
                         IsOffCooldown(Variant.VariantRampart) &&
                         canWeave)
                         return Variant.VariantRampart;
+
+                    if (canInterrupt)
+                        return All.HeadGraze;
 
                     if (canWeave)
                     {

--- a/XIVSlothCombo/Combos/PvE/MCH/MCH.cs
+++ b/XIVSlothCombo/Combos/PvE/MCH/MCH.cs
@@ -490,6 +490,10 @@ internal partial class MCH
                 CanWeave(actionID))
                 return Variant.VariantRampart;
 
+            // Interrupt
+            if (interruptReady)
+                return All.HeadGraze;
+
             //Full Metal Field
             if (HasEffect(Buffs.FullMetalMachinist) && LevelChecked(FullMetalField))
                 return FullMetalField;
@@ -602,6 +606,10 @@ internal partial class MCH
                 IsOffCooldown(Variant.VariantRampart) &&
                 CanWeave(actionID))
                 return Variant.VariantRampart;
+
+            // Interrupt
+            if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Interrupt) && interruptReady)
+                return All.HeadGraze;
 
             //Full Metal Field
             if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Stabilizer_FullMetalField) &&


### PR DESCRIPTION
Added interrupt to AoE Simple and advanced for bard and machinist to match dancer.

I did not touch machinists interrupt in delayed weave only.

Fixes #85 
Fixes #86 

Turned the songs in the ST ogcd feature into an option instead of forced
Added songs to the aoe ogcd Feature to match the st one. 

I ported the cleanup from the other PR from gakai into this one. The dot management is much nicer in ironjaws features. 

Added warden's paeon option to st and aoe for self cleansing cleansable debuffs

added small ast description text change to clarify aspected helios and helios conjuction being the same thing. wasnt worth its own fork