### PR TITLE
[DNC] [MCH] Add `has hostile target` checks to prepull features

### DIFF
--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -1,4 +1,5 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using ECommons.GameFunctions;
 using WrathCombo.Combos.PvE.Content;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Services;
@@ -238,6 +239,7 @@ namespace WrathCombo.Combos.PvE
                 var targetHpThresholdStandard = Config.DNC_ST_Adv_SSBurstPercent;
                 var targetHpThresholdTechnical = Config.DNC_ST_Adv_TSBurstPercent;
                 var gcd = GetCooldown(Fountain).CooldownTotal;
+                var hasHostileTarget = HasTarget() && CurrentTarget.IsHostile();
 
                 // Thresholds to wait for TS/SS to come off CD
                 var longAlignmentThreshold = 0.6f;
@@ -286,7 +288,7 @@ namespace WrathCombo.Combos.PvE
 
                 #region Pre-pull
 
-                if (!InCombat())
+                if (!InCombat() && hasHostileTarget)
                 {
                     // Dance Partner
                     if (IsEnabled(CustomComboPreset.DNC_ST_Adv_Partner) &&
@@ -304,8 +306,7 @@ namespace WrathCombo.Combos.PvE
                         !HasEffect(Buffs.FinishingMoveReady) &&
                         !HasEffect(Buffs.TechnicalFinish) &&
                         IsOffCooldown(TechnicalStep) &&
-                        IsOffCooldown(StandardStep) &&
-                        !HasTarget())
+                        IsOffCooldown(StandardStep))
                         return StandardStep;
 
                     // ST Standard Steps (Pre-pull)
@@ -313,8 +314,7 @@ namespace WrathCombo.Combos.PvE
                          IsEnabled(CustomComboPreset.DNC_ST_Adv_StandardFill) ||
                          IsEnabled(CustomComboPreset.DNC_ST_Adv_SS_Prepull)) &&
                         HasEffect(Buffs.StandardStep) &&
-                        gauge.CompletedSteps < 2 &&
-                        !HasTarget())
+                        gauge.CompletedSteps < 2)
                         return gauge.NextStep;
 
                     // ST Peloton
@@ -621,6 +621,7 @@ namespace WrathCombo.Combos.PvE
                 bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
                 var targetHpThresholdStandard = Config.DNC_AoE_Adv_SSBurstPercent;
                 var targetHpThresholdTechnical = Config.DNC_AoE_Adv_TSBurstPercent;
+                var hasHostileTarget = HasTarget() && CurrentTarget.IsHostile();
 
                 var needToTech =
                     IsEnabled(CustomComboPreset.DNC_AoE_Adv_TS) && // Enabled
@@ -653,6 +654,7 @@ namespace WrathCombo.Combos.PvE
 
                 // Dance Partner
                 if (!InCombat() &&
+                    hasHostileTarget &&
                     IsEnabled(CustomComboPreset.DNC_AoE_Adv_Partner) &&
                     ActionReady(ClosedPosition) &&
                     !HasEffect(Buffs.ClosedPosition) &&

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -1,5 +1,6 @@
 #region
 
+using ECommons.GameFunctions;
 using WrathCombo.Combos.PvE.Content;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Data;
@@ -21,6 +22,8 @@ internal partial class MCH
             if (actionID is not (SplitShot or HeatedSplitShot))
                 return actionID;
 
+            var hasHostileTarget = HasTarget() && CurrentTarget.IsHostile();
+
             if (IsEnabled(CustomComboPreset.MCH_Variant_Cure) &&
                 IsEnabled(Variant.VariantCure) &&
                 PlayerHealthPercentageHp() <= Config.MCH_VariantCure)
@@ -33,11 +36,12 @@ internal partial class MCH
                 return Variant.VariantRampart;
 
             // Opener
-            if (MCHOpener.DoFullOpener(ref actionID))
-                return actionID;
+            if (hasHostileTarget)
+                if (MCHOpener.DoFullOpener(ref actionID))
+                    return actionID;
 
             //Reassemble to start before combat
-            if (!HasEffect(Buffs.Reassembled) && ActionReady(Reassemble) && !InCombat())
+            if (!HasEffect(Buffs.Reassembled) && ActionReady(Reassemble) && !InCombat() && hasHostileTarget)
                 return Reassemble;
 
             // Interrupt
@@ -164,6 +168,8 @@ internal partial class MCH
             if (actionID is not (SplitShot or HeatedSplitShot))
                 return actionID;
 
+            var hasHostileTarget = HasTarget() && CurrentTarget.IsHostile();
+
             if (IsEnabled(CustomComboPreset.MCH_Variant_Cure) &&
                 IsEnabled(Variant.VariantCure) &&
                 PlayerHealthPercentageHp() <= Config.MCH_VariantCure)
@@ -176,12 +182,12 @@ internal partial class MCH
                 return Variant.VariantRampart;
 
             // Opener
-            if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Opener))
+            if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Opener) && hasHostileTarget)
                 if (MCHOpener.DoFullOpener(ref actionID))
                     return actionID;
 
             //Reassemble to start before combat
-            if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble) &&
+            if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble) && hasHostileTarget &&
                 !HasEffect(Buffs.Reassembled) && ActionReady(Reassemble) && !InCombat())
                 return Reassemble;
 


### PR DESCRIPTION
- [X] Adds check for a hostile target to all DNC prepull features
- [X] Adds same check to MCH ST openers and prepull `Reassemble`s