### PR TITLE
[DNC] Dance Partner Reminder

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1087,6 +1087,10 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(DNC_ST_AdvancedMode)]
         [CustomComboInfo("Panic Heals Option", "Includes Curing Waltz and Second Wind in the rotation when available and your HP is below the set percentages.", DNC.JobID, 13)]
         DNC_ST_Adv_PanicHeals = 4059,
+
+        [ParentCombo(DNC_ST_AdvancedMode)]
+        [CustomComboInfo("Dance Partner Reminder Option", "Includes Closed Position when out of combat and no dance partner is found.", DNC.JobID)]
+        DNC_ST_Adv_Partner = 4089,
         #endregion
 
         #region Advanced Dancer (AoE)
@@ -1164,6 +1168,10 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(DNC_AoE_AdvancedMode)]
         [CustomComboInfo("Panic Heals Option", "Includes Curing Waltz and Second Wind in the AoE rotation when available and your HP is below the set percentages.", DNC.JobID, 12)]
         DNC_AoE_Adv_PanicHeals = 4079,
+
+        [ParentCombo(DNC_AoE_AdvancedMode)]
+        [CustomComboInfo("Dance Partner Reminder Option", "Includes Closed Position when out of combat and no dance partner is found.", DNC.JobID)]
+        DNC_AoE_Adv_Partner = 4095,
         #endregion
 
         #region Variant
@@ -1180,7 +1188,7 @@ namespace XIVSlothCombo.Combos
 
         #endregion
 
-        // Last value = 4088
+        // Last value = 4090
 
         #endregion
 

--- a/XIVSlothCombo/Combos/PvE/DNC/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC/DNC.cs
@@ -43,6 +43,7 @@ namespace XIVSlothCombo.Combos.PvE
             // Other
             Peloton = 7557,
             SaberDance = 16005,
+            ClosedPosition = 16006,
             EnAvant = 16010,
             Devilment = 16011,
             ShieldSamba = 16012,
@@ -80,6 +81,7 @@ namespace XIVSlothCombo.Combos.PvE
                 FourFoldFanDance = 2699,
                 // Other
                 Peloton = 1199,
+                ClosedPosition = 1823, 
                 ShieldSamba = 1826,
                 LastDanceReady = 3867,
                 FinishingMoveReady = 3868,
@@ -286,6 +288,11 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (!InCombat())
                 {
+                    // Dance Partner
+
+                    if (IsEnabled(CustomComboPreset.DNC_ST_Adv_Partner) && ActionReady(ClosedPosition) && !HasEffect(Buffs.ClosedPosition) && (GetPartyMembers().Count > 1 || HasCompanionPresent()))
+                        return ClosedPosition;
+
                     // ST Standard Step (Pre-pull)
                     if (IsEnabled(CustomComboPreset.DNC_ST_Adv_SS_Prepull) &&
                         ActionReady(StandardStep) &&
@@ -635,6 +642,15 @@ namespace XIVSlothCombo.Combos.PvE
                     (IsOffCooldown(Flourish) ||
                      GetCooldownRemainingTime(Flourish) > 5) &&
                     !HasEffect(Buffs.TechnicalFinish);
+                #endregion
+
+                #region Prepull
+
+                // Dance Partner
+
+                if (!InCombat() && IsEnabled(CustomComboPreset.DNC_AoE_Adv_Partner) && ActionReady(ClosedPosition) && !HasEffect(Buffs.ClosedPosition) && (GetPartyMembers().Count > 1 || HasCompanionPresent()))
+                    return ClosedPosition;
+
                 #endregion
 
                 #region Dance Fills


### PR DESCRIPTION
Added Closed position, out of combat, for both st and aoe advanced. Must be in a party/trust or have a Chocobo out. Requires manual target choice.