### PR TITLE
[PvP] RDM Wrath Update

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -7147,35 +7147,46 @@ public enum CustomComboPreset
     #region RED MAGE
 
     [PvPCustomCombo]
-    [CustomComboInfo("Burst Mode", "Turns Jolt3 into an all-in-one damage button.", RDMPvP.JobID)]
+    [ReplaceSkill(RDMPvP.Jolt3)]
+    [CustomComboInfo("Burst Mode", "Turns Jolt III into an all-in-one button.\n- Will not attempt to cast Jolt III while moving.", RDMPvP.JobID)]
     RDMPvP_BurstMode = 123000,
 
     [PvPCustomCombo]
     [ParentCombo(RDMPvP_BurstMode)]
-    [CustomComboInfo("Corps-a-Corps Option", "Adds Corps-a-Corps to Burst Mode.", RDMPvP.JobID)]
-    RDMPvP_Burst_CorpsACorps = 123001,
+    [CustomComboInfo("Riposte Combo Option", "Uses Riposte and Scorch when available.\n- Requires melee range for Riposte Combo.", RDMPvP.JobID)]
+    RDMPvP_Riposte = 123001,
 
     [PvPCustomCombo]
     [ParentCombo(RDMPvP_BurstMode)]
-    [CustomComboInfo("Displacement Option", "Adds Displacement to Burst Mode.", RDMPvP.JobID)]
-    RDMPvP_Burst_Displacement = 123002,
+    [CustomComboInfo("Resolution Option", "Uses Resolution when available.\n- Will not use against non-players.\n- Requires target's HP to be under:", RDMPvP.JobID)]
+    RDMPvP_Resolution = 123002,
 
     [PvPCustomCombo]
     [ParentCombo(RDMPvP_BurstMode)]
-    [CustomComboInfo("Embolden Option", "Adds Embolden to Burst Mode.", RDMPvP.JobID)]
-    RDMPvP_Burst_Embolden = 123003,
+    [CustomComboInfo("Embolden Option", "Uses Embolden when available.\n- Requires Enchanted Riposte to be available.\n- Will use alongside Corps-a-corps if enabled.", RDMPvP.JobID)]
+    RDMPvP_Embolden = 123003,
 
     [PvPCustomCombo]
     [ParentCombo(RDMPvP_BurstMode)]
-    [CustomComboInfo("Resolution Option", "Adds Resolution to Burst Mode.", RDMPvP.JobID)]
-    RDMPvP_Burst_Resolution = 123004,
+    [CustomComboInfo("Corps-a-corps Option", "Uses Corps-a-corps when available.\n- Must remain within maximum range.\n- Requires Enchanted Riposte to be available.", RDMPvP.JobID)]
+    RDMPvP_Corps = 123004,
 
     [PvPCustomCombo]
     [ParentCombo(RDMPvP_BurstMode)]
-    [CustomComboInfo("Enchanted Riposte Option", "Adds Enchanted Riposte to Burst Mode.", RDMPvP.JobID)]
-    RDMPvP_Burst_EnchantedRiposte = 123005,
+    [CustomComboInfo("Displacement Option", "Uses Displacement when available.\n- Will use when Scorch becomes available.\n- Requires target to be within melee range.", RDMPvP.JobID)]
+    RDMPvP_Displacement = 123005,
 
-    // Last value = 123005
+    [PvPCustomCombo]
+    [ParentCombo(RDMPvP_BurstMode)]
+    [CustomComboInfo("Forte Option", "Uses Forte when available.\n- Will not use outside combat.\n- Requires player's HP to be under:", RDMPvP.JobID)]
+    RDMPvP_Forte = 123006,
+
+    [PvPCustomCombo]
+    [ReplaceSkill(RDMPvP.CorpsACorps, RDMPvP.Displacement)]
+    [CustomComboInfo("Corps-a-corps / Displacement Feature", "Adds Purify when affected by crowd control.\n- Requires Purify to be available.", RDMPvP.JobID)]
+    RDMPvP_Dash_Feature = 123007,
+
+    // Last value = 123007
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
@@ -6,6 +6,7 @@ using static WrathCombo.Window.Functions.UserConfig;
 using static WrathCombo.Window.Functions.SliderIncrements;
 using WrathCombo.Window.Functions;
 using WrathCombo.Data;
