### PR TITLE
[PVP] [BRD] Tweaks

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5447,7 +5447,12 @@ namespace WrathCombo.Combos
         [CustomComboInfo("Encore of Light Option", "Adds Encore of Light to Burst Mode.", BRD.JobID)]
         BRDPvP_EncoreOfLight = 113005,
 
-        // Last value = 113005
+        [PvPCustomCombo]
+        [ParentCombo(BRDPvP_BurstMode)]
+        [CustomComboInfo("Wardens Paeon Option", "Auto Self cleanse of soft cc. \n Half Asleep, Heavy, and Bind", BRD.JobID)]
+        BRDPvP_Wardens = 113006,
+
+        // Last value = 113006
 
         #endregion
 

--- a/WrathCombo/Combos/PvP/BRDPVP.cs
+++ b/WrathCombo/Combos/PvP/BRDPVP.cs
@@ -1,3 +1,4 @@
+using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 
 namespace WrathCombo.Combos.PvP
@@ -28,6 +29,18 @@ namespace WrathCombo.Combos.PvP
                 EncoreofLightReady = 4312,
                 FrontlineMarch = 3139;
         }
+        internal class Debuffs
+        {
+            public const ushort
+                Silence = 1347,
+                Bind = 1345,
+                Stun = 1343,
+                HalfAsleep = 3022,
+                Sleep = 1348,
+                DeepFreeze = 3219,
+                Heavy = 1344,
+                Unguarded = 3021;
+        }
 
         public static class Config
         {
@@ -41,6 +54,7 @@ namespace WrathCombo.Combos.PvP
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRDPvP_BurstMode;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+
             {
 
                 if (actionID == PowerfulShot)
@@ -50,6 +64,10 @@ namespace WrathCombo.Combos.PvP
 
                     if (!PvPCommon.IsImmuneToDamage())
                     {
+                        if (IsEnabled(CustomComboPreset.BRDPvP_Wardens) && InPvP() &&  //Autowardens set up only for soft ccs, it cant be used while cced like purify
+                            (HasEffectAny(Debuffs.Bind) || HasEffectAny(Debuffs.Heavy) || HasEffectAny(Debuffs.HalfAsleep)))
+                            return OriginalHook(WardensPaean);
+
                         if (canWeave)
                         {
                             // Silence shot that gives PP, set up to not happen right after apex to tighten burst and silence after the bigger damage. Apex > Harmonic> Silent > Burst > PP or Apex > Burst > Silent >  PP
@@ -82,7 +100,8 @@ namespace WrathCombo.Combos.PvP
                 }
 
                 return actionID;
-            }
+            }                       
         }
     }
+    
 }


### PR DESCRIPTION
- [x] Set Silence shot to not happen right after apex. This is to tighten the burst and silence after the larger hits or burst shot or harmonic
- [x] Added line to prevent silence from happening when you already have repertoire buff from repelling shot
- [x] Updated Harmonic execute to happen in stages for each charge level 1-3
- [x] Removed unnecessary line to use pitch perfect at the the end, it replaces the main action id anyway
- [x] Wardens paeon automatic for soft ccs