### PR TITLE
[DNC] Prevent new DP option from bricking Auto-Rotation

### DIFF
--- a/XIVSlothCombo/Combos/PvE/DNC/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC/DNC.cs
@@ -295,6 +295,7 @@ namespace XIVSlothCombo.Combos.PvE
                         (GetPartyMembers().Count > 1 || HasCompanionPresent()) &&
                         !(Service.Configuration.AutoActions[CustomComboPreset.DNC_ST_AdvancedMode] &&
                           Service.Configuration.RotationConfig.Enabled)) // Disabled in Auto-Rotation
+                        // todo: do not disable for auto-rotation, provide targeting
                         return ClosedPosition;
 
                     // ST Standard Step (Pre-pull)
@@ -658,6 +659,7 @@ namespace XIVSlothCombo.Combos.PvE
                     (GetPartyMembers().Count > 1 || HasCompanionPresent()) &&
                     !(Service.Configuration.AutoActions[CustomComboPreset.DNC_AoE_AdvancedMode] &&
                       Service.Configuration.RotationConfig.Enabled)) // Disabled in Auto-Rotation
+                    // todo: do not disable for auto-rotation, provide targeting
                     return ClosedPosition;
 
                 #endregion

--- a/XIVSlothCombo/Combos/PvE/DNC/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC/DNC.cs
@@ -289,8 +289,12 @@ namespace XIVSlothCombo.Combos.PvE
                 if (!InCombat())
                 {
                     // Dance Partner
-
-                    if (IsEnabled(CustomComboPreset.DNC_ST_Adv_Partner) && ActionReady(ClosedPosition) && !HasEffect(Buffs.ClosedPosition) && (GetPartyMembers().Count > 1 || HasCompanionPresent()))
+                    if (IsEnabled(CustomComboPreset.DNC_ST_Adv_Partner) &&
+                        ActionReady(ClosedPosition) &&
+                        !HasEffect(Buffs.ClosedPosition) &&
+                        (GetPartyMembers().Count > 1 || HasCompanionPresent()) &&
+                        !(Service.Configuration.AutoActions[CustomComboPreset.DNC_ST_AdvancedMode] &&
+                          Service.Configuration.RotationConfig.Enabled)) // Disabled in Auto-Rotation
                         return ClosedPosition;
 
                     // ST Standard Step (Pre-pull)
@@ -647,8 +651,13 @@ namespace XIVSlothCombo.Combos.PvE
                 #region Prepull
 
                 // Dance Partner
-
-                if (!InCombat() && IsEnabled(CustomComboPreset.DNC_AoE_Adv_Partner) && ActionReady(ClosedPosition) && !HasEffect(Buffs.ClosedPosition) && (GetPartyMembers().Count > 1 || HasCompanionPresent()))
+                if (!InCombat() &&
+                    IsEnabled(CustomComboPreset.DNC_AoE_Adv_Partner) &&
+                    ActionReady(ClosedPosition) &&
+                    !HasEffect(Buffs.ClosedPosition) &&
+                    (GetPartyMembers().Count > 1 || HasCompanionPresent()) &&
+                    !(Service.Configuration.AutoActions[CustomComboPreset.DNC_AoE_AdvancedMode] &&
+                      Service.Configuration.RotationConfig.Enabled)) // Disabled in Auto-Rotation
                     return ClosedPosition;
 
                 #endregion


### PR DESCRIPTION
- [X] Prevents the new DP pre-pull option (#95) from showing when this combo is running in Auto-Rotation

> [!NOTE]
> Ideally features are designed to also work in auto-rotation, not ever disabled for auto-rotation.
> In this case it would be better to implement this with default targeting to support auto-rotation, but we do not have the tools currently required to do so in a concise way and do plan to in the near-term.