### PR TITLE
[PvP] SAM Wrath Update

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5939,7 +5939,7 @@ namespace WrathCombo.Combos
 
         [PvPCustomCombo]
         [ParentCombo(SAMPvP_Burst)]
-        [CustomComboInfo("Meikyo Shisui Option", "Uses Meikyo Shisui when available.\n- Will not use while moving.\n- Requires target to be in melee range.", SAMPvP.JobID)]
+        [CustomComboInfo("Meikyo Shisui Option", "Uses Meikyo Shisui when available.\n- Requires target to be in melee range.", SAMPvP.JobID)]
         SAMPvP_Meikyo = 125001,
 
         [PvPCustomCombo]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5932,48 +5932,37 @@ namespace WrathCombo.Combos
 
         #region SAMURAI
 
-        #region Burst Mode
         [PvPCustomCombo]
-        [CustomComboInfo("Burst Mode", "Adds Meikyo Shisui, Midare: Setsugekka, Ogi Namikiri, Kaeshi: Namikiri and Soten to Meikyo Shisui.\nWill only cast Midare: Setsugekka and Ogi Namikiri when you're not moving.\nWill not use if target is guarding.", SAM.JobID)]
-        SAMPvP_BurstMode = 125000,
-
-        [PvPCustomCombo]
-        [ParentCombo(SAMPvP_BurstMode)]
-        [CustomComboInfo("Chiten Option", "Adds Chiten to Burst Mode when in combat and HP is below 95%.", SAM.JobID)]
-        SAMPvP_BurstMode_Chiten = 125001,
+        [ReplaceSkill(SAMPvP.Yukikaze)]
+        [CustomComboInfo("Burst Mode", "Turns Kasha Combo into an all-in-one button.\n- Actions with cast will not be used while moving.", SAMPvP.JobID)]
+        SAMPvP_Burst = 125000,
 
         [PvPCustomCombo]
-        [ParentCombo(SAMPvP_BurstMode)]
-        [CustomComboInfo("Mineuchi Option", "Adds Mineuchi to Burst Mode.", SAM.JobID)]
-        SAMPvP_BurstMode_Stun = 125002,
+        [ParentCombo(SAMPvP_Burst)]
+        [CustomComboInfo("Meikyo Shisui Option", "Uses Meikyo Shisui when available.\n- Will not interrupt Kaeshi: Namikiri.\n- Requires target to be in melee range.", SAMPvP.JobID)]
+        SAMPvP_Meikyo = 125001,
 
         [PvPCustomCombo]
-        [ParentCombo(SAMPvP_BurstMode)]
-        [CustomComboInfo("Burst Mode on Kasha Combo Option", "Adds Burst Mode to Kasha Combo instead.", SAM.JobID, 1)]
-        SAMPvP_BurstMode_MainCombo = 125003,
-
-        [ParentCombo(SAMPvP_BurstMode)]
-        [CustomComboInfo("Zanshin Option", "Adds Zanshin to Burst Mode.", SAM.JobID)]
-        SAMPvP_BurstMode_Zanshin = 125007,
-        #endregion
-
-        #region Kasha Features
-        [PvPCustomCombo]
-        [CustomComboInfo("Kasha Combo Features", "Collection of Features for Kasha Combo.", SAM.JobID)]
-        SAMPvP_KashaFeatures = 125004,
+        [ParentCombo(SAMPvP_Burst)]
+        [CustomComboInfo("Chiten Option", "Uses Chiten when available.\n- Will not use outside combat.\n- Requires player's HP to be under:", SAMPvP.JobID)]
+        SAMPvP_Chiten = 125002,
 
         [PvPCustomCombo]
-        [ParentCombo(SAMPvP_KashaFeatures)]
-        [CustomComboInfo("Soten Gap Closer Option", "Adds Soten to the Kasha Combo when out of melee range.", SAM.JobID)]
-        SAMPvP_KashaFeatures_GapCloser = 125005,
+        [ParentCombo(SAMPvP_Burst)]
+        [CustomComboInfo("Mineuchi Option", "Uses Mineuchi when available.\n- Will not use against non-players.\n- Requires target's HP to be under:", SAMPvP.JobID)]
+        SAMPvP_Mineuchi = 125003,
 
         [PvPCustomCombo]
-        [ParentCombo(SAMPvP_KashaFeatures)]
-        [CustomComboInfo("AoE Melee Protection Option", "Makes the AoE combos unusable if not in melee range of target.", SAM.JobID)]
-        SAMPvP_KashaFeatures_AoEMeleeProtection = 125006,
-        #endregion
+        [ParentCombo(SAMPvP_Burst)]
+        [CustomComboInfo("Soten Option", "Uses Soten when available.\n- Must remain within maximum range.\n- Will not use if already under Kaiten's effect.", SAMPvP.JobID)]
+        SAMPvP_Soten = 125004,
 
