### PR TITLE
[PvP] BLM Wrath Update

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6415,64 +6415,41 @@ public enum CustomComboPreset
     #region BLACK MAGE
 
     [PvPCustomCombo]
-    [CustomComboInfo("Burst Mode", "Turns Fire and Blizzard into all-in-one damage buttons.", BLM.JobID)]
+    [ReplaceSkill(BLMPvP.Fire)]
+    [CustomComboInfo("Burst Mode", "Turns Fire into an all-in-one button.\n- Uses Blizzard spells while moving.\n- Will use Paradox when appropriate.", BLMPvP.JobID)]
     BLMPvP_BurstMode = 112000,
 
     [ParentCombo(BLMPvP_BurstMode)]
     [PvPCustomCombo]
-    [CustomComboInfo("Aetherial Manipulation Option",
-        "Uses Aetherial Manipulation to gap close if Burst is off cooldown.", BLM.JobID)]
-    BLMPvP_BurstMode_AetherialManip = 112001,
+    [CustomComboInfo("Burst Option", "Uses Burst when available.\n- Requires target to be within range.", BLMPvP.JobID)]
+    BLMPvP_Burst = 112001,
 
     [ParentCombo(BLMPvP_BurstMode)]
     [PvPCustomCombo]
-    [CustomComboInfo("Burst cast Option", "Adds Burst to Burst Mode.", BLM.JobID)]
-    BLMPvP_BurstMode_Burst = 112002,
+    [CustomComboInfo("Xenoglossy Option", "Uses Xenoglossy when available.\n- Requires target's HP to be under:", BLMPvP.JobID)]
+    BLMPvP_Xenoglossy = 112002,
 
     [ParentCombo(BLMPvP_BurstMode)]
     [PvPCustomCombo]
-    [CustomComboInfo("Paradox Option", "Adds Paradox to Burst Mode.", BLM.JobID)]
-    BLMPvP_BurstMode_Paradox = 112003,
+    [CustomComboInfo("Lethargy Option", "Uses Lethargy when available.\n- Will not use against non-players.\n- Requires target's HP to be under:", BLMPvP.JobID)]
+    BLMPvP_Lethargy = 112003,
 
     [ParentCombo(BLMPvP_BurstMode)]
     [PvPCustomCombo]
-    [CustomComboInfo("Xenoglossy Option", "Adds Xenoglossy to Burst Mode.", BLM.JobID)]
-    BLMPvP_BurstMode_Xenoglossy = 112004,
+    [CustomComboInfo("Elemental Weave Option", "Uses Wreath of Fire when available.\n- Requires player's HP to be at or above:", BLMPvP.JobID)]
+    BLMPvP_ElementalWeave = 112004,
 
     [ParentCombo(BLMPvP_BurstMode)]
     [PvPCustomCombo]
-    [CustomComboInfo("Lethargy Option", "Adds Lethargy to Burst Mode.", BLM.JobID)]
-    BLMPvP_BurstMode_Lethargy = 112005,
+    [CustomComboInfo("Elemental Star Option", "Uses Elemental Star when available.\n- Prioritizes Flare Star unless expiring.", BLMPvP.JobID)]
+    BLMPvP_ElementalStar = 112005,
 
-    [ParentCombo(BLMPvP_BurstMode)]
     [PvPCustomCombo]
-    [CustomComboInfo("Wreath of Fire (Elemental Weave) Option",
-        "Adds Wreath of Fire to Burst Mode when the target is under Guard status.", BLM.JobID)]
-    BLMPvP_BurstMode_WreathOfFire = 112006,
+    [ReplaceSkill(BLMPvP.AetherialManipulation)]
+    [CustomComboInfo("Aetherial Manipulation Feature", "Adds Purify when affected by crowd control.\n- Requires Purify to be available.", BLMPvP.JobID)]
+    BLMPvP_Manipulation_Feature = 112006,
 
