### PR TITLE
[Core] Account more widely for player hitbox

### DIFF
--- a/WrathCombo/CustomCombo/Functions/Target.cs
+++ b/WrathCombo/CustomCombo/Functions/Target.cs
@@ -48,7 +48,8 @@ namespace WrathCombo.CustomComboNS.Functions
 
             Vector2 position = new(chara.Position.X, chara.Position.Z);
             Vector2 selfPosition = new(sourceChara.Position.X, sourceChara.Position.Z);
-            return Math.Max(0, Vector2.Distance(position, selfPosition) - chara.HitboxRadius);
+            return Math.Max(0, Vector2.Distance(position, selfPosition) - chara
+                .HitboxRadius - 0.5f); // 0.5 is the box itself, which also needs accounted for
         }
 
         /// <summary> Gets a value indicating whether you are in melee range from the current target. </summary>
@@ -63,7 +64,7 @@ namespace WrathCombo.CustomComboNS.Functions
             if (distance == 0)
                 return true;
 
-            if (distance > 3.5 + Service.Configuration.MeleeOffset)
+            if (distance > 3.0 + Service.Configuration.MeleeOffset)
                 return false;
 
             return true;

--- a/WrathCombo/CustomCombo/Functions/Target.cs
+++ b/WrathCombo/CustomCombo/Functions/Target.cs
@@ -49,7 +49,7 @@ namespace WrathCombo.CustomComboNS.Functions
             Vector2 position = new(chara.Position.X, chara.Position.Z);
             Vector2 selfPosition = new(sourceChara.Position.X, sourceChara.Position.Z);
             return Math.Max(0, Vector2.Distance(position, selfPosition) - chara
-                .HitboxRadius - 0.5f); // 0.5 is the box itself, which also needs accounted for
+                .HitboxRadius - sourceChara.HitboxRadius);
         }
 
         /// <summary> Gets a value indicating whether you are in melee range from the current target. </summary>


### PR DESCRIPTION
- [X] Moves the accounting for the enemy hitbox from `InMeleeRange` to `GetTargetDistance`, as suggested by Tauren, and with testing with spells not just melee