### PR TITLE
[PVP] RPR Fixes and updates

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5902,6 +5902,11 @@ namespace WrathCombo.Combos
 
         [PvPCustomCombo]
         [ParentCombo(RPRPvP_Burst)]
+        [CustomComboInfo("Grim Swathe Option", "Add's Grim Swathe onto the main combo on cd", RPR.JobID)]
+        RPRPvP_Burst_GrimSwathe = 122009,
+
+        [PvPCustomCombo]
+        [ParentCombo(RPRPvP_Burst)]
         [CustomComboInfo("Death Warrant Option", "Adds Death Warrant onto the main combo when Plentiful Harvest is ready to use, or when Plentiful Harvest's cooldown is longer than Death Warrant's.\nRespects Immortal Sacrifice Pooling Option.", RPR.JobID)]
         RPRPvP_Burst_DeathWarrant = 122001,
 
@@ -5942,7 +5947,7 @@ namespace WrathCombo.Combos
         [CustomComboInfo("Arcane Crest Option", "Adds Arcane Crest to the main combo when under the set HP perecentage.", RPR.JobID)]
         RPRPvP_Burst_ArcaneCircle = 122008,
 
-        // Last value = 122008
+        // Last value = 122009
 
         #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5912,11 +5912,6 @@ namespace WrathCombo.Combos
 
         [PvPCustomCombo]
         [ParentCombo(RPRPvP_Burst)]
-        [CustomComboInfo("Plentiful Harvest Opener Option", "Starts combat with Plentiful Harvest to immediately begin Limit Break generation.", RPR.JobID)]
-        RPRPvP_Burst_PlentifulOpener = 122002,
-
-        [PvPCustomCombo]
-        [ParentCombo(RPRPvP_Burst)]
         [CustomComboInfo("Plentiful Harvest + Immortal Sacrifice Pooling Option", "Pools stacks of Immortal Sacrifice before using Plentiful Harvest.\nAlso holds Plentiful Harvest if Death Warrant is on cooldown.\nSet the value to 3 or below to use Plentiful Harvest as soon as it's available.", RPR.JobID)]
         RPRPvP_Burst_ImmortalPooling = 122003,
 

--- a/WrathCombo/Combos/PvE/RPR/RPR_Config.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR_Config.cs
@@ -33,15 +33,9 @@ internal partial class RPR
                     DrawSliderInt(0, 8, RPRPvP.Config.RPRPvP_ImmortalStackThreshold,
                         "Set a value of Immortal Sacrifice Stacks to hold for burst.");
 
-                    DrawSliderInt(0, 8, RPRPvP.Config.RPRPvP_ImmortalStackThreshold,
-                        "Set a value of Immortal Sacrifice Stacks to hold for burst.");
-
                     break;
 
                 case CustomComboPreset.RPRPvP_Burst_ArcaneCircle:
-                    DrawSliderInt(5, 90, RPRPvP.Config.RPRPvP_ArcaneCircleThreshold,
-                        "Set a HP percentage value. Caps at 90 to prevent waste.");
-
                     DrawSliderInt(5, 90, RPRPvP.Config.RPRPvP_ArcaneCircleThreshold,
                         "Set a HP percentage value. Caps at 90 to prevent waste.");
 

--- a/WrathCombo/Combos/PvP/RPRPVP.cs
+++ b/WrathCombo/Combos/PvP/RPRPVP.cs
@@ -156,7 +156,8 @@ namespace WrathCombo.Combos.PvP
                                     return GrimSwathe;
                             }
                             // Harvest Moon Execute 
-                            if (IsEnabled(CustomComboPreset.RPRPvP_Burst_RangedHarvest) && EnemyHealthCurrentHp() < 12000)
+                            if (IsEnabled(CustomComboPreset.RPRPvP_Burst_RangedHarvest) && GetRemainingCharges(HarvestMoon) > 0 &&
+                                EnemyHealthCurrentHp() < 12000)
                                 return HarvestMoon;
                         }
                     }

