### PR TITLE
[PVP] [DRG] Update

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5531,7 +5531,7 @@ namespace WrathCombo.Combos
 
         #region DRAGOON
         [PvPCustomCombo]
-        [CustomComboInfo("Burst Mode", "Using Elusive Jump turns Drakesbane Combo into all-in-one burst damage button.", DRG.JobID)]
+        [CustomComboInfo("Burst Mode", "Turns Drakesbane Combo into an all-in-one damage button.", DRG.JobID)]
         DRGPvP_Burst = 116000,
 
         [ParentCombo(DRGPvP_Burst)]
@@ -5563,7 +5563,7 @@ namespace WrathCombo.Combos
         DRGPvP_HighJump = 116007,
 
         [ParentCombo(DRGPvP_Burst)]
-        [CustomComboInfo("Elusive Jump Burst Protection Option", "Disables Elusive Jump if Burst is not ready.", DRG.JobID)]
+        [CustomComboInfo("Elusive Jump Burst Option", "Using Elusive Jump turns Drakesbane Combo into all-in-one burst damage button once all cooldowns are ready. \n Disables Elusive Jump if Burst is not ready.", DRG.JobID)]
         DRGPvP_BurstProtection = 116008,
 
         // Last value = 116009

--- a/WrathCombo/Combos/PvE/DRG/DRG_Config.cs
+++ b/WrathCombo/Combos/PvE/DRG/DRG_Config.cs
@@ -81,13 +81,13 @@ internal partial class DRG
 
                 case CustomComboPreset.DRGPvP_ChaoticSpringSustain:
                     DrawSliderInt(0, 101, DRGPvP.Config.DRGPvP_CS_HP_Threshold,
-                        "Chaos Spring HP percentage threshold");
+                        "Chaotic Spring HP percentage threshold. Set to 100 to use on cd");
 
                     break;
 
                 case CustomComboPreset.DRGPvP_WyrmwindThrust:
                     DrawSliderInt(0, 20, DRGPvP.Config.DRGPvP_Distance_Threshold,
-                        "Distance Treshold for Wyrmwind Thrust");
+                        "Minimum Distance to use Wyrmwind Thrust. Maximum damage at 15 or more");
 
                     break;
             }

--- a/WrathCombo/Combos/PvP/DRGPVP.cs
+++ b/WrathCombo/Combos/PvP/DRGPVP.cs
@@ -51,38 +51,43 @@ namespace WrathCombo.Combos.PvP
             {
                 if (actionID is RaidenThrust or FangAndClaw or WheelingThrust or Drakesbane)
                 {
-                    bool enemyGuarded = TargetHasEffectAny(PvPCommon.Buffs.Guard);
-
-                    if (!enemyGuarded)
+                    if (!TargetHasEffectAny(PvPCommon.Buffs.Guard))
                     {
                         if (CanWeave(actionID))
                         {
-                            if (IsEnabled(CustomComboPreset.DRGPvP_HighJump) && IsOffCooldown(HighJump) && HasEffect(Buffs.LifeOfTheDragon))
+                            if (IsEnabled(CustomComboPreset.DRGPvP_HighJump) && IsOffCooldown(HighJump) && (HasEffect(Buffs.LifeOfTheDragon) || GetCooldownRemainingTime(Geirskogul) > 5)) // Will high jump after Gierskogul OR if Geir will be on cd for 2 more gcds.
                                 return HighJump;
 
-                            if (IsEnabled(CustomComboPreset.DRGPvP_Nastrond) && InMeleeRange())
+                            if (IsEnabled(CustomComboPreset.DRGPvP_Nastrond)) // Nastrond Finisher logic
                             {
                                 if (HasEffect(Buffs.LifeOfTheDragon) && PlayerHealthPercentageHp() < GetOptionValue(Config.DRGPvP_LOTD_HPValue)
                                  || HasEffect(Buffs.LifeOfTheDragon) && GetBuffRemainingTime(Buffs.LifeOfTheDragon) < GetOptionValue(Config.DRGPvP_LOTD_Duration))
                                     return Nastrond;
                             }
-                            if (IsEnabled(CustomComboPreset.DRGPvP_HorridRoar) && IsOffCooldown(HorridRoar) && InMeleeRange())
+
+                            if (IsEnabled(CustomComboPreset.DRGPvP_HorridRoar) && IsOffCooldown(HorridRoar) && GetTargetDistance() <= 10) // HorridRoar Roar on cd
                                 return HorridRoar;
                         }
-                        if (IsEnabled(CustomComboPreset.DRGPvP_ChaoticSpringSustain) && IsOffCooldown(ChaoticSpring) && PlayerHealthPercentageHp() < GetOptionValue(Config.DRGPvP_CS_HP_Threshold))
+                       
+                        if (IsEnabled(CustomComboPreset.DRGPvP_Geirskogul) && IsOffCooldown(Geirskogul)) 
                         {
-                            if (!HasEffect(Buffs.FirstmindsFocus) && !HasEffect(Buffs.LifeOfTheDragon) && IsOnCooldown(Geirskogul) && IsOnCooldown(ElusiveJump)
-                             || !HasEffect(Buffs.FirstmindsFocus) && HasEffect(Buffs.LifeOfTheDragon) && IsOnCooldown(Geirskogul) && IsOnCooldown(ElusiveJump) && WasLastWeaponskill(HeavensThrust))
-                                return ChaoticSpring;
-                        }
-                        if (IsEnabled(CustomComboPreset.DRGPvP_Geirskogul) && IsOffCooldown(Geirskogul) && WasLastAbility(ElusiveJump) && HasEffect(Buffs.FirstmindsFocus))
-                            return Geirskogul;
+                            if (IsEnabled(CustomComboPreset.DRGPvP_BurstProtection) && WasLastAbility(ElusiveJump) && HasEffect(Buffs.FirstmindsFocus))  // With evasive burst mode
+                                return Geirskogul;
+                            if (!IsEnabled(CustomComboPreset.DRGPvP_BurstProtection))                                                                    // Without evasive burst mode so you can still use Gier, which will let you still use high jump
+                                return Geirskogul;
+                        }                       
+                                                   
                         if (IsEnabled(CustomComboPreset.DRGPvP_WyrmwindThrust) && HasEffect(Buffs.FirstmindsFocus) && GetTargetDistance() >= GetOptionValue(Config.DRGPvP_Distance_Threshold))
                             return WyrmwindThrust;
                     }
-
-                    if (IsEnabled(CustomComboPreset.DRGPvP_ChaoticSpringExecute) && IsOffCooldown(ChaoticSpring) && EnemyHealthCurrentHp() <= 8000)
+                    if (IsOffCooldown(ChaoticSpring) && InMeleeRange())
+                    {
+                        if (IsEnabled(CustomComboPreset.DRGPvP_ChaoticSpringSustain) && PlayerHealthPercentageHp() < GetOptionValue(Config.DRGPvP_CS_HP_Threshold)) // Chaotic Spring as a self heal option, it does not break combos of other skills
                             return ChaoticSpring;
+                        if (IsEnabled(CustomComboPreset.DRGPvP_ChaoticSpringExecute) && EnemyHealthCurrentHp() <= 8000) // Chaotic Spring Execute
+                            return ChaoticSpring;
+                    }
+                  
                 }
                 return actionID;
             }

