### PR TITLE
[PvP] Misc. Fixes

### DIFF
--- a/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
@@ -126,6 +126,20 @@ internal partial class BLM
 
                 // PvP
 
+                // Movement Threshold
+                case CustomComboPreset.BLMPvP_BurstMode:
+                    ImGui.Indent();
+                    DrawRoundedSliderFloat(0, 3, BLMPvP.Config.BLMPvP_Movement_Threshold, "Movement Threshold", 137);
+                    ImGui.Unindent();
+                    if (ImGui.IsItemHovered())
+                    {
+                        ImGui.BeginTooltip();
+                        ImGui.TextUnformatted("When under the effect of Astral Fire, must be\nmoving this long before using Blizzard spells.");
+                        ImGui.EndTooltip();
+                    }
+
+                    break;
+
                 // Burst
                 case CustomComboPreset.BLMPvP_Burst:
                     DrawAdditionalBoolChoice(BLMPvP.Config.BLMPvP_Burst_SubOption, "Defensive Burst",

--- a/WrathCombo/Combos/PvP/BLMPVP.cs
+++ b/WrathCombo/Combos/PvP/BLMPVP.cs
@@ -55,16 +55,19 @@ namespace WrathCombo.Combos.PvP
 
         public static class Config
         {
-            internal static UserInt
+            public static UserInt
                 BLMPvP_ElementalWeave_PlayerHP = new("BLMPvP_ElementalWeave_PlayerHP", 50),
                 BLMPvP_Lethargy_TargetHP = new("BLMPvP_Lethargy_TargetHP", 50),
                 BLMPvP_Xenoglossy_TargetHP = new("BLMPvP_Xenoglossy_TargetHP", 50);
 
             public static UserBool
                 BLMPvP_Burst_SubOption = new("BLMPvP_Burst_SubOption"),
-                BLMPvP_ElementalWeave_SubOption = new ("BLMPvP_ElementalWeave_SubOption"),
+                BLMPvP_ElementalWeave_SubOption = new("BLMPvP_ElementalWeave_SubOption"),
                 BLMPvP_Lethargy_SubOption = new("BLMPvP_Lethargy_SubOption"),
-                BLMPvP_Xenoglossy_SubOption = new ("BLMPvP_Xenoglossy_SubOption");
+                BLMPvP_Xenoglossy_SubOption = new("BLMPvP_Xenoglossy_SubOption");
+
+            public static UserFloat
+                BLMPvP_Movement_Threshold = new("BLMPvP_Movement_Threshold", 0);
         }
 
         internal class BLMPvP_BurstMode : CustomCombo
@@ -93,6 +96,7 @@ namespace WrathCombo.Combos.PvP
                     bool targetHasHeavy = TargetHasEffectAny(PvPCommon.Debuffs.Heavy);
                     bool isPlayerTargeted = CurrentTarget?.TargetObjectId == LocalPlayer.GameObjectId;
                     bool isParadoxPrimed = HasEffect(Buffs.UmbralIce1) || HasEffect(Buffs.AstralFire1);
+                    bool isMovingAdjusted = TimeMoving.TotalSeconds >= Config.BLMPvP_Movement_Threshold;
                     bool isResonanceExpiring = HasEffect(Buffs.SoulResonance) && GetBuffRemainingTime(Buffs.SoulResonance) <= 10;
                     bool hasUmbralIce = HasEffect(Buffs.UmbralIce1) || HasEffect(Buffs.UmbralIce2) || HasEffect(Buffs.UmbralIce3);
                     bool isElementalStarDelayed = HasEffect(Buffs.ElementalStar) && GetBuffRemainingTime(Buffs.ElementalStar) <= 20;
@@ -159,12 +163,12 @@ namespace WrathCombo.Combos.PvP
                     if (hasParadox && ((isParadoxPrimed && !hasResonance) || (hasAstralFire && isMoving)))
                         return OriginalHook(Paradox);
 
-                    // Fire Mode
-                    if (!isMoving)
-                        return OriginalHook(actionID);
-
-                    // Ice Mode
-                    else return OriginalHook(Blizzard);
+                    // Basic Spells
+                    return !isMoving
+                        ? OriginalHook(actionID) // Fire Mode
+                        : !isMovingAdjusted && hasAstralFire
+                            ? OriginalHook(11) // Hold Mode
+                            : OriginalHook(Blizzard); // Ice Mode
                 }
 
                 return actionID;

