### PR TITLE
[BRD] Cleanup and organization

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -688,150 +688,154 @@ namespace WrathCombo.Combos
         [AutoAction(false, false)]
         [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
         [ConflictingCombos(BRD_ST_AdvMode)]
-        [CustomComboInfo("Simple Mode - Single Target", "Adds every single target ability to one button,\nIf there are DoTs on target, will try to maintain their uptime.", BRD.JobID)]
+        [CustomComboInfo("Simple Mode - Single Target", "Adds The entire single target rotation on Heavy Shot/Burst Shot." +
+        "\n Pools Bloodletter for Burst Window" +
+        "\n Set's Raging Jaws window to 6 seconds for dot snapshotting" +
+        "\n No waste set to 1 percent." +
+        "\n Second wind to 40 percent." +
+        "\n Auto self cleanse enabled.", BRD.JobID, 1)]
         BRD_ST_SimpleMode = 3036,
 
         [AutoAction(true, false)]
         [ConflictingCombos(BRD_AoE_Combo, BRD_AoE_AdvMode)]
         [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
-        [CustomComboInfo("Simple Mode - AoE", "Weaves oGCDs onto Quick Nock/Ladonsbite.", BRD.JobID)]
+        [CustomComboInfo("Simple Mode - AoE", "Adds The entire single target rotation on Quicknock/Ladonsbite." +
+        "\n Pools Rain of death for Burst Window" +
+        "\n No waste set to 5 percent. " +
+        "\n Second wind to 40 percent." +
+        "\n Auto self cleanse enabled.", BRD.JobID, 2)]
         BRD_AoE_SimpleMode = 3035,
 
         [AutoAction(false, false)]
         [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
         [ConflictingCombos(BRD_ST_SimpleMode)]
-        [CustomComboInfo("Advanced Mode - Single Target", "Adds every single target ability to one button,\nIf there are DoTs on target, will try to maintain their uptime.", BRD.JobID)]
+        [CustomComboInfo("Advanced Mode - Single Target", "Adds every single target ability to one button,\nIf there are DoTs on target, will try to maintain their uptime.", BRD.JobID, 3)]
         BRD_ST_AdvMode = 3009,
 
         [AutoAction(true, false)]
         [ConflictingCombos(BRD_AoE_Combo, BRD_AoE_SimpleMode)]
         [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
-        [CustomComboInfo("Advanced Mode - AoE", "Weaves oGCDs onto Quick Nock/Ladonsbite.", BRD.JobID)]
+        [CustomComboInfo("Advanced Mode - AoE", "Weaves oGCDs onto Quick Nock/Ladonsbite.", BRD.JobID, 4)]
         BRD_AoE_AdvMode = 3015,
 
         [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
         [ConflictingCombos(BRD_ST_AdvMode, BRD_ST_SimpleMode)]
-        [CustomComboInfo("Heavy Shot into Straight Shot Feature", "Replaces Heavy Shot/Burst Shot with Straight Shot/Refulgent Arrow when procced.", BRD.JobID)]
+        [CustomComboInfo("Heavy Shot into Straight Shot Feature", "Replaces Heavy Shot/Burst Shot with Straight Shot/Refulgent Arrow when procced.", BRD.JobID, 5)]
         BRD_StraightShotUpgrade = 3001,
                 
         [ParentCombo(BRD_StraightShotUpgrade)]
-        [CustomComboInfo("DoT Maintenance Option", "Enabling this option will make Heavy Shot into Straight Shot refresh your DoTs on your current.", BRD.JobID)]
+        [CustomComboInfo("DoT Maintenance Option", "Enabling this option will make Heavy Shot into Straight Shot refresh your DoTs on your current.", BRD.JobID, 1)]
         BRD_DoTMaintainance = 3002,
 
         [ParentCombo(BRD_StraightShotUpgrade)]
-        [CustomComboInfo("Apex Arrow Option", "Replaces Burst Shot with Apex Arrow when gauge is full and Blast Arrow when you are Blast Arrow ready.", BRD.JobID)]
+        [CustomComboInfo("Apex Arrow Option", "Replaces Burst Shot with Apex Arrow when gauge is full and Blast Arrow when you are Blast Arrow ready.", BRD.JobID, 2)]
         BRD_ApexST = 3034,
 
         [ReplaceSkill(BRD.IronJaws)]
         [ConflictingCombos(BRD_IronJaws_Alternate)]
-        [CustomComboInfo("Iron Jaws Feature", "Iron Jaws is replaced with Caustic Bite/Stormbite if one or both are not up.\nAlternates between the two if Iron Jaws isn't available.", BRD.JobID)]
+        [CustomComboInfo("Iron Jaws Feature", "Iron Jaws is replaced with Caustic Bite/Stormbite if one or both are not up.\nAlternates between the two if Iron Jaws isn't available.", BRD.JobID, 7)]
         BRD_IronJaws = 3003,
 
         [ReplaceSkill(BRD.IronJaws)]
         [ConflictingCombos(BRD_IronJaws)]
-        [CustomComboInfo("Iron Jaws Alternate Feature", "Iron Jaws is replaced with Caustic Bite/Stormbite if one or both are not up.\nIron Jaws will only show up when debuffs are about to expire.", BRD.JobID)]
+        [CustomComboInfo("Iron Jaws Alternate Feature", "Iron Jaws is replaced with Caustic Bite/Stormbite if one or both are not up.\nIron Jaws will only show up when debuffs are about to expire.", BRD.JobID, 8)]
         BRD_IronJaws_Alternate = 3004,
 
         [ParentCombo(BRD_AoE_Combo)]
-        [CustomComboInfo("Apex Arrow Option", "Replaces Ladonsbite and Quick Nock with Apex Arrow when gauge is full and Blast Arrow when you are Blast Arrow ready.", BRD.JobID)]
+        [CustomComboInfo("Apex Arrow Option", "Replaces Ladonsbite and Quick Nock with Apex Arrow when gauge is full and Blast Arrow when you are Blast Arrow ready.", BRD.JobID, 1)]
         BRD_Apex = 3005,
 
         [ReplaceSkill(BRD.Bloodletter)]
-        [CustomComboInfo("Single Target oGCD Feature", "All oGCD's on Bloodletter/Heartbreakshot", BRD.JobID)]
+        [CustomComboInfo("Single Target oGCD Feature", "All oGCD's on Bloodletter/Heartbreakshot", BRD.JobID, 6)]
         BRD_ST_oGCD = 3006,
 
         [ParentCombo(BRD_ST_oGCD)]
-        [CustomComboInfo("Quick song option", "Adds the songs to the oGCD feature. Wanderers > Mages > Armys", BRD.JobID)]
+        [CustomComboInfo("Quick song option", "Adds the songs to the oGCD feature. Wanderers > Mages > Armys", BRD.JobID, 1)]
         BRD_ST_oGCD_Songs = 3044,
 
         [ReplaceSkill(BRD.RainOfDeath)]       
-        [CustomComboInfo("AoE oGCD Feature", "All AoE oGCD's on Rain of Death depending on their CD.", BRD.JobID)]
+        [CustomComboInfo("AoE oGCD Feature", "All AoE oGCD's on Rain of Death depending on their CD.", BRD.JobID, 10)]
         BRD_AoE_oGCD = 3007,
 
         [ParentCombo(BRD_AoE_oGCD)]
-        [CustomComboInfo("Quick song option", "Adds the songs to the AoE oGCD feature. Wanderers > Mages > Armys", BRD.JobID)]
+        [CustomComboInfo("Quick song option", "Adds the songs to the AoE oGCD feature. Wanderers > Mages > Armys", BRD.JobID, 1)]
         BRD_AoE_oGCD_Songs = 3045,
 
         [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
         [ConflictingCombos(BRD_AoE_AdvMode, BRD_AoE_SimpleMode)]
-        [CustomComboInfo("Quick Nock Feature", "Replaces Quick Nock/Ladonsbite with Shadowbite when ready.", BRD.JobID)]
+        [CustomComboInfo("Quick Nock Feature", "Replaces Quick Nock/Ladonsbite with Shadowbite when ready.", BRD.JobID, 9)]
         BRD_AoE_Combo = 3008,
                 
         [ParentCombo(BRD_ST_AdvMode)]
-        [CustomComboInfo("Bard DoTs Option", "This option will make Bard apply DoTs if none are present on the target.", BRD.JobID)]
+        [CustomComboInfo("Bard DoTs Option", "This option will make Bard apply DoTs if none are present on the target.", BRD.JobID, 2)]
         BRD_Adv_DoT = 3010,
 
         [ParentCombo(BRD_ST_AdvMode)]
-        [CustomComboInfo("Bard Songs Option", "This option adds the Bard's Songs to the Advanced Bard Feature.", BRD.JobID)]
+        [CustomComboInfo("Bard Songs Option", "This option adds the Bard's Songs to the Advanced Bard Feature.", BRD.JobID, 1)]
         BRD_Adv_Song = 3011,       
 
         [ReplaceSkill(BRD.Barrage)]
-        [CustomComboInfo("Bard Buffs Feature", "Adds Raging Strikes and Battle Voice onto Barrage.", BRD.JobID)]
+        [CustomComboInfo("Bard Buffs Feature", "Adds Raging Strikes and Battle Voice onto Barrage.", BRD.JobID, 11)]
         BRD_Buffs = 3013,
 
         [ReplaceSkill(BRD.WanderersMinuet)]
-        [CustomComboInfo("One Button Songs Feature", "Add Mage's Ballad and Army's Paeon to Wanderer's Minuet depending on cooldowns.", BRD.JobID)]
+        [CustomComboInfo("One Button Songs Feature", "Add Mage's Ballad and Army's Paeon to Wanderer's Minuet depending on cooldowns.", BRD.JobID, 12)]
         BRD_OneButtonSongs = 3014,
                 
         [ParentCombo(BRD_AoE_AdvMode)]
-        [CustomComboInfo("Bard Song Option", "Weave Songs on the Advanced AoE.", BRD.JobID)]
+        [CustomComboInfo("Bard Song Option", "Weave Songs on the Advanced AoE.", BRD.JobID, 1)]
         BRD_AoE_Adv_Songs = 3016,
 
         [ParentCombo(BRD_AoE_AdvMode)]
-        [CustomComboInfo("Interrupt Option", "Uses interrupt during the rotation if applicable.", BRD.JobID)]
+        [CustomComboInfo("Interrupt Option", "Uses interrupt during the rotation if applicable.", BRD.JobID, 6)]
         BRD_AoE_Adv_Interrupt = 3043,
 
         [ParentCombo(BRD_AoE_AdvMode)]
-        [CustomComboInfo("oGcd Option", "Weave Sidewinder, Empyreal arrow, Rain of death, and Pitch perfect when available.", BRD.JobID)]
+        [CustomComboInfo("oGcd Option", "Weave Sidewinder, Empyreal arrow, Rain of death, and Pitch perfect when available.", BRD.JobID, 2)]
         BRD_AoE_Adv_oGCD = 3037,
 
         [ParentCombo(BRD_ST_AdvMode)]
-        [CustomComboInfo("oGcd Option", "Weave Sidewinder, Empyreal arrow, Rain of death, and Pitch perfect when available.", BRD.JobID)]
+        [CustomComboInfo("oGcd Option", "Weave Sidewinder, Empyreal arrow, Rain of death, and Pitch perfect when available.", BRD.JobID, 3)]
         BRD_ST_Adv_oGCD = 3038,
 
         [ParentCombo(BRD_ST_AdvMode)]
-        [CustomComboInfo("Buffs Option", "Adds buffs onto the Advanced Bard feature.", BRD.JobID)]
+        [CustomComboInfo("Buffs Option", "Adds buffs onto the Advanced Bard feature.", BRD.JobID, 5)]
         BRD_Adv_Buffs = 3017,
 
         [ParentCombo(BRD_ST_AdvMode)]
-        [CustomComboInfo("Resonant Option", "Adds Resonant Arrow to the Rotation after Barrage.", BRD.JobID)]
+        [CustomComboInfo("Resonant Option", "Adds Resonant Arrow to the Rotation after Barrage.", BRD.JobID, 8)]
         BRD_Adv_BuffsResonant = 3041,
 
         [ParentCombo(BRD_ST_AdvMode)]
-        [CustomComboInfo("Buffs - Radiant Option", "Adds Radiant Finale to the Advanced Bard feature.", BRD.JobID)]
+        [CustomComboInfo("Buffs - Radiant Option", "Adds Radiant Finale to the Advanced Bard feature.", BRD.JobID, 6)]
         BRD_Adv_BuffsRadiant = 3018,
 
         [ParentCombo(BRD_ST_AdvMode)]
-        [CustomComboInfo("Encore Option", "Adds Radiant Encore to the Rotation after Finale.", BRD.JobID)]
+        [CustomComboInfo("Encore Option", "Adds Radiant Encore to the Rotation after Finale.", BRD.JobID, 9)]
         BRD_Adv_BuffsEncore = 3042,
 
         [ParentCombo(BRD_ST_AdvMode)]
-        [CustomComboInfo("No Waste Option", "Adds enemy health checking on mobs for buffs, DoTs and Songs.\nThey will not be reapplied if less than specified.", BRD.JobID)]
+        [CustomComboInfo("No Waste Option", "Adds enemy health checking on mobs for buffs, DoTs and Songs.\nThey will not be reapplied if less than specified.", BRD.JobID, 12)]
         BRD_Adv_NoWaste = 3019,
 
         [ParentCombo(BRD_ST_AdvMode)]
-        [CustomComboInfo("Interrupt Option", "Uses interrupt during the rotation if applicable.", BRD.JobID)]
+        [CustomComboInfo("Interrupt Option", "Uses interrupt during the rotation if applicable.", BRD.JobID, 11)]
         BRD_Adv_Interrupt = 3020,
 
         [ParentCombo(BRD_ST_AdvMode)]
-        [CustomComboInfo("Apex Arrow Option", "Adds Apex Arrow and Blast shot", BRD.JobID)]
+        [CustomComboInfo("Apex Arrow Option", "Adds Apex Arrow and Blast shot", BRD.JobID, 10)]
         BRD_ST_ApexArrow = 3021,
 
         [ParentCombo(BRD_AoE_AdvMode)]
-        [CustomComboInfo("Apex Arrow Option", "Adds Apex Arrow and Blast shot", BRD.JobID)]
+        [CustomComboInfo("Apex Arrow Option", "Adds Apex Arrow and Blast shot", BRD.JobID, 5)]
         BRD_Aoe_ApexArrow = 3039,
 
-        //[ConflictingCombos(BardoGCDSingleTargetFeature)]
-        //[ParentCombo(SimpleBardFeature)]
-        //[CustomComboInfo("Simple Opener", "Adds the optimum opener to simple bard.\nThis conflicts with pretty much everything outside of simple bard options due to the nature of the opener.", BRD.JobID)]
-        //BardSimpleOpener = 3022,
-
         [ParentCombo(BRD_ST_AdvMode)]
-        [CustomComboInfo("Pooling Option", "84+ Pools Bloodletter charges to allow for optimum burst phases.", BRD.JobID)]
+        [CustomComboInfo("Pooling Option", "84+ Pools Bloodletter charges to allow for optimum burst phases.", BRD.JobID, 4)]
         BRD_Adv_Pooling = 3023,
 
         [ParentCombo(BRD_AoE_AdvMode)]
-        [CustomComboInfo("Pooling Option", "84+ Pools Rain of death charges to allow for optimum burst phases.", BRD.JobID)]
+        [CustomComboInfo("Pooling Option", "84+ Pools Rain of death charges to allow for optimum burst phases.", BRD.JobID, 3)]
         BRD_AoE_Pooling = 3040,
 
         [ParentCombo(BRD_IronJaws)]
@@ -839,27 +843,23 @@ namespace WrathCombo.Combos
         BRD_IronJawsApex = 3024,
 
         [ParentCombo(BRD_ST_AdvMode)]
-        [CustomComboInfo("Raging Jaws Option", "Enable the snapshotting of DoTs, within the remaining time of Raging Strikes below:", BRD.JobID)]
-        BRD_Adv_RagingJaws = 3025,
-
-        //[ParentCombo(BRD_AoE_Simple_Songs)]
-        //[CustomComboInfo("Exclude Wanderer's Minuet Option", "Dont use Wanderer's Minuet.", BRD.JobID)]
-        //BRD_AoE_Simple_SongsExcludeWM = 3027,
+        [CustomComboInfo("Raging Jaws Option", "Enable the snapshotting of DoTs, within the remaining time of Raging Strikes below:", BRD.JobID, 7)]
+        BRD_Adv_RagingJaws = 3025,           
 
         [ParentCombo(BRD_ST_AdvMode)]
-        [CustomComboInfo("Second Wind Option", "Uses Second Wind when below set HP percentage.", BRD.JobID)]
+        [CustomComboInfo("Second Wind Option", "Uses Second Wind when below set HP percentage.", BRD.JobID, 13)]
         BRD_ST_SecondWind = 3028,
 
         [ParentCombo(BRD_ST_AdvMode)]
-        [CustomComboInfo("Self Cleanse Option", "Uses Wardens Paeon when you have a cleansable debuff.", BRD.JobID)]
+        [CustomComboInfo("Self Cleanse Option", "Uses Wardens Paeon when you have a cleansable debuff.", BRD.JobID, 14)]
         BRD_ST_Wardens = 3047,
 
         [ParentCombo(BRD_AoE_AdvMode)]
-        [CustomComboInfo("Second Wind Option", "Uses Second Wind when below set HP percentage.", BRD.JobID)]
+        [CustomComboInfo("Second Wind Option", "Uses Second Wind when below set HP percentage.", BRD.JobID, 8)]
         BRD_AoE_SecondWind = 3029,
 
         [ParentCombo(BRD_AoE_AdvMode)]
-        [CustomComboInfo("Self Cleanse Option", "Uses Wardens Paeon when you have a cleansable debuff.", BRD.JobID)]
+        [CustomComboInfo("Self Cleanse Option", "Uses Wardens Paeon when you have a cleansable debuff.", BRD.JobID, 9)]
         BRD_AoE_Wardens = 3046,
 
         [Variant]
@@ -872,12 +872,12 @@ namespace WrathCombo.Combos
         [CustomComboInfo("Cure Option", "Use Variant Cure when HP is below set threshold.", BRD.JobID)]
         BRD_Variant_Cure = 3031,
 
-        [ParentCombo(BRD_AoE_Adv_Songs)]
-        [CustomComboInfo("AoE Buffs Option", "Adds buffs onto the Advance AoE Bard feature.", BRD.JobID)]
+        [ParentCombo(BRD_AoE_AdvMode)]
+        [CustomComboInfo("AoE Buffs Option", "Adds buffs onto the Advance AoE Bard feature.", BRD.JobID, 4)]
         BRD_AoE_Adv_Buffs = 3032,
 
         [ParentCombo(BRD_AoE_AdvMode)]
-        [CustomComboInfo("AoE No Waste Option", "Adds enemy health checking on targetted mob for songs.\nThey will not be reapplied if less than specified.", BRD.JobID)]
+        [CustomComboInfo("AoE No Waste Option", "Adds enemy health checking on targetted mob for songs.\nThey will not be reapplied if less than specified.", BRD.JobID, 7)]
         BRD_AoE_Adv_NoWaste = 3033,
         // Last value = 3047
 

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -582,13 +582,11 @@ namespace WrathCombo.Combos.PvE
                 {
                     BRDGauge? gauge = GetJobGauge<BRDGauge>();
                     bool canWeave = CanWeave(actionID) && !ActionWatching.HasDoubleWeaved();
-                    bool canWeaveBuffs = CanWeave(actionID, 0.6) && !ActionWatching.HasDoubleWeaved();
                     bool canWeaveDelayed = CanDelayedWeave(actionID, 0.9) && !ActionWatching.HasDoubleWeaved();
                     bool songNone = gauge.Song == Song.NONE;
                     bool songWanderer = gauge.Song == Song.WANDERER;
                     bool songMage = gauge.Song == Song.MAGE;
-                    bool songArmy = gauge.Song == Song.ARMY;
-                    bool canInterrupt = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze);
+                    bool songArmy = gauge.Song == Song.ARMY;                    
                     int targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_NoWasteHPPercentage);
                     bool isEnemyHealthHigh = !IsEnabled(CustomComboPreset.BRD_Adv_NoWaste) || GetTargetHPPercent() > targetHPThreshold;
 
@@ -597,9 +595,8 @@ namespace WrathCombo.Combos.PvE
                         openerFinished = false;
                     }
 
-                    if (IsEnabled(CustomComboPreset.BRD_Adv_Interrupt) && canInterrupt)
-                        return All.HeadGraze;
-
+                    #region Variants
+                    
                     if (IsEnabled(CustomComboPreset.BRD_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.BRD_VariantCure))
                         return Variant.VariantCure;
 
@@ -609,19 +606,18 @@ namespace WrathCombo.Combos.PvE
                         canWeave)
                         return Variant.VariantRampart;
 
+                    #endregion
+
+                    #region Songs
+
                     if (IsEnabled(CustomComboPreset.BRD_Adv_Song) && isEnemyHealthHigh)
                     {
                         int songTimerInSeconds = gauge.SongTimer / 1000;
 
                         // Limit optimisation to when you are high enough level to benefit from it.
                         if (LevelChecked(WanderersMinuet))
-                        {
-                            // 43s of Wanderer's Minute, ~36s of Mage's Ballad, and ~43s of Army's Paeon    
-                            bool minuetReady = IsOffCooldown(WanderersMinuet);
-                            bool balladReady = IsOffCooldown(MagesBallad);
-                            bool paeonReady = IsOffCooldown(ArmysPaeon);
-
-                            if (ActionReady(EmpyrealArrow) && JustUsed(WanderersMinuet))
+                        {                            
+                            if (ActionReady(EmpyrealArrow) && JustUsed(WanderersMinuet)) // Used to ensure Empyreal arrow goes off as soon as possible in opener
                                 return EmpyrealArrow;
 
                             if (canWeave)
@@ -629,11 +625,11 @@ namespace WrathCombo.Combos.PvE
                                 if (songNone)
                                 {
                                     // Logic to determine first song
-                                    if (minuetReady && !(JustUsed(MagesBallad) || JustUsed(ArmysPaeon)))
+                                    if (ActionReady(WanderersMinuet) && !(JustUsed(MagesBallad) || JustUsed(ArmysPaeon)))
                                         return WanderersMinuet;
-                                    if (balladReady && !(JustUsed(WanderersMinuet) || JustUsed(ArmysPaeon)))
+                                    if (ActionReady(MagesBallad) && !(JustUsed(WanderersMinuet) || JustUsed(ArmysPaeon)))
                                         return MagesBallad;
-                                    if (paeonReady && !(JustUsed(MagesBallad) || JustUsed(WanderersMinuet)))
+                                    if (ActionReady(ArmysPaeon) && !(JustUsed(MagesBallad) || JustUsed(WanderersMinuet)))
                                         return ArmysPaeon;
                                 }
 
@@ -641,7 +637,7 @@ namespace WrathCombo.Combos.PvE
                                 {
                                     if (songTimerInSeconds <= 3 && gauge.Repertoire > 0) // Spend any repertoire before switching to next song
                                         return OriginalHook(PitchPerfect);
-                                    if (songTimerInSeconds <= 3 && balladReady)          // Move to Mage's Ballad if <= 3 seconds left on song
+                                    if (songTimerInSeconds <= 3 && ActionReady(MagesBallad)) // Move to Mage's Ballad if <= 3 seconds left on song
                                         return MagesBallad;
                                 }
 
@@ -649,7 +645,7 @@ namespace WrathCombo.Combos.PvE
                                 {
 
                                     // Move to Army's Paeon if <= 3 seconds left on song
-                                    if (songTimerInSeconds <= 3 && paeonReady)
+                                    if (songTimerInSeconds <= 3 && ActionReady(ArmysPaeon))
                                     {
                                         // Special case for Empyreal Arrow: it must be cast before you change to it to avoid drift!
                                         if (ActionReady(EmpyrealArrow))
@@ -662,53 +658,57 @@ namespace WrathCombo.Combos.PvE
                             if (songArmy && canWeaveDelayed)
                             {
                                 // Move to Wanderer's Minuet if <= 12 seconds left on song or WM off CD and have 4 repertoires of AP
-                                if (songTimerInSeconds <= 12 || (minuetReady && gauge.Repertoire == 4))
+                                if (songTimerInSeconds <= 12 || (ActionReady(WanderersMinuet) && gauge.Repertoire == 4))
                                     return WanderersMinuet;
                             }
                         }
-                        else if (songTimerInSeconds <= 3 && canWeave)
-                        {
-                            bool balladReady = LevelChecked(MagesBallad) && IsOffCooldown(MagesBallad);
-                            bool paeonReady = LevelChecked(ArmysPaeon) && IsOffCooldown(ArmysPaeon);
 
-                            if (balladReady)
+                        else if (songTimerInSeconds <= 3 && canWeave) // Before you get Wanderers, it just toggles the two songs.
+                        {                            
+                            if (ActionReady(MagesBallad))
                                 return MagesBallad;
-                            if (paeonReady)
+                            if (ActionReady(ArmysPaeon))
                                 return ArmysPaeon;
                         }
                     }
 
+                    #endregion
+
+                    #region Buffs
+
                     if (IsEnabled(CustomComboPreset.BRD_Adv_Buffs) && (!songNone || !LevelChecked(MagesBallad)) && isEnemyHealthHigh)
                     {
                         bool radiantReady = LevelChecked(RadiantFinale) && IsOffCooldown(RadiantFinale) && TargetHasEffect(Debuffs.CausticBite) && TargetHasEffect(Debuffs.Stormbite);
-                        bool ragingReady = LevelChecked(RagingStrikes) && IsOffCooldown(RagingStrikes);
-                        bool battleVoiceReady = LevelChecked(BattleVoice) && IsOffCooldown(BattleVoice);
-                        bool barrageReady = LevelChecked(Barrage) && IsOffCooldown(Barrage);
                         float battleVoiceCD = GetCooldownRemainingTime(BattleVoice);
                         float ragingCD = GetCooldownRemainingTime(RagingStrikes);
 
+                        // Radiant Delayed weave into BV and Raging to ensure tight buff timing and minimize drift
                         if (canWeaveDelayed && IsEnabled(CustomComboPreset.BRD_Adv_BuffsRadiant) && radiantReady &&
                            (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet))
                            && (battleVoiceCD < 3 || ActionReady(BattleVoice)) && (ragingCD < 3 || ActionReady(RagingStrikes)))
                             return RadiantFinale;
 
-                        if (canWeaveBuffs && battleVoiceReady && (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale)))
+                        // BV and Raging will wait for radiant only when high enough level
+                        if (canWeave && ActionReady(BattleVoice) && (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale))) 
                             return BattleVoice;
-
-                        if (canWeaveBuffs && ragingReady && (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale)))
+                        if (canWeave && ActionReady(RagingStrikes) && (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale)))
                             return RagingStrikes;
 
-                        //removed requirement to not have hawks eye, it is better to maybe lose 60 potency than allow it to drift a 1000 potency gain out of the window
-                        if (canWeaveBuffs && barrageReady && HasEffect(Buffs.RagingStrikes))
+                        // Barrage Logic to check for Buffs at different level points
+                        if (canWeave && ActionReady(Barrage) && HasEffect(Buffs.RagingStrikes))
                         {
-                            if (LevelChecked(RadiantFinale) && HasEffect(Buffs.RadiantFinale))
+                            if (LevelChecked(RadiantFinale) && HasEffect(Buffs.RadiantFinale) && HasEffect(Buffs.BattleVoice))
                                 return Barrage;
-                            else if (LevelChecked(BattleVoice) && HasEffect(Buffs.BattleVoice))
+                            else if (!LevelChecked(RadiantFinale) && LevelChecked(BattleVoice) && HasEffect(Buffs.BattleVoice))
                                 return Barrage;
-                            else if (!LevelChecked(BattleVoice) && HasEffect(Buffs.RagingStrikes))
+                            else if (!LevelChecked(BattleVoice))
                                 return Barrage;
                         }
                     }
+
+                    #endregion
+
+                    #region OGCD
 
                     if (canWeave && IsEnabled(CustomComboPreset.BRD_ST_Adv_oGCD))
                     {
@@ -720,10 +720,12 @@ namespace WrathCombo.Combos.PvE
                         if (ActionReady(EmpyrealArrow))
                             return EmpyrealArrow;
 
+                        // Pitch Perfect loogic to use when full or when Empyreal arrow might overcap it. 
                         if (LevelChecked(PitchPerfect) && songWanderer &&
                             (gauge.Repertoire == 3 || (LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && empyrealCD < 2)))
                             return OriginalHook(PitchPerfect);
 
+                        // Sidewinder logic to use in burst window with buffs or on cd on the 1 minutes
                         if (ActionReady(Sidewinder))
                         {
                             if (IsEnabled(CustomComboPreset.BRD_Adv_Pooling))
@@ -741,14 +743,18 @@ namespace WrathCombo.Combos.PvE
                             else return Sidewinder;
                         }
 
+                        //Interupt Logic, set to delayed weave. Let someone else do it if they want. Better to be last line of defense and stay off cd.
+                        if (IsEnabled(CustomComboPreset.BRD_Adv_Interrupt) && CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && canWeaveDelayed)
+                            return All.HeadGraze;
 
+                        // Bloodletter pooling logic. Will Pool as buffs are coming up. 
                         if (ActionReady(Bloodletter) && !(WasLastAction(Bloodletter) || WasLastAction(HeartbreakShot)) && (empyrealCD > 1 || !LevelChecked(EmpyrealArrow)))
                         {
                             uint bloodletterCharges = GetRemainingCharges(Bloodletter);
 
                             if (IsEnabled(CustomComboPreset.BRD_Adv_Pooling) && LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
                             {
-                                if (songWanderer)
+                                if (songWanderer) // Pool until buffs go out in wanderers
                                 {
                                     if (((HasEffect(Buffs.RagingStrikes) || ragingCD > 10) &&
                                         (HasEffect(Buffs.BattleVoice) || battleVoiceCD > 10 ||
@@ -759,17 +765,20 @@ namespace WrathCombo.Combos.PvE
                                         return OriginalHook(Bloodletter);
                                 }
 
-                                if (songArmy && (bloodletterCharges == 3 || ((gauge.SongTimer / 1000) > 30 && bloodletterCharges > 0)))
+                                if (songArmy && (bloodletterCharges == 3 || ((gauge.SongTimer / 1000) > 30 && bloodletterCharges > 0))) // Start pooling in Army
                                     return OriginalHook(Bloodletter);
-                                if (songMage && bloodletterCharges > 0)
+                                if (songMage && bloodletterCharges > 0) //Don't pool in Mages
                                     return OriginalHook(Bloodletter);
-                                if (songNone && bloodletterCharges == 3)
+                                if (songNone && bloodletterCharges == 3) //Pool with no song
                                     return OriginalHook(Bloodletter);
                             }
                             else if (bloodletterCharges > 0)
                                 return OriginalHook(Bloodletter);
                         }
                     }
+                    #endregion
+
+                    #region Self Care
                     if (canWeave)
                     {
                         if (IsEnabled(CustomComboPreset.BRD_ST_SecondWind))
@@ -777,80 +786,59 @@ namespace WrathCombo.Combos.PvE
                             if (PlayerHealthPercentageHp() <= PluginConfiguration.GetCustomIntValue(Config.BRD_STSecondWindThreshold) && ActionReady(All.SecondWind))
                                 return All.SecondWind;
                         }
-                        if (IsEnabled(CustomComboPreset.BRD_ST_Wardens) && ActionReady(TheWardensPaeon) && HasCleansableDebuff(LocalPlayer))
+
+                        if (IsEnabled(CustomComboPreset.BRD_ST_Wardens) && ActionReady(TheWardensPaeon) && HasCleansableDebuff(LocalPlayer)) // Could be upgraded with a targetting system in the future
                             return OriginalHook(TheWardensPaeon);
                     }
+                    #endregion
 
-                    if (HasEffect(Buffs.RadiantEncoreReady) && !JustUsed(RadiantFinale) && GetCooldownElapsed(RadiantFinale) >= 4.2f && IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore))
-                        return OriginalHook(RadiantEncore);
+                    #region Dot Management
 
                     if (isEnemyHealthHigh)
-                    {
-                        bool venomous = TargetHasEffect(Debuffs.VenomousBite);
-                        bool windbite = TargetHasEffect(Debuffs.Windbite);
-                        bool caustic = TargetHasEffect(Debuffs.CausticBite);
-                        bool stormbite = TargetHasEffect(Debuffs.Stormbite);
-                        float venomRemaining = GetDebuffRemainingTime(Debuffs.VenomousBite);
-                        float windRemaining = GetDebuffRemainingTime(Debuffs.Windbite);
-                        float causticRemaining = GetDebuffRemainingTime(Debuffs.CausticBite);
-                        float stormRemaining = GetDebuffRemainingTime(Debuffs.Stormbite);
+                    {                        
+                        bool canIronJaws = LevelChecked(IronJaws);
+                        Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
+                        Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
+                        float purpleRemaining = purple?.RemainingTime ?? 0;
+                        float blueRemaining = blue?.RemainingTime ?? 0;
                         float ragingStrikesDuration = GetBuffRemainingTime(Buffs.RagingStrikes);
-                        float radiantFinaleDuration = GetBuffRemainingTime(Buffs.RadiantFinale);
                         int ragingJawsRenewTime = PluginConfiguration.GetCustomIntValue(Config.BRD_RagingJawsRenewTime);
-
-                        DotRecast poisonRecast = delegate (int duration)
-                        {
-                            return (venomous && venomRemaining < duration) || (caustic && causticRemaining < duration);
-                        };
-
-                        DotRecast windRecast = delegate (int duration)
-                        {
-                            return (windbite && windRemaining < duration) || (stormbite && stormRemaining < duration);
-                        };
 
                         if (IsEnabled(CustomComboPreset.BRD_Adv_DoT))
                         {
-                            if (ActionReady(IronJaws) && IsEnabled(CustomComboPreset.BRD_Adv_RagingJaws) && HasEffect(Buffs.RagingStrikes) &&
-                            !WasLastAction(IronJaws) && ragingStrikesDuration < ragingJawsRenewTime && poisonRecast(35) && windRecast(35))
+                            if (IsEnabled(CustomComboPreset.BRD_Adv_RagingJaws) && ActionReady(IronJaws) && HasEffect(Buffs.RagingStrikes) &&
+                            ragingStrikesDuration < ragingJawsRenewTime && // Raging Jaws Slider Check
+                            purpleRemaining < 35 && blueRemaining < 35)    // Prevention of double refreshing dots
+                                                     
                             {
                                 openerFinished = true;
                                 return IronJaws;
                             }
 
-                            if (LevelChecked(Stormbite) && !stormbite)
-                                return Stormbite;
-                            if (LevelChecked(CausticBite) && !caustic)
-                                return CausticBite;
-                            if (LevelChecked(Windbite) && !windbite && !LevelChecked(Stormbite))
-                                return Windbite;
-                            if (LevelChecked(VenomousBite) && !venomous && !LevelChecked(CausticBite))
-                                return VenomousBite;
+                            if (purple is not null && purpleRemaining < 4)
+                                return canIronJaws ? IronJaws : VenomousBite;
+                            if (blue is not null && blueRemaining < 4)
+                                return canIronJaws ? IronJaws : Windbite;
+                            if (blue is null)
+                                return OriginalHook(Windbite);
+                            if (purple is null)
+                                return OriginalHook(VenomousBite);
 
-                            if (ActionReady(IronJaws) && poisonRecast(4) && windRecast(4))
-                            {
-                                openerFinished = true;
-                                return IronJaws;
-                            }
-                            if (!LevelChecked(IronJaws))
-                            {
-                                if (windbite && windRemaining < 4)
-                                {
-                                    openerFinished = true;
-                                    return Windbite;
-                                }
-
-                                if (venomous && venomRemaining < 4)
-                                {
-                                    openerFinished = true;
-                                    return VenomousBite;
-                                }
-                            }
                         }
                     }
+                    #endregion
 
-                    if (IsEnabled(CustomComboPreset.BRD_ST_ApexArrow))
+                    #region GCDS
+
+                    if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
+                        return OriginalHook(StraightShot);
+
+                    if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore) && HasEffect(Buffs.RadiantEncoreReady) && GetBuffRemainingTime(Buffs.RadiantFinale) < 15) // Delay Encore enough for buff window
+                        return OriginalHook(RadiantEncore);
+
+                    if (IsEnabled(CustomComboPreset.BRD_ST_ApexArrow)) // Apex Logic to time song in buff window and in mages. 
                     {
-                        if (LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady))
+                        if (HasEffect(Buffs.BlastArrowReady))
                             return BlastArrow;
 
                         if (LevelChecked(ApexArrow))
@@ -868,11 +856,9 @@ namespace WrathCombo.Combos.PvE
                         }
                     }
 
-                    if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
-                        return OriginalHook(StraightShot);
-
                     if (HasEffect(Buffs.ResonantArrowReady) && IsEnabled(CustomComboPreset.BRD_Adv_BuffsResonant))
                         return ResonantArrow;
+                    #endregion
 
                 }
 

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -433,7 +433,7 @@ namespace WrathCombo.Combos.PvE
                                     return WanderersMinuet;
                             }
                         }