+using WrathCombo.Combos.PvP;
 
 namespace WrathCombo.Combos.PvE
 {
@@ -181,15 +182,43 @@ namespace WrathCombo.Combos.PvE
                         DrawSliderInt(1, 100, RDM_VariantCure, "HP% to be at or under", 200);
                         break;
 
-                    case CustomComboPreset.RDMPvP_Burst_CorpsACorps:
-                        DrawSliderInt(0, 1, RDMPvP_Burst_CorpsACorps,
-                            "How many charges to keep ready? (0 = Use all)");
+                    // PvP
+
+                    // Resolution
+                    case CustomComboPreset.RDMPvP_Resolution:
+                        DrawSliderInt(10, 100, RDMPvP.Config.RDMPvP_Resolution_TargetHP, "Target HP%", 210);
 
                         break;
 
-                    case CustomComboPreset.RDMPvP_Burst_Displacement:
-                        DrawSliderInt(0, 1, RDMPvP_Burst_Displacement,
-                            "How many charges to keep ready? (0 = Use all)");
+                    // Embolden / Prefulgence
+                    case CustomComboPreset.RDMPvP_Embolden:
+                        DrawAdditionalBoolChoice(RDMPvP.Config.RDMPvP_Embolden_SubOption, "Prefulgence Option",
+                            "Uses Prefulgence when available.");
+
+                        break;
+
+                    // Corps-a-Corps
+                    case CustomComboPreset.RDMPvP_Corps:
+                        DrawSliderInt(0, 1, RDMPvP.Config.RDMPvP_Corps_Charges, "Charges to Keep", 178);
+                        DrawSliderInt(5, 10, RDMPvP.Config.RDMPvP_Corps_Range, "Maximum Range", 173);
+
+                        break;
+
+                    // Displacement
+                    case CustomComboPreset.RDMPvP_Displacement:
+                        DrawSliderInt(0, 1, RDMPvP.Config.RDMPvP_Displacement_Charges, "Charges to Keep", 178);
+                        ImGui.Spacing();
+                        DrawAdditionalBoolChoice(RDMPvP.Config.RDMPvP_Displacement_SubOption, "No Movement Option",
+                            "Uses Displacement only when not moving.");
+
+                        break;
+
+                    // Forte / Vice of Thorns
+                    case CustomComboPreset.RDMPvP_Forte:
+                        DrawSliderInt(10, 100, RDMPvP.Config.RDMPvP_Forte_PlayerHP, "Player HP%", 210);
+                        ImGui.Spacing();
+                        DrawAdditionalBoolChoice(RDMPvP.Config.RDMPvP_Forte_SubOption, "Vice of Thorns Option",
+                            "Uses Vice of Thorns when available.");
 
                         break;
                 }

--- a/WrathCombo/Combos/PvP/RDMPVP.cs
+++ b/WrathCombo/Combos/PvP/RDMPVP.cs
@@ -1,4 +1,5 @@
 ﻿using WrathCombo.CustomComboNS;
