### PR TITLE
[WAR] Fix Action for Inner Release

### DIFF
--- a/WrathCombo/Combos/PvE/WAR/WAR.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR.cs
@@ -842,7 +842,7 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is Berserk) 
+                if (actionID == OriginalHook(Berserk))
                 {
                     if (LevelChecked(PrimalRend) && //Primal Rend is available
                         HasEffect(Buffs.PrimalRendReady)) //Primal Rend is ready


### PR DESCRIPTION
- [X] Changes `Inner Release` combo to go onto `Inner Release` or `Berserk` instead of only onto `Berserk`