-        // Last value = 125007
+        [PvPCustomCombo]
+        [ParentCombo(SAMPvP_Burst)]
+        [CustomComboInfo("Zantetsuken Option", "Uses Zantetsuken when available.\n- Will not use if target is invulnerable.\n- Requires target to have player's Kuzushi.", SAMPvP.JobID)]
+        SAMPvP_Zantetsuken = 125005,
+
+        // Last value = 125005
 
         #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5934,12 +5934,12 @@ namespace WrathCombo.Combos
 
         [PvPCustomCombo]
         [ReplaceSkill(SAMPvP.Yukikaze)]
-        [CustomComboInfo("Burst Mode", "Turns Kasha Combo into an all-in-one button.\n- Actions with cast will not be used while moving.", SAMPvP.JobID)]
+        [CustomComboInfo("Burst Mode", "Turns Kasha Combo into an all-in-one button.\n- Will not use actions with cast time while moving.", SAMPvP.JobID)]
         SAMPvP_Burst = 125000,
 
         [PvPCustomCombo]
         [ParentCombo(SAMPvP_Burst)]
-        [CustomComboInfo("Meikyo Shisui Option", "Uses Meikyo Shisui when available.\n- Will not interrupt Kaeshi: Namikiri.\n- Requires target to be in melee range.", SAMPvP.JobID)]
+        [CustomComboInfo("Meikyo Shisui Option", "Uses Meikyo Shisui when available.\n- Will not use while moving.\n- Requires target to be in melee range.", SAMPvP.JobID)]
         SAMPvP_Meikyo = 125001,
 
         [PvPCustomCombo]

--- a/WrathCombo/Combos/PvE/SAM/SAM_Config.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM_Config.cs
@@ -1,3 +1,4 @@
+using Dalamud.Interface.Colors;
 using WrathCombo.Combos.PvP;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Window.Functions;
@@ -77,19 +78,6 @@ internal partial class SAM
 
                     break;
 
-                //PvP
-                case CustomComboPreset.SAMPvP_BurstMode:
-                    UserConfig.DrawSliderInt(0, 2, SAMPvP.Config.SAMPvP_SotenCharges,
-                        "How many charges of Soten to keep ready? (0 = Use All).");
-
-                    break;
-
-                case CustomComboPreset.SAMPvP_KashaFeatures_GapCloser:
-                    UserConfig.DrawSliderInt(0, 100, SAMPvP.Config.SAMPvP_SotenHP,
-                        "Use Soten on enemies below selected HP.");
-
-                    break;
-
                 case CustomComboPreset.SAM_ST_KashaCombo:
                 {
                     UserConfig.DrawAdditionalBoolChoice(SAM_Kasha_KenkiOvercap, "Kenki Overcap Protection",
@@ -149,6 +137,29 @@ internal partial class SAM
 
                     break;
                 }
+
+                // PvP
+
+                // Chiten
+                case CustomComboPreset.SAMPvP_Chiten:
+                    UserConfig.DrawSliderInt(10, 100, SAMPvP.Config.SAMPvP_Chiten_PlayerHP, "Player HP%", 210);
+
+                    break;
+
+                // Mineuchi
+                case CustomComboPreset.SAMPvP_Mineuchi:
+                    UserConfig.DrawSliderInt(10, 100, SAMPvP.Config.SAMPvP_Mineuchi_TargetHP, "Target HP%", 210);
+                    UserConfig.DrawAdditionalBoolChoice(SAMPvP.Config.SAMPvP_Mineuchi_SubOption, "Burst Preparation", "- Also uses Mineuchi before Tendo Setsugekka.");
+
+                    break;
+
+                // Soten
+                case CustomComboPreset.SAMPvP_Soten:
+                    UserConfig.DrawSliderInt(0, 2, SAMPvP.Config.SAMPvP_Soten_Charges, "Charges to Keep", 178);
+                    UserConfig.DrawSliderInt(6, 10, SAMPvP.Config.SAMPvP_Soten_Range, "Maximum Range", 173);
+                    UserConfig.DrawAdditionalBoolChoice(SAMPvP.Config.SAMPvP_Soten_SubOption, "Yukikaze Only", "- Also requires next weaponskill to be Yukikaze.");
+
+                    break;
             }
         }
     }

--- a/WrathCombo/Combos/PvE/SAM/SAM_Config.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM_Config.cs
@@ -1,4 +1,3 @@
-using Dalamud.Interface.Colors;
 using WrathCombo.Combos.PvP;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Window.Functions;
@@ -149,7 +148,7 @@ internal partial class SAM
                 // Mineuchi
                 case CustomComboPreset.SAMPvP_Mineuchi:
                     UserConfig.DrawSliderInt(10, 100, SAMPvP.Config.SAMPvP_Mineuchi_TargetHP, "Target HP%", 210);
-                    UserConfig.DrawAdditionalBoolChoice(SAMPvP.Config.SAMPvP_Mineuchi_SubOption, "Burst Preparation", "- Also uses Mineuchi before Tendo Setsugekka.");
+                    UserConfig.DrawAdditionalBoolChoice(SAMPvP.Config.SAMPvP_Mineuchi_SubOption, "Burst Preparation", "Also uses Mineuchi before Tendo Setsugekka.");
 
                     break;
 