-                        else if (songTimerInSeconds <= 3 && canWeave)
+                        else if (songTimerInSeconds <= 3 && canWeaveDelayed)
                         {
                             if (ActionReady(MagesBallad))
                                 return MagesBallad;
@@ -697,7 +697,7 @@ namespace WrathCombo.Combos.PvE
                             }
                         }
 
-                        else if (songTimerInSeconds <= 3 && canWeave) // Before you get Wanderers, it just toggles the two songs.
+                        else if (songTimerInSeconds <= 3 && canWeaveDelayed) // Before you get Wanderers, it just toggles the two songs.
                         {
                             if (ActionReady(MagesBallad))
                                 return MagesBallad;
@@ -983,7 +983,7 @@ namespace WrathCombo.Combos.PvE
                                     return WanderersMinuet;
                             }
                         }
-                        else if (songTimerInSeconds <= 3 && canWeave) // Not high enough for wanderers Minuet yet
+                        else if (songTimerInSeconds <= 3 && canWeaveDelayed) // Not high enough for wanderers Minuet yet
                         {
                             if (ActionReady(MagesBallad))
                                 return MagesBallad;
@@ -1212,7 +1212,7 @@ namespace WrathCombo.Combos.PvE
                                     return WanderersMinuet;
                             }
                         }