+using WrathCombo.CustomComboNS.Functions;
 
 namespace WrathCombo.Combos.PvP
 {
@@ -7,39 +8,34 @@ namespace WrathCombo.Combos.PvP
         public const byte JobID = 35;
 
         public const uint
-            Verstone = 29683,
             EnchantedRiposte = 41488,
             Resolution = 41492,
-            MagickBarrier = 29697,
             CorpsACorps = 29699,
             Displacement = 29700,
             EnchantedZwerchhau = 41489,
             EnchantedRedoublement = 41490,
-            Frazzle = 29698,
-            SouthernCross = 29704,
-            Scorch = 41491,
+            SouthernCross = 41498,
             Embolden = 41494,
             Forte = 41496,
+            Scorch = 41491,
+            GrandImpact = 41487,
             Jolt3 = 41486,
-            ViceofThorns = 41493,
+            ViceOfThorns = 41493,
             Prefulgence = 41495;
 
         public static class Buffs
         {
             public const ushort
-                WhiteShift = 3245,
-                BlackShift = 3246,
                 Dualcast = 1393,
                 EnchantedRiposte = 3234,
                 EnchantedRedoublement = 3236,
                 EnchantedZwerchhau = 3235,
                 VermilionRadiance = 3233,
-                MagickBarrier = 3240,
                 Displacement = 3243,
                 Embolden = 2282,
                 Forte = 4320,
                 PrefulgenceReady = 4322,
-                ThornedFlourish = 0;
+                ThornedFlourish = 4321;
         }
 
         public static class Debuffs
@@ -49,11 +45,19 @@ namespace WrathCombo.Combos.PvP
         }
         public static class Config
         {
-            public const string
-                RDMPvP_Burst_CorpsACorps = "RDMPvP_Burst_CorpsACorps",
-                RDMPvP_Burst_Displacement = "RDMPvP_Burst_Displacement";
+            internal static UserInt
+                RDMPvP_Corps_Range = new("RDMPvP_Corps_Range", 5),
+                RDMPvP_Corps_Charges = new("RDMPvP_Corps_Charges", 1),
+                RDMPvP_Displacement_Charges = new("RDMPvP_Displacement_Charges", 1),
+                RDMPvP_Forte_PlayerHP = new("RDMPvP_Forte_PlayerHP", 50),
+                RDMPvP_Resolution_TargetHP = new("RDMPvP_Resolution_TargetHP", 50);
 
+            public static UserBool
+                RDMPvP_Forte_SubOption = new("RDMPvP_Forte_SubOption"),
+                RDMPvP_Embolden_SubOption = new("RDMPvP_Embolden_SubOption"),
+                RDMPvP_Displacement_SubOption = new("RDMPvP_Displacement_SubOption");
         }
+
         internal class RDMPvP_BurstMode : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDMPvP_BurstMode;