-    [ParentCombo(BLMPvP_BurstMode_WreathOfFire)]
-    [PvPCustomCombo]
-    [CustomComboInfo("Wreath of Fire (Elemental Weave) Execute Option",
-        "Adds Wreath of Fire to Burst Mode when the target is under selected %", BLM.JobID)]
-    BLMPvP_BurstMode_WreathOfFireExecute = 112010,
-
-    [ParentCombo(BLMPvP_BurstMode)]
-    [PvPCustomCombo]
-    [CustomComboInfo("Wreath of Ice (Elemental Weave) Option",
-        "Adds Wreath of Ice to Burst Mode when player is below set threshold", BLM.JobID)]
-    BLMPvP_BurstMode_WreathOfIce = 112007,
-
-    [ParentCombo(BLMPvP_BurstMode)]
-    [PvPCustomCombo]
-    [CustomComboInfo("Flare Star Option", "Adds Flare Star to Burst Mode.", BLM.JobID)]
-    BLMPvP_BurstMode_FlareStar = 112008,
-
-    [ParentCombo(BLMPvP_BurstMode)]
-    [PvPCustomCombo]
-    [CustomComboInfo("Frost Star Option", "Adds Frost Star to Burst Mode.", BLM.JobID)]
-    BLMPvP_BurstMode_FrostStar = 112009,
-
-    // Last value = 112010
+    // Last value = 112006
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
@@ -1,6 +1,3 @@
-using Dalamud.Interface.Colors;
-using Dalamud.Interface.Components;
-using Dalamud.Interface.Utility.Raii;
 using ImGuiNET;
 using WrathCombo.Combos.PvP;
 using WrathCombo.CustomComboNS.Functions;

--- a/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
@@ -1,3 +1,8 @@
+using Dalamud.Interface.Colors;
+using Dalamud.Interface.Components;
+using Dalamud.Interface.Utility.Raii;
+using ImGuiNET;
+using WrathCombo.Combos.PvP;
 using WrathCombo.CustomComboNS.Functions;
 using static WrathCombo.Window.Functions.UserConfig;
 
@@ -106,15 +111,39 @@ internal partial class BLM
 
                     break;
 
-                case CustomComboPreset.BLMPvP_BurstMode_WreathOfIce:
-                    DrawSliderInt(0, 100, BLMPvP_BurstMode_WreathOfIce,
-                        "Use Wreath of ice below this threshold");
+                // PvP
+
+                // Burst
+                case CustomComboPreset.BLMPvP_Burst:
+                    DrawAdditionalBoolChoice(BLMPvP.Config.BLMPvP_Burst_SubOption, "Defensive Burst",
+                        "Also uses Burst when under 50%% HP.\n- Will not use outside combat.");
 
                     break;
 
-                case CustomComboPreset.BLMPvP_BurstMode_WreathOfFireExecute:
-                    DrawSliderInt(0, 100, BLMPvP_BurstMode_WreathOfFireExecute,
-                        "Use Wreath of Fire below this % threshold");
+                // Elemental Weave
+                case CustomComboPreset.BLMPvP_ElementalWeave:
+                    DrawSliderInt(10, 100, BLMPvP.Config.BLMPvP_ElementalWeave_PlayerHP, "Player HP%", 180);
+                    ImGui.Spacing();
+                    DrawAdditionalBoolChoice(BLMPvP.Config.BLMPvP_ElementalWeave_SubOption, "Defensive Elemental Weave",
+                        "When under, uses Wreath of Ice instead.\n- Will not use outside combat.");
+
+                    break;
+
+                // Lethargy
+                case CustomComboPreset.BLMPvP_Lethargy:
+                    DrawSliderInt(10, 100, BLMPvP.Config.BLMPvP_Lethargy_TargetHP, "Target HP%", 180);
+                    ImGui.Spacing();
+                    DrawAdditionalBoolChoice(BLMPvP.Config.BLMPvP_Lethargy_SubOption, "Defensive Lethargy",
+                        "Also uses Lethargy when under 50%% HP.\n- Uses only when targeted by enemy.");
+
+                    break;
+
+                // Xenoglossy
+                case CustomComboPreset.BLMPvP_Xenoglossy:
+                    DrawSliderInt(10, 100, BLMPvP.Config.BLMPvP_Xenoglossy_TargetHP, "Target HP%", 180);
+                    ImGui.Spacing();
+                    DrawAdditionalBoolChoice(BLMPvP.Config.BLMPvP_Xenoglossy_SubOption, "Defensive Xenoglossy",
+                        "Also uses Xenoglossy when under 50%% HP.");
 
                     break;
             }

--- a/WrathCombo/Combos/PvP/BLMPVP.cs
+++ b/WrathCombo/Combos/PvP/BLMPVP.cs
@@ -1,23 +1,30 @@
 ﻿using WrathCombo.CustomComboNS;