--- a/WrathCombo/Combos/PvP/RPRPVP.cs
+++ b/WrathCombo/Combos/PvP/RPRPVP.cs
@@ -137,7 +137,7 @@ namespace WrathCombo.Combos.PvP
                             if (canWeave)
                             {                               
                                 // Death Warrant without pooling
-                                if (!IsEnabled(CustomComboPreset.RPRPvP_Burst_ImmortalPooling) && IsEnabled(CustomComboPreset.RPRPvP_Burst_DeathWarrant) && IsOffCooldown(DeathWarrant) && distance <= 25)
+                                if (!IsEnabled(CustomComboPreset.RPRPvP_Burst_ImmortalPooling) && IsEnabled(CustomComboPreset.RPRPvP_Burst_DeathWarrant) && deathWarrantReady && distance <= 25)
                                     return OriginalHook(DeathWarrant);
 
                                 // Grim Swathe Option

--- a/WrathCombo/Combos/PvP/RPRPVP.cs
+++ b/WrathCombo/Combos/PvP/RPRPVP.cs
@@ -76,10 +76,6 @@ namespace WrathCombo.Combos.PvP
 
                     if (!PvPCommon.IsImmuneToDamage()) // Guard check on target
                     {
-                        // Plentiful Harvest Opener
-                        if (IsEnabled(CustomComboPreset.RPRPvP_Burst_PlentifulOpener) && !InCombat() && plentifulReady && distance <= 15)
-                            return PlentifulHarvest;
-
                         // Harvest Moon Ranged Option
                         if (IsEnabled(CustomComboPreset.RPRPvP_Burst_RangedHarvest) && distance > 5)
                             return HarvestMoon;
@@ -125,7 +121,8 @@ namespace WrathCombo.Combos.PvP
                             {
                                 if (IsEnabled(CustomComboPreset.RPRPvP_Burst_DeathWarrant) && deathWarrantReady && distance <= 25 &&
                                 (GetCooldownRemainingTime(PlentifulHarvest) > 20 ||     //if plentiful will be back for the next death warrant
-                                (plentifulReady && immortalStacks >= immortalThreshold))) // if plentiful is ready for this death warrant and you have the charges you want
+                                (plentifulReady && immortalStacks >= immortalThreshold) || // if plentiful is ready for this death warrant and you have the charges you want
+                                (plentifulReady && immortalStacks <= immortalThreshold - 2))) // if plentiful is ready, but 2 grim swathes away from having the immortal threshold. Early fight. 
                                     return OriginalHook(DeathWarrant);
 
                                 if (plentifulReady && immortalStacks >= immortalThreshold &&

--- a/WrathCombo/Combos/PvP/RPRPVP.cs
+++ b/WrathCombo/Combos/PvP/RPRPVP.cs
@@ -58,19 +58,11 @@ namespace WrathCombo.Combos.PvP
                 if (actionID is Slice or WaxingSlice or InfernalSlice)
                 {
                     #region types
-                    bool canWeave = CanWeave(actionID);
-                    bool GCDStopped = !GetCooldown(OriginalHook(Slice)).IsCooldown;
                     double distance = GetTargetDistance();
-                    double playerHP = PlayerHealthPercentageHp();
+                    bool canWeave = CanWeave(actionID);                    
                     bool canBind = !TargetHasEffect(PvPCommon.Debuffs.Bind);
-                    bool enemyGuarded = TargetHasEffectAny(PvPCommon.Buffs.Guard);
-                    bool grimSwatheReady = IsOffCooldown(GrimSwathe);
-                    bool lemuresSliceReady = IsOffCooldown(LemuresSlice);
-                    bool arcaneReady = IsOffCooldown(ArcaneCrest);
-                    int arcaneThreshold = PluginConfiguration.GetCustomIntValue(Config.RPRPvP_ArcaneCircleThreshold);
                     bool deathWarrantReady = IsOffCooldown(DeathWarrant);
                     bool plentifulReady = IsOffCooldown(PlentifulHarvest);
-                    float plentifulCD = GetCooldownRemainingTime(PlentifulHarvest);
                     bool enshrouded = HasEffect(Buffs.Enshrouded);
                     float enshroudStacks = GetBuffStacks(Buffs.Enshrouded);
                     float immortalStacks = GetBuffStacks(Buffs.ImmortalSacrifice);
@@ -79,19 +71,17 @@ namespace WrathCombo.Combos.PvP
 
                     // Arcane Cirle Option
                     if (IsEnabled(CustomComboPreset.RPRPvP_Burst_ArcaneCircle)
-                        && arcaneReady && playerHP <= arcaneThreshold)
+                        && ActionReady(ArcaneCrest) && PlayerHealthPercentageHp() <= PluginConfiguration.GetCustomIntValue(Config.RPRPvP_ArcaneCircleThreshold))
                         return ArcaneCrest;
 
                     if (!PvPCommon.IsImmuneToDamage()) // Guard check on target
                     {
                         // Plentiful Harvest Opener
-                        if (IsEnabled(CustomComboPreset.RPRPvP_Burst_PlentifulOpener) &&
-                            !InCombat() && plentifulReady && distance <= 15)
+                        if (IsEnabled(CustomComboPreset.RPRPvP_Burst_PlentifulOpener) && !InCombat() && plentifulReady && distance <= 15)
                             return PlentifulHarvest;
 
                         // Harvest Moon Ranged Option
-                        if (IsEnabled(CustomComboPreset.RPRPvP_Burst_RangedHarvest) &&
-                            distance > 5 && GCDStopped)
+                        if (IsEnabled(CustomComboPreset.RPRPvP_Burst_RangedHarvest) && distance > 5)
                             return HarvestMoon;
 
                         // Enshroud
@@ -105,7 +95,7 @@ namespace WrathCombo.Combos.PvP
                                     return OriginalHook(DeathWarrant);
 
                                 // Lemure's Slice
-                                if (lemuresSliceReady && canBind && distance <= 8)
+                                if (ActionReady(LemuresSlice) && canBind && distance <= 8)
                                     return LemuresSlice;
                             }
 
@@ -127,32 +117,31 @@ namespace WrathCombo.Combos.PvP
                         // Outside of Enshroud
                         if (!enshrouded)
                         {
-
                             if (HasEffect(Buffs.PerfectioParata))
                                 return OriginalHook(TenebraeLemurum);
 
-                            // Death Warrant Option
-                            if (IsEnabled(CustomComboPreset.RPRPvP_Burst_DeathWarrant) &&
-                                deathWarrantReady && distance <= 25 &&
-                                ((plentifulCD > 20 && immortalStacks < immortalThreshold) ||
-                                (plentifulReady && immortalStacks >= immortalThreshold)) || HasEffect(Buffs.DeathWarrant) && GetBuffRemainingTime(Buffs.DeathWarrant) <= 3)
-                                return OriginalHook(DeathWarrant);
+                            // Pooling Plentiful with Death warrant
+                            if (IsEnabled(CustomComboPreset.RPRPvP_Burst_ImmortalPooling))
+                            {
+                                if (IsEnabled(CustomComboPreset.RPRPvP_Burst_DeathWarrant) && deathWarrantReady && distance <= 25 &&
+                                (GetCooldownRemainingTime(PlentifulHarvest) > 20 ||     //if plentiful will be back for the next death warrant
+                                (plentifulReady && immortalStacks >= immortalThreshold))) // if plentiful is ready for this death warrant and you have the charges you want
+                                    return OriginalHook(DeathWarrant);
 
-                            // Plentiful Harvest Pooling Option
-                            if (IsEnabled(CustomComboPreset.RPRPvP_Burst_ImmortalPooling) &&
-                                plentifulReady && immortalStacks >= immortalThreshold &&
+                                if (plentifulReady && immortalStacks >= immortalThreshold &&
                                 TargetHasEffect(Debuffs.DeathWarrant) && distance <= 15)
-                                return PlentifulHarvest;
+                                    return PlentifulHarvest;
+                            }
 
                             // Weaves
                             if (canWeave)
-                            {
-                                // Harvest Moon Proc
-                                if (IsOffCooldown(DeathWarrant)|| distance <= 25 && HasEffect(Buffs.DeathWarrant) && GetBuffRemainingTime(Buffs.DeathWarrant) <= 3)
+                            {                               
+                                // Death Warrant without pooling
+                                if (!IsEnabled(CustomComboPreset.RPRPvP_Burst_ImmortalPooling) && IsEnabled(CustomComboPreset.RPRPvP_Burst_DeathWarrant) && IsOffCooldown(DeathWarrant) && distance <= 25)
                                     return OriginalHook(DeathWarrant);
 
                                 // Grim Swathe Option
-                                if (grimSwatheReady && distance <= 8)
+                                if (IsEnabled(CustomComboPreset.RPRPvP_Burst_GrimSwathe) && ActionReady(GrimSwathe) && distance <= 8)
                                     return GrimSwathe;
                             }
                             // Harvest Moon Execute 


### PR DESCRIPTION
- [x] Remove double sliders for arcane crest and immortal sacrifice
- [x] Removed plentiful opener, as it is not needed to start lb gen anymore
- [x] Tweaked death warrant to account for the plentiful opener removal. It will fire as long as you are more than 2 stacks below threshold to hold for burst. 
- [x] Fix Harvest moon execute not checking for charges
- [x] Added grim swathe as an option instead of being forced
- [x] Fixed death warrant happening on cd without any options selected as well as the logic of respecting the pooling option
- [x] Clean up unnecessary bools


![image](https://github.com/user-attachments/assets/4a1a1227-2fd8-414a-ad3e-15db03e2d6f0)