@@ -157,7 +156,7 @@ internal partial class SAM
                 case CustomComboPreset.SAMPvP_Soten:
                     UserConfig.DrawSliderInt(0, 2, SAMPvP.Config.SAMPvP_Soten_Charges, "Charges to Keep", 178);
                     UserConfig.DrawSliderInt(6, 10, SAMPvP.Config.SAMPvP_Soten_Range, "Maximum Range", 173);
-                    UserConfig.DrawAdditionalBoolChoice(SAMPvP.Config.SAMPvP_Soten_SubOption, "Yukikaze Only", "- Also requires next weaponskill to be Yukikaze.");
+                    UserConfig.DrawAdditionalBoolChoice(SAMPvP.Config.SAMPvP_Soten_SubOption, "Yukikaze Only", "Also requires next weaponskill to be Yukikaze.");
 
                     break;
             }

--- a/WrathCombo/Combos/PvE/SAM/SAM_Config.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM_Config.cs
@@ -155,7 +155,7 @@ internal partial class SAM
                 // Soten
                 case CustomComboPreset.SAMPvP_Soten:
                     UserConfig.DrawSliderInt(0, 2, SAMPvP.Config.SAMPvP_Soten_Charges, "Charges to Keep", 178);
-                    UserConfig.DrawSliderInt(6, 10, SAMPvP.Config.SAMPvP_Soten_Range, "Maximum Range", 173);
+                    UserConfig.DrawSliderInt(1, 10, SAMPvP.Config.SAMPvP_Soten_Range, "Maximum Range", 173);
                     UserConfig.DrawAdditionalBoolChoice(SAMPvP.Config.SAMPvP_Soten_SubOption, "Yukikaze Only", "Also requires next weaponskill to be Yukikaze.");
 
                     break;

--- a/WrathCombo/Combos/PvP/SAMPVP.cs
+++ b/WrathCombo/Combos/PvP/SAMPVP.cs
@@ -70,6 +70,7 @@ namespace WrathCombo.Combos.PvP
                 bool isMoving = IsMoving;
                 bool inCombat = InCombat();
                 bool hasTarget = HasTarget();
+                bool inMeleeRange = targetDistance <= 5;
                 bool hasKaiten = HasEffect(Buffs.Kaiten);
                 bool hasZanshin = OriginalHook(Chiten) is Zanshin;
                 bool hasBind = HasEffectAny(PvPCommon.Debuffs.Bind);
@@ -110,14 +111,17 @@ namespace WrathCombo.Combos.PvP
                             (!Config.SAMPvP_Soten_SubOption || (Config.SAMPvP_Soten_SubOption && isYukikazePrimed)))
                             return OriginalHook(Soten);
 
-                        // Meikyo Shisui
-                        if (IsEnabled(CustomComboPreset.SAMPvP_Meikyo) && IsOffCooldown(MeikyoShisui) && !hasKaeshiNamikiri && targetDistance <= 6)
-                            return OriginalHook(MeikyoShisui);
+                        if (inMeleeRange)
+                        {
+                            // Meikyo Shisui
+                            if (IsEnabled(CustomComboPreset.SAMPvP_Meikyo) && IsOffCooldown(MeikyoShisui) && !hasKaeshiNamikiri)
+                                return OriginalHook(MeikyoShisui);
 
-                        // Mineuchi
-                        if (IsEnabled(CustomComboPreset.SAMPvP_Mineuchi) && isMineuchiPrimed &&
-                            (targetCurrentPercentHp < Config.SAMPvP_Mineuchi_TargetHP || (Config.SAMPvP_Mineuchi_SubOption && hasTendo)))
-                            return OriginalHook(Mineuchi);
+                            // Mineuchi
+                            if (IsEnabled(CustomComboPreset.SAMPvP_Mineuchi) && isMineuchiPrimed &&
+                                (targetCurrentPercentHp < Config.SAMPvP_Mineuchi_TargetHP || (Config.SAMPvP_Mineuchi_SubOption && hasTendo)))
+                                return OriginalHook(Mineuchi);
+                        }
                     }
 
                     // Tendo Kaeshi Setsugekka

--- a/WrathCombo/Combos/PvP/SAMPVP.cs
+++ b/WrathCombo/Combos/PvP/SAMPVP.cs
@@ -80,14 +80,14 @@ namespace WrathCombo.Combos.PvP
                 bool hasKaeshiNamikiri = OriginalHook(OgiNamikiri) is Kaeshi;
                 bool hasTendo = OriginalHook(MeikyoShisui) is TendoSetsugekka;
                 bool isYukikazePrimed = ComboTimer == 0 || lastComboMove is Kasha;
