### PR TITLE
[BLM PVP] Movement Fix for requiring astral fire

### DIFF
--- a/WrathCombo/Combos/PvP/BLMPVP.cs
+++ b/WrathCombo/Combos/PvP/BLMPVP.cs
@@ -171,7 +171,7 @@ namespace WrathCombo.Combos.PvP
 
 
                     // Basic Spells
-                    return isMovingAdjusted && Config.BLMPVP_BurstButtonOption == 0 && hasAstralFire
+                    return isMovingAdjusted && Config.BLMPVP_BurstButtonOption == 0
                         ? OriginalHook(Blizzard)
                         : OriginalHook(actionID);
 


### PR DESCRIPTION
2 Bugs reported. 

1. When starting out, it forces you fire first even if you are trying to move. Ignoring the movement check waiting for astral fire. 

2. When moving, for some reason, when getting to umbral 3, instead of casting ice spells while moving, it was trying to cast fire spells and failing to operate. 

Removing this one tag, seems to have fixed both issues for me in testing. 