--- a/WrathCombo/Combos/PvP/DRGPVP.cs
+++ b/WrathCombo/Combos/PvP/DRGPVP.cs
@@ -22,7 +22,8 @@ namespace WrathCombo.Combos.PvP
             Nastrond = 29492,
             Purify = 29056,
             Guard = 29054,
-            Drakesbane = 41449;
+            Drakesbane = 41449,
+            Starcross = 41450;
 
 
         public static class Buffs
@@ -30,7 +31,8 @@ namespace WrathCombo.Combos.PvP
             public const ushort
             FirstmindsFocus = 3178,
             LifeOfTheDragon = 3177,
-            Heavensent = 3176;
+            Heavensent = 3176,
+            StarCrossReady = 4302;
 
 
         }
@@ -55,7 +57,7 @@ namespace WrathCombo.Combos.PvP
                     {
                         if (CanWeave(actionID))
                         {
-                            if (IsEnabled(CustomComboPreset.DRGPvP_HighJump) && IsOffCooldown(HighJump) && (HasEffect(Buffs.LifeOfTheDragon) || GetCooldownRemainingTime(Geirskogul) > 5)) // Will high jump after Gierskogul OR if Geir will be on cd for 2 more gcds.
+                            if (IsEnabled(CustomComboPreset.DRGPvP_HighJump) && IsOffCooldown(HighJump) && !HasEffect(Buffs.StarCrossReady) && (HasEffect(Buffs.LifeOfTheDragon) || GetCooldownRemainingTime(Geirskogul) > 5)) // Will high jump after Gierskogul OR if Geir will be on cd for 2 more gcds.
                                 return HighJump;
 
                             if (IsEnabled(CustomComboPreset.DRGPvP_Nastrond)) // Nastrond Finisher logic
@@ -79,6 +81,10 @@ namespace WrathCombo.Combos.PvP
                                                    
                         if (IsEnabled(CustomComboPreset.DRGPvP_WyrmwindThrust) && HasEffect(Buffs.FirstmindsFocus) && GetTargetDistance() >= GetOptionValue(Config.DRGPvP_Distance_Threshold))
                             return WyrmwindThrust;
+
+                        if (IsEnabled(CustomComboPreset.DRGPvP_Geirskogul) && HasEffect(Buffs.StarCrossReady))
+                            return Starcross;
+                       
                     }
                     if (IsOffCooldown(ChaoticSpring) && InMeleeRange())
                     {


### PR DESCRIPTION
Key note. With elusive lockout the burst combo still functions exactly the same. This is primarily for those who dont want everything they have locked behind using backflip. 

- [x] Added logic to Gierskogul to function on cd when elusive lockout is not enabled. 
- [x] Added logic to high jump to not wait for almost en entire 10 second cooldown for gier to come up and burst be available. Gier is 20, jump is 10.
- [x] Removed melee range requirement from nastrond. It is a ranged attack. While it may hit more in the face, disabling it at range is bad. 
- [x] Removed melee range requirement from horrid roar. It is a ranged attack. While it may hit more in the face, disabling it at range is bad. 
- [x] Moved Chaotic sustain down with the execute. Removed the buff logic from it that could prevent the emergency heal. It does not break the combos that was trying to get in its way. 
- [x] Edited wording of options to be more clear so we field less questions about drg not working because people couldnt understand what they read. 
- [x] Added Starcross to happen before jumping back to the target during burst combo. This fixes hit detection. If you weave the jump during wyrmwind thrust its damage is cut in half. So you need to wait. Starcross fills this need. 