### PR TITLE
[PVP] Global Emergency Guard Anti Mash edit

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5312,6 +5312,10 @@ namespace WrathCombo.Combos
         [CustomComboInfo("Prevent Mash Cancelling Feature", "Stops you cancelling your guard if you're pressing buttons quickly.", ADV.JobID, 3)]
         PvP_MashCancel = 1100030,
 
+        [ParentCombo(PvP_MashCancel)]
+        [CustomComboInfo("Recuperate Option", "Allows you to cancel your guard with Recuperate on the Guard button if health is low enough to not waste it.", ADV.JobID)]
+        PvP_MashCancelRecup = 1100031,
+
         // Last value = 1100030
         // Extra 0 on the end keeps things working the way they should be. Nothing to see here.
 

--- a/WrathCombo/Combos/PvP/PVPCommon.cs
+++ b/WrathCombo/Combos/PvP/PVPCommon.cs
@@ -113,7 +113,7 @@ namespace WrathCombo.Combos.PvP
                 {
                     if (actionID == Guard)
                     {
-                        if (!JustUsed(Guard, 2f) && LocalPlayer.CurrentMp >= 2500 && LocalPlayer.CurrentHp <= LocalPlayer.MaxHp - 15000) 
+                        if (IsEnabled(CustomComboPreset.PvP_MashCancelRecup) && !JustUsed(Guard, 2f) && LocalPlayer.CurrentMp >= 2500 && LocalPlayer.CurrentHp <= LocalPlayer.MaxHp - 15000) 
                             return Recuperate;
                         return Guard;
                     }

--- a/WrathCombo/Combos/PvP/PVPCommon.cs
+++ b/WrathCombo/Combos/PvP/PVPCommon.cs
@@ -111,7 +111,12 @@ namespace WrathCombo.Combos.PvP
             {
                 if ((HasEffect(Buffs.Guard) || JustUsed(Guard)) && IsEnabled(CustomComboPreset.PvP_MashCancel))
                 {
-                    if (actionID == Guard) return Guard;
+                    if (actionID == Guard)
+                    {
+                        if (LocalPlayer.CurrentMp >= 2500 && LocalPlayer.CurrentHp <= LocalPlayer.MaxHp - 15000) 
+                            return Recuperate;
+                        else return Guard;
+                    }
                     else return OriginalHook(11);
                 }
 

--- a/WrathCombo/Combos/PvP/PVPCommon.cs
+++ b/WrathCombo/Combos/PvP/PVPCommon.cs
@@ -113,7 +113,7 @@ namespace WrathCombo.Combos.PvP
                 {
                     if (actionID == Guard)
                     {
-                        if (LocalPlayer.CurrentMp >= 2500 && LocalPlayer.CurrentHp <= LocalPlayer.MaxHp - 15000) 
+                        if (!JustUsed(Guard, 2f) && LocalPlayer.CurrentMp >= 2500 && LocalPlayer.CurrentHp <= LocalPlayer.MaxHp - 15000) 
                             return Recuperate;
                         return Guard;
                     }

--- a/WrathCombo/Combos/PvP/PVPCommon.cs
+++ b/WrathCombo/Combos/PvP/PVPCommon.cs
@@ -115,9 +115,9 @@ namespace WrathCombo.Combos.PvP
                     {
                         if (LocalPlayer.CurrentMp >= 2500 && LocalPlayer.CurrentHp <= LocalPlayer.MaxHp - 15000) 
                             return Recuperate;
-                            return Guard;
+                        return Guard;
                     }
-                    else return OriginalHook(11);
+                    return OriginalHook(11);
                 }
 
                 if (Execute() &&

--- a/WrathCombo/Combos/PvP/PVPCommon.cs
+++ b/WrathCombo/Combos/PvP/PVPCommon.cs
@@ -115,7 +115,7 @@ namespace WrathCombo.Combos.PvP
                     {
                         if (LocalPlayer.CurrentMp >= 2500 && LocalPlayer.CurrentHp <= LocalPlayer.MaxHp - 15000) 
                             return Recuperate;
-                        else return Guard;
+                            return Guard;
                     }
                     else return OriginalHook(11);
                 }


### PR DESCRIPTION
Edited the Anti mash feature. 

Original feature prevents you from unguarding by accident in pvp using your combo buttons. It only leaves guard untouched so you can use that to get out of guard. 

The change

If you have the mp AND could use the 15k healing with wasting it, it changes that guard button to recuperate so that can be used to take you out of guard. Exact same functionality, removing guard, but allows you to do it with the heal instead of having to hit guard and then heal resulting in a delay. 

The original request in discord wanted other skills, but to do that, would require unlocking those skills under guard and would likely result in the anti-mash feature having potential fails. 