-                        else if (songTimerInSeconds <= 3 && canWeave)
+                        else if (songTimerInSeconds <= 3 && canWeaveDelayed)
                         {      
                             if (ActionReady(MagesBallad))
                                 return MagesBallad;

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -1,7 +1,6 @@
 using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Statuses;
-using Microsoft.VisualBasic.ApplicationServices;
 using System;
 using WrathCombo.Combos.PvE.Content;
 using WrathCombo.Core;

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -86,7 +86,7 @@ namespace WrathCombo.Combos.PvE
         internal static bool SongIsWandererMinuet(Song value) => value == Song.WANDERER;
         #endregion
 
-        // Replace HS/BS with SS/RA when procced, Apex feature added. 
+        #region Smaller features
         internal class BRD_StraightShotUpgrade : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_StraightShotUpgrade;
@@ -95,18 +95,8 @@ namespace WrathCombo.Combos.PvE
             {
                 if (actionID is HeavyShot or BurstShot)
                 {
-
                     if (IsEnabled(CustomComboPreset.BRD_DoTMaintainance))
                     {
-                        bool venomous = TargetHasEffect(Debuffs.VenomousBite);
-                        bool windbite = TargetHasEffect(Debuffs.Windbite);
-                        bool caustic = TargetHasEffect(Debuffs.CausticBite);
-                        bool stormbite = TargetHasEffect(Debuffs.Stormbite);
-                        float venomRemaining = GetDebuffRemainingTime(Debuffs.VenomousBite);
-                        float windRemaining = GetDebuffRemainingTime(Debuffs.Windbite);
-                        float causticRemaining = GetDebuffRemainingTime(Debuffs.CausticBite);
-                        float stormRemaining = GetDebuffRemainingTime(Debuffs.Stormbite);
-
                         if (InCombat())
                         {
                             bool canIronJaws = LevelChecked(IronJaws);
@@ -248,6 +238,117 @@ namespace WrathCombo.Combos.PvE
             }
         }
 
+        internal class BRD_ST_oGCD : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_ST_oGCD;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is Bloodletter or HeartbreakShot)
+                {
+                    BRDGauge? gauge = GetJobGauge<BRDGauge>();
+                    bool songArmy = gauge.Song == Song.ARMY;
+                    bool songWanderer = gauge.Song == Song.WANDERER;
+
+                    if (IsEnabled(CustomComboPreset.BRD_ST_oGCD_Songs) && (gauge.SongTimer < 1 || songArmy))
+                    {
+                        if (ActionReady(WanderersMinuet))
+                            return WanderersMinuet;
+                        if (ActionReady(MagesBallad))
+                            return MagesBallad;
+                        if (ActionReady(ArmysPaeon))
+                            return ArmysPaeon;
+                    }
+
+                    if (songWanderer && gauge.Repertoire == 3)
+                        return OriginalHook(PitchPerfect);
+                    if (ActionReady(EmpyrealArrow))
+                        return EmpyrealArrow;
+                    if (ActionReady(Sidewinder))
+                        return Sidewinder;
+                    if (ActionReady(Bloodletter))
+                        return OriginalHook(Bloodletter);
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class BRD_AoE_Combo : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_AoE_Combo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is QuickNock or Ladonsbite)
+                {
+                    if (IsEnabled(CustomComboPreset.BRD_Apex))
+                    {
+                        BRDGauge? gauge = GetJobGauge<BRDGauge>();
+
+                        if (gauge.SoulVoice == 100)
+                            return ApexArrow;
+                        if (HasEffect(Buffs.BlastArrowReady))
+                            return BlastArrow;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.BRD_AoE_Combo) && ActionReady(WideVolley) && HasEffect(Buffs.HawksEye))
+                        return OriginalHook(WideVolley);
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class BRD_Buffs : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_Buffs;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is Barrage)
+                {
+                    if (ActionReady(RagingStrikes))
+                        return RagingStrikes;
+                    if (ActionReady(BattleVoice))
+                        return BattleVoice;
+                    if (ActionReady(RadiantFinale))
+                        return RadiantFinale;
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class BRD_OneButtonSongs : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_OneButtonSongs;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is WanderersMinuet)
+                {
+                    // Doesn't display the lowest cooldown song if they have been used out of order and are all on cooldown.
+                    BRDGauge? gauge = GetJobGauge<BRDGauge>();
+                    int songTimerInSeconds = gauge.SongTimer / 1000;
+
+                    if (ActionReady(WanderersMinuet) || (gauge.Song == Song.WANDERER && songTimerInSeconds > 11))
+                        return WanderersMinuet;
+
+                    if (ActionReady(MagesBallad) || (gauge.Song == Song.MAGE && songTimerInSeconds > 2))
+                        return MagesBallad;
+
+                    if (ActionReady(ArmysPaeon) || (gauge.Song == Song.ARMY && songTimerInSeconds > 2))
+                        return ArmysPaeon;
+
+                }
+
+                return actionID;
+            }
+        }
+        #endregion
+
+        #region Advanced Modes
         internal class BRD_AoE_AdvMode : CustomCombo
         {
             internal static bool inOpener = false;
@@ -464,70 +565,6 @@ namespace WrathCombo.Combos.PvE
             }
         }
 
