### PR TITLE
[BRD] OpenerRewrite Pitch Perfect edit

### DIFF
--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -643,7 +643,7 @@ namespace WrathCombo.Combos.PvE
                     {
                         if (ActionWatching.GetAttackType(Opener().CurrentOpenerAction) != ActionWatching.ActionAttackType.Ability && canWeave)
                         {
-                            if (gauge.Repertoire > 0)
+                            if (gauge.Repertoire == 3 || gauge.Repertoire == 2 && GetCooldownRemainingTime(EmpyrealArrow) < 2)
                                 return OriginalHook(PitchPerfect);
 
                             if (ActionReady(HeartbreakShot))


### PR DESCRIPTION
Fixes Override Logic for PP to use at 3 stacks, 2 if empy is about to be ready. Once in, bard opener is tested and functional.