### PR TITLE
[AST] Add option to hold certain card weaves (DPS cards and The Lord) until burst window

### DIFF
--- a/XIVSlothCombo/Combos/PvE/AST/AST_Config.cs
+++ b/XIVSlothCombo/Combos/PvE/AST/AST_Config.cs
@@ -27,7 +27,11 @@ namespace XIVSlothCombo.Combos.PvE
                 AST_AOE_LightSpeedOption = new("AST_AOE_LightSpeedOption"),
                 AST_DPS_CombustOption = new("AST_DPS_CombustOption"),
                 AST_QuickTarget_Override = new("AST_QuickTarget_Override"),
-                AST_ST_DPS_Play_SpeedSetting = new("AST_ST_DPS_Play_SpeedSetting");
+                AST_ST_DPS_Play_SpeedSetting = new("AST_ST_DPS_Play_SpeedSetting"),
+                AST_DPS_AutoPlay_HoldForBurst_BurstIndicator = new("AST_DPS_AutoPlay_HoldForBurst_BurstIndicator"),
+                AST_DPS_AutoPlay_HoldForBurst_SimpleCalculationThreshold = new("AST_DPS_AutoPlay_HoldForBurst_SimpleCalculationThreshold"),
+                AST_DPS_LazyLord_HoldForBurst_BurstIndicator = new("AST_DPS_LazyLord_HoldForBurst_BurstIndicator"),
+                AST_DPS_LazyLord_HoldForBurst_SimpleCalculationThreshold = new("AST_DPS_LazyLord_HoldForBurst_SimpleCalculationThreshold");
             public static UserBool
                 AST_QuickTarget_SkipDamageDown = new("AST_QuickTarget_SkipDamageDown"),
                 AST_QuickTarget_SkipRezWeakness = new("AST_QuickTarget_SkipRezWeakness"),
@@ -46,7 +50,11 @@ namespace XIVSlothCombo.Combos.PvE
                 AST_AoE_SimpleHeals_Horoscope = new("AST_AoE_SimpleHeals_Horoscope"),
                 AST_ST_DPS_OverwriteCards = new("AST_ST_DPS_OverwriteCards"),
                 AST_AOE_DPS_OverwriteCards = new("AST_AOE_DPS_OverwriteCards"),
-                AST_ST_DPS_CombustUptime_Adv = new("AST_ST_DPS_CombustUptime_Adv");
+                AST_ST_DPS_CombustUptime_Adv = new("AST_ST_DPS_CombustUptime_Adv"),
+                AST_DPS_AutoPlay_HoldForBurst = new("AST_DPS_AutoPlay_HoldForBurst"),
+                AST_DPS_AutoPlay_HoldForBurst_Adv = new("AST_DPS_AutoPlay_HoldForBurst_Adv"),
+                AST_DPS_LazyLord_HoldForBurst = new("AST_DPS_LazyLord_HoldForBurst"),
+                AST_DPS_LazyLord_HoldForBurst_Adv = new("AST_DPS_LazyLord_HoldForBurst_Adv");
             public static UserFloat
                 AST_ST_DPS_CombustUptime_Threshold = new("AST_ST_DPS_CombustUptime_Threshold");
 
@@ -186,10 +194,63 @@ namespace XIVSlothCombo.Combos.PvE
                         DrawRadioButton(AST_ST_DPS_Play_SpeedSetting, "Medium (2 DPS GCD minimum delay)", "", 2);
                         DrawRadioButton(AST_ST_DPS_Play_SpeedSetting, "Slow (3 DPS GCD minimum delay)", "", 3);
 