-        internal class BRD_ST_oGCD : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_ST_oGCD;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is Bloodletter or HeartbreakShot)
-                {
-                    BRDGauge? gauge = GetJobGauge<BRDGauge>();
-                    bool songArmy = gauge.Song == Song.ARMY;
-                    bool songWanderer = gauge.Song == Song.WANDERER;
-                    bool minuetReady = LevelChecked(WanderersMinuet) && IsOffCooldown(WanderersMinuet);
-                    bool balladReady = LevelChecked(MagesBallad) && IsOffCooldown(MagesBallad);
-                    bool paeonReady = LevelChecked(ArmysPaeon) && IsOffCooldown(ArmysPaeon);
-
-                    if (IsEnabled(CustomComboPreset.BRD_ST_oGCD_Songs) && (gauge.SongTimer < 1 || songArmy))
-                    {
-                        if (ActionReady(WanderersMinuet))
-                            return WanderersMinuet;
-                        if (ActionReady(MagesBallad))
-                            return MagesBallad;
-                        if (ActionReady(ArmysPaeon))
-                            return ArmysPaeon;
-                    }
-
-                    if (songWanderer && gauge.Repertoire == 3)
-                        return OriginalHook(PitchPerfect);
-                    if (ActionReady(EmpyrealArrow))
-                        return EmpyrealArrow;
-                    if (ActionReady(Sidewinder))
-                        return Sidewinder;
-                    if (ActionReady(Bloodletter))
-                        return OriginalHook(Bloodletter);
-
-                }
-
-                return actionID;
-            }
-        }
-        internal class BRD_AoE_Combo : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_AoE_Combo;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is QuickNock or Ladonsbite)
-                {
-                    if (IsEnabled(CustomComboPreset.BRD_Apex))
-                    {
-                        BRDGauge? gauge = GetJobGauge<BRDGauge>();
-                        
-                        if (gauge.SoulVoice == 100)
-                            return ApexArrow;
-                        if (HasEffect(Buffs.BlastArrowReady))
-                            return BlastArrow;
-                    }
-
-                    if (IsEnabled(CustomComboPreset.BRD_AoE_Combo) && ActionReady(WideVolley) && HasEffect(Buffs.HawksEye))
-                    return OriginalHook(WideVolley);
-                }
-
-                return actionID;
-            }
-        }
         internal class BRD_ST_AdvMode : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_ST_AdvMode;
