### PR TITLE
[SMN] Add movement and level checks to the Emerald Ruin 3 replacement option

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5365,14 +5365,14 @@ public enum CustomComboPreset
     SMN_DemiEgiMenu_EgiOrder_AoE = 17065,
 
     [ParentCombo(SMN_Advanced_Combo)]
-    [CustomComboInfo("Use Ruin III instead of Emerald Ruin III",
-        "Replaces Emerald Ruin III with Ruin III in the rotation when Ruin Mastery III is not active.",
-        SMN.JobID, 15)]
-    SMN_ST_Ruin3_Emerald_Ruin3 = 17067,
-
-    [ParentCombo(SMN_Advanced_Combo)]
     [CustomComboInfo("Balance Opener (Level 100)", "Adds the Balance opener at level 100.", SMN.JobID)]
     SMN_Advanced_Combo_Balance_Opener = 170001,
+
+    [ParentCombo(SMN_Advanced_Combo)]
+    [CustomComboInfo("Use Ruin III instead of Emerald Ruin III when standing still",
+        "Replaces Emerald Ruin III with Ruin III in the rotation when standing still and Ruin Mastery III is not active.",
+        SMN.JobID)]
+    SMN_ST_Ruin3_Emerald_Ruin3 = 17067,
 
     [ParentCombo(SMN_Advanced_Combo)]
     [CustomComboInfo("Demi Attacks Combo Option", "Adds Demi Summon oGCDs to the single target combo.", SMN.JobID)]

--- a/WrathCombo/Combos/PvE/SMN/SMN.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN.cs
@@ -740,7 +740,7 @@ namespace WrathCombo.Combos.PvE
                     if (IsGarudaAttuned)
                     {
                         // Use Ruin III instead of Emerald Ruin III if enabled and Ruin Mastery III is not active
-                        if (IsEnabled(CustomComboPreset.SMN_ST_Ruin3_Emerald_Ruin3) && !TraitLevelChecked(Traits.RuinMastery3))
+                        if (IsEnabled(CustomComboPreset.SMN_ST_Ruin3_Emerald_Ruin3) && !TraitLevelChecked(Traits.RuinMastery3) && LevelChecked(Ruin3))
                         {
                             return Ruin3;
                         }

--- a/WrathCombo/Combos/PvE/SMN/SMN.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN.cs
@@ -740,9 +740,10 @@ namespace WrathCombo.Combos.PvE
                     if (IsGarudaAttuned)
                     {
                         // Use Ruin III instead of Emerald Ruin III if enabled and Ruin Mastery III is not active
-                        if (IsEnabled(CustomComboPreset.SMN_ST_Ruin3_Emerald_Ruin3) && !TraitLevelChecked(Traits.RuinMastery3) && LevelChecked(Ruin3))
+                        if (IsEnabled(CustomComboPreset.SMN_ST_Ruin3_Emerald_Ruin3) && !TraitLevelChecked(Traits.RuinMastery3) && LevelChecked(Ruin3)) 
                         {
-                            return Ruin3;
+                            if (!IsMoving())
+                                return Ruin3;
                         }
                     }
 


### PR DESCRIPTION
This PR adds the following checks to the Emerald Ruin 3 replacement option:
- Add level check so it won't try to cast Ruin 3 when you haven't unlocked it yet (reported in Discord)
- Add movement check so it will use Emerald Ruin 3 if you are actively moving