### PR TITLE
[UI] Make the Ignore List more consistent

### DIFF
--- a/WrathCombo/Window/Tabs/AutoRotationTab.cs
+++ b/WrathCombo/Window/Tabs/AutoRotationTab.cs
@@ -84,7 +84,9 @@ namespace WrathCombo.Window.Tabs
                     {
                         foreach (var npc in npcs)
                         {
-                            if (ImGui.Selectable($"{Svc.Data.Excel.GetSheet<BNpcName>().GetRow(npc.Value).Singular}"))
+                            var npcData = Svc.Data.Excel
+                                .GetSheet<BNpcName>().GetRow(npc.Value);
+                            if (ImGui.Selectable($"{npcData.Singular} (ID: {npc.Key})"))
                             {
                                 _selectedNpc = npc.Key;
                             }

--- a/WrathCombo/Window/Tabs/AutoRotationTab.cs
+++ b/WrathCombo/Window/Tabs/AutoRotationTab.cs
@@ -77,7 +77,7 @@ namespace WrathCombo.Window.Tabs
 
                 var npcs = Service.Configuration.IgnoredNPCs.ToList();
                 var selected = npcs.FirstOrNull(x => x.Key == _selectedNpc);
-                var prev = selected is null ? "" : $"{Svc.Data.Excel.GetSheet<BNpcName>().GetRow(selected.Value.Value).Singular}";
+                var prev = selected is null ? "" : $"{Svc.Data.Excel.GetSheet<BNpcName>().GetRow(selected.Value.Value).Singular} (ID: {selected.Value.Key})";
                 ImGuiEx.TextUnderlined($"Ignored NPCs");
                 using (var combo = ImRaii.Combo("###Ignore", prev))
                 {

--- a/WrathCombo/Window/Tabs/AutoRotationTab.cs
+++ b/WrathCombo/Window/Tabs/AutoRotationTab.cs
@@ -78,7 +78,8 @@ namespace WrathCombo.Window.Tabs
                 var npcs = Service.Configuration.IgnoredNPCs.ToList();
                 var selected = npcs.FirstOrNull(x => x.Key == _selectedNpc);
                 var prev = selected is null ? "" : $"{Svc.Data.Excel.GetSheet<BNpcName>().GetRow(selected.Value.Value).Singular}";
-                using (var combo = ImRaii.Combo("Select NPC", prev))
+                ImGuiEx.TextUnderlined($"Ignored NPCs");
+                using (var combo = ImRaii.Combo("###Ignore", prev))
                 {
                     if (combo)
                     {
@@ -93,6 +94,10 @@ namespace WrathCombo.Window.Tabs
                         }
                     }
                 }
+                ImGuiComponents.HelpMarker("These NPCs will be ignored by Auto-Rotation.\n" +
+                                           "Every instance of this NPC will be excluded from automatic targeting.\n" +
+                                           "To remove an NPC from this list, select it and press the Delete button below.\n" +
+                                           "To add an NPC to this list, target the NPC and use the command: /wrath ignore");
 
                 if (_selectedNpc > 0)
                 {


### PR DESCRIPTION
- [X] Make the list consistent with the chat message, showing the target ID\
(especially useful for removing different levels of target dummies)
- [X] Make the list consistent with the other combo lists in the Auto-Rotation tab
  - Moves it's hint to be a hint tooltip
  - Clarifies the box with a header label instead

![image](https://github.com/user-attachments/assets/76ae073b-c3e9-4b8b-9e1d-702b90381a38)