@@ -842,49 +879,9 @@ namespace WrathCombo.Combos.PvE
                 return actionID;
             }
         }
-        internal class BRD_Buffs : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_Buffs;
+        #endregion
 
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is Barrage)
-                {
-                    if (ActionReady(RagingStrikes))
-                        return RagingStrikes;
-                    if (ActionReady(BattleVoice))
-                        return BattleVoice;
-                }
-
-                return actionID;
-            }
-        }
-        internal class BRD_OneButtonSongs : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_OneButtonSongs;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is WanderersMinuet)
-                {
-                    // Doesn't display the lowest cooldown song if they have been used out of order and are all on cooldown.
-                    BRDGauge? gauge = GetJobGauge<BRDGauge>();
-                    int songTimerInSeconds = gauge.SongTimer / 1000;
-
-                    if (ActionReady(WanderersMinuet) || (gauge.Song == Song.WANDERER && songTimerInSeconds > 11))
-                        return WanderersMinuet;
-
-                    if (ActionReady(MagesBallad) || (gauge.Song == Song.MAGE && songTimerInSeconds > 2))
-                        return MagesBallad;
-
-                    if (ActionReady(ArmysPaeon) || (gauge.Song == Song.ARMY && songTimerInSeconds > 2))
-                        return ArmysPaeon;
-
-                }
-
-                return actionID;
-            }
-        }
+        #region Simple Modes
         internal class BRD_AoE_SimpleMode : CustomCombo
         {
             internal static bool inOpener = false;
@@ -907,7 +904,7 @@ namespace WrathCombo.Combos.PvE
                     bool songArmy = gauge.Song == Song.ARMY;
                     bool canInterrupt = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze);
                     int targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_AoENoWasteHPPercentage);