+                bool isMeikyoPrimed = !hasKaeshiNamikiri && !hasKaiten && !isMoving;
                 bool hasTendoKaeshi = OriginalHook(MeikyoShisui) is TendoKaeshiSetsugekka;
                 bool hasPrioWeaponskill = hasTendo || hasTendoKaeshi || hasKaeshiNamikiri;
-                bool isMineuchiPrimed = IsOffCooldown(Mineuchi) && !HasBattleTarget() && !targetHasImmunity;
                 bool isZanshinExpiring = HasEffect(Buffs.ZanshinReady) && GetBuffRemainingTime(Buffs.ZanshinReady) <= 3;
                 bool isZantetsukenPrimed = IsLB1Ready && !hasBind && hasTarget && targetHasKuzushi && targetDistance <= 20;
+                bool isSotenPrimed = chargesSoten > Config.SAMPvP_Soten_Charges && !hasKaiten && !hasBind && !hasPrioWeaponskill;
                 bool isTendoExpiring = HasEffect(Buffs.TendoSetsugekkaReady) && GetBuffRemainingTime(Buffs.TendoSetsugekkaReady) <= 3;
-                bool isTargetInvincible = HasEffectAny(PLDPvP.Buffs.HallowedGround) || TargetHasEffectAny(DRKPvP.Buffs.UndeadRedemption);
-                bool isSotenPrimed = chargesSoten > Config.SAMPvP_Soten_Charges && !hasBind && !targetHasImmunity && !hasPrioWeaponskill;
+                bool isTargetInvincible = TargetHasEffectAny(PLDPvP.Buffs.HallowedGround) || TargetHasEffectAny(DRKPvP.Buffs.UndeadRedemption);
                 #endregion
 
                 if (actionID is Yukikaze or Gekko or Kasha)
@@ -104,22 +104,22 @@ namespace WrathCombo.Combos.PvP
                     if (hasZanshin && ((isTargetPrimed && targetDistance <= 8) || isZanshinExpiring))
                         return OriginalHook(Chiten);
 
