### PR TITLE
[Core] `/wrath` auto-rotation enable and disable commands fix

### DIFF
--- a/XIVSlothCombo/XIVSlothCombo.cs
+++ b/XIVSlothCombo/XIVSlothCombo.cs
@@ -623,28 +623,10 @@ namespace XIVSlothCombo
                     }
                 case "auto":
                     {
-                        Service.Configuration.RotationConfig.Enabled = !Service.Configuration.RotationConfig.Enabled;
+                        Service.Configuration.RotationConfig.Enabled = argumentsParts.Length > 1 ? argumentsParts[1].ToLower() == "on" : !Service.Configuration.RotationConfig.Enabled;
                         Service.Configuration.Save();
 
                         Svc.Chat.Print("Auto-Rotation set to " + (Service.Configuration.RotationConfig.Enabled ? "ON" : "OFF"));
-
-                        break;
-                    }
-                case "auto on":
-                    {
-                        Service.Configuration.RotationConfig.Enabled = true;
-                        Service.Configuration.Save();
-
-                        Svc.Chat.Print("Auto-Rotation set to ON");
-
-                        break;
-                    }
-                case "auto off":
-                    {
-                        Service.Configuration.RotationConfig.Enabled = false;
-                        Service.Configuration.Save();
-
-                        Svc.Chat.Print("Auto-Rotation set to OFF");
 
                         break;
                     }

--- a/XIVSlothCombo/XIVSlothCombo.cs
+++ b/XIVSlothCombo/XIVSlothCombo.cs
@@ -623,10 +623,15 @@ namespace XIVSlothCombo
                     }
                 case "auto":
                     {
-                        Service.Configuration.RotationConfig.Enabled = argumentsParts.Length > 1 ? argumentsParts[1].ToLower() == "on" : !Service.Configuration.RotationConfig.Enabled;
-                        Service.Configuration.Save();
+                        bool newVal = argumentsParts.Length > 1 ? argumentsParts[1].ToLower() == "on" : !Service.Configuration.RotationConfig.Enabled;
 
-                        Svc.Chat.Print("Auto-Rotation set to " + (Service.Configuration.RotationConfig.Enabled ? "ON" : "OFF"));
+                        if (newVal != Service.Configuration.RotationConfig.Enabled)
+                        {
+                            Service.Configuration.RotationConfig.Enabled = newVal;
+                            Service.Configuration.Save();
+
+                            Svc.Chat.Print("Auto-Rotation set to " + (Service.Configuration.RotationConfig.Enabled ? "ON" : "OFF"));
+                        }
 
                         break;
                     }


### PR DESCRIPTION
fix for https://github.com/PunishXIV/WrathCombo/pull/63

the command switch only operates on the first word, not on multiple.