### PR TITLE
[PVP] [MNK] Riddle of Earth fix and LB option

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5690,6 +5690,11 @@ namespace WrathCombo.Combos
 
         [ParentCombo(MNKPvP_Burst)]
         [PvPCustomCombo]
+        [CustomComboInfo("Meteodrive Option", "Adds Meteodrive Limit break to Burst Mode when target is below 20k and guarded", MNK.JobID)]
+        MNKPvP_Burst_Meteodrive = 119006,
+
+        [ParentCombo(MNKPvP_Burst)]
+        [PvPCustomCombo]
         [CustomComboInfo("Thunderclap Option", "Adds Thunderclap to Burst Mode when not buffed with Wind Resonance.", MNK.JobID)]
         MNKPvP_Burst_Thunderclap = 119001,
 
@@ -5713,7 +5718,7 @@ namespace WrathCombo.Combos
         [CustomComboInfo("Wind's Reply Option", "Adds Wind's Reply to Burst Mode.", MNK.JobID)]
         MNKPvP_Burst_WindsReply = 119005,
 
-        // Last value = 119004
+        // Last value = 119006
 
         #endregion
 

--- a/WrathCombo/Combos/PvP/MNKPVP.cs
+++ b/WrathCombo/Combos/PvP/MNKPVP.cs
@@ -17,7 +17,7 @@ namespace WrathCombo.Combos.PvP
             RiddleOfEarth = 29482,
             ThunderClap = 29484,
             EarthsReply = 29483,
-            Meteordrive = 29485,
+            Meteodrive = 29485,
             WindsReply = 41509,
             FlintsReply = 41447,
             LeapingOpo = 41444,
@@ -47,31 +47,33 @@ namespace WrathCombo.Combos.PvP
             {
                 if (actionID is DragonKick or TwinSnakes or Demolish or LeapingOpo or RisingRaptor or PouncingCoeurl or PhantomRush)
                 {
+                    if (IsEnabled(CustomComboPreset.MNKPvP_Burst_Meteodrive) && PvPCommon.IsImmuneToDamage() && EnemyHealthCurrentHp() <= 20000 && IsLB1Ready) // LB options for when something is guarded and low on health. Meteo breaks thier shield and locks them in place
+                        return Meteodrive;
 
                     if (!PvPCommon.IsImmuneToDamage())
                     {
                         if (IsEnabled(CustomComboPreset.MNKPvP_Burst_RisingPhoenix))
                         {
-                            if (!HasEffect(Buffs.FireResonance) && GetRemainingCharges(RisingPhoenix) > 1 || WasLastWeaponskill(PouncingCoeurl) && GetRemainingCharges(RisingPhoenix) > 0)
+                            if (!HasEffect(Buffs.FireResonance) && GetRemainingCharges(RisingPhoenix) > 1 || WasLastWeaponskill(PouncingCoeurl) && GetRemainingCharges(RisingPhoenix) > 0) // Uses Rising Pheonix at 2, always retains one for use with phantom rush
                                 return OriginalHook(RisingPhoenix);
                             if (HasEffect(Buffs.FireResonance) && WasLastWeaponskill(PouncingCoeurl))
-                                return actionID;
+                                return actionID; // makes sure it uses it on phantom rush
                         }
 
-                        if (IsEnabled(CustomComboPreset.MNKPvP_Burst_RiddleOfEarth) && IsOffCooldown(RiddleOfEarth) && PlayerHealthPercentageHp() <= 95)
-                            return OriginalHook(RiddleOfEarth);
+                        if (IsEnabled(CustomComboPreset.MNKPvP_Burst_RiddleOfEarth))
+                        {
+                            if (IsOffCooldown(RiddleOfEarth) && PlayerHealthPercentageHp() <= 95)  // Uses riddle of earth when you health starts to drop by being struck
+                                return RiddleOfEarth;
+                            if (HasEffect(Buffs.EarthResonance) && GetBuffRemainingTime(Buffs.EarthResonance) <= 2) // Uses earths reply when the buff is less than 2 secons remaining
+                                return EarthsReply; 
+                        }
+                            
 
-                        if (IsEnabled(CustomComboPreset.MNKPvP_Burst_Thunderclap) && GetRemainingCharges(ThunderClap) > 0 && !InMeleeRange())
+                        if (IsEnabled(CustomComboPreset.MNKPvP_Burst_Thunderclap) && GetRemainingCharges(ThunderClap) > 0 && !InMeleeRange()) // gap closer
                             return OriginalHook(ThunderClap);
 
                         if (IsEnabled(CustomComboPreset.MNKPvP_Burst_WindsReply) && InActionRange(WindsReply) && IsOffCooldown(WindsReply))
                             return WindsReply;
-
-                        if (CanWeave(actionID))
-                        {
-                                if (IsEnabled(CustomComboPreset.MNKPvP_Burst_RiddleOfEarth) && HasEffect(Buffs.EarthResonance) && GetBuffRemainingTime(Buffs.EarthResonance) < 6)
-                                return OriginalHook(EarthsReply);
-                        }
 
                         if (IsEnabled(CustomComboPreset.MNKPvP_Burst_FlintsReply))
                         {


### PR DESCRIPTION
- [x] Fixed riddle of earth popping too early. It was set to 6 seconds left when it should have been set to 2
- [x] Added monk lb to combo. Specifically against under 20k low health targets WITH guard bc the LB breaks the shield. It is its strongest feature. 