### PR TITLE
[PVP] Healer fixes and changes

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5287,10 +5287,6 @@ namespace WrathCombo.Combos
         ASTPvP_Burst = 111000,
 
         [ParentCombo(ASTPvP_Burst)]
-        [CustomComboInfo("Double Cast Option", "Adds Double Cast to Burst Mode.", AST.JobID)]
-        ASTPvP_DoubleCast = 111001,
-
-        [ParentCombo(ASTPvP_Burst)]
         [CustomComboInfo("Card Draw Option", "Adds Drawing Cards to Burst Mode.", AST.JobID)]
         ASTPvP_Burst_DrawCard = 111002,
 
@@ -5302,16 +5298,20 @@ namespace WrathCombo.Combos
         [CustomComboInfo("Double Cast Heal Feature", "Adds Double Cast to Aspected Benefic.", AST.JobID)]
         ASTPvP_Heal = 111004,
 
-        [ParentCombo(ASTPvP_DoubleCast)]
+        [ParentCombo(ASTPvP_Burst)]
         [CustomComboInfo("Double Malefic Cast Option", "Adds Double Malefic Cast to Burst Mode.", AST.JobID)]
         ASTPvP_Burst_DoubleMalefic = 111005,
 
-        [ParentCombo(ASTPvP_DoubleCast)]
-        [CustomComboInfo("Double Gravity Cast Option", "Adds Double Gravity Cast to Burst Mode.", AST.JobID)]
+        [ParentCombo(ASTPvP_Burst_Gravity)]
+        [CustomComboInfo("Double Gravity Cast Option", "Adds Double Malefic Cast to Burst Mode.", AST.JobID)]
+        ASTPvP_Burst_DoubleGravity = 111009,
+
+        [ParentCombo(ASTPvP_Burst)]
+        [CustomComboInfo("Gravity Burst Option", "Adds Gravity Cast to Burst Mode.", AST.JobID)]
         ASTPvP_Burst_Gravity = 111006,
 
         [ParentCombo(ASTPvP_Burst)]
-        [CustomComboInfo("Macrocosmos Option", "Adds Macrocosmos to Burst Mode.", AST.JobID)]
+        [CustomComboInfo("Macrocosmos Option", "Adds Macrocosmos to Burst Mode. \n If Double Gravity is enabled, it will hold Macrocosmos for the double gravity burst.", AST.JobID)]
         ASTPvP_Burst_Macrocosmos = 111007,
 
         [PvPCustomCombo]
@@ -5319,7 +5319,7 @@ namespace WrathCombo.Combos
         ASTPvP_Epicycle = 111008,
 
 
-        // Last value = 111003
+        // Last value = 111009
         #endregion
 
         #region BLACK MAGE

--- a/WrathCombo/Combos/PvP/ASTPVP.cs
+++ b/WrathCombo/Combos/PvP/ASTPVP.cs
@@ -40,40 +40,46 @@ namespace WrathCombo.Combos.PvP
             {
                 if (actionID is Malefic)
                 {
+                    // Card Draw
                     if (IsEnabled(CustomComboPreset.ASTPvP_Burst_DrawCard) && IsOffCooldown(MinorArcana) && (!HasEffect(Buffs.LadyOfCrowns) && !HasEffect(Buffs.LordOfCrowns)))
-                        return MinorArcana;
+                        return MinorArcana;                                      
+                   
+                    var cardPlayOption = PluginConfiguration.GetCustomIntValue(AST.Config.ASTPvP_Burst_PlayCardOption);
 
-                    if (!PvPCommon.IsImmuneToDamage())
+                    if (IsEnabled(CustomComboPreset.ASTPvP_Burst_PlayCard))
                     {
-                        var cardPlayOption = PluginConfiguration.GetCustomIntValue(AST.Config.ASTPvP_Burst_PlayCardOption);
+                        bool hasLadyOfCrowns = HasEffect(Buffs.LadyOfCrowns);
+                        bool hasLordOfCrowns = HasEffect(Buffs.LordOfCrowns);
 
-                        if (IsEnabled(CustomComboPreset.ASTPvP_Burst_PlayCard) && CanWeave(actionID))
-                        {
-                            bool hasLadyOfCrowns = HasEffect(Buffs.LadyOfCrowns);
-                            bool hasLordOfCrowns = HasEffect(Buffs.LordOfCrowns);
+                        // Card Playing Split so Lady can still be used if target is immune
+                        if ((cardPlayOption == 1 && hasLordOfCrowns && !PvPCommon.IsImmuneToDamage()) ||
+                            (cardPlayOption == 1 && hasLadyOfCrowns) ||
+                            (cardPlayOption == 2 && hasLordOfCrowns && !PvPCommon.IsImmuneToDamage()) ||
+                            (cardPlayOption == 3 && hasLadyOfCrowns))
 
-                            if ((cardPlayOption == 1 && (hasLadyOfCrowns || hasLordOfCrowns)) ||
-                                (cardPlayOption == 2 && hasLordOfCrowns) ||
-                                (cardPlayOption == 3 && hasLadyOfCrowns))
-                            {
-                                return OriginalHook(MinorArcana);
-                            }
-                        }
-
-
-                        if (IsEnabled(CustomComboPreset.ASTPvP_Burst_Macrocosmos) && lastComboMove == DoubleGravity && IsOffCooldown(Macrocosmos))
+                            return OriginalHook(MinorArcana);
+                    }    
+                        
+                    if (!PvPCommon.IsImmuneToDamage())
+                    { 
+                        // Macrocosmos only with double gravity or on coodlown when double gravity is disabled
+                        if (IsEnabled(CustomComboPreset.ASTPvP_Burst_Macrocosmos) && IsOffCooldown(Macrocosmos) &&
+                           (lastComboMove == DoubleGravity || !IsEnabled(CustomComboPreset.ASTPvP_Burst_DoubleGravity)))
                             return Macrocosmos;
 
-                        if (IsEnabled(CustomComboPreset.ASTPvP_DoubleCast) && lastComboMove == Gravity && HasCharges(DoubleCast))
+                        // Double Gravity
+                        if (IsEnabled(CustomComboPreset.ASTPvP_Burst_DoubleGravity) && lastComboMove == Gravity && HasCharges(DoubleCast))
                             return DoubleGravity;
 
+                        // Gravity on cd
                         if (IsEnabled(CustomComboPreset.ASTPvP_Burst_Gravity) && IsOffCooldown(Gravity))
                             return Gravity;
 
+                        // Double Malefic logic to not leave gravity without a charge
                         if (IsEnabled(CustomComboPreset.ASTPvP_Burst_DoubleMalefic))
                         {
                             if (lastComboMove == Malefic && (GetRemainingCharges(DoubleCast) > 1 ||
-                                GetCooldownRemainingTime(Gravity) > 7.5f) && CanWeave(actionID) && IsEnabled(CustomComboPreset.ASTPvP_DoubleCast))
+                                GetCooldownRemainingTime(Gravity) > 7.5f) && CanWeave(actionID))
                                 return DoubleMalefic;
                         }
 


### PR DESCRIPTION
AST
Fixed the gravity options to work properly. It was ONLY working with double gravity. 
Fixed macrocosmos to work without double gravity if not selected but still hold for double gravity if selected.
Removed pvpimmune tag from lady of crowns as it is an aoe heal. 