@@ -62,38 +66,137 @@ namespace WrathCombo.Combos.PvP
             {
                 if (actionID is Jolt3)
                 {
-                    if (ActionReady(Forte) && CanWeave())
-                        return Forte;
+                    #region Variables
+                    float targetDistance = GetTargetDistance();
+                    float targetCurrentPercentHp = GetTargetHPPercent();
+                    float playerCurrentPercentHp = PlayerHealthPercentageHp();
+                    uint chargesCorps = HasCharges(CorpsACorps) ? GetCooldown(CorpsACorps).RemainingCharges : 0;
+                    uint chargesDisplacement = HasCharges(Displacement) ? GetCooldown(Displacement).RemainingCharges : 0;
+                    bool isMoving = IsMoving();
+                    bool inCombat = InCombat();
+                    bool hasTarget = HasTarget();
+                    bool isTargetNPC = HasBattleTarget();
+                    bool inMeleeRange = targetDistance <= 5;
+                    bool hasBind = HasEffectAny(PvPCommon.Debuffs.Bind);
+                    bool isCorpsAvailable = chargesCorps > 0 && !hasBind;
+                    bool hasScorch = OriginalHook(EnchantedRiposte) is Scorch;
+                    bool hasViceOfThorns = OriginalHook(Forte) is ViceOfThorns;
+                    bool hasPrefulgence = OriginalHook(Embolden) is Prefulgence;
+                    bool hasGrandImpact = OriginalHook(actionID) is GrandImpact;
+                    bool targetHasGuard = TargetHasEffectAny(PvPCommon.Buffs.Guard);
+                    bool hasForte = IsOffCooldown(Forte) && OriginalHook(Forte) is Forte;
+                    bool hasEmbolden = IsOffCooldown(Embolden) && OriginalHook(Embolden) is Embolden;
+                    bool isEmboldenDelayDependant = !JustUsed(Embolden, 5f) || IsOnCooldown(EnchantedRiposte);
+                    bool hasMeleeCombo = OriginalHook(EnchantedRiposte) is EnchantedZwerchhau or EnchantedRedoublement;
+                    bool isEnabledViceOfThorns = IsEnabled(CustomComboPreset.RDMPvP_Forte) && Config.RDMPvP_Forte_SubOption;
+                    bool isEnabledPrefulgence = IsEnabled(CustomComboPreset.RDMPvP_Embolden) && Config.RDMPvP_Embolden_SubOption;
+                    bool hasEnchantedRiposte = IsOffCooldown(EnchantedRiposte) && OriginalHook(EnchantedRiposte) is EnchantedRiposte;
+                    bool isViceOfThornsExpiring = HasEffect(Buffs.ThornedFlourish) && GetBuffRemainingTime(Buffs.ThornedFlourish) <= 3;
+                    bool isPrefulgenceExpiring = HasEffect(Buffs.PrefulgenceReady) && GetBuffRemainingTime(Buffs.PrefulgenceReady) <= 3;
+                    bool isMovementDependant = !Config.RDMPvP_Displacement_SubOption || (Config.RDMPvP_Displacement_SubOption && !isMoving);
+                    bool targetHasImmunity = TargetHasEffectAny(PLDPvP.Buffs.HallowedGround) || TargetHasEffectAny(DRKPvP.Buffs.UndeadRedemption);
+                    bool isDisplacementPrimed = !hasBind && !JustUsed(Displacement, 8f) && !HasEffect(Buffs.Displacement) && hasScorch && inMeleeRange;
+                    bool isCorpsPrimed = !hasBind && !JustUsed(CorpsACorps, 8f) && chargesCorps > Config.RDMPvP_Corps_Charges && targetDistance <= Config.RDMPvP_Corps_Range;
+                    #endregion
 
-                    if (IsEnabled(CustomComboPreset.RDMPvP_Burst_Resolution) && ActionReady(Resolution) && !PvPCommon.TargetImmuneToDamage())
-                        return OriginalHook(Resolution);
+                    // Forte
+                    if (IsEnabled(CustomComboPreset.RDMPvP_Forte) && hasForte && inCombat &&
+                        playerCurrentPercentHp < Config.RDMPvP_Forte_PlayerHP)
+                        return OriginalHook(Forte);
 
-                    if (IsEnabled(CustomComboPreset.RDMPvP_Burst_CorpsACorps) && GetRemainingCharges(CorpsACorps) > GetOptionValue(Config.RDMPvP_Burst_CorpsACorps) && ActionReady(EnchantedRiposte) && !InMeleeRange())
-                        return OriginalHook(CorpsACorps);
-
-                    if (InMeleeRange())
+                    if (hasTarget && !targetHasImmunity)
                     {
-                        if (IsEnabled(CustomComboPreset.RDMPvP_Burst_Embolden))
+                        if (!targetHasGuard)
                         {
-                            if (ActionReady(Embolden) && OriginalHook(Embolden) == Embolden && (WasLastAbility(CorpsACorps) || TargetHasEffect(Debuffs.Monomachy)))
+                            // Vice of Thorns
+                            if (isEnabledViceOfThorns && hasViceOfThorns && (!isTargetNPC || isViceOfThornsExpiring))
+                                return OriginalHook(Forte);
+
+                            // Displacement
+                            if (IsEnabled(CustomComboPreset.RDMPvP_Displacement) && isDisplacementPrimed &&
+                                isMovementDependant && chargesDisplacement > Config.RDMPvP_Displacement_Charges)
+                                return OriginalHook(Displacement);
+                        }
+
+                        if (hasEnchantedRiposte)
+                        {
+                            // Embolden
+                            if (IsEnabled(CustomComboPreset.RDMPvP_Embolden) && hasEmbolden)
+                            {
+                                // Combo Setting
+                                if (IsEnabled(CustomComboPreset.RDMPvP_Corps) && (isCorpsPrimed || (!isCorpsPrimed && inMeleeRange)))
+                                    return OriginalHook(Embolden);
+
+                                // Solo Setting
+                                if (IsNotEnabled(CustomComboPreset.RDMPvP_Corps) && (inMeleeRange || (inCombat && isCorpsAvailable)))
+                                    return OriginalHook(Embolden);
+                            }
+
+                            // Corps-a-Corps
+                            if (IsEnabled(CustomComboPreset.RDMPvP_Corps) && isCorpsPrimed)
+                                return OriginalHook(CorpsACorps);
+                        }
+
+                        // Riposte Combo
+                        if (IsEnabled(CustomComboPreset.RDMPvP_Riposte) && inMeleeRange && (hasEnchantedRiposte || hasMeleeCombo))
+                            return OriginalHook(EnchantedRiposte);
+
+                        // Prefulgence
+                        if (isEnabledPrefulgence && hasPrefulgence && isEmboldenDelayDependant)
+                        {
+                            // Conditional
+                            if (isPrefulgenceExpiring || playerCurrentPercentHp < 50)
+                                return OriginalHook(Embolden);
+
+                            // Offensive
+                            if (!targetHasGuard && !hasScorch)
                                 return OriginalHook(Embolden);
                         }
 
-                        if (IsEnabled(CustomComboPreset.RDMPvP_Burst_Displacement) && GetRemainingCharges(Displacement) > GetOptionValue(Config.RDMPvP_Burst_Displacement) && !ActionReady(EnchantedRiposte) && OriginalHook(EnchantedRiposte) == Scorch)
-                            return OriginalHook(Displacement);
-
-                        if (IsEnabled(CustomComboPreset.RDMPvP_Burst_EnchantedRiposte))
+                        if (!targetHasGuard)
                         {
-                            if (ActionReady(EnchantedRiposte) || OriginalHook(EnchantedRiposte) != EnchantedRiposte)
+                            // Scorch
+                            if (IsEnabled(CustomComboPreset.RDMPvP_Riposte) && hasScorch)
                                 return OriginalHook(EnchantedRiposte);
-                        }                                                
+
+                            // Resolution
+                            if (IsEnabled(CustomComboPreset.RDMPvP_Resolution) && IsOffCooldown(Resolution) &&
+                                !isTargetNPC && targetCurrentPercentHp < Config.RDMPvP_Resolution_TargetHP)
+                                return OriginalHook(Resolution);
+                        }
                     }
-                    if (OriginalHook(EnchantedRiposte) == Scorch)
-                        return OriginalHook(EnchantedRiposte);
 
-                    if (IsEnabled(CustomComboPreset.RDMPvP_Burst_Embolden) && OriginalHook(Embolden) == Prefulgence)
-                        return OriginalHook(Embolden);
+                    // Grand Impact / Jolt III
+                    return hasGrandImpact || !isMoving ? OriginalHook(actionID) : OriginalHook(11);
+                }
 