-                    if (hasTarget && !hasKaiten)
+                    if (hasTarget && !targetHasImmunity)
                     {
                         // Soten
-                        if (IsEnabled(CustomComboPreset.SAMPvP_Soten) && targetDistance <= Config.SAMPvP_Soten_Range && isSotenPrimed &&
+                        if (IsEnabled(CustomComboPreset.SAMPvP_Soten) && isSotenPrimed && targetDistance <= Config.SAMPvP_Soten_Range &&
                             (!Config.SAMPvP_Soten_SubOption || (Config.SAMPvP_Soten_SubOption && isYukikazePrimed)))
                             return OriginalHook(Soten);
 
                         if (inMeleeRange)
                         {
                             // Meikyo Shisui
-                            if (IsEnabled(CustomComboPreset.SAMPvP_Meikyo) && IsOffCooldown(MeikyoShisui) && !hasKaeshiNamikiri && !isMoving)
+                            if (IsEnabled(CustomComboPreset.SAMPvP_Meikyo) && IsOffCooldown(MeikyoShisui) && isMeikyoPrimed)
                                 return OriginalHook(MeikyoShisui);
 
                             // Mineuchi
-                            if (IsEnabled(CustomComboPreset.SAMPvP_Mineuchi) && isMineuchiPrimed &&
-                                (targetCurrentPercentHp < Config.SAMPvP_Mineuchi_TargetHP || (Config.SAMPvP_Mineuchi_SubOption && hasTendo)))
+                            if (IsEnabled(CustomComboPreset.SAMPvP_Mineuchi) && IsOffCooldown(Mineuchi) && !HasBattleTarget() &&
+                                (targetCurrentPercentHp < Config.SAMPvP_Mineuchi_TargetHP || (Config.SAMPvP_Mineuchi_SubOption && hasTendo && !hasKaiten)))
                                 return OriginalHook(Mineuchi);
                         }
                     }
@@ -133,7 +133,7 @@ namespace WrathCombo.Combos.PvP
                         return OriginalHook(OgiNamikiri);
 
                     // Kaiten
-                    if (hasKaiten && !isTendoExpiring)
+                    if (hasKaiten && (!isTendoExpiring || isMoving))
                         return OriginalHook(actionID);
 
                     if (!isMoving)

--- a/WrathCombo/Combos/PvP/SAMPVP.cs
+++ b/WrathCombo/Combos/PvP/SAMPVP.cs
@@ -46,10 +46,10 @@ namespace WrathCombo.Combos.PvP
         public static class Config
         {
             public static UserInt
-                SAMPvP_Soten_Range = new("SAMPvP_Soten_Range", 1),
+                SAMPvP_Soten_Range = new("SAMPvP_Soten_Range", 3),
                 SAMPvP_Soten_Charges = new("SAMPvP_Soten_Charges", 1),
                 SAMPvP_Chiten_PlayerHP = new("SAMPvP_Chiten_PlayerHP", 70),
-                SAMPvP_Mineuchi_TargetHP = new("SAMPvP_Mineuchi_TargetHP", 70);
+                SAMPvP_Mineuchi_TargetHP = new("SAMPvP_Mineuchi_TargetHP", 40);
 
             public static UserBool
                 SAMPvP_Soten_SubOption = new("SAMPvP_Soten_SubOption"),
@@ -87,7 +87,7 @@ namespace WrathCombo.Combos.PvP
                 bool isZantetsukenPrimed = IsLB1Ready && !hasBind && hasTarget && targetHasKuzushi && targetDistance <= 20;
                 bool isTendoExpiring = HasEffect(Buffs.TendoSetsugekkaReady) && GetBuffRemainingTime(Buffs.TendoSetsugekkaReady) <= 3;
                 bool isTargetInvincible = HasEffectAny(PLDPvP.Buffs.HallowedGround) || TargetHasEffectAny(DRKPvP.Buffs.UndeadRedemption);
-                bool isSotenPrimed = chargesSoten > Config.SAMPvP_Soten_Charges && targetDistance <= Config.SAMPvP_Soten_Range && !hasBind && !targetHasImmunity && !hasPrioWeaponskill;
+                bool isSotenPrimed = chargesSoten > Config.SAMPvP_Soten_Charges && !hasBind && !targetHasImmunity && !hasPrioWeaponskill;
                 #endregion
 
                 if (actionID is Yukikaze or Gekko or Kasha)
@@ -107,14 +107,14 @@ namespace WrathCombo.Combos.PvP
                     if (hasTarget && !hasKaiten)
                     {
                         // Soten
-                        if (IsEnabled(CustomComboPreset.SAMPvP_Soten) && isSotenPrimed &&
+                        if (IsEnabled(CustomComboPreset.SAMPvP_Soten) && targetDistance <= Config.SAMPvP_Soten_Range && isSotenPrimed &&
                             (!Config.SAMPvP_Soten_SubOption || (Config.SAMPvP_Soten_SubOption && isYukikazePrimed)))
                             return OriginalHook(Soten);
 
                         if (inMeleeRange)
                         {
                             // Meikyo Shisui
-                            if (IsEnabled(CustomComboPreset.SAMPvP_Meikyo) && IsOffCooldown(MeikyoShisui) && !hasKaeshiNamikiri)
+                            if (IsEnabled(CustomComboPreset.SAMPvP_Meikyo) && IsOffCooldown(MeikyoShisui) && !hasKaeshiNamikiri && !isMoving)
                                 return OriginalHook(MeikyoShisui);
 
                             // Mineuchi
@@ -133,7 +133,7 @@ namespace WrathCombo.Combos.PvP
                         return OriginalHook(OgiNamikiri);
 
                     // Kaiten
-                    if (hasKaiten)
+                    if (hasKaiten && !isTendoExpiring)
                         return OriginalHook(actionID);
 
                     if (!isMoving)

--- a/WrathCombo/Combos/PvP/SAMPVP.cs
+++ b/WrathCombo/Combos/PvP/SAMPVP.cs
@@ -82,9 +82,9 @@ namespace WrathCombo.Combos.PvP
                 bool isYukikazePrimed = ComboTimer == 0 || lastComboMove is Kasha;
                 bool hasTendoKaeshi = OriginalHook(MeikyoShisui) is TendoKaeshiSetsugekka;
                 bool hasPrioWeaponskill = hasTendo || hasTendoKaeshi || hasKaeshiNamikiri;
-                bool isZantetsukenPrimed = IsLB1Ready && !hasBind && hasTarget && targetHasKuzushi;
                 bool isMineuchiPrimed = IsOffCooldown(Mineuchi) && !HasBattleTarget() && !targetHasImmunity;
                 bool isZanshinExpiring = HasEffect(Buffs.ZanshinReady) && GetBuffRemainingTime(Buffs.ZanshinReady) <= 3;
+                bool isZantetsukenPrimed = IsLB1Ready && !hasBind && hasTarget && targetHasKuzushi && targetDistance <= 20;
                 bool isTendoExpiring = HasEffect(Buffs.TendoSetsugekkaReady) && GetBuffRemainingTime(Buffs.TendoSetsugekkaReady) <= 3;
                 bool isTargetInvincible = HasEffectAny(PLDPvP.Buffs.HallowedGround) || TargetHasEffectAny(DRKPvP.Buffs.UndeadRedemption);
                 bool isSotenPrimed = chargesSoten > Config.SAMPvP_Soten_Charges && targetDistance <= Config.SAMPvP_Soten_Range && !hasBind && !targetHasImmunity && !hasPrioWeaponskill;

--- a/WrathCombo/Combos/PvP/SAMPVP.cs
+++ b/WrathCombo/Combos/PvP/SAMPVP.cs
@@ -83,10 +83,8 @@ namespace WrathCombo.Combos.PvP
                 bool isMeikyoPrimed = !hasKaeshiNamikiri && !hasKaiten && !isMoving;
                 bool hasTendoKaeshi = OriginalHook(MeikyoShisui) is TendoKaeshiSetsugekka;
                 bool hasPrioWeaponskill = hasTendo || hasTendoKaeshi || hasKaeshiNamikiri;
-                bool isZanshinExpiring = HasEffect(Buffs.ZanshinReady) && GetBuffRemainingTime(Buffs.ZanshinReady) <= 3;
                 bool isZantetsukenPrimed = IsLB1Ready && !hasBind && hasTarget && targetHasKuzushi && targetDistance <= 20;
                 bool isSotenPrimed = chargesSoten > Config.SAMPvP_Soten_Charges && !hasKaiten && !hasBind && !hasPrioWeaponskill;
-                bool isTendoExpiring = HasEffect(Buffs.TendoSetsugekkaReady) && GetBuffRemainingTime(Buffs.TendoSetsugekkaReady) <= 3;
                 bool isTargetInvincible = TargetHasEffectAny(PLDPvP.Buffs.HallowedGround) || TargetHasEffectAny(DRKPvP.Buffs.UndeadRedemption);
                 #endregion
 
@@ -100,12 +98,12 @@ namespace WrathCombo.Combos.PvP
                     if (IsEnabled(CustomComboPreset.SAMPvP_Chiten) && IsOffCooldown(Chiten) && inCombat && playerCurrentPercentHp < Config.SAMPvP_Chiten_PlayerHP)
                         return OriginalHook(Chiten);
 
-                    // Zanshin
-                    if (hasZanshin && ((isTargetPrimed && targetDistance <= 8) || isZanshinExpiring))
-                        return OriginalHook(Chiten);
-
-                    if (hasTarget && !targetHasImmunity)
+                    if (isTargetPrimed)
                     {
+                        // Zanshin
+                        if (hasZanshin && targetDistance <= 8)
+                            return OriginalHook(Chiten);
+
                         // Soten
                         if (IsEnabled(CustomComboPreset.SAMPvP_Soten) && isSotenPrimed && targetDistance <= Config.SAMPvP_Soten_Range &&
                             (!Config.SAMPvP_Soten_SubOption || (Config.SAMPvP_Soten_SubOption && isYukikazePrimed)))
@@ -133,17 +131,17 @@ namespace WrathCombo.Combos.PvP
                         return OriginalHook(OgiNamikiri);
 
                     // Kaiten
-                    if (hasKaiten && (!isTendoExpiring || isMoving))
+                    if (hasKaiten)
                         return OriginalHook(actionID);
 
-                    if (!isMoving)
+                    if (!isMoving && isTargetPrimed)
                     {
                         // Tendo Setsugekka
-                        if (hasTendo && (isTargetPrimed || isTendoExpiring))
+                        if (hasTendo)
                             return OriginalHook(MeikyoShisui);
 
                         // Ogi Namikiri
-                        if (IsOffCooldown(OgiNamikiri) && isTargetPrimed)
+                        if (IsOffCooldown(OgiNamikiri))
                             return OriginalHook(OgiNamikiri);
                     }
                 }

--- a/WrathCombo/Combos/PvP/SAMPVP.cs
+++ b/WrathCombo/Combos/PvP/SAMPVP.cs
@@ -1,6 +1,4 @@
-﻿using WrathCombo.Combos.PvE;
-using WrathCombo.Core;
-using WrathCombo.CustomComboNS;
+﻿using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 
 namespace WrathCombo.Combos.PvP

--- a/WrathCombo/Combos/PvP/SAMPVP.cs
+++ b/WrathCombo/Combos/PvP/SAMPVP.cs
@@ -1,6 +1,7 @@
 ﻿using WrathCombo.Combos.PvE;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
+using WrathCombo.CustomComboNS.Functions;
 
 namespace WrathCombo.Combos.PvP
 {
@@ -9,7 +10,7 @@ namespace WrathCombo.Combos.PvP
         public const byte JobID = 34;
 
         public const uint
-            KashakCombo = 58,
+            KashaCombo = 58,
             Yukikaze = 29523,
             Gekko = 29524,
             Kasha = 29525,
@@ -25,15 +26,17 @@ namespace WrathCombo.Combos.PvP
             Kaeshi = 29531,
             Zantetsuken = 29537,
             TendoSetsugekka = 41454,
-            TendoKaeshiSetsugekka = 41455;
+            TendoKaeshiSetsugekka = 41455,
+            Zanshin = 41577;
 
         public static class Buffs
         {
             public const ushort
+                Chiten = 1240,
+                ZanshinReady = 1318,
+                MeikyoShisui = 1320,
                 Kaiten = 3201,
-                Midare = 3203,
-                TendoSetsugekkaReady = 3203,
-                ZanshinReady = 1318;
+                TendoSetsugekkaReady = 3203;
         }
 
         public static class Debuffs
@@ -44,75 +47,102 @@ namespace WrathCombo.Combos.PvP
 
         public static class Config
         {
-            public const string
-                SAMPvP_SotenCharges = "SamSotenCharges",
-                SAMPvP_SotenHP = "SamSotenHP";
+            public static UserInt
+                SAMPvP_Soten_Range = new("SAMPvP_Soten_Range", 1),
+                SAMPvP_Soten_Charges = new("SAMPvP_Soten_Charges", 1),
+                SAMPvP_Chiten_PlayerHP = new("SAMPvP_Chiten_PlayerHP", 70),
+                SAMPvP_Mineuchi_TargetHP = new("SAMPvP_Mineuchi_TargetHP", 70);
 
+            public static UserBool
+                SAMPvP_Soten_SubOption = new("SAMPvP_Soten_SubOption"),
+                SAMPvP_Mineuchi_SubOption = new("SAMPvP_Mineuchi_SubOption");
         }
 
         internal class SAMPvP_BurstMode : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SAMPvP_BurstMode;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SAMPvP_Burst;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var sotenCharges = PluginConfiguration.GetCustomIntValue(Config.SAMPvP_SotenCharges);
+                #region Variables
+                float targetDistance = GetTargetDistance();
+                float targetCurrentPercentHp = GetTargetHPPercent();
+                float playerCurrentPercentHp = PlayerHealthPercentageHp();
+                uint chargesSoten = HasCharges(Soten) ? GetCooldown(Soten).RemainingCharges : 0;
+                bool isMoving = IsMoving;
+                bool inCombat = InCombat();
+                bool hasTarget = HasTarget();
+                bool hasKaiten = HasEffect(Buffs.Kaiten);
+                bool hasZanshin = OriginalHook(Chiten) is Zanshin;
+                bool hasBind = HasEffectAny(PvPCommon.Debuffs.Bind);
+                bool targetHasImmunity = PvPCommon.IsImmuneToDamage();
+                bool isTargetPrimed = hasTarget && !targetHasImmunity;
+                bool targetHasKuzushi = TargetHasEffect(Debuffs.Kuzushi);
+                bool hasKaeshiNamikiri = OriginalHook(OgiNamikiri) is Kaeshi;
+                bool hasTendo = OriginalHook(MeikyoShisui) is TendoSetsugekka;
+                bool isYukikazePrimed = ComboTimer == 0 || lastComboMove is Kasha;
+                bool hasTendoKaeshi = OriginalHook(MeikyoShisui) is TendoKaeshiSetsugekka;
+                bool hasPrioWeaponskill = hasTendo || hasTendoKaeshi || hasKaeshiNamikiri;
+                bool isZantetsukenPrimed = IsLB1Ready && !hasBind && hasTarget && targetHasKuzushi;
+                bool isMineuchiPrimed = IsOffCooldown(Mineuchi) && !HasBattleTarget() && !targetHasImmunity;
+                bool isZanshinExpiring = HasEffect(Buffs.ZanshinReady) && GetBuffRemainingTime(Buffs.ZanshinReady) <= 3;
+                bool isTendoExpiring = HasEffect(Buffs.TendoSetsugekkaReady) && GetBuffRemainingTime(Buffs.TendoSetsugekkaReady) <= 3;
+                bool isTargetInvincible = HasEffectAny(PLDPvP.Buffs.HallowedGround) || TargetHasEffectAny(DRKPvP.Buffs.UndeadRedemption);
+                bool isSotenPrimed = chargesSoten > Config.SAMPvP_Soten_Charges && targetDistance <= Config.SAMPvP_Soten_Range && !hasBind && !targetHasImmunity && !hasPrioWeaponskill;
+                #endregion
 
-                if ((IsNotEnabled(CustomComboPreset.SAMPvP_BurstMode_MainCombo) && actionID == MeikyoShisui) ||
-                    (IsEnabled(CustomComboPreset.SAMPvP_BurstMode_MainCombo) && actionID is Yukikaze or Gekko or Kasha or Hyosetsu or Oka or Mangetsu))
+                if (actionID is Yukikaze or Gekko or Kasha)
                 {
-                    if (!TargetHasEffectAny(PvPCommon.Buffs.Guard))
+                    // Zantetsuken
+                    if (IsEnabled(CustomComboPreset.SAMPvP_Zantetsuken) && isZantetsukenPrimed && !isTargetInvincible)
+                        return OriginalHook(Zantetsuken);
+
+                    // Chiten
+                    if (IsEnabled(CustomComboPreset.SAMPvP_Chiten) && IsOffCooldown(Chiten) && inCombat && playerCurrentPercentHp < Config.SAMPvP_Chiten_PlayerHP)
+                        return OriginalHook(Chiten);
+
+                    // Zanshin
+                    if (hasZanshin && ((isTargetPrimed && targetDistance <= 8) || isZanshinExpiring))
+                        return OriginalHook(Chiten);
+
+                    if (hasTarget && !hasKaiten)
                     {
-                        if (IsEnabled(CustomComboPreset.SAMPvP_BurstMode_Zanshin) && CanWeave(actionID) && HasEffect(Buffs.ZanshinReady))
-                            return OriginalHook(Chiten);
-
-                        if (IsOffCooldown(MeikyoShisui) || HasEffect(Buffs.TendoSetsugekkaReady))
-                            return OriginalHook(MeikyoShisui);
-
-                        if (IsEnabled(CustomComboPreset.SAMPvP_BurstMode_Chiten) && IsOffCooldown(Chiten) && InCombat() && PlayerHealthPercentageHp() <= 95)
-                            return OriginalHook(Chiten);
-
-                        if (GetCooldownRemainingTime(Soten) < 1 && CanWeave(Yukikaze))
+                        // Soten
+                        if (IsEnabled(CustomComboPreset.SAMPvP_Soten) && isSotenPrimed &&
+                            (!Config.SAMPvP_Soten_SubOption || (Config.SAMPvP_Soten_SubOption && isYukikazePrimed)))
                             return OriginalHook(Soten);
 
-                        if ((OriginalHook(MeikyoShisui) == TendoSetsugekka || OriginalHook(MeikyoShisui) == TendoKaeshiSetsugekka) && !IsMoving)
+                        // Meikyo Shisui
+                        if (IsEnabled(CustomComboPreset.SAMPvP_Meikyo) && IsOffCooldown(MeikyoShisui) && !hasKaeshiNamikiri && targetDistance <= 6)
                             return OriginalHook(MeikyoShisui);
 
-                        if (IsEnabled(CustomComboPreset.SAMPvP_BurstMode_Stun) && IsOffCooldown(Mineuchi))
+                        // Mineuchi
+                        if (IsEnabled(CustomComboPreset.SAMPvP_Mineuchi) && isMineuchiPrimed &&
+                            (targetCurrentPercentHp < Config.SAMPvP_Mineuchi_TargetHP || (Config.SAMPvP_Mineuchi_SubOption && hasTendo)))
                             return OriginalHook(Mineuchi);
-
-                        if (IsOffCooldown(OgiNamikiri) && !IsMoving)
-                            return OriginalHook(OgiNamikiri);
-
-                        if (GetRemainingCharges(Soten) > sotenCharges && CanWeave(Yukikaze))
-                            return OriginalHook(Soten);
-
-                        if (OriginalHook(OgiNamikiri) == Kaeshi)
-                            return OriginalHook(OgiNamikiri);
                     }
-                }
 
-                return actionID;
-            }
-        }
+                    // Tendo Kaeshi Setsugekka
+                    if (hasTendoKaeshi)
+                        return OriginalHook(MeikyoShisui);
 
-        internal class SAMPvP_KashaFeatures : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SAMPvP_KashaFeatures;
+                    // Kaeshi Namikiri
+                    if (hasKaeshiNamikiri)
+                        return OriginalHook(OgiNamikiri);
 
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                var SamSotenHP = PluginConfiguration.GetCustomIntValue(Config.SAMPvP_SotenHP);
+                    // Kaiten
+                    if (hasKaiten)
+                        return OriginalHook(actionID);
 
-                if (actionID is Yukikaze or Gekko or Kasha or Hyosetsu or Mangetsu or Oka)
-                {
-                    if (!InMeleeRange())
+                    if (!isMoving)
                     {
-                        if (IsEnabled(CustomComboPreset.SAMPvP_KashaFeatures_GapCloser) && GetRemainingCharges(Soten) > 0 && GetTargetHPPercent() <= SamSotenHP)
-                            return OriginalHook(Soten);
+                        // Tendo Setsugekka
+                        if (hasTendo && (isTargetPrimed || isTendoExpiring))
+                            return OriginalHook(MeikyoShisui);
 
-                        if (IsEnabled(CustomComboPreset.SAMPvP_KashaFeatures_AoEMeleeProtection) && !IsOriginal(Yukikaze) && !HasEffect(Buffs.Midare) && IsOnCooldown(MeikyoShisui) && IsOnCooldown(OgiNamikiri) && OriginalHook(OgiNamikiri) != Kaeshi)
-                            return SAM.Yukikaze;
+                        // Ogi Namikiri
+                        if (IsOffCooldown(OgiNamikiri) && isTargetPrimed)
+                            return OriginalHook(OgiNamikiri);
                     }
                 }
 


### PR DESCRIPTION
Samurai is now fully 7.1 tested and supported.

- [x] Improved combat logic significantly.
- [x] Updated all necessary action and buff IDs.
- [x] Improved behavior when using auto-targeting.
- [x] Fixed Meikyo Shisui breaking Ogi Namikiri combo.
- [x] Fixed logic attempting to use Mineuchi out of range.
- [x] Fixed Tendo Setsugekka not respecting movement check.
- [x] Added Zantetsuken option.
- [x] Added several checks for conditional actions.
- [x] Added customizable toggles for Chiten, Mineuchi and Soten.

![45876192](https://github.com/user-attachments/assets/f507c95d-a328-405b-bdad-4b8c61ac2fc5)