### PR TITLE
[PVP] Various small pvp fixes Work in progress

### DIFF
--- a/XIVSlothCombo/Combos/PvE/DRK/DRK_Config.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK/DRK_Config.cs
@@ -176,7 +176,7 @@ internal partial class DRK
 
                 #region PVP
 
-                case CustomComboPreset.DRKPvP_Burst:
+                case CustomComboPreset.DRKPvP_Shadowbringer:
                     UserConfig.DrawSliderInt(1, 100,
                         DRKPvP.Config.ShadowbringerThreshold,
                         "HP% to be at or Above to use " +

--- a/XIVSlothCombo/Combos/PvP/DRKPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/DRKPVP.cs
@@ -21,7 +21,7 @@ namespace XIVSlothCombo.Combos.PvP
         {
             public const ushort
                 Blackblood = 3033,
-                BlackestNight = 1038,
+                BlackestNight = 1308,
                 SaltedEarthDMG = 3036,
                 SaltedEarthDEF = 3037,
                 DarkArts = 3034,
@@ -60,7 +60,7 @@ namespace XIVSlothCombo.Combos.PvP
 
                         if (canWeave)
                         {
-                            if (IsEnabled(CustomComboPreset.DRKPvP_BlackestNight) && ActionReady(BlackestNight) && !HasEffect(Buffs.BlackestNight))
+                            if (IsEnabled(CustomComboPreset.DRKPvP_BlackestNight) && ActionReady(BlackestNight) && !HasEffect(Buffs.BlackestNight) && !WasLastAbility(BlackestNight))
                                 return OriginalHook(BlackestNight);
 
                             if (IsEnabled(CustomComboPreset.DRKPvP_SaltedEarth) && ActionReady(SaltedEarth) && IsEnabled(CustomComboPreset.DRKPvP_SaltedEarth))


### PR DESCRIPTION
DRK
Fixed the wrong buff code on blackest night, it was overwriting itself. Added was last ability used as good measure bc of server ticks.
Move the shadowbringer health slider to where it should be in config screen.