-                    bool isEnemyHealthHigh = GetTargetHPPercent() > 1;
+                    bool isEnemyHealthHigh = GetTargetHPPercent() > 5;
 
                     if (IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= 50)
                         return Variant.VariantCure;
@@ -1315,7 +1312,7 @@ namespace WrathCombo.Combos.PvE
                         float stormRemaining = GetDebuffRemainingTime(Debuffs.Stormbite);
                         float ragingStrikesDuration = GetBuffRemainingTime(Buffs.RagingStrikes);
                         float radiantFinaleDuration = GetBuffRemainingTime(Buffs.RadiantFinale);
-                        int ragingJawsRenewTime = 5;
+                        int ragingJawsRenewTime = 6;
 
                         DotRecast poisonRecast = delegate (int duration)
                         {
@@ -1390,5 +1387,6 @@ namespace WrathCombo.Combos.PvE
                 return actionID;
             }
         }
+        #endregion
     }
 }


### PR DESCRIPTION
TLDR. Basically a full and final cleaning of bards spaghetti. Inspired by zbees dancer code, set up regions and comments on sections so anyone can quickly read and troubleshoot issues in bard code. Lastly implemented Gakais dot management code across all features that need it as it cuts the section in half. 

Fixed: Added delayed weave to low lvl song toggle to keep it from doubleweaving them together due to speed on autorotation. 