+                return actionID;
+            }
+        }
+
+        internal class RDMPvP_Dash_Feature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDMPvP_Dash_Feature;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is CorpsACorps)
+                {
+                    bool hasCrowdControl = HasEffectAny(PvPCommon.Debuffs.Stun) || HasEffectAny(PvPCommon.Debuffs.DeepFreeze) ||
+                                           HasEffectAny(PvPCommon.Debuffs.Bind) || HasEffectAny(PvPCommon.Debuffs.Silence) ||
+                                           HasEffectAny(PvPCommon.Debuffs.MiracleOfNature);
+
+                    if (HasCharges(CorpsACorps) && IsOffCooldown(PvPCommon.Purify) && hasCrowdControl)
+                        return OriginalHook(PvPCommon.Purify);
+                }
+
+                if (actionID is Displacement)
+                {
+                    bool hasCrowdControl = HasEffectAny(PvPCommon.Debuffs.Stun) || HasEffectAny(PvPCommon.Debuffs.DeepFreeze) ||
+                                           HasEffectAny(PvPCommon.Debuffs.Bind) || HasEffectAny(PvPCommon.Debuffs.Silence) ||
+                                           HasEffectAny(PvPCommon.Debuffs.MiracleOfNature);
+
+                    if (HasCharges(Displacement) && IsOffCooldown(PvPCommon.Purify) && hasCrowdControl)
+                        return OriginalHook(PvPCommon.Purify);
                 }
 
                 return actionID;


### PR DESCRIPTION
Red Mage has been revisited for Patch 7.15.

## Major Changes
- Complete logic rework.
- Rearranged the flow, priority and conditions of all actions.
- Certain features will combo with one another when enabled.
- Enchanted Riposte combo and Scorch now behave as intended.
- Several actions now have toggles and/or sliders to improve usage.

## Minor Changes
- Resolution will no longer be used against NPCs.
- Most actions will no longer be used against players with immunity.
- Now prevents Jolt III from being spammed during player movement.
- Corps-a-corps can be used at any range within the defined maximum.
- Will no longer attempt to use Corps-a-corps or Displacement when bound.

## Other Changes
- Removed all weaving checks and obsolete IDs.
- Added `Corps-a-corps / Displacement Feature` for quick debuff cleansing.

![7863485734](https://github.com/user-attachments/assets/d780f817-3b62-4096-a456-183c5bb990ac)