+using WrathCombo.CustomComboNS.Functions;
 
 namespace WrathCombo.Combos.PvP
 {
     internal static class BLMPvP
     {
+        public const byte JobID = 25;
+
         public const uint
             Fire = 29649,
             Blizzard = 29653,
             Burst = 29657,
             Paradox = 29663,
-            NightWing = 29659,
             AetherialManipulation = 29660,
-            Superflare = 29661,
+            Fire3 = 30896,
             Fire4 = 29650,
             Flare = 29651,
+            Blizzard3 = 30897,
             Blizzard4 = 29654,
             Freeze = 29655,
             Lethargy = 41510,
+            HighFireII = 41473,
+            HighBlizzardII = 41474,
             ElementalWeave = 41475,
+            FlareStar = 41480,
+            FrostStar = 41481,
             SoulResonance = 29662,
             Xenoglossy = 29658;
 
@@ -32,27 +39,32 @@ namespace WrathCombo.Combos.PvP
                 UmbralIce3 = 3382,
                 Burst = 3221,
                 SoulResonance = 3222,
-                Polyglot = 3169,
                 ElementalStar = 4317,
-                WreathOfFire= 4315,
+                WreathOfFire = 4315,
+                WreathOfIce = 4316,
                 Paradox = 3223;
         }
 
         public static class Debuffs
         {
             public const ushort
-                AstralWarmth = 3216,
-                UmbralFreeze = 3217,
                 Burns = 3218,
-                DeepFreeze = 3219;
+                DeepFreeze = 3219,
+                Lethargy = 4333;
         }
 
         public static class Config
         {
-            public const string
-                BLMPvP_BurstMode_WreathOfIce = "BLMPvP_BurstMode_WreathOfIce",
-                BLMPvP_BurstMode_WreathOfFireExecute = "BLMPvP_BurstMode_WreathOfFireExecute";
+            internal static UserInt
+                BLMPvP_ElementalWeave_PlayerHP = new("BLMPvP_ElementalWeave_PlayerHP", 50),
+                BLMPvP_Lethargy_TargetHP = new("BLMPvP_Lethargy_TargetHP", 50),
+                BLMPvP_Xenoglossy_TargetHP = new("BLMPvP_Xenoglossy_TargetHP", 50);
 
+            public static UserBool
+                BLMPvP_Burst_SubOption = new("BLMPvP_Burst_SubOption"),
+                BLMPvP_ElementalWeave_SubOption = new ("BLMPvP_ElementalWeave_SubOption"),
+                BLMPvP_Lethargy_SubOption = new("BLMPvP_Lethargy_SubOption"),
+                BLMPvP_Xenoglossy_SubOption = new ("BLMPvP_Xenoglossy_SubOption");
         }
 
         internal class BLMPvP_BurstMode : CustomCombo
@@ -61,76 +73,123 @@ namespace WrathCombo.Combos.PvP
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                bool canWeave = CanSpellWeave(actionID);
+                #region Variables
+                float targetDistance = GetTargetDistance();
+                float targetCurrentPercentHp = GetTargetHPPercent();
+                float playerCurrentPercentHp = PlayerHealthPercentageHp();
+                uint chargesXenoglossy = HasCharges(Xenoglossy) ? GetCooldown(Xenoglossy).RemainingCharges : 0;
+                bool isMoving = IsMoving;
+                bool inCombat = InCombat();
+                bool hasTarget = HasTarget();
+                bool isTargetNPC = HasBattleTarget();
+                bool hasParadox = HasEffect(Buffs.Paradox);
+                bool hasIceAoE = HasEffect(Buffs.UmbralIce3);
+                bool hasResonance = HasEffect(Buffs.SoulResonance);
+                bool hasWreathOfFire = HasEffect(Buffs.WreathOfFire);
+                bool hasFlareStar = OriginalHook(SoulResonance) is FlareStar;
+                bool hasFrostStar = OriginalHook(SoulResonance) is FrostStar;
+                bool targetHasGuard = TargetHasEffectAny(PvPCommon.Buffs.Guard);
+                bool targetHasHeavy = TargetHasEffectAny(PvPCommon.Debuffs.Heavy);
+                bool isPlayerTargeted = CurrentTarget?.TargetObjectId == LocalPlayer.GameObjectId;
+                bool isParadoxPrimed = HasEffect(Buffs.UmbralIce1) || HasEffect(Buffs.AstralFire1);
+                bool isResonanceExpiring = HasEffect(Buffs.SoulResonance) && GetBuffRemainingTime(Buffs.SoulResonance) <= 10;
+                bool hasUmbralIce = HasEffect(Buffs.UmbralIce1) || HasEffect(Buffs.UmbralIce2) || HasEffect(Buffs.UmbralIce3);
+                bool isElementalStarExpiring = HasEffect(Buffs.ElementalStar) && GetBuffRemainingTime(Buffs.ElementalStar) <= 10;
+                bool hasAstralFire = HasEffect(Buffs.AstralFire1) || HasEffect(Buffs.AstralFire2) || HasEffect(Buffs.AstralFire3);
+                bool targetHasImmunity = TargetHasEffectAny(PLDPvP.Buffs.HallowedGround) || TargetHasEffectAny(DRKPvP.Buffs.UndeadRedemption);
+                #endregion
 
-                if (actionID is Fire or Fire4 or Flare)
+                if (actionID is Fire or Fire3 or Fire4 or HighFireII or Flare)
                 {
-
-                    if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_WreathOfFire))
+                    if (inCombat)
                     {
-                        if (IsOffCooldown(ElementalWeave) && (TargetHasEffectAny(PvPCommon.Buffs.Guard) || GetTargetHPPercent() < GetOptionValue(Config.BLMPvP_BurstMode_WreathOfFireExecute) && IsEnabled(CustomComboPreset.BLMPvP_BurstMode_WreathOfFireExecute))
-                            && canWeave && (HasEffect(Buffs.AstralFire1) || HasEffect(Buffs.AstralFire2) || HasEffect(Buffs.AstralFire3)))
+                        // Burst (Defensive)
+                        if (IsEnabled(CustomComboPreset.BLMPvP_Burst) && Config.BLMPvP_Burst_SubOption && IsOffCooldown(Burst) && playerCurrentPercentHp < 50)
+                            return OriginalHook(Burst);
+
+                        // Elemental Weave (Defensive)
+                        if (IsEnabled(CustomComboPreset.BLMPvP_ElementalWeave) && Config.BLMPvP_ElementalWeave_SubOption &&
+                            IsOffCooldown(ElementalWeave) && hasUmbralIce && playerCurrentPercentHp < Config.BLMPvP_ElementalWeave_PlayerHP)
                             return OriginalHook(ElementalWeave);
                     }
 