+                        ImGui.Spacing();
+                        DrawAdditionalBoolChoice(AST_DPS_AutoPlay_HoldForBurst, "Hold DPS Cards for Burst", "Wait to weave DPS cards until burst window, rather than immediately. Has no effect during opener if that option is enabled.");
+                        ImGui.Spacing();
+
+                        if (AST_DPS_AutoPlay_HoldForBurst)
+                        {
+                            ImGui.Indent();
+
+                            DrawAdditionalBoolChoice(AST_DPS_AutoPlay_HoldForBurst_Adv, "Advanced Options", "", isConditionalChoice: true);
+                            if (AST_DPS_AutoPlay_HoldForBurst_Adv)
+                            {
+                                ImGui.Indent(); ImGui.Spacing();
+
+                                DrawRadioButton(AST_DPS_AutoPlay_HoldForBurst_BurstIndicator, "Use Divination to determine burst window. Recommended.", "", 0);
+                                DrawRadioButton(AST_DPS_AutoPlay_HoldForBurst_BurstIndicator, "Use a simple calculation to determine burst window. Not Recommended.", "", 1);
+
+                                if (AST_DPS_AutoPlay_HoldForBurst_BurstIndicator == 1)
+                                {
+                                    ImGui.Spacing();
+                                    DrawSliderInt(0, 55, AST_DPS_AutoPlay_HoldForBurst_SimpleCalculationThreshold, "Weaves The Balance when Umbral Draw's remaining cooldown is at or below this value. Set to Zero to only weave when Umbral Draw is off cooldown. The Spear is always played immediately.");
+                                }
+
+                                ImGui.Unindent();
+                            }
+                        }
+
                         break;
 
                     case CustomComboPreset.AST_DPS_AutoDraw:
                         DrawAdditionalBoolChoice(AST_ST_DPS_OverwriteCards, "Overwrite Non-DPS Cards", "Will draw even if you have healing cards remaining.");
+                        break;
+
+                    case CustomComboPreset.AST_DPS_LazyLord:
+                        DrawAdditionalBoolChoice(AST_DPS_LazyLord_HoldForBurst, "Hold The Lord until Burst", "Wait to weave The Lord until burst window, rather than immediately. Has no effect during opener if that option is enabled.");
+
+                        if (AST_DPS_LazyLord_HoldForBurst)
+                        {
+                            ImGui.Indent();
+
+                            DrawAdditionalBoolChoice(AST_DPS_LazyLord_HoldForBurst_Adv, "Advanced Options", "", isConditionalChoice: true);
+                            if (AST_DPS_LazyLord_HoldForBurst_Adv)
+                            {
+                                ImGui.Indent(); ImGui.Spacing();
+
+                                DrawRadioButton(AST_DPS_LazyLord_HoldForBurst_BurstIndicator, "Use Divination to determine burst window. Recommended.", "", 0);
+                                DrawRadioButton(AST_DPS_LazyLord_HoldForBurst_BurstIndicator, "Use a simple calculation to determine burst window. Not Recommended.", "", 1);
+
+                                if (AST_DPS_LazyLord_HoldForBurst_BurstIndicator == 1)
+                                {
+                                    ImGui.Spacing();
+                                    DrawSliderInt(0, 55, AST_DPS_LazyLord_HoldForBurst_SimpleCalculationThreshold, "Weaves The Lord when Umbral Draw's remaining cooldown is at or below this value. Set to Zero to only weave when Umbral Draw is off cooldown.");
+                                }
+
+                                ImGui.Unindent();
+                            }
+                        }
+
                         break;
                 }
             }


### PR DESCRIPTION
Hello! This is my first time contributing to this project (or any Dalamud plugin in general, for that matter) but the Readme said that PRs are always welcome so I thought I'd give a shot at implementing some new features I've wanted for a while. 

If I've broken any project conventions or done anything wrong, formatting, software design, or otherwise, feel free to let me know!

The main focus of this PR is to add the option to hold playing The Balance, The Spear, and The Lord until burst window is up, when using the "Autoplay Cards" options. The current behavior is to just play those cards immediately as soon as they're available. This behavior is generally fine in Normal content (perhaps even desired in situations like dungeons), but makes these setting effectively useless in higher-end content. To that end, I've added new options to control when these specific cards get played. By default Divination is used as an indicator to determine when the player's burst window is up, but I've also added a (not recommended) option to a use a simple calculation, if the user so desires for whatever reason.

I've also added a priority call to use Oracle if the Divining buff is about to fall off (only if Oracle option is enabled) and done some minor clean-up plus rearrangement of action priority.

I've tested these changes locally and all works as intended for me.

If this kind of change is not what you guys are looking for and/or outside the scope of this plug-in, feel free to close this PR with prejudice and I will refrain from submitting others like it in the future.