Combo Preset Cleanup and Option ordering, Feature cleanup and organization.
- [x] Added Advanced slider information to simple description
- [x] Added job ID numbers to organize options in the settings, it was getting a bit unruly
- [x] Removed commented out settings leftover from sloth
- [x] Removed unused bools from heavy to straight-shot feature. 
- [x] Set up regions to separate bard code into smaller features, advanced mode, simple mode
- [x] Moves st ogcd, bardbuffs, and bard aoecombo exactly as written up into the smaller features section
- [x] Changed the raging jaws refresh on simple st mode from 5 to 6 to be safe, its what Ive been using on advanced
- [x] Changed the nowaste on simple aoe to 5%, it always shoudl have been higher than 1. 

Simple and Advanced Cleanup
- [x] Added Regions to match dancer code organization. ST and AOE
- [x] Removed needless Bools when a single action ready would suffice.  ST and AOE
- [x] Left notes to make the code easy to understand at a glance.  ST and AOE
- [x] Employed Gakai's Dot Management slimming it down significantly. ST
- [x] Slimmed Barrage logic, doesn't need to check all buffs when raging goes last anyway.  ST and AOE
- [x] Moved Hawks eye logic above the other gcds with more time to fire them off. Hopefully fewer overwrites.  ST and AOE
- [x] Put Interrupt in the middle of ogcd delayed weave to not block dps tools but still get a chance to happen.  ST and AOE