-                    if (!PvPCommon.TargetImmuneToDamage() || HasEffect(Buffs.WreathOfFire))
+                    if (hasTarget && !targetHasImmunity)
                     {
-                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_FlareStar) && HasEffect(Buffs.ElementalStar) && (HasEffect(Buffs.AstralFire1) || HasEffect(Buffs.AstralFire2) || HasEffect(Buffs.AstralFire3)))
-                            return OriginalHook(SoulResonance);
+                        // Elemental Weave (Offensive)
+                        if (IsEnabled(CustomComboPreset.BLMPvP_ElementalWeave) && IsOffCooldown(ElementalWeave) && hasAstralFire &&
+                            targetDistance <= 25 && playerCurrentPercentHp >= Config.BLMPvP_ElementalWeave_PlayerHP)
+                            return OriginalHook(ElementalWeave);
 
-                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_Xenoglossy) && HasCharges(Xenoglossy))
-                            return Xenoglossy;
+                        if (!targetHasGuard)
+                        {
+                            // Lethargy
+                            if (IsEnabled(CustomComboPreset.BLMPvP_Lethargy) && IsOffCooldown(Lethargy) && !isTargetNPC)
+                            {
+                                // Offensive
+                                if (targetCurrentPercentHp < Config.BLMPvP_Lethargy_TargetHP && !targetHasHeavy)
+                                    return OriginalHook(Lethargy);
 
-                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_AetherialManip) &&
-                            ActionReady(AetherialManipulation) &&
-                            !InMeleeRange() && IsOffCooldown(Burst) && canWeave)
-                            return AetherialManipulation;
+                                // Defensive
+                                if (Config.BLMPvP_Lethargy_SubOption && playerCurrentPercentHp < 50 && isPlayerTargeted)
+                                    return OriginalHook(Lethargy);
+                            }
 
-                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_Burst) && InMeleeRange() &&
-                            IsOffCooldown(Burst))
-                            return Burst;
+                            // Burst (Offensive)
+                            if (IsEnabled(CustomComboPreset.BLMPvP_Burst) && IsOffCooldown(Burst) && targetDistance <= 4)
+                                return OriginalHook(Burst);
 
-                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_Lethargy) && IsOffCooldown(Lethargy) && canWeave)
-                            return Lethargy;
+                            // Flare Star / Frost Star
+                            if (IsEnabled(CustomComboPreset.BLMPvP_ElementalStar) && ((hasFlareStar && !isMoving) || (hasFrostStar && isElementalStarExpiring)))
+                                return OriginalHook(SoulResonance);
 