--- a/WrathCombo/Combos/PvP/BLMPVP.cs
+++ b/WrathCombo/Combos/PvP/BLMPVP.cs
@@ -20,8 +20,8 @@ namespace WrathCombo.Combos.PvP
             Blizzard4 = 29654,
             Freeze = 29655,
             Lethargy = 41510,
-            HighFireII = 41473,
-            HighBlizzardII = 41474,
+            HighFire2 = 41473,
+            HighBlizzard2 = 41474,
             ElementalWeave = 41475,
             FlareStar = 41480,
             FrostStar = 41481,
@@ -73,34 +73,33 @@ namespace WrathCombo.Combos.PvP
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                #region Variables
-                float targetDistance = GetTargetDistance();
-                float targetCurrentPercentHp = GetTargetHPPercent();
-                float playerCurrentPercentHp = PlayerHealthPercentageHp();
-                uint chargesXenoglossy = HasCharges(Xenoglossy) ? GetCooldown(Xenoglossy).RemainingCharges : 0;
-                bool isMoving = IsMoving();
-                bool inCombat = InCombat();
-                bool hasTarget = HasTarget();
-                bool isTargetNPC = HasBattleTarget();
-                bool hasParadox = HasEffect(Buffs.Paradox);
-                bool hasIceAoE = HasEffect(Buffs.UmbralIce3);
-                bool hasResonance = HasEffect(Buffs.SoulResonance);
-                bool hasWreathOfFire = HasEffect(Buffs.WreathOfFire);
-                bool hasFlareStar = OriginalHook(SoulResonance) is FlareStar;
-                bool hasFrostStar = OriginalHook(SoulResonance) is FrostStar;
-                bool targetHasGuard = TargetHasEffectAny(PvPCommon.Buffs.Guard);
-                bool targetHasHeavy = TargetHasEffectAny(PvPCommon.Debuffs.Heavy);
-                bool isPlayerTargeted = CurrentTarget?.TargetObjectId == LocalPlayer.GameObjectId;
-                bool isParadoxPrimed = HasEffect(Buffs.UmbralIce1) || HasEffect(Buffs.AstralFire1);
-                bool isResonanceExpiring = HasEffect(Buffs.SoulResonance) && GetBuffRemainingTime(Buffs.SoulResonance) <= 10;
-                bool hasUmbralIce = HasEffect(Buffs.UmbralIce1) || HasEffect(Buffs.UmbralIce2) || HasEffect(Buffs.UmbralIce3);
-                bool isElementalStarExpiring = HasEffect(Buffs.ElementalStar) && GetBuffRemainingTime(Buffs.ElementalStar) <= 10;
-                bool hasAstralFire = HasEffect(Buffs.AstralFire1) || HasEffect(Buffs.AstralFire2) || HasEffect(Buffs.AstralFire3);
-                bool targetHasImmunity = TargetHasEffectAny(PLDPvP.Buffs.HallowedGround) || TargetHasEffectAny(DRKPvP.Buffs.UndeadRedemption);
-                #endregion
-
-                if (actionID is Fire or Fire3 or Fire4 or HighFireII or Flare)
+                if (actionID is Fire or Fire3 or Fire4 or HighFire2 or Flare)
                 {
+                    #region Variables
+                    float targetDistance = GetTargetDistance();
+                    float targetCurrentPercentHp = GetTargetHPPercent();
+                    float playerCurrentPercentHp = PlayerHealthPercentageHp();
+                    uint chargesXenoglossy = HasCharges(Xenoglossy) ? GetCooldown(Xenoglossy).RemainingCharges : 0;
+                    bool isMoving = IsMoving();
+                    bool inCombat = InCombat();
+                    bool hasTarget = HasTarget();
+                    bool isTargetNPC = HasBattleTarget();
+                    bool hasParadox = HasEffect(Buffs.Paradox);
+                    bool hasResonance = HasEffect(Buffs.SoulResonance);
+                    bool hasWreathOfFire = HasEffect(Buffs.WreathOfFire);
+                    bool hasFlareStar = OriginalHook(SoulResonance) is FlareStar;
+                    bool hasFrostStar = OriginalHook(SoulResonance) is FrostStar;
+                    bool targetHasGuard = TargetHasEffectAny(PvPCommon.Buffs.Guard);
+                    bool targetHasHeavy = TargetHasEffectAny(PvPCommon.Debuffs.Heavy);
+                    bool isPlayerTargeted = CurrentTarget?.TargetObjectId == LocalPlayer.GameObjectId;
+                    bool isParadoxPrimed = HasEffect(Buffs.UmbralIce1) || HasEffect(Buffs.AstralFire1);
+                    bool isResonanceExpiring = HasEffect(Buffs.SoulResonance) && GetBuffRemainingTime(Buffs.SoulResonance) <= 10;
+                    bool hasUmbralIce = HasEffect(Buffs.UmbralIce1) || HasEffect(Buffs.UmbralIce2) || HasEffect(Buffs.UmbralIce3);
+                    bool isElementalStarDelayed = HasEffect(Buffs.ElementalStar) && GetBuffRemainingTime(Buffs.ElementalStar) <= 20;
+                    bool hasAstralFire = HasEffect(Buffs.AstralFire1) || HasEffect(Buffs.AstralFire2) || HasEffect(Buffs.AstralFire3);
+                    bool targetHasImmunity = TargetHasEffectAny(PLDPvP.Buffs.HallowedGround) || TargetHasEffectAny(DRKPvP.Buffs.UndeadRedemption);
+                    #endregion
+
                     if (inCombat)
                     {
                         // Burst (Defensive)
@@ -139,7 +138,7 @@ namespace WrathCombo.Combos.PvP
                                 return OriginalHook(Burst);
 
                             // Flare Star / Frost Star
-                            if (IsEnabled(CustomComboPreset.BLMPvP_ElementalStar) && ((hasFlareStar && !isMoving) || (hasFrostStar && isElementalStarExpiring)))
+                            if (IsEnabled(CustomComboPreset.BLMPvP_ElementalStar) && ((hasFlareStar && !isMoving) || (hasFrostStar && isElementalStarDelayed)))
                                 return OriginalHook(SoulResonance);
 
                             // Xenoglossy
@@ -162,13 +161,7 @@ namespace WrathCombo.Combos.PvP
 
                     // Fire Mode
                     if (!isMoving)
-                    {
-                        // High Blizzard II
-                        if (hasIceAoE && !hasResonance)
-                            return OriginalHook(Blizzard);
-
                         return OriginalHook(actionID);
-                    }
 
                     // Ice Mode
                     else return OriginalHook(Blizzard);
@@ -183,11 +176,11 @@ namespace WrathCombo.Combos.PvP
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BLMPvP_Manipulation_Feature;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                bool hasCrowdControl = HasEffectAny(PvPCommon.Debuffs.Stun) || HasEffectAny(PvPCommon.Debuffs.DeepFreeze) ||
-                                       HasEffectAny(PvPCommon.Debuffs.Bind) || HasEffectAny(PvPCommon.Debuffs.Silence) || HasEffectAny(PvPCommon.Debuffs.MiracleOfNature);
-
                 if (actionID is AetherialManipulation)
                 {
+                    bool hasCrowdControl = HasEffectAny(PvPCommon.Debuffs.Stun) || HasEffectAny(PvPCommon.Debuffs.DeepFreeze) ||
+                                           HasEffectAny(PvPCommon.Debuffs.Bind) || HasEffectAny(PvPCommon.Debuffs.Silence) || HasEffectAny(PvPCommon.Debuffs.MiracleOfNature);
+
                     if (IsOffCooldown(AetherialManipulation) && IsOffCooldown(PvPCommon.Purify) && hasCrowdControl)
                         return OriginalHook(PvPCommon.Purify);
                 }

--- a/WrathCombo/Combos/PvP/SAMPVP.cs
+++ b/WrathCombo/Combos/PvP/SAMPVP.cs
@@ -62,34 +62,34 @@ namespace WrathCombo.Combos.PvP
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                #region Variables
-                float targetDistance = GetTargetDistance();
-                float targetCurrentPercentHp = GetTargetHPPercent();
-                float playerCurrentPercentHp = PlayerHealthPercentageHp();
-                uint chargesSoten = HasCharges(Soten) ? GetCooldown(Soten).RemainingCharges : 0;
-                bool isMoving = IsMoving();
-                bool inCombat = InCombat();
-                bool hasTarget = HasTarget();
-                bool inMeleeRange = targetDistance <= 5;
-                bool hasKaiten = HasEffect(Buffs.Kaiten);
-                bool hasZanshin = OriginalHook(Chiten) is Zanshin;
-                bool hasBind = HasEffectAny(PvPCommon.Debuffs.Bind);
-                bool targetHasImmunity = PvPCommon.TargetImmuneToDamage();
-                bool isTargetPrimed = hasTarget && !targetHasImmunity;
-                bool targetHasKuzushi = TargetHasEffect(Debuffs.Kuzushi);
-                bool hasKaeshiNamikiri = OriginalHook(OgiNamikiri) is Kaeshi;
-                bool hasTendo = OriginalHook(MeikyoShisui) is TendoSetsugekka;
-                bool isYukikazePrimed = ComboTimer == 0 || lastComboMove is Kasha;
-                bool isMeikyoPrimed = !hasKaeshiNamikiri && !hasKaiten && !isMoving;
-                bool hasTendoKaeshi = OriginalHook(MeikyoShisui) is TendoKaeshiSetsugekka;
-                bool hasPrioWeaponskill = hasTendo || hasTendoKaeshi || hasKaeshiNamikiri;
-                bool isZantetsukenPrimed = IsLB1Ready && !hasBind && hasTarget && targetHasKuzushi && targetDistance <= 20;
-                bool isSotenPrimed = chargesSoten > Config.SAMPvP_Soten_Charges && !hasKaiten && !hasBind && !hasPrioWeaponskill;
-                bool isTargetInvincible = TargetHasEffectAny(PLDPvP.Buffs.HallowedGround) || TargetHasEffectAny(DRKPvP.Buffs.UndeadRedemption);
-                #endregion
-
                 if (actionID is Yukikaze or Gekko or Kasha)
                 {
+                    #region Variables
+                    float targetDistance = GetTargetDistance();
+                    float targetCurrentPercentHp = GetTargetHPPercent();
+                    float playerCurrentPercentHp = PlayerHealthPercentageHp();
+                    uint chargesSoten = HasCharges(Soten) ? GetCooldown(Soten).RemainingCharges : 0;
+                    bool isMoving = IsMoving();
+                    bool inCombat = InCombat();
+                    bool hasTarget = HasTarget();
+                    bool inMeleeRange = targetDistance <= 5;
+                    bool hasKaiten = HasEffect(Buffs.Kaiten);
+                    bool hasZanshin = OriginalHook(Chiten) is Zanshin;
+                    bool hasBind = HasEffectAny(PvPCommon.Debuffs.Bind);
+                    bool targetHasImmunity = PvPCommon.TargetImmuneToDamage();
+                    bool isTargetPrimed = hasTarget && !targetHasImmunity;
+                    bool targetHasKuzushi = TargetHasEffect(Debuffs.Kuzushi);
+                    bool hasKaeshiNamikiri = OriginalHook(OgiNamikiri) is Kaeshi;
+                    bool hasTendo = OriginalHook(MeikyoShisui) is TendoSetsugekka;
+                    bool isYukikazePrimed = ComboTimer == 0 || lastComboMove is Kasha;
+                    bool hasTendoKaeshi = OriginalHook(MeikyoShisui) is TendoKaeshiSetsugekka;
+                    bool hasPrioWeaponskill = hasTendo || hasTendoKaeshi || hasKaeshiNamikiri;
+                    bool isMeikyoPrimed = IsOnCooldown(OgiNamikiri) && !hasKaeshiNamikiri && !hasKaiten && !isMoving;
+                    bool isZantetsukenPrimed = IsLB1Ready && !hasBind && hasTarget && targetHasKuzushi && targetDistance <= 20;
+                    bool isSotenPrimed = chargesSoten > Config.SAMPvP_Soten_Charges && !hasKaiten && !hasBind && !hasPrioWeaponskill;
+                    bool isTargetInvincible = TargetHasEffectAny(PLDPvP.Buffs.HallowedGround) || TargetHasEffectAny(DRKPvP.Buffs.UndeadRedemption);
+                    #endregion
+
                     // Zantetsuken
                     if (IsEnabled(CustomComboPreset.SAMPvP_Zantetsuken) && isZantetsukenPrimed && !isTargetInvincible)
                         return OriginalHook(Zantetsuken);

--- a/WrathCombo/Combos/PvP/VPRPVP.cs
+++ b/WrathCombo/Combos/PvP/VPRPVP.cs
@@ -66,37 +66,37 @@ namespace WrathCombo.Combos.PvP
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.VPRPvP_Burst;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                #region Variables
-                float targetDistance = GetTargetDistance();
-                float targetCurrentPercentHp = GetTargetHPPercent();
-                float playerCurrentPercentHp = PlayerHealthPercentageHp();
-                uint chargesSlither = HasCharges(Slither) ? GetCooldown(Slither).RemainingCharges : 0;
-                uint chargesUncoiledFury = HasCharges(UncoiledFury) ? GetCooldown(UncoiledFury).RemainingCharges : 0;
-                bool[] optionsRattlingCoil = Config.VPRPvP_RattlingCoil_SubOptions;
-                bool hasTarget = HasTarget();
-                bool inMeleeRange = targetDistance <= 5;
-                bool hasSlither = HasEffect(Buffs.Slither);
-                bool hasBind = HasEffectAny(PvPCommon.Debuffs.Bind);
-                bool targetHasImmunity = PvPCommon.TargetImmuneToDamage();
-                bool hasBacklash = OriginalHook(SnakeScales) is Backlash;
-                bool hasOuroboros = OriginalHook(Bloodcoil) is Ouroboros;
-                bool hasSnakesBane = hasBacklash && HasEffect(Buffs.SnakesBane);
-                bool hasSanguineFeast = OriginalHook(Bloodcoil) is SanguineFeast;
-                bool isMeleeDependant = !hasTarget || (hasTarget && inMeleeRange);
-                bool isSnakeScalesDown = IsOnCooldown(SnakeScales) && !hasBacklash;
-                bool isUncoiledFuryEnabled = IsEnabled(CustomComboPreset.VPRPvP_UncoiledFury);
-                bool hasRangedWeave = OriginalHook(SerpentsTail) is UncoiledTwinfang or UncoiledTwinblood;
-                bool hasCommonWeave = OriginalHook(SerpentsTail) is DeathRattle or TwinfangBite or TwinbloodBite;
-                bool hasLegacyWeave = OriginalHook(SerpentsTail) is FirstLegacy or SecondLegacy or ThirdLegacy or FourthLegacy;
-                bool isBloodcoilPrimed = IsOffCooldown(Bloodcoil) && hasTarget && !targetHasImmunity && !hasOuroboros && !hasSanguineFeast;
-                bool inGenerationsCombo = OriginalHook(actionID) is FirstGeneration or SecondGeneration or ThirdGeneration or FourthGeneration;
-                bool isUncoiledFuryPrimed = chargesUncoiledFury > 0 && hasTarget && !targetHasImmunity && targetCurrentPercentHp < Config.VPRPvP_UncoiledFury_TargetHP;
-                bool isUncoiledFuryDependant = !isUncoiledFuryEnabled || !(isUncoiledFuryEnabled && isUncoiledFuryPrimed);
-                bool isSlitherPrimed = hasTarget && !inMeleeRange && isUncoiledFuryDependant && !hasSlither && !hasBind;
-                #endregion
-
                 if (actionID is SteelFangs or HuntersSting or BarbarousSlice or PiercingFangs or SwiftskinsSting or RavenousBite)
                 {
+                    #region Variables
+                    float targetDistance = GetTargetDistance();
+                    float targetCurrentPercentHp = GetTargetHPPercent();
+                    float playerCurrentPercentHp = PlayerHealthPercentageHp();
+                    uint chargesSlither = HasCharges(Slither) ? GetCooldown(Slither).RemainingCharges : 0;
+                    uint chargesUncoiledFury = HasCharges(UncoiledFury) ? GetCooldown(UncoiledFury).RemainingCharges : 0;
+                    bool[] optionsRattlingCoil = Config.VPRPvP_RattlingCoil_SubOptions;
+                    bool hasTarget = HasTarget();
+                    bool inMeleeRange = targetDistance <= 5;
+                    bool hasSlither = HasEffect(Buffs.Slither);
+                    bool hasBind = HasEffectAny(PvPCommon.Debuffs.Bind);
+                    bool targetHasImmunity = PvPCommon.TargetImmuneToDamage();
+                    bool hasBacklash = OriginalHook(SnakeScales) is Backlash;
+                    bool hasOuroboros = OriginalHook(Bloodcoil) is Ouroboros;
+                    bool hasSnakesBane = hasBacklash && HasEffect(Buffs.SnakesBane);
+                    bool hasSanguineFeast = OriginalHook(Bloodcoil) is SanguineFeast;
+                    bool isMeleeDependant = !hasTarget || (hasTarget && inMeleeRange);
+                    bool isSnakeScalesDown = IsOnCooldown(SnakeScales) && !hasBacklash;
+                    bool isUncoiledFuryEnabled = IsEnabled(CustomComboPreset.VPRPvP_UncoiledFury);
+                    bool hasRangedWeave = OriginalHook(SerpentsTail) is UncoiledTwinfang or UncoiledTwinblood;
+                    bool hasCommonWeave = OriginalHook(SerpentsTail) is DeathRattle or TwinfangBite or TwinbloodBite;
+                    bool hasLegacyWeave = OriginalHook(SerpentsTail) is FirstLegacy or SecondLegacy or ThirdLegacy or FourthLegacy;
+                    bool isBloodcoilPrimed = IsOffCooldown(Bloodcoil) && hasTarget && !targetHasImmunity && !hasOuroboros && !hasSanguineFeast;
+                    bool inGenerationsCombo = OriginalHook(actionID) is FirstGeneration or SecondGeneration or ThirdGeneration or FourthGeneration;
+                    bool isUncoiledFuryPrimed = chargesUncoiledFury > 0 && hasTarget && !targetHasImmunity && targetCurrentPercentHp < Config.VPRPvP_UncoiledFury_TargetHP;
+                    bool isUncoiledFuryDependant = !isUncoiledFuryEnabled || !(isUncoiledFuryEnabled && isUncoiledFuryPrimed);
+                    bool isSlitherPrimed = hasTarget && !inMeleeRange && isUncoiledFuryDependant && !hasSlither && !hasBind;
+                    #endregion
+
                     // Backlash
                     if (IsEnabled(CustomComboPreset.VPRPvP_Backlash) && ((!Config.VPRPvP_Backlash_SubOption && hasBacklash) ||
                         (Config.VPRPvP_Backlash_SubOption && hasSnakesBane)))


### PR DESCRIPTION
## Black Mage
- [x] Rearranged locations of variables.
- [x] Adjusted timing of `Frost Star` to be more flexible.
- [x] Removed the `High Blizzard II` restriction when not moving.
- [x] Added new `Movement Threshold` slider to control usage of Blizzard spells.

## Samurai
- [x] Rearranged locations of variables.
- [x] Now uses `Ogi Namikiri` and `Kaeshi: Namikiri` before `Meikyo Shisui`.

## Viper
- [x] Rearranged locations of variables.