### PR TITLE
[IPC] Update DTR to show IPC-Controlled

### DIFF
--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -231,11 +231,20 @@ namespace WrathCombo
             BlueMageService.PopulateBLUSpells();
             TargetHelper.Draw();
             AutoRotationController.Run();
+
             var autoOn = IPC.GetAutoRotationState();
-            DtrBarEntry.Text = new SeString(
-                new IconPayload(autoOn ? BitmapFontIcon.SwordUnsheathed : BitmapFontIcon.SwordSheathed),
-                new TextPayload($"{(autoOn ? $": On ({P.IPCSearch.ActiveJobPresets} active)" : ": Off")}")
-                );
+            var icon = new IconPayload(autoOn
+                ? BitmapFontIcon.SwordUnsheathed
+                : BitmapFontIcon.SwordSheathed);
+            var text = autoOn
+                ? $": On ({P.IPCSearch.ActiveJobPresets} active)"
+                : ": Off";
+            var ipcControlledText =
+                IPC.UIHelper.AutoRotationStateControlled() is not null
+                    ? " (Locked)"
+                    : "";
+            var payloadText = new TextPayload(text + ipcControlledText);
+            DtrBarEntry.Text = new SeString(icon, payloadText);
         }
 
         private static void KillRedundantIDs()


### PR DESCRIPTION
- [X] DTR bar will now show " (Locked)" if IPC-Controlled
  - Will already show the On/Off status as the user's settings with IPC state on top of that.
  - Already shows in the text feedback on-click if the setting change was ignored because it is IPC-controlled.