-                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_Paradox) && HasEffect(Buffs.Paradox))
-                            return Paradox;
+                            // Xenoglossy
+                            if (IsEnabled(CustomComboPreset.BLMPvP_Xenoglossy) && chargesXenoglossy > 0)
+                            {
+                                // Defensive
+                                if (Config.BLMPvP_Xenoglossy_SubOption && playerCurrentPercentHp < 50)
+                                    return OriginalHook(Xenoglossy);
+
+                                // Offensive
+                                if (!isResonanceExpiring && (isTargetNPC ? chargesXenoglossy > 1 && hasWreathOfFire : targetCurrentPercentHp < Config.BLMPvP_Xenoglossy_TargetHP))
+                                    return OriginalHook(Xenoglossy);
+                            }
+                        }
                     }
 
+                    // Paradox
+                    if (hasParadox && ((isParadoxPrimed && !hasResonance) || (hasAstralFire && isMoving)))
+                        return OriginalHook(Paradox);
+
+                    // Fire Mode
+                    if (!isMoving)
+                    {
+                        // High Blizzard II
+                        if (hasIceAoE && !hasResonance)
+                            return OriginalHook(Blizzard);
+
+                        return OriginalHook(actionID);
+                    }
+
+                    // Ice Mode
+                    else return OriginalHook(Blizzard);
                 }
 
-                if (actionID is Blizzard or Blizzard4 or Freeze)
+                return actionID;
+            }
+        }
+
+        internal class BLMPvP_Manipulation_Feature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BLMPvP_Manipulation_Feature;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                bool hasCrowdControl = HasEffectAny(PvPCommon.Debuffs.Stun) || HasEffectAny(PvPCommon.Debuffs.DeepFreeze) ||
+                                       HasEffectAny(PvPCommon.Debuffs.Bind) || HasEffectAny(PvPCommon.Debuffs.Silence) || HasEffectAny(PvPCommon.Debuffs.MiracleOfNature);
+
+                if (actionID is AetherialManipulation)
                 {
-
-                    if (!PvPCommon.TargetImmuneToDamage() || HasEffect(Buffs.WreathOfFire))
-                    {
-                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_FrostStar) && HasEffect(Buffs.ElementalStar) && (HasEffect(Buffs.UmbralIce1) || HasEffect(Buffs.UmbralIce2) || HasEffect(Buffs.UmbralIce3)))
-                            return OriginalHook(SoulResonance);
-
-                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_Xenoglossy) && HasCharges(Xenoglossy))
-                            return Xenoglossy;
-
-                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_AetherialManip) &&
-                            ActionReady(AetherialManipulation) &&
-                            !InMeleeRange() &&
-                            IsOffCooldown(Burst) &&
-                            canWeave)
-                            return AetherialManipulation;
-
-                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_Burst) && InMeleeRange() &&
-                            IsOffCooldown(Burst))
-                            return Burst;
-
-                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_Lethargy) && IsOffCooldown(Lethargy) && canWeave)
-                            return Lethargy;
-
-                        if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_Paradox) && HasEffect(Buffs.Paradox))
-                            return Paradox;
-                    }
-
-                    if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_WreathOfIce) && IsOffCooldown(ElementalWeave) && canWeave && PlayerHealthPercentageHp() <= GetOptionValue(Config.BLMPvP_BurstMode_WreathOfIce)
-                        && (HasEffect(Buffs.UmbralIce1) || HasEffect(Buffs.UmbralIce2) || HasEffect(Buffs.UmbralIce3)))
-                        return OriginalHook(ElementalWeave);
+                    if (IsOffCooldown(AetherialManipulation) && IsOffCooldown(PvPCommon.Purify) && hasCrowdControl)
+                        return OriginalHook(PvPCommon.Purify);
                 }
 
                 return actionID;


### PR DESCRIPTION
Black Mage has been revisited for Patch 7.15.

## Major Changes
- Complete logic rework.
- Fire and Blizzard spells have been condensed into one button.
- Smart Paradox usage for higher damage and fire-aspected uptime.
- Elemental Weave now accommodates both Fire and Ice wreaths.
- Several actions now have toggles to include defensive usage.

## Minor Changes
- Lethargy will no longer be used against NPCs.
- Xenoglossy prefers saving charges when used against NPCs.
- Aetherial Manipulation removed as it no longer grants Swiftcast.

## Other Changes
- Removed all weaving checks and obsolete IDs.
- Added missing actionIDs for Fire/Blizzard III and High Fire/Blizzard II.
- Added `Aetherial Manipulation Feature` for quick debuff cleansing.

![987456844](https://github.com/user-attachments/assets/2351d91d-7a47-44fa-a68b-d8d0c6c4c6dc)