### PR TITLE
[Core] Make combo action checks consistent

### DIFF
--- a/WrathCombo/Combos/PvE/AST/AST.cs
+++ b/WrathCombo/Combos/PvE/AST/AST.cs
@@ -273,76 +273,76 @@ namespace WrathCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AST_AOE_DPS;
             protected override uint Invoke(uint actionID)
             {
-                if (GravityList.Contains(actionID))
-                {
-                    //Variant stuff
-                    if (IsEnabled(CustomComboPreset.AST_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanSpellWeave())
-                        return Variant.VariantRampart;
+                if (!GravityList.Contains(actionID))
+                    return actionID;
 
-                    Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
-                    if (IsEnabled(CustomComboPreset.AST_Variant_SpiritDart) &&
-                        IsEnabled(Variant.VariantSpiritDart) &&
-                        (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3) &&
-                        CanSpellWeave() &&
-                        IsEnabled(CustomComboPreset.AST_AOE_DPS) && GravityList.Contains(actionID))
-                        return Variant.VariantSpiritDart;                                   
+                //Variant stuff
+                if (IsEnabled(CustomComboPreset.AST_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart) &&
+                    CanSpellWeave())
+                    return Variant.VariantRampart;
 
-                    if (IsEnabled(CustomComboPreset.AST_AOE_LightSpeed) &&
-                        ActionReady(Lightspeed) &&
-                        GetTargetHPPercent() > Config.AST_AOE_LightSpeedOption &&
-                        IsMoving() &&
-                        !HasEffect(Buffs.Lightspeed))
-                        return Lightspeed;
+                Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+                if (IsEnabled(CustomComboPreset.AST_Variant_SpiritDart) &&
+                    IsEnabled(Variant.VariantSpiritDart) &&
+                    (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3) &&
+                    CanSpellWeave() &&
+                    IsEnabled(CustomComboPreset.AST_AOE_DPS) && GravityList.Contains(actionID))
+                    return Variant.VariantSpiritDart;
 
-                    if (IsEnabled(CustomComboPreset.AST_AOE_Lucid) &&
-                        ActionReady(All.LucidDreaming) &&
-                        LocalPlayer.CurrentMp <= Config.AST_LucidDreaming &&
-                        CanSpellWeave())
-                        return All.LucidDreaming;
+                if (IsEnabled(CustomComboPreset.AST_AOE_LightSpeed) &&
+                    ActionReady(Lightspeed) &&
+                    GetTargetHPPercent() > Config.AST_AOE_LightSpeedOption &&
+                    IsMoving() &&
+                    !HasEffect(Buffs.Lightspeed))
+                    return Lightspeed;
 
-                    //Play Card
-                    if (IsEnabled(CustomComboPreset.AST_AOE_AutoPlay) &&
-                        ActionReady(Play1) &&
-                        Gauge.DrawnCards[0] is not CardType.NONE &&
-                        CanSpellWeave())
-                        return OriginalHook(Play1);
+                if (IsEnabled(CustomComboPreset.AST_AOE_Lucid) &&
+                    ActionReady(All.LucidDreaming) &&
+                    LocalPlayer.CurrentMp <= Config.AST_LucidDreaming &&
+                    CanSpellWeave())
+                    return All.LucidDreaming;
 
-                    //Card Draw
-                    if (IsEnabled(CustomComboPreset.AST_AOE_AutoDraw) &&
-                        ActionReady(OriginalHook(AstralDraw)) &&
-                        (Gauge.DrawnCards.All(x => x is CardType.NONE) || (DrawnCard == CardType.NONE && Config.AST_AOE_DPS_OverwriteCards)) &&
-                        CanDelayedWeave())
-                        return OriginalHook(AstralDraw);
+                //Play Card
+                if (IsEnabled(CustomComboPreset.AST_AOE_AutoPlay) &&
+                    ActionReady(Play1) &&
+                    Gauge.DrawnCards[0] is not CardType.NONE &&
+                    CanSpellWeave())
+                    return OriginalHook(Play1);
 
-                    //Divination
-                    if (IsEnabled(CustomComboPreset.AST_AOE_Divination) &&
-                        ActionReady(Divination) &&
-                        !HasEffectAny(Buffs.Divination) && //Overwrite protection
-                        GetTargetHPPercent() > Config.AST_AOE_DivinationOption &&
-                        CanDelayedWeave() &&
-                        ActionWatching.NumberOfGcdsUsed >= 3)
-                        return Divination;
-                    //Earthly Star
-                    if (IsEnabled(CustomComboPreset.AST_AOE_DPS_EarthlyStar) && !IsMoving() &&
-                        ActionReady(EarthlyStar) &&
-                        CanSpellWeave())
-                        return EarthlyStar;
+                //Card Draw
+                if (IsEnabled(CustomComboPreset.AST_AOE_AutoDraw) &&
+                    ActionReady(OriginalHook(AstralDraw)) &&
+                    (Gauge.DrawnCards.All(x => x is CardType.NONE) || (DrawnCard == CardType.NONE && Config.AST_AOE_DPS_OverwriteCards)) &&
+                    CanDelayedWeave())
+                    return OriginalHook(AstralDraw);
 
-                    if (IsEnabled(CustomComboPreset.AST_AOE_Oracle) &&
-                        HasEffect(Buffs.Divining) &&
-                        CanSpellWeave())
-                        return Oracle;
+                //Divination
+                if (IsEnabled(CustomComboPreset.AST_AOE_Divination) &&
+                    ActionReady(Divination) &&
+                    !HasEffectAny(Buffs.Divination) && //Overwrite protection
+                    GetTargetHPPercent() > Config.AST_AOE_DivinationOption &&
+                    CanDelayedWeave() &&
+                    ActionWatching.NumberOfGcdsUsed >= 3)
+                    return Divination;
+                //Earthly Star
+                if (IsEnabled(CustomComboPreset.AST_AOE_DPS_EarthlyStar) && !IsMoving() &&
+                    ActionReady(EarthlyStar) &&
+                    CanSpellWeave())
+                    return EarthlyStar;
 
-                    //Minor Arcana / Lord of Crowns
-                    if (ActionReady(OriginalHook(MinorArcana)) &&
-                        IsEnabled(CustomComboPreset.AST_AOE_LazyLord) && Gauge.DrawnCrownCard is CardType.LORD &&
-                        HasBattleTarget() &&
-                        CanDelayedWeave())
-                        return OriginalHook(MinorArcana);
-                }
+                if (IsEnabled(CustomComboPreset.AST_AOE_Oracle) &&
+                    HasEffect(Buffs.Divining) &&
+                    CanSpellWeave())
+                    return Oracle;
+
+                //Minor Arcana / Lord of Crowns
+                if (ActionReady(OriginalHook(MinorArcana)) &&
+                    IsEnabled(CustomComboPreset.AST_AOE_LazyLord) && Gauge.DrawnCrownCard is CardType.LORD &&
+                    HasBattleTarget() &&
+                    CanDelayedWeave())
+                    return OriginalHook(MinorArcana);
                 return actionID;
             }
         }
@@ -354,52 +354,53 @@ namespace WrathCombo.Combos.PvE
             {
                 bool NonaspectedMode = GetIntOptionAsBool(Config.AST_AoEHeals_AltMode); //(0 or 1 radio values)
 
-                if (NonaspectedMode && actionID is Helios || !NonaspectedMode && actionID is AspectedHelios or HeliosConjuction)
+                if ((!NonaspectedMode || actionID is not Helios) &&
+                    (NonaspectedMode || actionID is not (AspectedHelios or HeliosConjuction)))
+                    return actionID;
+
+                var canLady = (Config.AST_AoE_SimpleHeals_WeaveLady && CanSpellWeave()) || !Config.AST_AoE_SimpleHeals_WeaveLady;
+                var canHoroscope = (Config.AST_AoE_SimpleHeals_Horoscope && CanSpellWeave()) || !Config.AST_AoE_SimpleHeals_Horoscope;
+                var canOppose = (Config.AST_AoE_SimpleHeals_Opposition && CanSpellWeave()) || !Config.AST_AoE_SimpleHeals_Opposition;
+
+                if (!LevelChecked(AspectedHelios)) //Level check to return helios immediately below 40
+                    return Helios;
+
+                if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_LazyLady) &&
+                    ActionReady(MinorArcana) &&
+                    Gauge.DrawnCrownCard is CardType.LADY
+                    && canLady)
+                    return OriginalHook(MinorArcana);
+
+                if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_CelestialOpposition) &&
+                    ActionReady(CelestialOpposition) &&
+                    canOppose)
+                    return CelestialOpposition;
+
+                if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_Horoscope))
                 {
-                    var canLady = (Config.AST_AoE_SimpleHeals_WeaveLady && CanSpellWeave()) || !Config.AST_AoE_SimpleHeals_WeaveLady;
-                    var canHoroscope = (Config.AST_AoE_SimpleHeals_Horoscope && CanSpellWeave()) || !Config.AST_AoE_SimpleHeals_Horoscope;
-                    var canOppose = (Config.AST_AoE_SimpleHeals_Opposition && CanSpellWeave()) || !Config.AST_AoE_SimpleHeals_Opposition;
+                    if (ActionReady(Horoscope) &&
+                        canHoroscope)
+                        return Horoscope;
 
-                    if (!LevelChecked(AspectedHelios)) //Level check to return helios immediately below 40
-                        return Helios;
-
-                    if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_LazyLady) &&
-                        ActionReady(MinorArcana) &&
-                        Gauge.DrawnCrownCard is CardType.LADY
-                        && canLady)
-                        return OriginalHook(MinorArcana);
-
-                    if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_CelestialOpposition) &&
-                        ActionReady(CelestialOpposition) &&
-                        canOppose)
-                        return CelestialOpposition;
-
-                    if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_Horoscope))
-                    {
-                        if (ActionReady(Horoscope) &&
-                            canHoroscope)
-                            return Horoscope;                                               
-
-                        if (HasEffect(Buffs.HoroscopeHelios) &&
-                            canHoroscope)
-                            return OriginalHook(Horoscope);
-                    }
-
-                    // Only check for our own HoTs
-                    var hotCheck = HeliosConjuction.LevelChecked() ? FindEffect(Buffs.HeliosConjunction, LocalPlayer, LocalPlayer?.GameObjectId) : FindEffect(Buffs.AspectedHelios, LocalPlayer, LocalPlayer?.GameObjectId);
-
-                    if ((IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_Aspected) && NonaspectedMode) || // Helios mode: option must be on
-                        !NonaspectedMode) // Aspected mode: option is not required
-                    {
-                        if ((ActionReady(AspectedHelios)
-                                 && hotCheck is null)
-                             || (HasEffect(Buffs.NeutralSect) && !HasEffect(Buffs.NeutralSectShield)))
-                            return OriginalHook(AspectedHelios);
-                    }
-
-                    if (hotCheck is not null && hotCheck.RemainingTime > GetActionCastTime(OriginalHook(AspectedHelios)) + 1f)
-                        return Helios;
+                    if (HasEffect(Buffs.HoroscopeHelios) &&
+                        canHoroscope)
+                        return OriginalHook(Horoscope);
                 }
+
+                // Only check for our own HoTs
+                var hotCheck = HeliosConjuction.LevelChecked() ? FindEffect(Buffs.HeliosConjunction, LocalPlayer, LocalPlayer?.GameObjectId) : FindEffect(Buffs.AspectedHelios, LocalPlayer, LocalPlayer?.GameObjectId);
+
+                if ((IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_Aspected) && NonaspectedMode) || // Helios mode: option must be on
+                    !NonaspectedMode) // Aspected mode: option is not required
+                {
+                    if ((ActionReady(AspectedHelios)
+                         && hotCheck is null)
+                        || (HasEffect(Buffs.NeutralSect) && !HasEffect(Buffs.NeutralSectShield)))
+                        return OriginalHook(AspectedHelios);
+                }
+
+                if (hotCheck is not null && hotCheck.RemainingTime > GetActionCastTime(OriginalHook(AspectedHelios)) + 1f)
+                    return Helios;
 
                 return actionID;
             }
@@ -411,78 +412,78 @@ namespace WrathCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AST_ST_SimpleHeals;
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is Benefic2)
+                if (actionID is not Benefic2)
+                    return actionID;
+
+                var canDignity = (Config.AST_ST_SimpleHeals_WeaveDignity && CanSpellWeave()) || !Config.AST_ST_SimpleHeals_WeaveDignity;
+                var canIntersect = (Config.AST_ST_SimpleHeals_WeaveIntersection && CanSpellWeave()) || !Config.AST_ST_SimpleHeals_WeaveIntersection;
+                var canExalt = (Config.AST_ST_SimpleHeals_WeaveExalt && CanSpellWeave()) || !Config.AST_ST_SimpleHeals_WeaveExalt;
+                var canEwer = (Config.AST_ST_SimpleHeals_WeaveEwer && CanSpellWeave()) || !Config.AST_ST_SimpleHeals_WeaveEwer;
+                var canSpire = (Config.AST_ST_SimpleHeals_WeaveSpire && CanSpellWeave()) || !Config.AST_ST_SimpleHeals_WeaveSpire;
+                var canBole = (Config.AST_ST_SimpleHeals_WeaveBole && CanSpellWeave()) || !Config.AST_ST_SimpleHeals_WeaveBole;
+                var canArrow = (Config.AST_ST_SimpleHeals_WeaveArrow && CanSpellWeave()) || !Config.AST_ST_SimpleHeals_WeaveArrow;
+
+                //Grab our target (Soft->Hard->Self)
+                IGameObject? healTarget = this.OptionalTarget ?? GetHealTarget(Config.AST_ST_SimpleHeals_Adv && Config.AST_ST_SimpleHeals_UIMouseOver);
+
+                if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Esuna) && ActionReady(All.Esuna) &&
+                    GetTargetHPPercent(healTarget, Config.AST_ST_SimpleHeals_IncludeShields) >= Config.AST_ST_SimpleHeals_Esuna &&
+                    HasCleansableDebuff(healTarget))
+                    return All.Esuna;
+
+                if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Spire) &&
+                    Gauge.DrawnCards[2] == CardType.SPIRE &&
+                    GetTargetHPPercent(healTarget, Config.AST_ST_SimpleHeals_IncludeShields) <= Config.AST_Spire &&
+                    ActionReady(Play3) &&
+                    canSpire)
+                    return OriginalHook(Play3);
+
+                if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Ewer) &&
+                    Gauge.DrawnCards[2] == CardType.EWER &&
+                    GetTargetHPPercent(healTarget, Config.AST_ST_SimpleHeals_IncludeShields) <= Config.AST_Ewer &&
+                    ActionReady(Play3) &&
+                    canEwer)
+                    return OriginalHook(Play3);
+
+                if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Arrow) &&
+                    Gauge.DrawnCards[1] == CardType.ARROW &&
+                    GetTargetHPPercent(healTarget, Config.AST_ST_SimpleHeals_IncludeShields) <= Config.AST_Arrow &&
+                    ActionReady(Play2) &&
+                    canArrow)
+                    return OriginalHook(Play2);
+
+                if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Bole) &&
+                    Gauge.DrawnCards[1] == CardType.BOLE &&
+                    GetTargetHPPercent(healTarget, Config.AST_ST_SimpleHeals_IncludeShields) <= Config.AST_Bole &&
+                    ActionReady(Play2) &&
+                    canBole)
+                    return OriginalHook(Play2);
+
+                if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_EssentialDignity) &&
+                    ActionReady(EssentialDignity) &&
+                    GetTargetHPPercent(healTarget, Config.AST_ST_SimpleHeals_IncludeShields) <= Config.AST_EssentialDignity &&
+                    canDignity)
+                    return EssentialDignity;
+
+                if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Exaltation) &&
+                    ActionReady(Exaltation) &&
+                    canExalt)
+                    return Exaltation;
+
+                if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_CelestialIntersection) &&
+                    ActionReady(CelestialIntersection) &&
+                    canIntersect &&
+                    !(healTarget as IBattleChara)!.HasShield())
+                    return CelestialIntersection;
+
+                if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_AspectedBenefic) && ActionReady(AspectedBenefic))
                 {
-                    var canDignity = (Config.AST_ST_SimpleHeals_WeaveDignity && CanSpellWeave()) || !Config.AST_ST_SimpleHeals_WeaveDignity;
-                    var canIntersect = (Config.AST_ST_SimpleHeals_WeaveIntersection && CanSpellWeave()) || !Config.AST_ST_SimpleHeals_WeaveIntersection;
-                    var canExalt = (Config.AST_ST_SimpleHeals_WeaveExalt && CanSpellWeave()) || !Config.AST_ST_SimpleHeals_WeaveExalt;
-                    var canEwer = (Config.AST_ST_SimpleHeals_WeaveEwer && CanSpellWeave()) || !Config.AST_ST_SimpleHeals_WeaveEwer;
-                    var canSpire = (Config.AST_ST_SimpleHeals_WeaveSpire && CanSpellWeave()) || !Config.AST_ST_SimpleHeals_WeaveSpire;
-                    var canBole = (Config.AST_ST_SimpleHeals_WeaveBole && CanSpellWeave()) || !Config.AST_ST_SimpleHeals_WeaveBole;
-                    var canArrow = (Config.AST_ST_SimpleHeals_WeaveArrow && CanSpellWeave()) || !Config.AST_ST_SimpleHeals_WeaveArrow;
-
-                    //Grab our target (Soft->Hard->Self)
-                    IGameObject? healTarget = this.OptionalTarget ?? GetHealTarget(Config.AST_ST_SimpleHeals_Adv && Config.AST_ST_SimpleHeals_UIMouseOver);
-
-                    if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Esuna) && ActionReady(All.Esuna) &&
-                        GetTargetHPPercent(healTarget, Config.AST_ST_SimpleHeals_IncludeShields) >= Config.AST_ST_SimpleHeals_Esuna &&
-                        HasCleansableDebuff(healTarget))
-                        return All.Esuna;
-
-                    if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Spire) &&
-                        Gauge.DrawnCards[2] == CardType.SPIRE &&
-                        GetTargetHPPercent(healTarget, Config.AST_ST_SimpleHeals_IncludeShields) <= Config.AST_Spire &&
-                        ActionReady(Play3) &&
-                        canSpire)
-                        return OriginalHook(Play3);
-
-                    if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Ewer) &&
-                        Gauge.DrawnCards[2] == CardType.EWER &&
-                        GetTargetHPPercent(healTarget, Config.AST_ST_SimpleHeals_IncludeShields) <= Config.AST_Ewer &&
-                        ActionReady(Play3) &&
-                        canEwer)
-                        return OriginalHook(Play3);
-
-                    if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Arrow) &&
-                        Gauge.DrawnCards[1] == CardType.ARROW &&
-                        GetTargetHPPercent(healTarget, Config.AST_ST_SimpleHeals_IncludeShields) <= Config.AST_Arrow &&
-                        ActionReady(Play2) &&
-                        canArrow)
-                        return OriginalHook(Play2);
-                    
-                    if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Bole) &&
-                        Gauge.DrawnCards[1] == CardType.BOLE &&
-                        GetTargetHPPercent(healTarget, Config.AST_ST_SimpleHeals_IncludeShields) <= Config.AST_Bole &&
-                        ActionReady(Play2) &&
-                        canBole)
-                        return OriginalHook(Play2);
-
-                    if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_EssentialDignity) &&
-                        ActionReady(EssentialDignity) &&
-                        GetTargetHPPercent(healTarget, Config.AST_ST_SimpleHeals_IncludeShields) <= Config.AST_EssentialDignity &&
-                        canDignity)
-                        return EssentialDignity;
-
-                    if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Exaltation) &&
-                        ActionReady(Exaltation) &&
-                        canExalt)
-                        return Exaltation;
-
-                    if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_CelestialIntersection) &&
-                        ActionReady(CelestialIntersection) &&
-                        canIntersect &&
-                        !(healTarget as IBattleChara)!.HasShield())
-                        return CelestialIntersection;
-
-                    if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_AspectedBenefic) && ActionReady(AspectedBenefic))
-                    {
-                        Status? aspectedBeneficHoT = FindEffect(Buffs.AspectedBenefic, healTarget, LocalPlayer?.GameObjectId);
-                        Status? NeutralSectShield = FindEffect(Buffs.NeutralSectShield, healTarget, LocalPlayer?.GameObjectId);
-                        Status? NeutralSectBuff = FindEffect(Buffs.NeutralSect, healTarget, LocalPlayer?.GameObjectId);
-                        if ((aspectedBeneficHoT is null) || (aspectedBeneficHoT.RemainingTime <= 3)
-                            || ((NeutralSectShield is null) && (NeutralSectBuff is not null)))
-                            return AspectedBenefic;
-                    }
+                    Status? aspectedBeneficHoT = FindEffect(Buffs.AspectedBenefic, healTarget, LocalPlayer?.GameObjectId);
+                    Status? NeutralSectShield = FindEffect(Buffs.NeutralSectShield, healTarget, LocalPlayer?.GameObjectId);
+                    Status? NeutralSectBuff = FindEffect(Buffs.NeutralSect, healTarget, LocalPlayer?.GameObjectId);
+                    if ((aspectedBeneficHoT is null) || (aspectedBeneficHoT.RemainingTime <= 3)
+                                                     || ((NeutralSectShield is null) && (NeutralSectBuff is not null)))
+                        return AspectedBenefic;
                 }
                 return actionID;
             }

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -15,173 +15,150 @@ internal static partial class BLM
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Fire)
+            if (actionID is not Fire) return actionID;
+
+            if (IsEnabled(CustomComboPreset.BLM_Variant_Cure) &&
+                IsEnabled(Variant.VariantCure) &&
+                PlayerHealthPercentageHp() <= Config.BLM_VariantCure)
+                return Variant.VariantCure;
+
+            if (IsEnabled(CustomComboPreset.BLM_Variant_Rampart) &&
+                IsEnabled(Variant.VariantRampart) &&
+                IsOffCooldown(Variant.VariantRampart) &&
+                CanSpellWeave())
+                return Variant.VariantRampart;
+
+            //Weaves
+            if (CanSpellWeave())
             {
-                if (IsEnabled(CustomComboPreset.BLM_Variant_Cure) &&
-                    IsEnabled(Variant.VariantCure) &&
-                    PlayerHealthPercentageHp() <= Config.BLM_VariantCure)
-                    return Variant.VariantCure;
+                if (ActionReady(Amplifier) && RemainingPolyglotCD >= 20000)
+                    return Amplifier;
 
-                if (IsEnabled(CustomComboPreset.BLM_Variant_Rampart) &&
-                    IsEnabled(Variant.VariantRampart) &&
-                    IsOffCooldown(Variant.VariantRampart) &&
-                    CanSpellWeave())
-                    return Variant.VariantRampart;
+                if (ActionReady(LeyLines) && !HasEffect(Buffs.LeyLines))
+                    return LeyLines;
+            }
 
-                //Weaves
-                if (CanSpellWeave())
+            if (HasEffect(Buffs.Thunderhead) && GCDsInTimer > 1 && LevelChecked(Thunder) &&
+                GetTargetHPPercent() >= Config.BLM_ST_ThunderHP &&
+                (ThunderDebuffST is null || ThunderDebuffST.RemainingTime < 3))
+                return OriginalHook(Thunder);
+
+            if (IsMoving())
+            {
+                if (ActionReady(Amplifier) && Gauge.PolyglotStacks < MaxPolyglot)
+                    return Amplifier;
+
+                if (HasPolyglotStacks(Gauge))
+                    return LevelChecked(Xenoglossy)
+                        ? Xenoglossy
+                        : Foul;
+            }
+
+            if (Gauge.InAstralFire)
+            {
+                if (Gauge.IsParadoxActive && GCDsInTimer < 2 && CurMp >= MP.FireI)
+                    return Paradox;
+
+                if ((HasEffect(Buffs.Firestarter) && GCDsInTimer < 2 &&
+                     CurMp >= MP.FireI) || (HasEffect(Buffs.Firestarter) && Gauge.AstralFireStacks < 3))
+                    return Fire3;
+
+                if (CurMp < MP.FireI && LevelChecked(Despair) && CurMp >= MP.Despair)
+                    return Despair;
+
+                if (CurMp == 0 && LevelChecked(FlareStar) && Gauge.AstralSoulStacks == 6)
                 {
-                    if (ActionReady(Amplifier) && RemainingPolyglotCD >= 20000)
-                        return Amplifier;
+                    if (CanSpellWeave() && ActionReady(Triplecast) &&
+                        GetBuffStacks(Buffs.Triplecast) == 0 &&
+                        ActionReady(Triplecast))
+                        return Triplecast;
 
-                    if (ActionReady(LeyLines) && !HasEffect(Buffs.LeyLines))
-                        return LeyLines;
+                    if (CanSpellWeave() && ActionReady(All.Swiftcast) &&
+                        GetBuffStacks(Buffs.Triplecast) == 0)
+                        return All.Swiftcast;
+
+                    return FlareStar;
                 }
 
-                if (HasEffect(Buffs.Thunderhead) && GCDsInTimer > 1 && LevelChecked(Thunder) &&
-                    GetTargetHPPercent() >= Config.BLM_ST_ThunderHP &&
-                    (ThunderDebuffST is null || ThunderDebuffST.RemainingTime < 3))
-                    return OriginalHook(Thunder);
-
-                if (IsMoving())
-                {
-                    if (ActionReady(Amplifier) && Gauge.PolyglotStacks < MaxPolyglot)
-                        return Amplifier;
-
-                    if (HasPolyglotStacks(Gauge))
-                        return LevelChecked(Xenoglossy)
-                            ? Xenoglossy
-                            : Foul;
-                }
-
-                if (Gauge.InAstralFire)
-                {
-                    if (Gauge.IsParadoxActive && GCDsInTimer < 2 && CurMp >= MP.FireI)
-                        return Paradox;
-
-                    if ((HasEffect(Buffs.Firestarter) && GCDsInTimer < 2 &&
-                         CurMp >= MP.FireI) || (HasEffect(Buffs.Firestarter) && Gauge.AstralFireStacks < 3))
-                        return Fire3;
-
-                    if (CurMp < MP.FireI && LevelChecked(Despair) && CurMp >= MP.Despair)
-                        return Despair;
-
-                    if (CurMp == 0 && LevelChecked(FlareStar) && Gauge.AstralSoulStacks == 6)
+                if (LevelChecked(Fire4))
+                    if (GCDsInTimer > 1 && CurMp >= MP.FireI)
                     {
                         if (CanSpellWeave() && ActionReady(Triplecast) &&
                             GetBuffStacks(Buffs.Triplecast) == 0 &&
                             ActionReady(Triplecast))
                             return Triplecast;
 
-                        if (CanSpellWeave() && ActionReady(All.Swiftcast) &&
-                            GetBuffStacks(Buffs.Triplecast) == 0)
-                            return All.Swiftcast;
-
-                        return FlareStar;
-                    }
-
-                    if (LevelChecked(Fire4))
-                        if (GCDsInTimer > 1 && CurMp >= MP.FireI)
-                        {
-                            if (CanSpellWeave() && ActionReady(Triplecast) &&
-                                GetBuffStacks(Buffs.Triplecast) == 0 &&
-                                ActionReady(Triplecast))
-                                return Triplecast;
-
-                            if (HasEffect(Buffs.Thunderhead) && GCDsInTimer > 1 &&
-                                (ThunderDebuffST is null || ThunderDebuffST.RemainingTime < 3))
-                                return OriginalHook(Thunder);
-
-                            if (HasPolyglotStacks(Gauge) &&
-                                CanSpellWeave() && ActionReady(Triplecast) &&
-                                GetBuffStacks(Buffs.Triplecast) == 0 &&
-                                ActionReady(Triplecast))
-                                return Xenoglossy.LevelChecked()
-                                    ? Xenoglossy
-                                    : Foul;
-
-                            return Fire4;
-                        }
-
-                    if (CurMp >= MP.FireI)
-                        return Fire;
-
-                    if (ActionReady(Manafont))
-                        return HasEffect(Buffs.Firestarter)
-                            ? Fire3
-                            : Manafont;
-
-                    if (ActionReady(Blizzard3) &&
-                        (ActionReady(All.Swiftcast) || HasEffect(Buffs.Triplecast)))
-                    {
-                        if (CanSpellWeave() && ActionReady(Transpose))
-                            return Transpose;
-
-                        if (HasEffect(Buffs.Thunderhead) &&
+                        if (HasEffect(Buffs.Thunderhead) && GCDsInTimer > 1 &&
                             (ThunderDebuffST is null || ThunderDebuffST.RemainingTime < 3))
                             return OriginalHook(Thunder);
 
-                        if (HasPolyglotStacks(Gauge))
-                            return LevelChecked(Xenoglossy)
+                        if (HasPolyglotStacks(Gauge) &&
+                            CanSpellWeave() && ActionReady(Triplecast) &&
+                            GetBuffStacks(Buffs.Triplecast) == 0 &&
+                            ActionReady(Triplecast))
+                            return Xenoglossy.LevelChecked()
                                 ? Xenoglossy
                                 : Foul;
+
+                        return Fire4;
                     }
 
-                    return LevelChecked(Blizzard3)
-                        ? Blizzard3
-                        : Transpose;
-                }
+                if (CurMp >= MP.FireI)
+                    return Fire;
 
-                if (Gauge.InUmbralIce)
+                if (ActionReady(Manafont))
+                    return HasEffect(Buffs.Firestarter)
+                        ? Fire3
+                        : Manafont;
+
+                if (ActionReady(Blizzard3) &&
+                    (ActionReady(All.Swiftcast) || HasEffect(Buffs.Triplecast)))
                 {
-                    if (ActionReady(Blizzard3) && Gauge.UmbralIceStacks < 3 && TraitLevelChecked(Traits.UmbralHeart))
-                    {
-                        if (HasEffect(All.Buffs.Swiftcast) || HasEffect(Buffs.Triplecast))
-                            return Blizzard3;
+                    if (CanSpellWeave() && ActionReady(Transpose))
+                        return Transpose;
 
-                        if (GetBuffStacks(Buffs.Triplecast) == 0 && IsOffCooldown(All.Swiftcast))
-                            return All.Swiftcast;
-
-                        if (GetBuffStacks(Buffs.Triplecast) == 0 && ActionReady(Triplecast))
-                            return Triplecast;
-                    }
-
-                    if (LevelChecked(Blizzard4) && Gauge.UmbralHearts < 3 && TraitLevelChecked(Traits.UmbralHeart))
-                        return Blizzard4;
-
-                    if (Gauge.IsParadoxActive)
-                        return Paradox;
+                    if (HasEffect(Buffs.Thunderhead) &&
+                        (ThunderDebuffST is null || ThunderDebuffST.RemainingTime < 3))
+                        return OriginalHook(Thunder);
 
                     if (HasPolyglotStacks(Gauge))
-                    {
-                        if (!HasEffect(Buffs.Firestarter) ||
-                            !(GetBuffRemainingTime(Buffs.Firestarter) <= 3))
-                            return LevelChecked(Xenoglossy)
-                                ? Xenoglossy
-                                : Foul;
-
-                        if (CurMp + nextMpGain <= 10000 || CurMp < 7500)
-                            return Blizzard;
-
-                        if (ActionReady(Transpose) && CanSpellWeave() &&
-                            CurMp is MP.MaxMP && HasEffect(Buffs.Firestarter))
-                            return Transpose;
-
-                        if (LevelChecked(Fire3))
-                            return Fire3;
-
                         return LevelChecked(Xenoglossy)
                             ? Xenoglossy
                             : Foul;
-                    }
+                }
 
-                    if (CurMp + nextMpGain >= 7500 &&
-                        (LocalPlayer?.CastActionId == Blizzard ||
-                         WasLastSpell(Blizzard) ||
-                         WasLastSpell(Blizzard4)))
-                        return LevelChecked(Fire3)
-                            ? Fire3
-                            : Fire;
+                return LevelChecked(Blizzard3)
+                    ? Blizzard3
+                    : Transpose;
+            }
+
+            if (Gauge.InUmbralIce)
+            {
+                if (ActionReady(Blizzard3) && Gauge.UmbralIceStacks < 3 && TraitLevelChecked(Traits.UmbralHeart))
+                {
+                    if (HasEffect(All.Buffs.Swiftcast) || HasEffect(Buffs.Triplecast))
+                        return Blizzard3;
+
+                    if (GetBuffStacks(Buffs.Triplecast) == 0 && IsOffCooldown(All.Swiftcast))
+                        return All.Swiftcast;
+
+                    if (GetBuffStacks(Buffs.Triplecast) == 0 && ActionReady(Triplecast))
+                        return Triplecast;
+                }
+
+                if (LevelChecked(Blizzard4) && Gauge.UmbralHearts < 3 && TraitLevelChecked(Traits.UmbralHeart))
+                    return Blizzard4;
+
+                if (Gauge.IsParadoxActive)
+                    return Paradox;
+
+                if (HasPolyglotStacks(Gauge))
+                {
+                    if (!HasEffect(Buffs.Firestarter) ||
+                        !(GetBuffRemainingTime(Buffs.Firestarter) <= 3))
+                        return LevelChecked(Xenoglossy)
+                            ? Xenoglossy
+                            : Foul;
 
                     if (CurMp + nextMpGain <= 10000 || CurMp < 7500)
                         return Blizzard;
@@ -190,14 +167,36 @@ internal static partial class BLM
                         CurMp is MP.MaxMP && HasEffect(Buffs.Firestarter))
                         return Transpose;
 
-                    return LevelChecked(Fire3)
-                        ? Fire3
-                        : Transpose;
+                    if (LevelChecked(Fire3))
+                        return Fire3;
+
+                    return LevelChecked(Xenoglossy)
+                        ? Xenoglossy
+                        : Foul;
                 }
 
-                if (Blizzard3.LevelChecked())
-                    return Blizzard3;
+                if (CurMp + nextMpGain >= 7500 &&
+                    (LocalPlayer?.CastActionId == Blizzard ||
+                     WasLastSpell(Blizzard) ||
+                     WasLastSpell(Blizzard4)))
+                    return LevelChecked(Fire3)
+                        ? Fire3
+                        : Fire;
+
+                if (CurMp + nextMpGain <= 10000 || CurMp < 7500)
+                    return Blizzard;
+
+                if (ActionReady(Transpose) && CanSpellWeave() &&
+                    CurMp is MP.MaxMP && HasEffect(Buffs.Firestarter))
+                    return Transpose;
+
+                return LevelChecked(Fire3)
+                    ? Fire3
+                    : Transpose;
             }
+
+            if (Blizzard3.LevelChecked())
+                return Blizzard3;
             return actionID;
         }
     }
@@ -208,73 +207,91 @@ internal static partial class BLM
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Fire)
-            {
-                int polyglotStacks = Gauge.PolyglotStacks;
-                float triplecastChargetime = GetCooldownChargeRemainingTime(Triplecast);
+            if (actionID is not Fire) return actionID;
 
-                if (IsEnabled(CustomComboPreset.BLM_Variant_Cure) &&
+            int polyglotStacks = Gauge.PolyglotStacks;
+            float triplecastChargetime = GetCooldownChargeRemainingTime(Triplecast);
+
+            if (IsEnabled(CustomComboPreset.BLM_Variant_Cure) &&
                 IsEnabled(Variant.VariantCure) &&
                 PlayerHealthPercentageHp() <= Config.BLM_VariantCure)
-                    return Variant.VariantCure;
+                return Variant.VariantCure;
 
-                if (IsEnabled(CustomComboPreset.BLM_Variant_Rampart) &&
-                    IsEnabled(Variant.VariantRampart) &&
-                    IsOffCooldown(Variant.VariantRampart) &&
-                    CanSpellWeave())
-                    return Variant.VariantRampart;
+            if (IsEnabled(CustomComboPreset.BLM_Variant_Rampart) &&
+                IsEnabled(Variant.VariantRampart) &&
+                IsOffCooldown(Variant.VariantRampart) &&
+                CanSpellWeave())
+                return Variant.VariantRampart;
 
-                if (IsEnabled(CustomComboPreset.BLM_ST_Opener))
-                    if (Opener().FullOpener(ref actionID))
-                        return actionID;
+            if (IsEnabled(CustomComboPreset.BLM_ST_Opener))
+                if (Opener().FullOpener(ref actionID))
+                    return actionID;
 
-                //Weaves
-                if (CanSpellWeave())
+            //Weaves
+            if (CanSpellWeave())
+            {
+                if (IsEnabled(CustomComboPreset.BLM_ST_Amplifier) &&
+                    ActionReady(Amplifier) && RemainingPolyglotCD >= 20000)
+                    return Amplifier;
+
+                if (IsEnabled(CustomComboPreset.BLM_ST_LeyLines) &&
+                    ActionReady(LeyLines) && !HasEffect(Buffs.LeyLines) &&
+                    GetRemainingCharges(LeyLines) > Config.BLM_ST_LeyLinesCharges)
+                    return LeyLines;
+            }
+
+            if (IsEnabled(CustomComboPreset.BLM_ST_Thunder) &&
+                HasEffect(Buffs.Thunderhead) && GCDsInTimer > 1 && LevelChecked(Thunder) &&
+                GetTargetHPPercent() >= Config.BLM_ST_ThunderHP &&
+                (ThunderDebuffST is null || ThunderDebuffST.RemainingTime < 3))
+                return OriginalHook(Thunder);
+
+            if (IsMoving())
+            {
+                if (IsEnabled(CustomComboPreset.BLM_ST_Amplifier) &&
+                    ActionReady(Amplifier) && Gauge.PolyglotStacks < MaxPolyglot)
+                    return Amplifier;
+
+                if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglotMoving) &&
+                    polyglotStacks > Config.BLM_ST_UsePolyglotMoving_HoldCharges)
+                    return LevelChecked(Xenoglossy)
+                        ? Xenoglossy
+                        : Foul;
+            }
+
+            if (Gauge.InAstralFire)
+            {
+                if (Gauge.IsParadoxActive && GCDsInTimer < 2 && CurMp >= MP.FireI)
+                    return Paradox;
+
+                if ((HasEffect(Buffs.Firestarter) && GCDsInTimer < 2 &&
+                     CurMp >= MP.FireI) || (HasEffect(Buffs.Firestarter) && Gauge.AstralFireStacks < 3))
+                    return Fire3;
+
+                if (IsEnabled(CustomComboPreset.BLM_ST_Despair) &&
+                    CurMp < MP.FireI && LevelChecked(Despair) && CurMp >= MP.Despair)
+                    return Despair;
+
+                if (IsEnabled(CustomComboPreset.BLM_ST_FlareStar) &&
+                    CurMp == 0 && LevelChecked(FlareStar) && Gauge.AstralSoulStacks == 6)
                 {
-                    if (IsEnabled(CustomComboPreset.BLM_ST_Amplifier) &&
-                        ActionReady(Amplifier) && RemainingPolyglotCD >= 20000)
-                        return Amplifier;
+                    if (IsEnabled(CustomComboPreset.BLM_ST_Triplecast) &&
+                        CanSpellWeave() && ActionReady(Triplecast) &&
+                        GetBuffStacks(Buffs.Triplecast) == 0 &&
+                        (GetRemainingCharges(Triplecast) > Config.BLM_ST_Triplecast_HoldCharges ||
+                         triplecastChargetime <= Config.BLM_ST_Triplecast_ChargeTime))
+                        return Triplecast;
 
-                    if (IsEnabled(CustomComboPreset.BLM_ST_LeyLines) &&
-                        ActionReady(LeyLines) && !HasEffect(Buffs.LeyLines) &&
-                        GetRemainingCharges(LeyLines) > Config.BLM_ST_LeyLinesCharges)
-                        return LeyLines;
+                    if (IsEnabled(CustomComboPreset.BLM_ST_Swiftcast) &&
+                        CanSpellWeave() && ActionReady(All.Swiftcast) &&
+                        GetBuffStacks(Buffs.Triplecast) == 0)
+                        return All.Swiftcast;
+
+                    return FlareStar;
                 }
 
-                if (IsEnabled(CustomComboPreset.BLM_ST_Thunder) &&
-                    HasEffect(Buffs.Thunderhead) && GCDsInTimer > 1 && LevelChecked(Thunder) &&
-                    GetTargetHPPercent() >= Config.BLM_ST_ThunderHP &&
-                    (ThunderDebuffST is null || ThunderDebuffST.RemainingTime < 3))
-                    return OriginalHook(Thunder);
-
-                if (IsMoving())
-                {
-                    if (IsEnabled(CustomComboPreset.BLM_ST_Amplifier) &&
-                        ActionReady(Amplifier) && Gauge.PolyglotStacks < MaxPolyglot)
-                        return Amplifier;
-
-                    if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglotMoving) &&
-                        polyglotStacks > Config.BLM_ST_UsePolyglotMoving_HoldCharges)
-                        return LevelChecked(Xenoglossy)
-                            ? Xenoglossy
-                            : Foul;
-                }
-
-                if (Gauge.InAstralFire)
-                {
-                    if (Gauge.IsParadoxActive && GCDsInTimer < 2 && CurMp >= MP.FireI)
-                        return Paradox;
-
-                    if ((HasEffect(Buffs.Firestarter) && GCDsInTimer < 2 &&
-                         CurMp >= MP.FireI) || (HasEffect(Buffs.Firestarter) && Gauge.AstralFireStacks < 3))
-                        return Fire3;
-
-                    if (IsEnabled(CustomComboPreset.BLM_ST_Despair) &&
-                        CurMp < MP.FireI && LevelChecked(Despair) && CurMp >= MP.Despair)
-                        return Despair;
-
-                    if (IsEnabled(CustomComboPreset.BLM_ST_FlareStar) &&
-                        CurMp == 0 && LevelChecked(FlareStar) && Gauge.AstralSoulStacks == 6)
+                if (LevelChecked(Fire4))
+                    if (GCDsInTimer > 1 && CurMp >= MP.FireI)
                     {
                         if (IsEnabled(CustomComboPreset.BLM_ST_Triplecast) &&
                             CanSpellWeave() && ActionReady(Triplecast) &&
@@ -283,133 +300,91 @@ internal static partial class BLM
                              triplecastChargetime <= Config.BLM_ST_Triplecast_ChargeTime))
                             return Triplecast;
 
-                        if (IsEnabled(CustomComboPreset.BLM_ST_Swiftcast) &&
-                            CanSpellWeave() && ActionReady(All.Swiftcast) &&
-                            GetBuffStacks(Buffs.Triplecast) == 0)
-                            return All.Swiftcast;
-
-                        return FlareStar;
-                    }
-
-                    if (LevelChecked(Fire4))
-                        if (GCDsInTimer > 1 && CurMp >= MP.FireI)
-                        {
-                            if (IsEnabled(CustomComboPreset.BLM_ST_Triplecast) &&
-                                CanSpellWeave() && ActionReady(Triplecast) &&
-                                GetBuffStacks(Buffs.Triplecast) == 0 &&
-                                (GetRemainingCharges(Triplecast) > Config.BLM_ST_Triplecast_HoldCharges ||
-                                 triplecastChargetime <= Config.BLM_ST_Triplecast_ChargeTime))
-                                return Triplecast;
-
-                            if (IsEnabled(CustomComboPreset.BLM_ST_Thunder) &&
-                                HasEffect(Buffs.Thunderhead) && GCDsInTimer > 1 &&
-                                (ThunderDebuffST is null || ThunderDebuffST.RemainingTime < 3))
-                                return OriginalHook(Thunder);
-
-                            if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot) &&
-                                polyglotStacks > Config.BLM_ST_UsePolyglot_HoldCharges &&
-                                IsEnabled(CustomComboPreset.BLM_ST_Triplecast) &&
-                                CanSpellWeave() && ActionReady(Triplecast) &&
-                                GetBuffStacks(Buffs.Triplecast) == 0 &&
-                                (GetRemainingCharges(Triplecast) > Config.BLM_ST_Triplecast_HoldCharges ||
-                                 triplecastChargetime <= Config.BLM_ST_Triplecast_ChargeTime))
-                                return Xenoglossy.LevelChecked()
-                                    ? Xenoglossy
-                                    : Foul;
-
-                            return Fire4;
-                        }
-
-                    if (CurMp >= MP.FireI)
-                        return Fire;
-
-                    if (IsEnabled(CustomComboPreset.BLM_ST_Manafont) &&
-                        ActionReady(Manafont))
-                        return HasEffect(Buffs.Firestarter)
-                            ? Fire3
-                            : Manafont;
-
-                    if (ActionReady(Blizzard3) &&
-                        ((IsEnabled(CustomComboPreset.BLM_ST_Swiftcast) && ActionReady(All.Swiftcast)) ||
-                         HasEffect(Buffs.Triplecast)))
-                    {
-                        if (IsEnabled(CustomComboPreset.BLM_ST_Transpose) &&
-                            CanSpellWeave() && ActionReady(Transpose))
-                            return Transpose;
-
                         if (IsEnabled(CustomComboPreset.BLM_ST_Thunder) &&
-                            HasEffect(Buffs.Thunderhead) &&
+                            HasEffect(Buffs.Thunderhead) && GCDsInTimer > 1 &&
                             (ThunderDebuffST is null || ThunderDebuffST.RemainingTime < 3))
                             return OriginalHook(Thunder);
 
                         if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot) &&
-                            polyglotStacks > Config.BLM_ST_UsePolyglot_HoldCharges)
-                            return LevelChecked(Xenoglossy)
-                                ? Xenoglossy
-                                : Foul;
-                    }
-
-                    return LevelChecked(Blizzard3)
-                        ? Blizzard3
-                        : Transpose;
-                }
-
-                if (Gauge.InUmbralIce)
-                {
-                    if (ActionReady(Blizzard3) && Gauge.UmbralIceStacks < 3 && TraitLevelChecked(Traits.UmbralHeart))
-                    {
-                        if (HasEffect(All.Buffs.Swiftcast) || HasEffect(Buffs.Triplecast))
-                            return Blizzard3;
-
-                        if (IsEnabled(CustomComboPreset.BLM_ST_Swiftcast) &&
-                            GetBuffStacks(Buffs.Triplecast) == 0 && IsOffCooldown(All.Swiftcast))
-                            return All.Swiftcast;
-
-                        if (IsEnabled(CustomComboPreset.BLM_ST_Triplecast) &&
-                            LevelChecked(Triplecast) && GetBuffStacks(Buffs.Triplecast) == 0 &&
+                            polyglotStacks > Config.BLM_ST_UsePolyglot_HoldCharges &&
+                            IsEnabled(CustomComboPreset.BLM_ST_Triplecast) &&
+                            CanSpellWeave() && ActionReady(Triplecast) &&
+                            GetBuffStacks(Buffs.Triplecast) == 0 &&
                             (GetRemainingCharges(Triplecast) > Config.BLM_ST_Triplecast_HoldCharges ||
                              triplecastChargetime <= Config.BLM_ST_Triplecast_ChargeTime))
-                            return Triplecast;
+                            return Xenoglossy.LevelChecked()
+                                ? Xenoglossy
+                                : Foul;
+
+                        return Fire4;
                     }
 
-                    if (LevelChecked(Blizzard4) && Gauge.UmbralHearts < 3 && TraitLevelChecked(Traits.UmbralHeart))
-                        return Blizzard4;
+                if (CurMp >= MP.FireI)
+                    return Fire;
 
-                    if (Gauge.IsParadoxActive)
-                        return Paradox;
+                if (IsEnabled(CustomComboPreset.BLM_ST_Manafont) &&
+                    ActionReady(Manafont))
+                    return HasEffect(Buffs.Firestarter)
+                        ? Fire3
+                        : Manafont;
+
+                if (ActionReady(Blizzard3) &&
+                    ((IsEnabled(CustomComboPreset.BLM_ST_Swiftcast) && ActionReady(All.Swiftcast)) ||
+                     HasEffect(Buffs.Triplecast)))
+                {
+                    if (IsEnabled(CustomComboPreset.BLM_ST_Transpose) &&
+                        CanSpellWeave() && ActionReady(Transpose))
+                        return Transpose;
+
+                    if (IsEnabled(CustomComboPreset.BLM_ST_Thunder) &&
+                        HasEffect(Buffs.Thunderhead) &&
+                        (ThunderDebuffST is null || ThunderDebuffST.RemainingTime < 3))
+                        return OriginalHook(Thunder);
 
                     if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot) &&
                         polyglotStacks > Config.BLM_ST_UsePolyglot_HoldCharges)
-                    {
-                        if (!HasEffect(Buffs.Firestarter) ||
-                            !(GetBuffRemainingTime(Buffs.Firestarter) <= 3))
-                            return LevelChecked(Xenoglossy)
-                                ? Xenoglossy
-                                : Foul;
-
-                        if (CurMp + nextMpGain <= 10000 || CurMp < 7500)
-                            return Blizzard;
-
-                        if (IsEnabled(CustomComboPreset.BLM_ST_Transpose) &&
-                            ActionReady(Transpose) && CanSpellWeave() &&
-                            CurMp is MP.MaxMP && HasEffect(Buffs.Firestarter))
-                            return Transpose;
-
-                        if (LevelChecked(Fire3))
-                            return Fire3;
-
                         return LevelChecked(Xenoglossy)
                             ? Xenoglossy
                             : Foul;
-                    }
+                }
 
-                    if (CurMp + nextMpGain >= 7500 &&
-                        (LocalPlayer?.CastActionId == Blizzard ||
-                         WasLastSpell(Blizzard) ||
-                         WasLastSpell(Blizzard4)))
-                        return LevelChecked(Fire3)
-                            ? Fire3
-                            : Fire;
+                return LevelChecked(Blizzard3)
+                    ? Blizzard3
+                    : Transpose;
+            }
+
+            if (Gauge.InUmbralIce)
+            {
+                if (ActionReady(Blizzard3) && Gauge.UmbralIceStacks < 3 && TraitLevelChecked(Traits.UmbralHeart))
+                {
+                    if (HasEffect(All.Buffs.Swiftcast) || HasEffect(Buffs.Triplecast))
+                        return Blizzard3;
+
+                    if (IsEnabled(CustomComboPreset.BLM_ST_Swiftcast) &&
+                        GetBuffStacks(Buffs.Triplecast) == 0 && IsOffCooldown(All.Swiftcast))
+                        return All.Swiftcast;
+
+                    if (IsEnabled(CustomComboPreset.BLM_ST_Triplecast) &&
+                        LevelChecked(Triplecast) && GetBuffStacks(Buffs.Triplecast) == 0 &&
+                        (GetRemainingCharges(Triplecast) > Config.BLM_ST_Triplecast_HoldCharges ||
+                         triplecastChargetime <= Config.BLM_ST_Triplecast_ChargeTime))
+                        return Triplecast;
+                }
+
+                if (LevelChecked(Blizzard4) && Gauge.UmbralHearts < 3 && TraitLevelChecked(Traits.UmbralHeart))
+                    return Blizzard4;
+
+                if (Gauge.IsParadoxActive)
+                    return Paradox;
+
+                if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot) &&
+                    polyglotStacks > Config.BLM_ST_UsePolyglot_HoldCharges)
+                {
+                    if (!HasEffect(Buffs.Firestarter) ||
+                        !(GetBuffRemainingTime(Buffs.Firestarter) <= 3))
+                        return LevelChecked(Xenoglossy)
+                            ? Xenoglossy
+                            : Foul;
 
                     if (CurMp + nextMpGain <= 10000 || CurMp < 7500)
                         return Blizzard;
@@ -419,14 +394,37 @@ internal static partial class BLM
                         CurMp is MP.MaxMP && HasEffect(Buffs.Firestarter))
                         return Transpose;
 
-                    return LevelChecked(Fire3)
-                        ? Fire3
-                        : Transpose;
+                    if (LevelChecked(Fire3))
+                        return Fire3;
+
+                    return LevelChecked(Xenoglossy)
+                        ? Xenoglossy
+                        : Foul;
                 }
 
-                if (Blizzard3.LevelChecked())
-                    return Blizzard3;
+                if (CurMp + nextMpGain >= 7500 &&
+                    (LocalPlayer?.CastActionId == Blizzard ||
+                     WasLastSpell(Blizzard) ||
+                     WasLastSpell(Blizzard4)))
+                    return LevelChecked(Fire3)
+                        ? Fire3
+                        : Fire;
+
+                if (CurMp + nextMpGain <= 10000 || CurMp < 7500)
+                    return Blizzard;
+
+                if (IsEnabled(CustomComboPreset.BLM_ST_Transpose) &&
+                    ActionReady(Transpose) && CanSpellWeave() &&
+                    CurMp is MP.MaxMP && HasEffect(Buffs.Firestarter))
+                    return Transpose;
+
+                return LevelChecked(Fire3)
+                    ? Fire3
+                    : Transpose;
             }
+
+            if (Blizzard3.LevelChecked())
+                return Blizzard3;
             return actionID;
         }
     }
@@ -437,210 +435,60 @@ internal static partial class BLM
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Blizzard2 or HighBlizzard2)
+            if (actionID is not (Blizzard2 or HighBlizzard2)) return actionID;
+
+            if (IsEnabled(CustomComboPreset.BLM_Variant_Cure) &&
+                IsEnabled(Variant.VariantCure) &&
+                PlayerHealthPercentageHp() <= Config.BLM_VariantCure)
+                return Variant.VariantCure;
+
+            if (IsEnabled(CustomComboPreset.BLM_Variant_Rampart) &&
+                IsEnabled(Variant.VariantRampart) &&
+                IsOffCooldown(Variant.VariantRampart) &&
+                CanSpellWeave())
+                return Variant.VariantRampart;
+
+            if (WasLastSpell(UmbralSoul))
+                return OriginalHook(Fire2);
+
+            if ((HasEffect(Buffs.Thunderhead) && GCDsInTimer > 1 && Thunder2.LevelChecked() &&
+                 ThunderDebuffAoE is null) || ThunderDebuffAoE?.RemainingTime < 3)
+                return OriginalHook(Thunder2);
+
+            if (ActionReady(Amplifier) && RemainingPolyglotCD >= 20000 && CanSpellWeave())
+                return Amplifier;
+
+            if (IsMoving())
             {
-                if (IsEnabled(CustomComboPreset.BLM_Variant_Cure) &&
-                    IsEnabled(Variant.VariantCure) &&
-                    PlayerHealthPercentageHp() <= Config.BLM_VariantCure)
-                    return Variant.VariantCure;
-
-                if (IsEnabled(CustomComboPreset.BLM_Variant_Rampart) &&
-                    IsEnabled(Variant.VariantRampart) &&
-                    IsOffCooldown(Variant.VariantRampart) &&
-                    CanSpellWeave())
-                    return Variant.VariantRampart;
-
-                if (WasLastSpell(UmbralSoul))
-                    return OriginalHook(Fire2);
-
-                if ((HasEffect(Buffs.Thunderhead) && GCDsInTimer > 1 && Thunder2.LevelChecked() &&
-                     ThunderDebuffAoE is null) || ThunderDebuffAoE?.RemainingTime < 3)
-                    return OriginalHook(Thunder2);
-
-                if (ActionReady(Amplifier) && RemainingPolyglotCD >= 20000 && CanSpellWeave())
+                if (ActionReady(Amplifier) && Gauge.PolyglotStacks < MaxPolyglot)
                     return Amplifier;
 
-                if (IsMoving())
+                if (HasPolyglotStacks(Gauge))
+                    return Foul;
+            }
+
+            if (CanSpellWeave() &&
+                ActionReady(LeyLines) && !HasEffect(Buffs.LeyLines))
+                return LeyLines;
+
+            if (Gauge.InAstralFire)
+            {
+                if (CurMp == 0 && FlareStar.LevelChecked() && Gauge.AstralSoulStacks == 6)
+                    return FlareStar;
+
+                if (!FlareStar.LevelChecked() && Fire2.LevelChecked() && CurMp >= MP.FireAoE &&
+                    (Gauge.UmbralHearts > 1 || !TraitLevelChecked(Traits.UmbralHeart)))
+                    return OriginalHook(Fire2);
+
+                if (Flare.LevelChecked() && CurMp >= MP.AllMPSpells)
                 {
-                    if (ActionReady(Amplifier) && Gauge.PolyglotStacks < MaxPolyglot)
-                        return Amplifier;
-
-                    if (HasPolyglotStacks(Gauge))
-                        return Foul;
-                }
-
-                if (CanSpellWeave() &&
-                    ActionReady(LeyLines) && !HasEffect(Buffs.LeyLines))
-                    return LeyLines;
-
-                if (Gauge.InAstralFire)
-                {
-                    if (CurMp == 0 && FlareStar.LevelChecked() && Gauge.AstralSoulStacks == 6)
-                        return FlareStar;
-
-                    if (!FlareStar.LevelChecked() && Fire2.LevelChecked() && CurMp >= MP.FireAoE &&
-                        (Gauge.UmbralHearts > 1 || !TraitLevelChecked(Traits.UmbralHeart)))
-                        return OriginalHook(Fire2);
-
-                    if (Flare.LevelChecked() && CurMp >= MP.AllMPSpells)
+                    if (ActionReady(Triplecast) && GetBuffStacks(Buffs.Triplecast) == 0 &&
+                        CanSpellWeave())
+                        return Triplecast;
+                    if (Flare.LevelChecked() && CurMp >= MP.FlareAoE)
                     {
                         if (ActionReady(Triplecast) && GetBuffStacks(Buffs.Triplecast) == 0 &&
                             CanSpellWeave())
-                            return Triplecast;
-                        if (Flare.LevelChecked() && CurMp >= MP.FlareAoE)
-                        {
-                            if (ActionReady(Triplecast) && GetBuffStacks(Buffs.Triplecast) == 0 &&
-                                CanSpellWeave())
-                                return Triplecast;
-
-                            return Flare;
-                        }
-
-                        if (Fire2.LevelChecked())
-                            if (GCDsInTimer > 1 && CurMp >= MP.FireAoE)
-                                return OriginalHook(Fire2);
-
-                        if (ActionReady(Manafont))
-                            return Manafont;
-
-                        if (ActionReady(Transpose) && (!TraitLevelChecked(Traits.AspectMasteryIII) || CanSwiftF))
-                            return Transpose;
-
-                        if (ActionReady(Blizzard2) && TraitLevelChecked(Traits.AspectMasteryIII))
-                            return OriginalHook(Blizzard2);
-                    }
-
-                    if (Gauge.InUmbralIce)
-                    {
-                        if (HasPolyglotStacks(Gauge))
-                            return Foul;
-
-                        if (ActionWatching.WhichOfTheseActionsWasLast(OriginalHook(Fire2), OriginalHook(Freeze),
-                                OriginalHook(Flare), OriginalHook(FlareStar)) == OriginalHook(Freeze) &&
-                            FlareStar.LevelChecked())
-                        {
-                            if (ActionReady(Transpose) && CanSpellWeave())
-                                return Transpose;
-
-                            return OriginalHook(Fire2);
-                        }
-
-                        if (ActionReady(OriginalHook(Blizzard2)) && Gauge.UmbralIceStacks < 3 &&
-                            TraitLevelChecked(Traits.AspectMasteryIII))
-                        {
-                            if (ActionReady(Triplecast) && GetBuffStacks(Buffs.Triplecast) == 0 &&
-                                CanSpellWeave())
-                                return Triplecast;
-
-                            if (GetBuffStacks(Buffs.Triplecast) == 0 && IsOffCooldown(All.Swiftcast) &&
-                                CanSpellWeave())
-                                return All.Swiftcast;
-
-                            if (HasEffect(All.Buffs.Swiftcast) || GetBuffStacks(Buffs.Triplecast) > 0)
-                                return OriginalHook(Blizzard2);
-                        }
-
-                        if (Gauge.UmbralIceStacks < 3 && ActionReady(OriginalHook(Blizzard2)))
-                            return OriginalHook(Blizzard2);
-
-                        if (Freeze.LevelChecked() && Gauge.UmbralHearts < 3 && TraitLevelChecked(Traits.UmbralHeart))
-                            return Freeze;
-
-                        if (DoubleBlizz() && Fire2.LevelChecked())
-                            return OriginalHook(Fire2);
-
-                        if (CurMp < LocalPlayer?.MaxMp)
-                            return Freeze.LevelChecked()
-                                ? OriginalHook(Freeze)
-                                : OriginalHook(Blizzard2);
-
-                        if (IsEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
-                            ActionReady(Transpose) &&
-                            ((CanSpellWeave() && Flare.LevelChecked()) ||
-                             !TraitLevelChecked(Traits.AspectMasteryIII)))
-                            return Transpose;
-
-                        if (Fire2.LevelChecked() && TraitLevelChecked(Traits.AspectMasteryIII))
-                            return OriginalHook(Fire2);
-                    }
-
-                    if (Blizzard2.LevelChecked())
-                        return OriginalHook(Blizzard2);
-                }
-            }
-            return actionID;
-        }
-    }
-
-    internal class BLM_AoE_AdvancedMode : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BLM_AoE_AdvancedMode;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is Blizzard2 or HighBlizzard2)
-            {
-                int polyglotStacks = Gauge.PolyglotStacks;
-                float triplecastChargetime = GetCooldownChargeRemainingTime(Triplecast);
-
-                if (IsEnabled(CustomComboPreset.BLM_Variant_Cure) &&
-                    IsEnabled(Variant.VariantCure) &&
-                    PlayerHealthPercentageHp() <= Config.BLM_VariantCure)
-                    return Variant.VariantCure;
-
-                if (IsEnabled(CustomComboPreset.BLM_Variant_Rampart) &&
-                    IsEnabled(Variant.VariantRampart) &&
-                    IsOffCooldown(Variant.VariantRampart) &&
-                    CanSpellWeave())
-                    return Variant.VariantRampart;
-
-                if (WasLastSpell(UmbralSoul))
-                    return OriginalHook(Fire2);
-
-                if ((IsEnabled(CustomComboPreset.BLM_AoE_Thunder) &&
-                     HasEffect(Buffs.Thunderhead) && GCDsInTimer > 1 && LevelChecked(Thunder2) &&
-                     GetTargetHPPercent() >= Config.BLM_AoE_ThunderHP &&
-                     ThunderDebuffAoE is null) || ThunderDebuffAoE?.RemainingTime < 3)
-                    return OriginalHook(Thunder2);
-
-                if (IsEnabled(CustomComboPreset.BLM_AoE_Amplifier) &&
-                    ActionReady(Amplifier) && RemainingPolyglotCD >= 20000 && CanSpellWeave())
-                    return Amplifier;
-
-                if (IsMoving())
-                {
-                    if (IsEnabled(CustomComboPreset.BLM_AoE_Amplifier) &&
-                        ActionReady(Amplifier) && Gauge.PolyglotStacks < MaxPolyglot)
-                        return Amplifier;
-
-                    if (IsEnabled(CustomComboPreset.BLM_AoE_UsePolyglotMoving) &&
-                        polyglotStacks > Config.BLM_AoE_UsePolyglotMoving_HoldCharges)
-                        return Foul;
-                }
-
-                if (IsEnabled(CustomComboPreset.BLM_AoE_LeyLines) &&
-                    CanSpellWeave() &&
-                    ActionReady(LeyLines) && !HasEffect(Buffs.LeyLines) &&
-                    GetRemainingCharges(LeyLines) > Config.BLM_AoE_LeyLinesCharges)
-                    return LeyLines;
-
-                if (Gauge.InAstralFire)
-                {
-                    if (IsEnabled(CustomComboPreset.BLM_AoE_FlareStar) &&
-                        CurMp == 0 && FlareStar.LevelChecked() && Gauge.AstralSoulStacks == 6)
-                        return FlareStar;
-
-                    if (!FlareStar.LevelChecked() && Fire2.LevelChecked() && CurMp >= MP.FireAoE &&
-                        (Gauge.UmbralHearts > 1 || !TraitLevelChecked(Traits.UmbralHeart)))
-                        return OriginalHook(Fire2);
-
-                    if (IsEnabled(CustomComboPreset.BLM_AoE_Flare) &&
-                        Flare.LevelChecked() && CurMp >= MP.FlareAoE)
-                    {
-                        if (LevelChecked(Triplecast) && CanSpellWeave() &&
-                            GetBuffStacks(Buffs.Triplecast) == 0 &&
-                            (GetRemainingCharges(Triplecast) > Config.BLM_AoE_Triplecast_HoldCharges ||
-                             triplecastChargetime <= Config.BLM_AoE_Triplecast_ChargeTime))
                             return Triplecast;
 
                         return Flare;
@@ -650,12 +498,10 @@ internal static partial class BLM
                         if (GCDsInTimer > 1 && CurMp >= MP.FireAoE)
                             return OriginalHook(Fire2);
 
-                    if (IsEnabled(CustomComboPreset.BLM_AoE_Manafont) &&
-                        ActionReady(Manafont))
+                    if (ActionReady(Manafont))
                         return Manafont;
 
-                    if (IsEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
-                        ActionReady(Transpose) && (!TraitLevelChecked(Traits.AspectMasteryIII) || CanSwiftF))
+                    if (ActionReady(Transpose) && (!TraitLevelChecked(Traits.AspectMasteryIII) || CanSwiftF))
                         return Transpose;
 
                     if (ActionReady(Blizzard2) && TraitLevelChecked(Traits.AspectMasteryIII))
@@ -664,16 +510,14 @@ internal static partial class BLM
 
                 if (Gauge.InUmbralIce)
                 {
-                    if (IsEnabled(CustomComboPreset.BLM_AoE_UsePolyglot) &&
-                        polyglotStacks > Config.BLM_AoE_UsePolyglot_HoldCharges)
+                    if (HasPolyglotStacks(Gauge))
                         return Foul;
 
                     if (ActionWatching.WhichOfTheseActionsWasLast(OriginalHook(Fire2), OriginalHook(Freeze),
                             OriginalHook(Flare), OriginalHook(FlareStar)) == OriginalHook(Freeze) &&
                         FlareStar.LevelChecked())
                     {
-                        if (IsEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
-                            ActionReady(Transpose) && CanSpellWeave())
+                        if (ActionReady(Transpose) && CanSpellWeave())
                             return Transpose;
 
                         return OriginalHook(Fire2);
@@ -682,15 +526,11 @@ internal static partial class BLM
                     if (ActionReady(OriginalHook(Blizzard2)) && Gauge.UmbralIceStacks < 3 &&
                         TraitLevelChecked(Traits.AspectMasteryIII))
                     {
-                        if (IsEnabled(CustomComboPreset.BLM_AoE_Triplecast) &&
-                            LevelChecked(Triplecast) && CanSpellWeave() &&
-                            GetBuffStacks(Buffs.Triplecast) == 0 &&
-                            (GetRemainingCharges(Triplecast) > Config.BLM_AoE_Triplecast_HoldCharges ||
-                             triplecastChargetime <= Config.BLM_AoE_Triplecast_ChargeTime))
+                        if (ActionReady(Triplecast) && GetBuffStacks(Buffs.Triplecast) == 0 &&
+                            CanSpellWeave())
                             return Triplecast;
 
-                        if (IsEnabled(CustomComboPreset.BLM_AoE_Swiftcast) &&
-                            GetBuffStacks(Buffs.Triplecast) == 0 && IsOffCooldown(All.Swiftcast) &&
+                        if (GetBuffStacks(Buffs.Triplecast) == 0 && IsOffCooldown(All.Swiftcast) &&
                             CanSpellWeave())
                             return All.Swiftcast;
 
@@ -725,6 +565,162 @@ internal static partial class BLM
                 if (Blizzard2.LevelChecked())
                     return OriginalHook(Blizzard2);
             }
+            return actionID;
+        }
+    }
+
+    internal class BLM_AoE_AdvancedMode : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BLM_AoE_AdvancedMode;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not (Blizzard2 or HighBlizzard2)) return actionID;
+
+            int polyglotStacks = Gauge.PolyglotStacks;
+            float triplecastChargetime = GetCooldownChargeRemainingTime(Triplecast);
+
+            if (IsEnabled(CustomComboPreset.BLM_Variant_Cure) &&
+                IsEnabled(Variant.VariantCure) &&
+                PlayerHealthPercentageHp() <= Config.BLM_VariantCure)
+                return Variant.VariantCure;
+
+            if (IsEnabled(CustomComboPreset.BLM_Variant_Rampart) &&
+                IsEnabled(Variant.VariantRampart) &&
+                IsOffCooldown(Variant.VariantRampart) &&
+                CanSpellWeave())
+                return Variant.VariantRampart;
+
+            if (WasLastSpell(UmbralSoul))
+                return OriginalHook(Fire2);
+
+            if ((IsEnabled(CustomComboPreset.BLM_AoE_Thunder) &&
+                 HasEffect(Buffs.Thunderhead) && GCDsInTimer > 1 && LevelChecked(Thunder2) &&
+                 GetTargetHPPercent() >= Config.BLM_AoE_ThunderHP &&
+                 ThunderDebuffAoE is null) || ThunderDebuffAoE?.RemainingTime < 3)
+                return OriginalHook(Thunder2);
+
+            if (IsEnabled(CustomComboPreset.BLM_AoE_Amplifier) &&
+                ActionReady(Amplifier) && RemainingPolyglotCD >= 20000 && CanSpellWeave())
+                return Amplifier;
+
+            if (IsMoving())
+            {
+                if (IsEnabled(CustomComboPreset.BLM_AoE_Amplifier) &&
+                    ActionReady(Amplifier) && Gauge.PolyglotStacks < MaxPolyglot)
+                    return Amplifier;
+
+                if (IsEnabled(CustomComboPreset.BLM_AoE_UsePolyglotMoving) &&
+                    polyglotStacks > Config.BLM_AoE_UsePolyglotMoving_HoldCharges)
+                    return Foul;
+            }
+
+            if (IsEnabled(CustomComboPreset.BLM_AoE_LeyLines) &&
+                CanSpellWeave() &&
+                ActionReady(LeyLines) && !HasEffect(Buffs.LeyLines) &&
+                GetRemainingCharges(LeyLines) > Config.BLM_AoE_LeyLinesCharges)
+                return LeyLines;
+
+            if (Gauge.InAstralFire)
+            {
+                if (IsEnabled(CustomComboPreset.BLM_AoE_FlareStar) &&
+                    CurMp == 0 && FlareStar.LevelChecked() && Gauge.AstralSoulStacks == 6)
+                    return FlareStar;
+
+                if (!FlareStar.LevelChecked() && Fire2.LevelChecked() && CurMp >= MP.FireAoE &&
+                    (Gauge.UmbralHearts > 1 || !TraitLevelChecked(Traits.UmbralHeart)))
+                    return OriginalHook(Fire2);
+
+                if (IsEnabled(CustomComboPreset.BLM_AoE_Flare) &&
+                    Flare.LevelChecked() && CurMp >= MP.FlareAoE)
+                {
+                    if (LevelChecked(Triplecast) && CanSpellWeave() &&
+                        GetBuffStacks(Buffs.Triplecast) == 0 &&
+                        (GetRemainingCharges(Triplecast) > Config.BLM_AoE_Triplecast_HoldCharges ||
+                         triplecastChargetime <= Config.BLM_AoE_Triplecast_ChargeTime))
+                        return Triplecast;
+
+                    return Flare;
+                }
+
+                if (Fire2.LevelChecked())
+                    if (GCDsInTimer > 1 && CurMp >= MP.FireAoE)
+                        return OriginalHook(Fire2);
+
+                if (IsEnabled(CustomComboPreset.BLM_AoE_Manafont) &&
+                    ActionReady(Manafont))
+                    return Manafont;
+
+                if (IsEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
+                    ActionReady(Transpose) && (!TraitLevelChecked(Traits.AspectMasteryIII) || CanSwiftF))
+                    return Transpose;
+
+                if (ActionReady(Blizzard2) && TraitLevelChecked(Traits.AspectMasteryIII))
+                    return OriginalHook(Blizzard2);
+            }
+
+            if (Gauge.InUmbralIce)
+            {
+                if (IsEnabled(CustomComboPreset.BLM_AoE_UsePolyglot) &&
+                    polyglotStacks > Config.BLM_AoE_UsePolyglot_HoldCharges)
+                    return Foul;
+
+                if (ActionWatching.WhichOfTheseActionsWasLast(OriginalHook(Fire2), OriginalHook(Freeze),
+                        OriginalHook(Flare), OriginalHook(FlareStar)) == OriginalHook(Freeze) &&
+                    FlareStar.LevelChecked())
+                {
+                    if (IsEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
+                        ActionReady(Transpose) && CanSpellWeave())
+                        return Transpose;
+
+                    return OriginalHook(Fire2);
+                }
+
+                if (ActionReady(OriginalHook(Blizzard2)) && Gauge.UmbralIceStacks < 3 &&
+                    TraitLevelChecked(Traits.AspectMasteryIII))
+                {
+                    if (IsEnabled(CustomComboPreset.BLM_AoE_Triplecast) &&
+                        LevelChecked(Triplecast) && CanSpellWeave() &&
+                        GetBuffStacks(Buffs.Triplecast) == 0 &&
+                        (GetRemainingCharges(Triplecast) > Config.BLM_AoE_Triplecast_HoldCharges ||
+                         triplecastChargetime <= Config.BLM_AoE_Triplecast_ChargeTime))
+                        return Triplecast;
+
+                    if (IsEnabled(CustomComboPreset.BLM_AoE_Swiftcast) &&
+                        GetBuffStacks(Buffs.Triplecast) == 0 && IsOffCooldown(All.Swiftcast) &&
+                        CanSpellWeave())
+                        return All.Swiftcast;
+
+                    if (HasEffect(All.Buffs.Swiftcast) || GetBuffStacks(Buffs.Triplecast) > 0)
+                        return OriginalHook(Blizzard2);
+                }
+
+                if (Gauge.UmbralIceStacks < 3 && ActionReady(OriginalHook(Blizzard2)))
+                    return OriginalHook(Blizzard2);
+
+                if (Freeze.LevelChecked() && Gauge.UmbralHearts < 3 && TraitLevelChecked(Traits.UmbralHeart))
+                    return Freeze;
+
+                if (DoubleBlizz() && Fire2.LevelChecked())
+                    return OriginalHook(Fire2);
+
+                if (CurMp < LocalPlayer?.MaxMp)
+                    return Freeze.LevelChecked()
+                        ? OriginalHook(Freeze)
+                        : OriginalHook(Blizzard2);
+
+                if (IsEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
+                    ActionReady(Transpose) &&
+                    ((CanSpellWeave() && Flare.LevelChecked()) ||
+                     !TraitLevelChecked(Traits.AspectMasteryIII)))
+                    return Transpose;
+
+                if (Fire2.LevelChecked() && TraitLevelChecked(Traits.AspectMasteryIII))
+                    return OriginalHook(Fire2);
+            }
+
+            if (Blizzard2.LevelChecked())
+                return OriginalHook(Blizzard2);
             return actionID;
         }
     }

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -95,38 +95,37 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is HeavyShot or BurstShot)
+                if (actionID is not (HeavyShot or BurstShot)) return actionID;
+
+                if (IsEnabled(CustomComboPreset.BRD_DoTMaintainance))
                 {
-                    if (IsEnabled(CustomComboPreset.BRD_DoTMaintainance))
+                    if (InCombat())
                     {
-                        if (InCombat())
-                        {
-                            bool canIronJaws = LevelChecked(IronJaws);
-                            Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
-                            Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
-                            float purpleRemaining = purple?.RemainingTime ?? 0;
-                            float blueRemaining = blue?.RemainingTime ?? 0;
+                        bool canIronJaws = LevelChecked(IronJaws);
+                        Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
+                        Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
+                        float purpleRemaining = purple?.RemainingTime ?? 0;
+                        float blueRemaining = blue?.RemainingTime ?? 0;
 
-                            if (purple is not null && purpleRemaining < 4)
-                                return canIronJaws ? IronJaws : VenomousBite;
-                            if (blue is not null && blueRemaining < 4)
-                                return canIronJaws ? IronJaws : Windbite;
-                        }
+                        if (purple is not null && purpleRemaining < 4)
+                            return canIronJaws ? IronJaws : VenomousBite;
+                        if (blue is not null && blueRemaining < 4)
+                            return canIronJaws ? IronJaws : Windbite;
                     }
-
-                    if (IsEnabled(CustomComboPreset.BRD_ApexST))
-                    {
-                        BRDGauge? gauge = GetJobGauge<BRDGauge>();
-
-                        if (gauge.SoulVoice == 100)
-                            return ApexArrow;
-                        if (HasEffect(Buffs.BlastArrowReady))
-                            return BlastArrow;
-                    }
-
-                    if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
-                        return OriginalHook(StraightShot);
                 }
+
+                if (IsEnabled(CustomComboPreset.BRD_ApexST))
+                {
+                    BRDGauge? gauge = GetJobGauge<BRDGauge>();
+
+                    if (gauge.SoulVoice == 100)
+                        return ApexArrow;
+                    if (HasEffect(Buffs.BlastArrowReady))
+                        return BlastArrow;
+                }
+
+                if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
+                    return OriginalHook(StraightShot);
 
                 return actionID;
             }
@@ -138,39 +137,38 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is IronJaws)
+                if (actionID is not IronJaws) return actionID;
+
+                Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
+                Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
+                float purpleRemaining = purple?.RemainingTime ?? 0;
+                float blueRemaining = blue?.RemainingTime ?? 0;
+
+                // Before Iron Jaws: Alternate between DoTs
+                if (!LevelChecked(IronJaws))
+                    return LevelChecked(Windbite) && blueRemaining <= purpleRemaining ? Windbite : VenomousBite;
+
+                // At least Lv56 (Iron Jaws) from here on...
+
+                // DoT application takes priority, as Iron Jaws always cuts ticks
+                if (blue is null && LevelChecked(Windbite))
+                    return OriginalHook(Windbite);
+                if (purple is null && LevelChecked(VenomousBite))
+                    return OriginalHook(VenomousBite);
+
+                // DoT refresh over Apex Option
+                if (purpleRemaining < 4 || blueRemaining < 4)
+                    return IronJaws;
+
+                // Apex Option
+                if (IsEnabled(CustomComboPreset.BRD_IronJawsApex))
                 {
-                    Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
-                    Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
-                    float purpleRemaining = purple?.RemainingTime ?? 0;
-                    float blueRemaining = blue?.RemainingTime ?? 0;
+                    BRDGauge? gauge = GetJobGauge<BRDGauge>();
 
-                    // Before Iron Jaws: Alternate between DoTs
-                    if (!LevelChecked(IronJaws))
-                        return LevelChecked(Windbite) && blueRemaining <= purpleRemaining ? Windbite : VenomousBite;
-
-                    // At least Lv56 (Iron Jaws) from here on...
-
-                    // DoT application takes priority, as Iron Jaws always cuts ticks
-                    if (blue is null && LevelChecked(Windbite))
-                        return OriginalHook(Windbite);
-                    if (purple is null && LevelChecked(VenomousBite))
-                        return OriginalHook(VenomousBite);
-
-                    // DoT refresh over Apex Option
-                    if (purpleRemaining < 4 || blueRemaining < 4)
-                        return IronJaws;
-
-                    // Apex Option
-                    if (IsEnabled(CustomComboPreset.BRD_IronJawsApex))
-                    {
-                        BRDGauge? gauge = GetJobGauge<BRDGauge>();
-
-                        if (LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady))
-                            return BlastArrow;
-                        if (gauge.SoulVoice == 100)
-                            return ApexArrow;
-                    }
+                    if (LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady))
+                        return BlastArrow;
+                    if (gauge.SoulVoice == 100)
+                        return ApexArrow;
                 }
                 return actionID;
             }
@@ -182,25 +180,23 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is IronJaws)
-                {
-                    Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
-                    Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
-                    float purpleRemaining = purple?.RemainingTime ?? 0;
-                    float blueRemaining = blue?.RemainingTime ?? 0;
+                if (actionID is not IronJaws) return actionID;
 
-                    // Iron Jaws only if it is applicable
-                    if (LevelChecked(IronJaws) && (
+                Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
+                Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
+                float purpleRemaining = purple?.RemainingTime ?? 0;
+                float blueRemaining = blue?.RemainingTime ?? 0;
+
+                // Iron Jaws only if it is applicable
+                if (LevelChecked(IronJaws) && (
                         (purple is not null && purpleRemaining < 4) ||
                         (blue is not null && blueRemaining < 4)))
-                        return IronJaws;
+                    return IronJaws;
 
-                    // Otherwise alternate between DoTs as needed
-                    return LevelChecked(Windbite) && blueRemaining <= purpleRemaining ?
-                        OriginalHook(Windbite) :
-                        OriginalHook(VenomousBite);
-                }
-                return actionID;
+                // Otherwise alternate between DoTs as needed
+                return LevelChecked(Windbite) && blueRemaining <= purpleRemaining ?
+                    OriginalHook(Windbite) :
+                    OriginalHook(VenomousBite);
             }
         }
 
@@ -210,31 +206,30 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is RainOfDeath)
-                {
-                    BRDGauge? gauge = GetJobGauge<BRDGauge>();
-                    bool songArmy = gauge.Song == Song.ARMY;
-                    bool songWanderer = gauge.Song == Song.WANDERER;
-                    
-                    if (IsEnabled(CustomComboPreset.BRD_AoE_oGCD_Songs) && (gauge.SongTimer < 1 || songArmy))
-                    {
-                        if (ActionReady(WanderersMinuet))
-                            return WanderersMinuet;
-                        if (ActionReady(MagesBallad))
-                            return MagesBallad;
-                        if (ActionReady(ArmysPaeon))
-                            return ArmysPaeon;
-                    }
+                if (actionID is not RainOfDeath) return actionID;
 
-                    if (songWanderer && gauge.Repertoire == 3)
-                        return OriginalHook(PitchPerfect);
-                    if (ActionReady(EmpyrealArrow))
-                        return EmpyrealArrow;
-                    if (ActionReady(RainOfDeath))
-                        return RainOfDeath;
-                    if (ActionReady(Sidewinder))
-                        return Sidewinder;
+                BRDGauge? gauge = GetJobGauge<BRDGauge>();
+                bool songArmy = gauge.Song == Song.ARMY;
+                bool songWanderer = gauge.Song == Song.WANDERER;
+
+                if (IsEnabled(CustomComboPreset.BRD_AoE_oGCD_Songs) && (gauge.SongTimer < 1 || songArmy))
+                {
+                    if (ActionReady(WanderersMinuet))
+                        return WanderersMinuet;
+                    if (ActionReady(MagesBallad))
+                        return MagesBallad;
+                    if (ActionReady(ArmysPaeon))
+                        return ArmysPaeon;
                 }
+
+                if (songWanderer && gauge.Repertoire == 3)
+                    return OriginalHook(PitchPerfect);
+                if (ActionReady(EmpyrealArrow))
+                    return EmpyrealArrow;
+                if (ActionReady(RainOfDeath))
+                    return RainOfDeath;
+                if (ActionReady(Sidewinder))
+                    return Sidewinder;
 
                 return actionID;
             }
@@ -246,31 +241,30 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is Bloodletter or HeartbreakShot)
+                if (actionID is not (Bloodletter or HeartbreakShot)) return actionID;
+
+                BRDGauge? gauge = GetJobGauge<BRDGauge>();
+                bool songArmy = gauge.Song == Song.ARMY;
+                bool songWanderer = gauge.Song == Song.WANDERER;
+
+                if (IsEnabled(CustomComboPreset.BRD_ST_oGCD_Songs) && (gauge.SongTimer < 1 || songArmy))
                 {
-                    BRDGauge? gauge = GetJobGauge<BRDGauge>();
-                    bool songArmy = gauge.Song == Song.ARMY;
-                    bool songWanderer = gauge.Song == Song.WANDERER;
-
-                    if (IsEnabled(CustomComboPreset.BRD_ST_oGCD_Songs) && (gauge.SongTimer < 1 || songArmy))
-                    {
-                        if (ActionReady(WanderersMinuet))
-                            return WanderersMinuet;
-                        if (ActionReady(MagesBallad))
-                            return MagesBallad;
-                        if (ActionReady(ArmysPaeon))
-                            return ArmysPaeon;
-                    }
-
-                    if (songWanderer && gauge.Repertoire == 3)
-                        return OriginalHook(PitchPerfect);
-                    if (ActionReady(EmpyrealArrow))
-                        return EmpyrealArrow;
-                    if (ActionReady(Sidewinder))
-                        return Sidewinder;
-                    if (ActionReady(Bloodletter))
-                        return OriginalHook(Bloodletter);
+                    if (ActionReady(WanderersMinuet))
+                        return WanderersMinuet;
+                    if (ActionReady(MagesBallad))
+                        return MagesBallad;
+                    if (ActionReady(ArmysPaeon))
+                        return ArmysPaeon;
                 }
+
+                if (songWanderer && gauge.Repertoire == 3)
+                    return OriginalHook(PitchPerfect);
+                if (ActionReady(EmpyrealArrow))
+                    return EmpyrealArrow;
+                if (ActionReady(Sidewinder))
+                    return Sidewinder;
+                if (ActionReady(Bloodletter))
+                    return OriginalHook(Bloodletter);
 
                 return actionID;
             }
@@ -282,21 +276,20 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is QuickNock or Ladonsbite)
+                if (actionID is not (QuickNock or Ladonsbite)) return actionID;
+
+                if (IsEnabled(CustomComboPreset.BRD_Apex))
                 {
-                    if (IsEnabled(CustomComboPreset.BRD_Apex))
-                    {
-                        BRDGauge? gauge = GetJobGauge<BRDGauge>();
+                    BRDGauge? gauge = GetJobGauge<BRDGauge>();
 
-                        if (gauge.SoulVoice == 100)
-                            return ApexArrow;
-                        if (HasEffect(Buffs.BlastArrowReady))
-                            return BlastArrow;
-                    }
-
-                    if (IsEnabled(CustomComboPreset.BRD_AoE_Combo) && ActionReady(WideVolley) && HasEffect(Buffs.HawksEye))
-                        return OriginalHook(WideVolley);
+                    if (gauge.SoulVoice == 100)
+                        return ApexArrow;
+                    if (HasEffect(Buffs.BlastArrowReady))
+                        return BlastArrow;
                 }
+
+                if (IsEnabled(CustomComboPreset.BRD_AoE_Combo) && ActionReady(WideVolley) && HasEffect(Buffs.HawksEye))
+                    return OriginalHook(WideVolley);
 
                 return actionID;
             }
@@ -308,15 +301,14 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is Barrage)
-                {
-                    if (ActionReady(RagingStrikes))
-                        return RagingStrikes;
-                    if (ActionReady(BattleVoice))
-                        return BattleVoice;
-                    if (ActionReady(RadiantFinale))
-                        return RadiantFinale;
-                }
+                if (actionID is not Barrage) return actionID;
+
+                if (ActionReady(RagingStrikes))
+                    return RagingStrikes;
+                if (ActionReady(BattleVoice))
+                    return BattleVoice;
+                if (ActionReady(RadiantFinale))
+                    return RadiantFinale;
 
                 return actionID;
             }
@@ -328,22 +320,20 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is WanderersMinuet)
-                {
-                    // Doesn't display the lowest cooldown song if they have been used out of order and are all on cooldown.
-                    BRDGauge? gauge = GetJobGauge<BRDGauge>();
-                    int songTimerInSeconds = gauge.SongTimer / 1000;
+                if (actionID is not WanderersMinuet) return actionID;
 
-                    if (ActionReady(WanderersMinuet) || (gauge.Song == Song.WANDERER && songTimerInSeconds > 11))
-                        return WanderersMinuet;
+                // Doesn't display the lowest cooldown song if they have been used out of order and are all on cooldown.
+                BRDGauge? gauge = GetJobGauge<BRDGauge>();
+                int songTimerInSeconds = gauge.SongTimer / 1000;
 
-                    if (ActionReady(MagesBallad) || (gauge.Song == Song.MAGE && songTimerInSeconds > 2))
-                        return MagesBallad;
+                if (ActionReady(WanderersMinuet) || (gauge.Song == Song.WANDERER && songTimerInSeconds > 11))
+                    return WanderersMinuet;
 
-                    if (ActionReady(ArmysPaeon) || (gauge.Song == Song.ARMY && songTimerInSeconds > 2))
-                        return ArmysPaeon;
+                if (ActionReady(MagesBallad) || (gauge.Song == Song.MAGE && songTimerInSeconds > 2))
+                    return MagesBallad;
 
-                }
+                if (ActionReady(ArmysPaeon) || (gauge.Song == Song.ARMY && songTimerInSeconds > 2))
+                    return ArmysPaeon;
 
                 return actionID;
             }
@@ -357,597 +347,37 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is Ladonsbite or QuickNock)
+                if (actionID is not (Ladonsbite or QuickNock)) return actionID;
+
+                BRDGauge? gauge = GetJobGauge<BRDGauge>();
+                bool canWeave = CanWeave() && !ActionWatching.HasDoubleWeaved();
+                bool canWeaveDelayed = CanDelayedWeave(0.9) && !ActionWatching.HasDoubleWeaved();
+                int songTimerInSeconds = gauge.SongTimer / 1000;
+                bool songNone = gauge.Song == Song.NONE;
+                bool songWanderer = gauge.Song == Song.WANDERER;
+                bool songMage = gauge.Song == Song.MAGE;
+                bool songArmy = gauge.Song == Song.ARMY;
+                int targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_AoENoWasteHPPercentage);
+                bool isEnemyHealthHigh = !IsEnabled(CustomComboPreset.BRD_AoE_Adv_NoWaste) || GetTargetHPPercent() > targetHPThreshold;
+                bool hasTarget = HasBattleTarget();
+
+                #region Variants
+
+                if (IsEnabled(CustomComboPreset.BRD_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.BRD_VariantCure))
+                    return Variant.VariantCure;
+
+                if (IsEnabled(CustomComboPreset.BRD_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart) &&
+                    canWeave)
+                    return Variant.VariantRampart;
+
+                #endregion
+
+                #region Songs
+                if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Songs))
                 {
-                    BRDGauge? gauge = GetJobGauge<BRDGauge>();
-                    bool canWeave = CanWeave() && !ActionWatching.HasDoubleWeaved();                    
-                    bool canWeaveDelayed = CanDelayedWeave(0.9) && !ActionWatching.HasDoubleWeaved();
-                    int songTimerInSeconds = gauge.SongTimer / 1000;
-                    bool songNone = gauge.Song == Song.NONE;
-                    bool songWanderer = gauge.Song == Song.WANDERER;
-                    bool songMage = gauge.Song == Song.MAGE;
-                    bool songArmy = gauge.Song == Song.ARMY;
-                    int targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_AoENoWasteHPPercentage);
-                    bool isEnemyHealthHigh = !IsEnabled(CustomComboPreset.BRD_AoE_Adv_NoWaste) || GetTargetHPPercent() > targetHPThreshold;
-                    bool hasTarget = HasBattleTarget();
 
-                    #region Variants
-
-                    if (IsEnabled(CustomComboPreset.BRD_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.BRD_VariantCure))
-                        return Variant.VariantCure;
-
-                    if (IsEnabled(CustomComboPreset.BRD_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        canWeave)
-                        return Variant.VariantRampart;
-
-                    #endregion
-                                        
-                    #region Songs
-                    if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Songs))
-                    {
-
-                        // Limit optimisation to when you are high enough level to benefit from it.
-                        if (LevelChecked(WanderersMinuet))
-                        {
-                            if (canWeave || !hasTarget)
-                            {
-                                if (songNone && InCombat())
-                                {
-                                    // Logic to determine first song
-                                    if (ActionReady(WanderersMinuet) && !(JustUsed(MagesBallad) || JustUsed(ArmysPaeon)))
-                                        return WanderersMinuet;
-                                    if (ActionReady(MagesBallad) && !(JustUsed(WanderersMinuet) || JustUsed(ArmysPaeon)))
-                                        return MagesBallad;
-                                    if (ActionReady(ArmysPaeon) && !(JustUsed(MagesBallad) || JustUsed(WanderersMinuet)))
-                                        return ArmysPaeon;
-                                }
-
-                                if (songWanderer)
-                                {
-                                    if (songTimerInSeconds <= 3 && gauge.Repertoire > 0 && hasTarget) // Spend any repertoire before switching to next song
-                                        return OriginalHook(PitchPerfect);
-                                    if (songTimerInSeconds <= 3 && ActionReady(MagesBallad))          // Move to Mage's Ballad if <= 3 seconds left on song
-                                        return MagesBallad;
-                                }
-
-                                if (songMage)
-                                {
-
-                                    // Move to Army's Paeon if < 3 seconds left on song
-                                    if (songTimerInSeconds <= 3 && ActionReady(ArmysPaeon))
-                                    {
-                                        // Special case for Empyreal Arrow: it must be cast before you change to it to avoid drift!
-                                        if (ActionReady(EmpyrealArrow) && hasTarget)
-                                            return EmpyrealArrow;
-                                        return ArmysPaeon;
-                                    }
-                                }
-                            }
-
-                            if (songArmy && (canWeaveDelayed || !hasTarget))
-                            {
-                                // Move to Wanderer's Minuet if <= 12 seconds left on song or WM off CD and have 4 repertoires of AP
-                                if (songTimerInSeconds <= 12 || (ActionReady(WanderersMinuet) && gauge.Repertoire == 4))
-                                    return WanderersMinuet;
-                            }
-                        }
-                        else if (songTimerInSeconds <= 3 && canWeaveDelayed)
-                        {
-                            if (ActionReady(MagesBallad))
-                                return MagesBallad;
-                            if (ActionReady(ArmysPaeon))
-                                return ArmysPaeon;
-                        }
-                    }
-                    #endregion
-
-                    #region Buffs
-
-                    if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs) && (!songNone || !LevelChecked(MagesBallad)) && isEnemyHealthHigh)
-                    {
-                        float ragingCD = GetCooldownRemainingTime(RagingStrikes);
-
-                        // Late weave Battle voice logic first, timed with raging strikes cd to keep buffs tight. 
-                        if (canWeaveDelayed && ActionReady(BattleVoice) && songWanderer && (ragingCD < 3 || ActionReady(RagingStrikes)))
-                            return BattleVoice;
-
-                        // Radiant next, must have battlevoice buff for it to fire
-                        if (canWeave && ActionReady(RadiantFinale) &&
-                           (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet)) &&
-                           HasEffect(Buffs.BattleVoice))
-                            return RadiantFinale;
-
-                        // Late weave Raging last, must have battle voice buff OR not be high enough level for Battlecoice
-                        if (canWeave && ActionReady(RagingStrikes) && (HasEffect(Buffs.BattleVoice) || !LevelChecked(BattleVoice)))
-                            return RagingStrikes;
-
-                        // Barrage Logic to check for raging for low level reasons and it doesn't really need to check for the other buffs
-                        if (canWeave && ActionReady(Barrage) && HasEffect(Buffs.RagingStrikes))
-                            return Barrage;
-                    }
-
-                    #endregion
-
-                    #region OGCDS
-
-                    if (canWeave && IsEnabled(CustomComboPreset.BRD_AoE_Adv_oGCD))
-                    {
-                        
-                        if (ActionReady(EmpyrealArrow))
-                            return EmpyrealArrow;
-
-                        // Pitch perfect logic. Uses when full, or at 2 stacks before Empy arrow to prevent overcap
-                        if (LevelChecked(PitchPerfect) && songWanderer &&
-                            (gauge.Repertoire == 3 || (LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && GetCooldownRemainingTime(EmpyrealArrow) < 2)))
-                            return OriginalHook(PitchPerfect);
-
-                        // Sidewinder Logic to stay in the buff window on 2 min, but on cd with the 1 min
-                        if (ActionReady(Sidewinder))
-                        {
-                            if (songWanderer)
-                            {
-                                if ((HasEffect(Buffs.RagingStrikes) || GetCooldownRemainingTime(RagingStrikes) > 10) &&
-                                (HasEffect(Buffs.BattleVoice) || GetCooldownRemainingTime(BattleVoice) > 10) &&
-                                (HasEffect(Buffs.RadiantFinale) || GetCooldownRemainingTime(RadiantFinale) > 10 ||
-                                !LevelChecked(RadiantFinale)))
-                                    return Sidewinder;
-                            }
-                            else return Sidewinder;
-                        }
-                    }
-
-                    // Interupt Logic, set to delayed weave. Let someone else do it if they want. Better to be last line of defense and stay off cd.
-                    if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Interrupt) && CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && canWeaveDelayed)
-                        return All.HeadGraze;
-
-                    // Rain of death Logic 
-                    if (canWeave && IsEnabled(CustomComboPreset.BRD_AoE_Adv_oGCD))
-                    {
-                        if (LevelChecked(RainOfDeath) && !WasLastAction(RainOfDeath) && (GetCooldownRemainingTime(EmpyrealArrow) > 1 || !LevelChecked(EmpyrealArrow)))
-                        {
-
-                            uint rainOfDeathCharges = LevelChecked(RainOfDeath) ? GetRemainingCharges(RainOfDeath) : 0;
-
-                            if (IsEnabled(CustomComboPreset.BRD_AoE_Pooling) && LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
-                            {
-                                if (songWanderer) //Stop pooling for buff window
-                                {
-                                    if (((HasEffect(Buffs.RagingStrikes) || GetCooldownRemainingTime(RagingStrikes) > 10) &&
-                                        (HasEffect(Buffs.BattleVoice) || GetCooldownRemainingTime(BattleVoice) > 10 ||
-                                        !LevelChecked(BattleVoice)) &&
-                                        (HasEffect(Buffs.RadiantFinale) || GetCooldownRemainingTime(RadiantFinale) > 10 ||
-                                        !LevelChecked(RadiantFinale)) &&
-                                        rainOfDeathCharges > 0) || rainOfDeathCharges > 2)
-                                        return OriginalHook(RainOfDeath);
-                                }
-
-                                if (songArmy && (rainOfDeathCharges == 3 || ((gauge.SongTimer / 1000) > 30 && rainOfDeathCharges > 0))) //Start pooling in Armys
-                                    return OriginalHook(RainOfDeath);
-                                if (songMage && rainOfDeathCharges > 0) // Dont poolin mages
-                                    return OriginalHook(RainOfDeath);
-                                if (songNone && rainOfDeathCharges == 3) //Pool when no song
-                                    return OriginalHook(RainOfDeath);
-                            }
-                            else if (rainOfDeathCharges > 0) //Dont pool when not enabled
-                                return OriginalHook(RainOfDeath);
-                        }
-                        if (!LevelChecked(RainOfDeath) && !(WasLastAction(Bloodletter) && GetRemainingCharges(Bloodletter) > 0))
-                            return OriginalHook(Bloodletter);
-                    }
-
-                    #endregion
-
-                    #region Self Care
-
-                    if (canWeave)
-                    {
-                        if (IsEnabled(CustomComboPreset.BRD_ST_SecondWind))
-                        {
-                            if (PlayerHealthPercentageHp() <= PluginConfiguration.GetCustomIntValue(Config.BRD_STSecondWindThreshold) && ActionReady(All.SecondWind))
-                                return All.SecondWind;
-                        }
-
-                        if (IsEnabled(CustomComboPreset.BRD_ST_Wardens))
-                        {
-                            if (ActionReady(TheWardensPaeon) && HasCleansableDebuff(LocalPlayer)) // Could be upgraded with a targetting system in the future
-                                return OriginalHook(TheWardensPaeon);
-                        }
-                    }
-
-                    #endregion
-
-                    #region GCDS
-
-                    
-                    if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
-                        return OriginalHook(WideVolley);
-
-                    if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore))
-                    {
-                        if (HasEffect(Buffs.RadiantEncoreReady) && GetBuffRemainingTime(Buffs.RadiantFinale) < 15) // Delay Encore enough for buff window
-                            return OriginalHook(RadiantEncore);
-                    }
-
-                    if (IsEnabled(CustomComboPreset.BRD_ST_ApexArrow)) // Apex Logic to time song in buff window and in mages. 
-                    {
-                        if (HasEffect(Buffs.BlastArrowReady))
-                            return BlastArrow;
-
-                        if (LevelChecked(ApexArrow))
-                        {
-                            if (songMage && gauge.SoulVoice == 100)
-                                return ApexArrow;
-                            if (songMage && gauge.SoulVoice >= 80 &&
-                                songTimerInSeconds > 18 && songTimerInSeconds < 22)
-                                return ApexArrow;
-                            if (songWanderer && HasEffect(Buffs.RagingStrikes) && HasEffect(Buffs.BattleVoice) &&
-                                (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale)) && gauge.SoulVoice >= 80)
-                                return ApexArrow;
-                        }
-                    }
-
-                    if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsResonant))
-                    {
-                        if (HasEffect(Buffs.ResonantArrowReady))
-                            return ResonantArrow;
-                    }
-
-                    #endregion
-                }
-
-                return actionID;
-            }
-        }
-
-        internal class BRD_ST_AdvMode : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_ST_AdvMode;
-            internal static bool usedStraightShotReady = false;
-            internal static bool usedPitchPerfect = false;
-            internal delegate bool DotRecast(int value);
-
-            protected override uint Invoke(uint actionID)
-            {
-                if (actionID is HeavyShot or BurstShot)
-                {
-                    BRDGauge? gauge = GetJobGauge<BRDGauge>();
-                    bool canWeave = CanWeave() && !ActionWatching.HasDoubleWeaved();
-                    bool canWeaveDelayed = CanDelayedWeave(0.9) && !ActionWatching.HasDoubleWeaved();
-                    bool songNone = gauge.Song == Song.NONE;
-                    bool songWanderer = gauge.Song == Song.WANDERER;
-                    bool songMage = gauge.Song == Song.MAGE;
-                    bool songArmy = gauge.Song == Song.ARMY;
-                    int songTimerInSeconds = gauge.SongTimer / 1000;
-                    int targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_NoWasteHPPercentage);
-                    bool isEnemyHealthHigh = !IsEnabled(CustomComboPreset.BRD_Adv_NoWaste) || GetTargetHPPercent() > targetHPThreshold;
-                    bool hasTarget = HasBattleTarget();
-
-
-                    #region Variants
-
-                    if (IsEnabled(CustomComboPreset.BRD_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.BRD_VariantCure))
-                        return Variant.VariantCure;
-
-                    if (IsEnabled(CustomComboPreset.BRD_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        canWeave)
-                        return Variant.VariantRampart;
-
-                    #endregion
-
-                    if (IsEnabled(CustomComboPreset.BRD_ST_Adv_Balance_Standard) &&
-                        Opener().FullOpener(ref actionID))
-                    {
-                        if (ActionWatching.GetAttackType(Opener().CurrentOpenerAction) != ActionWatching.ActionAttackType.Ability && canWeave)
-                        {
-                            if (gauge.Repertoire == 3 || gauge.Repertoire == 2 && GetCooldownRemainingTime(EmpyrealArrow) < 2)
-                                return OriginalHook(PitchPerfect);
-
-                            if (ActionReady(HeartbreakShot))
-                                return HeartbreakShot;
-                        }
-
-                        return actionID;
-
-                    }
-
-                    #region Songs
-
-                    if (IsEnabled(CustomComboPreset.BRD_Adv_Song) && isEnemyHealthHigh)
-                    {
-                      
-                        // Limit optimisation to when you are high enough level to benefit from it.
-                        if (LevelChecked(WanderersMinuet))
-                        {
-                            if (ActionReady(EmpyrealArrow) && JustUsed(WanderersMinuet)) // Used to ensure Empyreal arrow goes off as soon as possible in opener
-                                return EmpyrealArrow;
-
-                            if (canWeave || !hasTarget)
-                            {
-                                if (songNone && InCombat())
-                                {
-                                    // Logic to determine first song
-                                    if (ActionReady(WanderersMinuet) && !(JustUsed(MagesBallad) || JustUsed(ArmysPaeon)))
-                                        return WanderersMinuet;
-                                    if (ActionReady(MagesBallad) && !(JustUsed(WanderersMinuet) || JustUsed(ArmysPaeon)))
-                                        return MagesBallad;
-                                    if (ActionReady(ArmysPaeon) && !(JustUsed(MagesBallad) || JustUsed(WanderersMinuet)))
-                                        return ArmysPaeon;
-                                }
-
-                                if (songWanderer)
-                                {
-                                    if (songTimerInSeconds <= 3 && gauge.Repertoire > 0 && hasTarget) // Spend any repertoire before switching to next song
-                                        return OriginalHook(PitchPerfect);
-                                    if (songTimerInSeconds <= 3 && ActionReady(MagesBallad)) // Move to Mage's Ballad if <= 3 seconds left on song
-                                        return MagesBallad;
-                                }
-
-                                if (songMage)
-                                {
-
-                                    // Move to Army's Paeon if <= 3 seconds left on song
-                                    if (songTimerInSeconds <= 3 && ActionReady(ArmysPaeon))
-                                    {
-                                        // Special case for Empyreal Arrow: it must be cast before you change to it to avoid drift!
-                                        if (ActionReady(EmpyrealArrow) && hasTarget)
-                                            return EmpyrealArrow;
-                                        return ArmysPaeon;
-                                    }
-                                }
-                            }
-
-                            if (songArmy && (canWeaveDelayed || !hasTarget))
-                            {
-                                // Move to Wanderer's Minuet if <= 12 seconds left on song or WM off CD and have 4 repertoires of AP
-                                if (songTimerInSeconds <= 12 || (ActionReady(WanderersMinuet) && gauge.Repertoire == 4))
-                                    return WanderersMinuet;
-                            }
-                        }
-
-                        else if (songTimerInSeconds <= 3 && canWeaveDelayed) // Before you get Wanderers, it just toggles the two songs.
-                        {
-                            if (ActionReady(MagesBallad))
-                                return MagesBallad;
-                            if (ActionReady(ArmysPaeon))
-                                return ArmysPaeon;
-                        }
-                    }
-
-                    #endregion
-
-                    #region Buffs
-
-                    if (IsEnabled(CustomComboPreset.BRD_Adv_Buffs) && (!songNone || !LevelChecked(MagesBallad)) && isEnemyHealthHigh)
-                    {
-                        float ragingCD = GetCooldownRemainingTime(RagingStrikes);
-
-                        // Late weave Battle voice logic first, timed with raging strikes cd to keep buffs tight. 
-                        if (canWeaveDelayed && ActionReady(BattleVoice) && songWanderer && (ragingCD < 3 || ActionReady(RagingStrikes)))
-                            return BattleVoice;
-
-                        // Radiant next, must have battlevoice buff for it to fire
-                        if (canWeave && ActionReady(RadiantFinale) &&
-                           (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet)) &&
-                           HasEffect(Buffs.BattleVoice))
-                            return RadiantFinale;
-
-                        // Late weave Raging last, must have battle voice buff OR not be high enough level for Battlecoice
-                        if (canWeave && ActionReady(RagingStrikes) && (HasEffect(Buffs.BattleVoice) || !LevelChecked(BattleVoice)))
-                            return RagingStrikes;
-
-                        // Barrage Logic to check for raging for low level reasons and it doesn't really need to check for the other buffs
-                        if (canWeave && ActionReady(Barrage) && HasEffect(Buffs.RagingStrikes))
-                            return Barrage;
-
-                    }
-
-                    #endregion
-
-                    #region OGCD
-
-                    if (canWeave && IsEnabled(CustomComboPreset.BRD_ST_Adv_oGCD))
-                    {
-                        if (ActionReady(EmpyrealArrow))
-                            return EmpyrealArrow;
-
-                        // Pitch Perfect loogic to use when full or when Empyreal arrow might overcap it. 
-                        if (LevelChecked(PitchPerfect) && songWanderer &&
-                            (gauge.Repertoire == 3 || (LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && GetCooldownRemainingTime(EmpyrealArrow) < 2)))
-                            return OriginalHook(PitchPerfect);
-
-                        // Sidewinder logic to use in burst window with buffs or on cd on the 1 minutes
-                        if (ActionReady(Sidewinder))
-                        {
-                            if (IsEnabled(CustomComboPreset.BRD_Adv_Pooling))
-                            {
-                                if (songWanderer)
-                                {
-                                    if ((HasEffect(Buffs.RagingStrikes) || GetCooldownRemainingTime(RagingStrikes) > 10) &&
-                                        (HasEffect(Buffs.BattleVoice) || GetCooldownRemainingTime(BattleVoice) > 10) &&
-                                        (HasEffect(Buffs.RadiantFinale) || GetCooldownRemainingTime(RadiantFinale) > 10 ||
-                                        !LevelChecked(RadiantFinale)))
-                                        return Sidewinder;
-                                }
-                                else return Sidewinder;
-                            }
-                            else return Sidewinder;
-                        }
-                    }
-                    //Interupt Logic, set to delayed weave. Let someone else do it if they want. Better to be last line of defense and stay off cd.
-                    if (IsEnabled(CustomComboPreset.BRD_Adv_Interrupt) && CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && canWeaveDelayed)
-                        return All.HeadGraze;
-
-                    // Bloodletter pooling logic. Will Pool as buffs are coming up. 
-                    if (canWeave && IsEnabled(CustomComboPreset.BRD_ST_Adv_oGCD))
-                    {
-                        if (ActionReady(Bloodletter) && !(WasLastAction(Bloodletter) || WasLastAction(HeartbreakShot)) && (GetCooldownRemainingTime(EmpyrealArrow) > 1 || !LevelChecked(EmpyrealArrow)))
-                        {
-                            uint bloodletterCharges = GetRemainingCharges(Bloodletter);
-
-                            if (IsEnabled(CustomComboPreset.BRD_Adv_Pooling) && LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
-                            {
-                                if (songWanderer) // Pool until buffs go out in wanderers
-                                {
-                                    if (((HasEffect(Buffs.RagingStrikes) || GetCooldownRemainingTime(RagingStrikes) > 10) &&
-                                        (HasEffect(Buffs.BattleVoice) || GetCooldownRemainingTime(BattleVoice) > 10 ||
-                                        !LevelChecked(BattleVoice)) &&
-                                        (HasEffect(Buffs.RadiantFinale) || GetCooldownRemainingTime(RadiantFinale) > 10 ||
-                                        !LevelChecked(RadiantFinale)) &&
-                                        bloodletterCharges > 0) || bloodletterCharges > 2)
-                                        return OriginalHook(Bloodletter);
-                                }
-                                if (songArmy && (bloodletterCharges == 3 || ((gauge.SongTimer / 1000) > 30 && bloodletterCharges > 0))) // Start pooling in Army
-                                    return OriginalHook(Bloodletter);
-                                if (songMage && bloodletterCharges > 0) //Don't pool in Mages
-                                    return OriginalHook(Bloodletter);
-                                if (songNone && bloodletterCharges == 3) //Pool with no song
-                                    return OriginalHook(Bloodletter);
-                            }
-                            else if (bloodletterCharges > 0)
-                                return OriginalHook(Bloodletter);
-                        }
-                    }
-
-                    #endregion
-
-                    #region Self Care
-                    if (canWeave)
-                    {
-                        if (IsEnabled(CustomComboPreset.BRD_ST_SecondWind))
-                        {
-                            if (PlayerHealthPercentageHp() <= PluginConfiguration.GetCustomIntValue(Config.BRD_STSecondWindThreshold) && ActionReady(All.SecondWind))
-                                return All.SecondWind;
-                        }
-
-                        if (IsEnabled(CustomComboPreset.BRD_ST_Wardens))
-                        {
-                            if (ActionReady(TheWardensPaeon) && HasCleansableDebuff(LocalPlayer)) // Could be upgraded with a targetting system in the future
-                                return OriginalHook(TheWardensPaeon);
-                        }
-                    }
-                    #endregion
-
-                    #region Dot Management
-
-                    if (isEnemyHealthHigh)
-                    {
-                        bool canIronJaws = LevelChecked(IronJaws);
-                        Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
-                        Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
-                        float purpleRemaining = purple?.RemainingTime ?? 0;
-                        float blueRemaining = blue?.RemainingTime ?? 0;
-                        float ragingStrikesDuration = GetBuffRemainingTime(Buffs.RagingStrikes);
-                        int ragingJawsRenewTime = PluginConfiguration.GetCustomIntValue(Config.BRD_RagingJawsRenewTime);
-
-                        if (IsEnabled(CustomComboPreset.BRD_Adv_DoT))
-                        {                            
-                            if (purple is not null && purpleRemaining < 4)
-                                return canIronJaws ? IronJaws : VenomousBite;
-                            if (blue is not null && blueRemaining < 4)
-                                return canIronJaws ? IronJaws : Windbite;
-                            if (blue is null && LevelChecked(Windbite))
-                                return OriginalHook(Windbite);
-                            if (purple is null && LevelChecked(VenomousBite))
-                                return OriginalHook(VenomousBite);
-
-                            if (IsEnabled(CustomComboPreset.BRD_Adv_RagingJaws) && ActionReady(IronJaws) && HasEffect(Buffs.RagingStrikes) &&
-                            ragingStrikesDuration < ragingJawsRenewTime && // Raging Jaws Slider Check
-                            purpleRemaining < 35 && blueRemaining < 35)    // Prevention of double refreshing dots
-                            {
-                                return IronJaws;
-                            }
-
-                        }
-                    }
-                    #endregion
-
-                    #region GCDS
-
-                    if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
-                        return OriginalHook(StraightShot);
-
-                    if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore))
-                    {
-                        if (HasEffect(Buffs.RadiantEncoreReady) && GetBuffRemainingTime(Buffs.RadiantFinale) < 15) // Delay Encore enough for buff window
-                            return OriginalHook(RadiantEncore);
-                    }
-
-                    if (IsEnabled(CustomComboPreset.BRD_ST_ApexArrow)) // Apex Logic to time song in buff window and in mages. 
-                    {
-                        if (HasEffect(Buffs.BlastArrowReady))
-                            return BlastArrow;
-
-                        if (LevelChecked(ApexArrow))
-                        {
-                            if (songMage && gauge.SoulVoice == 100)
-                                return ApexArrow;
-                            if (songMage && gauge.SoulVoice >= 80 &&
-                                songTimerInSeconds > 18 && songTimerInSeconds < 22)
-                                return ApexArrow;
-                            if (songWanderer && HasEffect(Buffs.RagingStrikes) && HasEffect(Buffs.BattleVoice) &&
-                                (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale)) && gauge.SoulVoice >= 80)
-                                return ApexArrow;
-                        }
-                    }
-
-                    if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsResonant))
-                    {
-                        if (HasEffect(Buffs.ResonantArrowReady))
-                            return ResonantArrow;
-                    }
-                    #endregion
-
-                }
-
-                return actionID;
-            }
-        }
-        #endregion
-
-        #region Simple Modes
-        internal class BRD_AoE_SimpleMode : CustomCombo
-        {
-            internal static bool inOpener = false;
-            internal static bool openerFinished = false;
-
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_AoE_SimpleMode;
-
-            protected override uint Invoke(uint actionID)
-            {
-                if (actionID is Ladonsbite or QuickNock)
-                {
-                    BRDGauge? gauge = GetJobGauge<BRDGauge>();
-                    bool canWeave = CanWeave() && !ActionWatching.HasDoubleWeaved();
-                    bool canWeaveDelayed = CanDelayedWeave(0.9) && !ActionWatching.HasDoubleWeaved();
-                    int songTimerInSeconds = gauge.SongTimer / 1000;
-                    bool songNone = gauge.Song == Song.NONE;
-                    bool songWanderer = gauge.Song == Song.WANDERER;
-                    bool songMage = gauge.Song == Song.MAGE;
-                    bool songArmy = gauge.Song == Song.ARMY;                    
-                    int targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_AoENoWasteHPPercentage);
-                    bool isEnemyHealthHigh = GetTargetHPPercent() > 5;
-                    bool hasTarget = HasBattleTarget();
-
-                    #region Variants
-
-                    if (IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= 50)
-                        return Variant.VariantCure;
-
-                    if (IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        canWeave)
-                        return Variant.VariantRampart;
-
-                    #endregion
-
-                    #region Songs
-
-                   
-                    
                     // Limit optimisation to when you are high enough level to benefit from it.
                     if (LevelChecked(WanderersMinuet))
                     {
@@ -989,190 +419,239 @@ namespace WrathCombo.Combos.PvE
                         if (songArmy && (canWeaveDelayed || !hasTarget))
                         {
                             // Move to Wanderer's Minuet if <= 12 seconds left on song or WM off CD and have 4 repertoires of AP
-                            if ((songTimerInSeconds <= 12 || gauge.Repertoire == 4) && ActionReady(WanderersMinuet))
+                            if (songTimerInSeconds <= 12 || (ActionReady(WanderersMinuet) && gauge.Repertoire == 4))
                                 return WanderersMinuet;
                         }
                     }
-                    else if (songTimerInSeconds <= 3 && canWeaveDelayed) // Not high enough for wanderers Minuet yet
+                    else if (songTimerInSeconds <= 3 && canWeaveDelayed)
                     {
                         if (ActionReady(MagesBallad))
                             return MagesBallad;
                         if (ActionReady(ArmysPaeon))
                             return ArmysPaeon;
                     }
-                    
-                    #endregion
+                }
+                #endregion
 
-                    #region Buffs
+                #region Buffs
 
-                    if ((!songNone || !LevelChecked(MagesBallad)) && isEnemyHealthHigh)
+                if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs) && (!songNone || !LevelChecked(MagesBallad)) && isEnemyHealthHigh)
+                {
+                    float ragingCD = GetCooldownRemainingTime(RagingStrikes);
+
+                    // Late weave Battle voice logic first, timed with raging strikes cd to keep buffs tight.
+                    if (canWeaveDelayed && ActionReady(BattleVoice) && songWanderer && (ragingCD < 3 || ActionReady(RagingStrikes)))
+                        return BattleVoice;
+
+                    // Radiant next, must have battlevoice buff for it to fire
+                    if (canWeave && ActionReady(RadiantFinale) &&
+                        (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet)) &&
+                        HasEffect(Buffs.BattleVoice))
+                        return RadiantFinale;
+
+                    // Late weave Raging last, must have battle voice buff OR not be high enough level for Battlecoice
+                    if (canWeave && ActionReady(RagingStrikes) && (HasEffect(Buffs.BattleVoice) || !LevelChecked(BattleVoice)))
+                        return RagingStrikes;
+
+                    // Barrage Logic to check for raging for low level reasons and it doesn't really need to check for the other buffs
+                    if (canWeave && ActionReady(Barrage) && HasEffect(Buffs.RagingStrikes))
+                        return Barrage;
+                }
+
+                #endregion
+
+                #region OGCDS
+
+                if (canWeave && IsEnabled(CustomComboPreset.BRD_AoE_Adv_oGCD))
+                {
+
+                    if (ActionReady(EmpyrealArrow))
+                        return EmpyrealArrow;
+
+                    // Pitch perfect logic. Uses when full, or at 2 stacks before Empy arrow to prevent overcap
+                    if (LevelChecked(PitchPerfect) && songWanderer &&
+                        (gauge.Repertoire == 3 || (LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && GetCooldownRemainingTime(EmpyrealArrow) < 2)))
+                        return OriginalHook(PitchPerfect);
+
+                    // Sidewinder Logic to stay in the buff window on 2 min, but on cd with the 1 min
+                    if (ActionReady(Sidewinder))
                     {
-                        float ragingCD = GetCooldownRemainingTime(RagingStrikes);
-
-                        // Late weave Battle voice logic first, timed with raging strikes cd to keep buffs tight. 
-                        if (canWeaveDelayed && ActionReady(BattleVoice) && songWanderer && (ragingCD < 3 || ActionReady(RagingStrikes)))
-                            return BattleVoice;
-
-                        // Radiant next, must have battlevoice buff for it to fire
-                        if (canWeave && ActionReady(RadiantFinale) &&
-                           (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet)) &&
-                           HasEffect(Buffs.BattleVoice))
-                            return RadiantFinale;
-
-                        // Late weave Raging last, must have battle voice buff OR not be high enough level for Battlecoice
-                        if (canWeave && ActionReady(RagingStrikes) && (HasEffect(Buffs.BattleVoice) || !LevelChecked(BattleVoice)))
-                            return RagingStrikes;
-
-                        // Barrage Logic to check for raging for low level reasons and it doesn't really need to check for the other buffs
-                        if (canWeave && ActionReady(Barrage) && HasEffect(Buffs.RagingStrikes))
-                            return Barrage;
-
-                    }
-
-                    #endregion
-
-                    #region OGCDS and Selfcare 
-
-                    if (canWeave)
-                    {
-                        float battleVoiceCD = GetCooldownRemainingTime(BattleVoice);
-                        float empyrealCD = GetCooldownRemainingTime(EmpyrealArrow);
-                        float ragingCD = GetCooldownRemainingTime(RagingStrikes);
-                        float radiantCD = GetCooldownRemainingTime(RadiantFinale);
-
-                        if (ActionReady(EmpyrealArrow))
-                            return EmpyrealArrow;
-
-                        // Pitch Perfect logic to use when full or when Empy arrow can cause an overcap
-                        if (LevelChecked(PitchPerfect) && songWanderer &&
-                            (gauge.Repertoire == 3 || (LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && empyrealCD < 2)))
-                            return OriginalHook(PitchPerfect);
-
-                        // Sidewinder Logic to use in Window and on the 1 min
-                        if (ActionReady(Sidewinder))
+                        if (songWanderer)
                         {
-                            if (songWanderer)
-                            {
-                                if ((HasEffect(Buffs.RagingStrikes) || ragingCD > 10) &&
-                                    (HasEffect(Buffs.BattleVoice) || battleVoiceCD > 10) &&
-                                    (HasEffect(Buffs.RadiantFinale) || radiantCD > 10 ||
-                                    !LevelChecked(RadiantFinale)))
-                                    return Sidewinder;
-
-                            }
-                            else return Sidewinder;
+                            if ((HasEffect(Buffs.RagingStrikes) || GetCooldownRemainingTime(RagingStrikes) > 10) &&
+                                (HasEffect(Buffs.BattleVoice) || GetCooldownRemainingTime(BattleVoice) > 10) &&
+                                (HasEffect(Buffs.RadiantFinale) || GetCooldownRemainingTime(RadiantFinale) > 10 ||
+                                 !LevelChecked(RadiantFinale)))
+                                return Sidewinder;
                         }
+                        else return Sidewinder;
+                    }
+                }
 
-                        // Interupt
-                        if (CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && canWeaveDelayed)
-                            return All.HeadGraze;
+                // Interupt Logic, set to delayed weave. Let someone else do it if they want. Better to be last line of defense and stay off cd.
+                if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Interrupt) && CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && canWeaveDelayed)
+                    return All.HeadGraze;
 
-                        // Pooling logic for rain of death basied on song
-                        if (LevelChecked(RainOfDeath) && !WasLastAction(RainOfDeath) && (empyrealCD > 1 || !LevelChecked(EmpyrealArrow)))
+                // Rain of death Logic
+                if (canWeave && IsEnabled(CustomComboPreset.BRD_AoE_Adv_oGCD))
+                {
+                    if (LevelChecked(RainOfDeath) && !WasLastAction(RainOfDeath) && (GetCooldownRemainingTime(EmpyrealArrow) > 1 || !LevelChecked(EmpyrealArrow)))
+                    {
+
+                        uint rainOfDeathCharges = LevelChecked(RainOfDeath) ? GetRemainingCharges(RainOfDeath) : 0;
+
+                        if (IsEnabled(CustomComboPreset.BRD_AoE_Pooling) && LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
                         {
-                            uint rainOfDeathCharges = LevelChecked(RainOfDeath) ? GetRemainingCharges(RainOfDeath) : 0;
-
-                            if (LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
+                            if (songWanderer) //Stop pooling for buff window
                             {
-                                if (songWanderer)
-                                {
-                                    if (((HasEffect(Buffs.RagingStrikes) || ragingCD > 10) &&
-                                        (HasEffect(Buffs.BattleVoice) || battleVoiceCD > 10 ||
-                                        !LevelChecked(BattleVoice)) &&
-                                        (HasEffect(Buffs.RadiantFinale) || radiantCD > 10 ||
-                                        !LevelChecked(RadiantFinale)) &&
-                                        rainOfDeathCharges > 0) || rainOfDeathCharges > 2)
-                                        return OriginalHook(RainOfDeath);
-                                }
-
-                                if (songArmy && (rainOfDeathCharges == 3 || ((gauge.SongTimer / 1000) > 30 && rainOfDeathCharges > 0)))
-                                    return OriginalHook(RainOfDeath);
-                                if (songMage && rainOfDeathCharges > 0)
-                                    return OriginalHook(RainOfDeath);
-                                if (songNone && rainOfDeathCharges == 3)
+                                if (((HasEffect(Buffs.RagingStrikes) || GetCooldownRemainingTime(RagingStrikes) > 10) &&
+                                     (HasEffect(Buffs.BattleVoice) || GetCooldownRemainingTime(BattleVoice) > 10 ||
+                                      !LevelChecked(BattleVoice)) &&
+                                     (HasEffect(Buffs.RadiantFinale) || GetCooldownRemainingTime(RadiantFinale) > 10 ||
+                                      !LevelChecked(RadiantFinale)) &&
+                                     rainOfDeathCharges > 0) || rainOfDeathCharges > 2)
                                     return OriginalHook(RainOfDeath);
                             }
-                            else if (rainOfDeathCharges > 0)
+
+                            if (songArmy && (rainOfDeathCharges == 3 || ((gauge.SongTimer / 1000) > 30 && rainOfDeathCharges > 0))) //Start pooling in Armys
+                                return OriginalHook(RainOfDeath);
+                            if (songMage && rainOfDeathCharges > 0) // Dont poolin mages
+                                return OriginalHook(RainOfDeath);
+                            if (songNone && rainOfDeathCharges == 3) //Pool when no song
                                 return OriginalHook(RainOfDeath);
                         }
+                        else if (rainOfDeathCharges > 0) //Dont pool when not enabled
+                            return OriginalHook(RainOfDeath);
+                    }
+                    if (!LevelChecked(RainOfDeath) && !(WasLastAction(Bloodletter) && GetRemainingCharges(Bloodletter) > 0))
+                        return OriginalHook(Bloodletter);
+                }
 
-                        if (!LevelChecked(RainOfDeath) && !(WasLastAction(Bloodletter) && GetRemainingCharges(Bloodletter) > 0))
-                            return OriginalHook(Bloodletter);
+                #endregion
 
-                        // Self care section for healing and debuff removal
+                #region Self Care
 
-                        if (PlayerHealthPercentageHp() <= 40 && ActionReady(All.SecondWind))
+                if (canWeave)
+                {
+                    if (IsEnabled(CustomComboPreset.BRD_ST_SecondWind))
+                    {
+                        if (PlayerHealthPercentageHp() <= PluginConfiguration.GetCustomIntValue(Config.BRD_STSecondWindThreshold) && ActionReady(All.SecondWind))
                             return All.SecondWind;
+                    }
 
-                        if (ActionReady(TheWardensPaeon) && HasCleansableDebuff(LocalPlayer))
+                    if (IsEnabled(CustomComboPreset.BRD_ST_Wardens))
+                    {
+                        if (ActionReady(TheWardensPaeon) && HasCleansableDebuff(LocalPlayer)) // Could be upgraded with a targetting system in the future
                             return OriginalHook(TheWardensPaeon);
                     }
-                    #endregion
+                }
 
-                    #region GCDS
-                        
-                    if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))  //Ahead of other gcds because of higher risk of losing a proc than a ready buff
-                        return OriginalHook(WideVolley);
+                #endregion
 
-                    if (LevelChecked(ApexArrow) && gauge.SoulVoice == 100)
-                        return ApexArrow;
+                #region GCDS
 
+
+                if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
+                    return OriginalHook(WideVolley);
+
+                if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore))
+                {
+                    if (HasEffect(Buffs.RadiantEncoreReady) && GetBuffRemainingTime(Buffs.RadiantFinale) < 15) // Delay Encore enough for buff window
+                        return OriginalHook(RadiantEncore);
+                }
+
+                if (IsEnabled(CustomComboPreset.BRD_ST_ApexArrow)) // Apex Logic to time song in buff window and in mages.
+                {
                     if (HasEffect(Buffs.BlastArrowReady))
                         return BlastArrow;
 
+                    if (LevelChecked(ApexArrow))
+                    {
+                        if (songMage && gauge.SoulVoice == 100)
+                            return ApexArrow;
+                        if (songMage && gauge.SoulVoice >= 80 &&
+                            songTimerInSeconds > 18 && songTimerInSeconds < 22)
+                            return ApexArrow;
+                        if (songWanderer && HasEffect(Buffs.RagingStrikes) && HasEffect(Buffs.BattleVoice) &&
+                            (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale)) && gauge.SoulVoice >= 80)
+                            return ApexArrow;
+                    }
+                }
+
+                if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsResonant))
+                {
                     if (HasEffect(Buffs.ResonantArrowReady))
                         return ResonantArrow;
-
-                    if (HasEffect(Buffs.RadiantEncoreReady))
-                        return OriginalHook(RadiantEncore);
-
-                    #endregion
-
                 }
+
+                #endregion
 
                 return actionID;
             }
         }
-        internal class BRD_ST_SimpleMode : CustomCombo
+
+        internal class BRD_ST_AdvMode : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_ST_SimpleMode;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_ST_AdvMode;
             internal static bool usedStraightShotReady = false;
             internal static bool usedPitchPerfect = false;
             internal delegate bool DotRecast(int value);
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is HeavyShot or BurstShot)
+                if (actionID is not (HeavyShot or BurstShot)) return actionID;
+
+                BRDGauge? gauge = GetJobGauge<BRDGauge>();
+                bool canWeave = CanWeave() && !ActionWatching.HasDoubleWeaved();
+                bool canWeaveDelayed = CanDelayedWeave(0.9) && !ActionWatching.HasDoubleWeaved();
+                bool songNone = gauge.Song == Song.NONE;
+                bool songWanderer = gauge.Song == Song.WANDERER;
+                bool songMage = gauge.Song == Song.MAGE;
+                bool songArmy = gauge.Song == Song.ARMY;
+                int songTimerInSeconds = gauge.SongTimer / 1000;
+                int targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_NoWasteHPPercentage);
+                bool isEnemyHealthHigh = !IsEnabled(CustomComboPreset.BRD_Adv_NoWaste) || GetTargetHPPercent() > targetHPThreshold;
+                bool hasTarget = HasBattleTarget();
+
+
+                #region Variants
+
+                if (IsEnabled(CustomComboPreset.BRD_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.BRD_VariantCure))
+                    return Variant.VariantCure;
+
+                if (IsEnabled(CustomComboPreset.BRD_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart) &&
+                    canWeave)
+                    return Variant.VariantRampart;
+
+                #endregion
+
+                if (IsEnabled(CustomComboPreset.BRD_ST_Adv_Balance_Standard) &&
+                    Opener().FullOpener(ref actionID))
                 {
-                    BRDGauge? gauge = GetJobGauge<BRDGauge>();
-                    bool canWeave = CanWeave() && !ActionWatching.HasDoubleWeaved();
-                    bool canWeaveDelayed = CanDelayedWeave(0.9) && !ActionWatching.HasDoubleWeaved();
-                    bool songNone = gauge.Song == Song.NONE;
-                    bool songWanderer = gauge.Song == Song.WANDERER;
-                    bool songMage = gauge.Song == Song.MAGE;
-                    bool songArmy = gauge.Song == Song.ARMY;
-                    bool isEnemyHealthHigh = GetTargetHPPercent() > 1;
-                    int songTimerInSeconds = gauge.SongTimer / 1000;
-                    bool hasTarget = HasBattleTarget();
+                    if (ActionWatching.GetAttackType(Opener().CurrentOpenerAction) != ActionWatching.ActionAttackType.Ability && canWeave)
+                    {
+                        if (gauge.Repertoire == 3 || gauge.Repertoire == 2 && GetCooldownRemainingTime(EmpyrealArrow) < 2)
+                            return OriginalHook(PitchPerfect);
 
-                    #region Variants
-                    if (IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= 50)
-                        return Variant.VariantCure;
+                        if (ActionReady(HeartbreakShot))
+                            return HeartbreakShot;
+                    }
 
-                    if (IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        canWeave)
-                        return Variant.VariantRampart;
-                    #endregion
+                    return actionID;
 
-                    #region Songs
+                }
+
+                #region Songs
+
+                if (IsEnabled(CustomComboPreset.BRD_Adv_Song) && isEnemyHealthHigh)
+                {
 
                     // Limit optimisation to when you are high enough level to benefit from it.
                     if (LevelChecked(WanderersMinuet))
                     {
-                        // 43s of Wanderer's Minute, ~36s of Mage's Ballad, and ~43s of Army's Paeon    
-                            
-                        if (ActionReady(EmpyrealArrow) && JustUsed(WanderersMinuet))
+                        if (ActionReady(EmpyrealArrow) && JustUsed(WanderersMinuet)) // Used to ensure Empyreal arrow goes off as soon as possible in opener
                             return EmpyrealArrow;
 
                         if (canWeave || !hasTarget)
@@ -1192,7 +671,7 @@ namespace WrathCombo.Combos.PvE
                             {
                                 if (songTimerInSeconds <= 3 && gauge.Repertoire > 0 && hasTarget) // Spend any repertoire before switching to next song
                                     return OriginalHook(PitchPerfect);
-                                if (songTimerInSeconds <= 3 && ActionReady(MagesBallad))          // Move to Mage's Ballad if <= 3 seconds left on song
+                                if (songTimerInSeconds <= 3 && ActionReady(MagesBallad)) // Move to Mage's Ballad if <= 3 seconds left on song
                                     return MagesBallad;
                             }
 
@@ -1217,164 +696,181 @@ namespace WrathCombo.Combos.PvE
                                 return WanderersMinuet;
                         }
                     }
-                    else if (songTimerInSeconds <= 3 && canWeaveDelayed)
-                    {      
+
+                    else if (songTimerInSeconds <= 3 && canWeaveDelayed) // Before you get Wanderers, it just toggles the two songs.
+                    {
                         if (ActionReady(MagesBallad))
                             return MagesBallad;
                         if (ActionReady(ArmysPaeon))
                             return ArmysPaeon;
                     }
-                    
-                    #endregion
+                }
 
-                    #region Buffs
+                #endregion
 
-                    if ((!songNone || !LevelChecked(MagesBallad)) && isEnemyHealthHigh)
+                #region Buffs
+
+                if (IsEnabled(CustomComboPreset.BRD_Adv_Buffs) && (!songNone || !LevelChecked(MagesBallad)) && isEnemyHealthHigh)
+                {
+                    float ragingCD = GetCooldownRemainingTime(RagingStrikes);
+
+                    // Late weave Battle voice logic first, timed with raging strikes cd to keep buffs tight.
+                    if (canWeaveDelayed && ActionReady(BattleVoice) && songWanderer && (ragingCD < 3 || ActionReady(RagingStrikes)))
+                        return BattleVoice;
+
+                    // Radiant next, must have battlevoice buff for it to fire
+                    if (canWeave && ActionReady(RadiantFinale) &&
+                        (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet)) &&
+                        HasEffect(Buffs.BattleVoice))
+                        return RadiantFinale;
+
+                    // Late weave Raging last, must have battle voice buff OR not be high enough level for Battlecoice
+                    if (canWeave && ActionReady(RagingStrikes) && (HasEffect(Buffs.BattleVoice) || !LevelChecked(BattleVoice)))
+                        return RagingStrikes;
+
+                    // Barrage Logic to check for raging for low level reasons and it doesn't really need to check for the other buffs
+                    if (canWeave && ActionReady(Barrage) && HasEffect(Buffs.RagingStrikes))
+                        return Barrage;
+
+                }
+
+                #endregion
+
+                #region OGCD
+
+                if (canWeave && IsEnabled(CustomComboPreset.BRD_ST_Adv_oGCD))
+                {
+                    if (ActionReady(EmpyrealArrow))
+                        return EmpyrealArrow;
+
+                    // Pitch Perfect loogic to use when full or when Empyreal arrow might overcap it.
+                    if (LevelChecked(PitchPerfect) && songWanderer &&
+                        (gauge.Repertoire == 3 || (LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && GetCooldownRemainingTime(EmpyrealArrow) < 2)))
+                        return OriginalHook(PitchPerfect);
+
+                    // Sidewinder logic to use in burst window with buffs or on cd on the 1 minutes
+                    if (ActionReady(Sidewinder))
                     {
-                        float ragingCD = GetCooldownRemainingTime(RagingStrikes);
-
-                        // Late weave Battle voice logic first, timed with raging strikes cd to keep buffs tight. 
-                        if (canWeaveDelayed && ActionReady(BattleVoice) && songWanderer && (ragingCD < 3 || ActionReady(RagingStrikes)))
-                            return BattleVoice;
-
-                        // Radiant next, must have battlevoice buff for it to fire
-                        if (canWeave && ActionReady(RadiantFinale) &&
-                           (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet)) &&
-                           HasEffect(Buffs.BattleVoice))
-                            return RadiantFinale;
-
-                        // Late weave Raging last, must have battle voice buff OR not be high enough level for Battlecoice
-                        if (canWeave && ActionReady(RagingStrikes) && (HasEffect(Buffs.BattleVoice) || !LevelChecked(BattleVoice)))
-                            return RagingStrikes;
-
-                        // Barrage Logic to check for raging for low level reasons and it doesn't really need to check for the other buffs
-                        if (canWeave && ActionReady(Barrage) && HasEffect(Buffs.RagingStrikes))
-                            return Barrage;
-
-                    }
-
-                    #endregion
-
-                    #region OGCDS
-
-                    if (canWeave)
-                    {
-                        float battleVoiceCD = GetCooldownRemainingTime(BattleVoice);
-                        float empyrealCD = GetCooldownRemainingTime(EmpyrealArrow);
-                        float ragingCD = GetCooldownRemainingTime(RagingStrikes);
-                        float radiantCD = GetCooldownRemainingTime(RadiantFinale);
-
-                        // Empyreal Arrow first to minimize drift
-                        if (ActionReady(EmpyrealArrow))
-                            return EmpyrealArrow;
-
-                        //Pitch Perfect Logic to not let Empyreal arrow overcap
-                        if (LevelChecked(PitchPerfect) && songWanderer &&
-                            (gauge.Repertoire == 3 || (LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && empyrealCD < 2)))
-                            return OriginalHook(PitchPerfect);
-
-                        // Sidewinder Logic for burst window and 1 min
-                        if (ActionReady(Sidewinder))
+                        if (IsEnabled(CustomComboPreset.BRD_Adv_Pooling))
                         {
                             if (songWanderer)
                             {
-                                if ((HasEffect(Buffs.RagingStrikes) || ragingCD > 10) &&
-                                    (HasEffect(Buffs.BattleVoice) || battleVoiceCD > 10) &&
-                                    (HasEffect(Buffs.RadiantFinale) || radiantCD > 10 ||
-                                    !LevelChecked(RadiantFinale)))
+                                if ((HasEffect(Buffs.RagingStrikes) || GetCooldownRemainingTime(RagingStrikes) > 10) &&
+                                    (HasEffect(Buffs.BattleVoice) || GetCooldownRemainingTime(BattleVoice) > 10) &&
+                                    (HasEffect(Buffs.RadiantFinale) || GetCooldownRemainingTime(RadiantFinale) > 10 ||
+                                     !LevelChecked(RadiantFinale)))
                                     return Sidewinder;
                             }
                             else return Sidewinder;
                         }
+                        else return Sidewinder;
+                    }
+                }
+                //Interupt Logic, set to delayed weave. Let someone else do it if they want. Better to be last line of defense and stay off cd.
+                if (IsEnabled(CustomComboPreset.BRD_Adv_Interrupt) && CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && canWeaveDelayed)
+                    return All.HeadGraze;
 
-                        //Interupt delayered weave
-                        if (CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && canWeaveDelayed)
-                            return All.HeadGraze;
+                // Bloodletter pooling logic. Will Pool as buffs are coming up.
+                if (canWeave && IsEnabled(CustomComboPreset.BRD_ST_Adv_oGCD))
+                {
+                    if (ActionReady(Bloodletter) && !(WasLastAction(Bloodletter) || WasLastAction(HeartbreakShot)) && (GetCooldownRemainingTime(EmpyrealArrow) > 1 || !LevelChecked(EmpyrealArrow)))
+                    {
+                        uint bloodletterCharges = GetRemainingCharges(Bloodletter);
 
-                        // Bloodletter pooling logic
-                        if (ActionReady(Bloodletter) && !(WasLastAction(Bloodletter) || WasLastAction(HeartbreakShot)) && (empyrealCD > 1 || !LevelChecked(EmpyrealArrow)))
+                        if (IsEnabled(CustomComboPreset.BRD_Adv_Pooling) && LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
                         {
-                            uint bloodletterCharges = GetRemainingCharges(Bloodletter);
-
-                            if (LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
+                            if (songWanderer) // Pool until buffs go out in wanderers
                             {
-                                if (songWanderer) // Stop pooling in burst window
-                                {
-                                    if (((HasEffect(Buffs.RagingStrikes) || ragingCD > 10) &&
-                                        (HasEffect(Buffs.BattleVoice) || battleVoiceCD > 10 ||
-                                        !LevelChecked(BattleVoice)) &&
-                                        (HasEffect(Buffs.RadiantFinale) || radiantCD > 10 ||
-                                        !LevelChecked(RadiantFinale)) &&
-                                        bloodletterCharges > 0) || bloodletterCharges > 2)
-                                        return OriginalHook(Bloodletter);
-                                }
-
-                                if (songArmy && (bloodletterCharges == 3 || ((gauge.SongTimer / 1000) > 30 && bloodletterCharges > 0))) // Start pooling in army
-                                    return OriginalHook(Bloodletter);
-                                if (songMage && bloodletterCharges > 0) // Dont pool in mages
-                                    return OriginalHook(Bloodletter);
-                                if (songNone && bloodletterCharges == 3) // No song pooling
+                                if (((HasEffect(Buffs.RagingStrikes) || GetCooldownRemainingTime(RagingStrikes) > 10) &&
+                                     (HasEffect(Buffs.BattleVoice) || GetCooldownRemainingTime(BattleVoice) > 10 ||
+                                      !LevelChecked(BattleVoice)) &&
+                                     (HasEffect(Buffs.RadiantFinale) || GetCooldownRemainingTime(RadiantFinale) > 10 ||
+                                      !LevelChecked(RadiantFinale)) &&
+                                     bloodletterCharges > 0) || bloodletterCharges > 2)
                                     return OriginalHook(Bloodletter);
                             }
-                            else if (bloodletterCharges > 0)
+                            if (songArmy && (bloodletterCharges == 3 || ((gauge.SongTimer / 1000) > 30 && bloodletterCharges > 0))) // Start pooling in Army
+                                return OriginalHook(Bloodletter);
+                            if (songMage && bloodletterCharges > 0) //Don't pool in Mages
+                                return OriginalHook(Bloodletter);
+                            if (songNone && bloodletterCharges == 3) //Pool with no song
                                 return OriginalHook(Bloodletter);
                         }
+                        else if (bloodletterCharges > 0)
+                            return OriginalHook(Bloodletter);
+                    }
+                }
 
-                        // Self Care
+                #endregion
 
-                        if (PlayerHealthPercentageHp() <= 40 && ActionReady(All.SecondWind))
+                #region Self Care
+                if (canWeave)
+                {
+                    if (IsEnabled(CustomComboPreset.BRD_ST_SecondWind))
+                    {
+                        if (PlayerHealthPercentageHp() <= PluginConfiguration.GetCustomIntValue(Config.BRD_STSecondWindThreshold) && ActionReady(All.SecondWind))
                             return All.SecondWind;
+                    }
 
-                        if (ActionReady(TheWardensPaeon) && HasCleansableDebuff(LocalPlayer))
+                    if (IsEnabled(CustomComboPreset.BRD_ST_Wardens))
+                    {
+                        if (ActionReady(TheWardensPaeon) && HasCleansableDebuff(LocalPlayer)) // Could be upgraded with a targetting system in the future
                             return OriginalHook(TheWardensPaeon);
                     }
-                    #endregion
+                }
+                #endregion
 
-                    #region Dot Management
+                #region Dot Management
 
-                    if (isEnemyHealthHigh)
+                if (isEnemyHealthHigh)
+                {
+                    bool canIronJaws = LevelChecked(IronJaws);
+                    Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
+                    Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
+                    float purpleRemaining = purple?.RemainingTime ?? 0;
+                    float blueRemaining = blue?.RemainingTime ?? 0;
+                    float ragingStrikesDuration = GetBuffRemainingTime(Buffs.RagingStrikes);
+                    int ragingJawsRenewTime = PluginConfiguration.GetCustomIntValue(Config.BRD_RagingJawsRenewTime);
+
+                    if (IsEnabled(CustomComboPreset.BRD_Adv_DoT))
                     {
-                        bool canIronJaws = LevelChecked(IronJaws);
-                        Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
-                        Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
-                        float purpleRemaining = purple?.RemainingTime ?? 0;
-                        float blueRemaining = blue?.RemainingTime ?? 0;
-                        float ragingStrikesDuration = GetBuffRemainingTime(Buffs.RagingStrikes);
-                        int ragingJawsRenewTime = 6;
-
-                        // Raging jaws dot snapshotting logic
-                        if (ActionReady(IronJaws) && HasEffect(Buffs.RagingStrikes) &&
-                        ragingStrikesDuration < ragingJawsRenewTime && // Raging Jaws 
-                        purpleRemaining < 35 && blueRemaining < 35)    // Prevention of double refreshing dots
-                        {
-                            return IronJaws;
-                        }
-
-                        // Iron jaws Dot refresh, or low level manaul dot refresh
                         if (purple is not null && purpleRemaining < 4)
                             return canIronJaws ? IronJaws : VenomousBite;
                         if (blue is not null && blueRemaining < 4)
                             return canIronJaws ? IronJaws : Windbite;
-
-                        // Dot application
                         if (blue is null && LevelChecked(Windbite))
                             return OriginalHook(Windbite);
                         if (purple is null && LevelChecked(VenomousBite))
                             return OriginalHook(VenomousBite);
 
+                        if (IsEnabled(CustomComboPreset.BRD_Adv_RagingJaws) && ActionReady(IronJaws) && HasEffect(Buffs.RagingStrikes) &&
+                            ragingStrikesDuration < ragingJawsRenewTime && // Raging Jaws Slider Check
+                            purpleRemaining < 35 && blueRemaining < 35)    // Prevention of double refreshing dots
+                        {
+                            return IronJaws;
+                        }
 
                     }
-                    #endregion
+                }
+                #endregion
 
-                    #region GCDS
+                #region GCDS
 
-                    if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
-                        return OriginalHook(StraightShot);
+                if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
+                    return OriginalHook(StraightShot);
 
-                    if (LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady))
+                if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore))
+                {
+                    if (HasEffect(Buffs.RadiantEncoreReady) && GetBuffRemainingTime(Buffs.RadiantFinale) < 15) // Delay Encore enough for buff window
+                        return OriginalHook(RadiantEncore);
+                }
+
+                if (IsEnabled(CustomComboPreset.BRD_ST_ApexArrow)) // Apex Logic to time song in buff window and in mages.
+                {
+                    if (HasEffect(Buffs.BlastArrowReady))
                         return BlastArrow;
 
-                    if (LevelChecked(ApexArrow)) //Apex Logic to use in the burst window and around the 1 min. 
+                    if (LevelChecked(ApexArrow))
                     {
                         if (songMage && gauge.SoulVoice == 100)
                             return ApexArrow;
@@ -1385,14 +881,502 @@ namespace WrathCombo.Combos.PvE
                             (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale)) && gauge.SoulVoice >= 80)
                             return ApexArrow;
                     }
-                  
+                }
+
+                if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsResonant))
+                {
                     if (HasEffect(Buffs.ResonantArrowReady))
                         return ResonantArrow;
-
-                    if (HasEffect(Buffs.RadiantEncoreReady) && !JustUsed(RadiantFinale) && GetCooldownElapsed(BattleVoice) >= 4.2f)
-                        return OriginalHook(RadiantEncore);
-                    #endregion
                 }
+                #endregion
+
+                return actionID;
+            }
+        }
+        #endregion
+
+        #region Simple Modes
+        internal class BRD_AoE_SimpleMode : CustomCombo
+        {
+            internal static bool inOpener = false;
+            internal static bool openerFinished = false;
+
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_AoE_SimpleMode;
+
+            protected override uint Invoke(uint actionID)
+            {
+                if (actionID is not (Ladonsbite or QuickNock)) return actionID;
+
+                BRDGauge? gauge = GetJobGauge<BRDGauge>();
+                bool canWeave = CanWeave() && !ActionWatching.HasDoubleWeaved();
+                bool canWeaveDelayed = CanDelayedWeave(0.9) && !ActionWatching.HasDoubleWeaved();
+                int songTimerInSeconds = gauge.SongTimer / 1000;
+                bool songNone = gauge.Song == Song.NONE;
+                bool songWanderer = gauge.Song == Song.WANDERER;
+                bool songMage = gauge.Song == Song.MAGE;
+                bool songArmy = gauge.Song == Song.ARMY;
+                int targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_AoENoWasteHPPercentage);
+                bool isEnemyHealthHigh = GetTargetHPPercent() > 5;
+                bool hasTarget = HasBattleTarget();
+
+                #region Variants
+
+                if (IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= 50)
+                    return Variant.VariantCure;
+
+                if (IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart) &&
+                    canWeave)
+                    return Variant.VariantRampart;
+
+                #endregion
+
+                #region Songs
+
+
+
+                // Limit optimisation to when you are high enough level to benefit from it.
+                if (LevelChecked(WanderersMinuet))
+                {
+                    if (canWeave || !hasTarget)
+                    {
+                        if (songNone && InCombat())
+                        {
+                            // Logic to determine first song
+                            if (ActionReady(WanderersMinuet) && !(JustUsed(MagesBallad) || JustUsed(ArmysPaeon)))
+                                return WanderersMinuet;
+                            if (ActionReady(MagesBallad) && !(JustUsed(WanderersMinuet) || JustUsed(ArmysPaeon)))
+                                return MagesBallad;
+                            if (ActionReady(ArmysPaeon) && !(JustUsed(MagesBallad) || JustUsed(WanderersMinuet)))
+                                return ArmysPaeon;
+                        }
+
+                        if (songWanderer)
+                        {
+                            if (songTimerInSeconds <= 3 && gauge.Repertoire > 0 && hasTarget) // Spend any repertoire before switching to next song
+                                return OriginalHook(PitchPerfect);
+                            if (songTimerInSeconds <= 3 && ActionReady(MagesBallad))          // Move to Mage's Ballad if <= 3 seconds left on song
+                                return MagesBallad;
+                        }
+
+                        if (songMage)
+                        {
+
+                            // Move to Army's Paeon if < 3 seconds left on song
+                            if (songTimerInSeconds <= 3 && ActionReady(ArmysPaeon))
+                            {
+                                // Special case for Empyreal Arrow: it must be cast before you change to it to avoid drift!
+                                if (ActionReady(EmpyrealArrow) && hasTarget)
+                                    return EmpyrealArrow;
+                                return ArmysPaeon;
+                            }
+                        }
+                    }
+
+                    if (songArmy && (canWeaveDelayed || !hasTarget))
+                    {
+                        // Move to Wanderer's Minuet if <= 12 seconds left on song or WM off CD and have 4 repertoires of AP
+                        if ((songTimerInSeconds <= 12 || gauge.Repertoire == 4) && ActionReady(WanderersMinuet))
+                            return WanderersMinuet;
+                    }
+                }
+                else if (songTimerInSeconds <= 3 && canWeaveDelayed) // Not high enough for wanderers Minuet yet
+                {
+                    if (ActionReady(MagesBallad))
+                        return MagesBallad;
+                    if (ActionReady(ArmysPaeon))
+                        return ArmysPaeon;
+                }
+
+                #endregion
+
+                #region Buffs
+
+                if ((!songNone || !LevelChecked(MagesBallad)) && isEnemyHealthHigh)
+                {
+                    float ragingCD = GetCooldownRemainingTime(RagingStrikes);
+
+                    // Late weave Battle voice logic first, timed with raging strikes cd to keep buffs tight.
+                    if (canWeaveDelayed && ActionReady(BattleVoice) && songWanderer && (ragingCD < 3 || ActionReady(RagingStrikes)))
+                        return BattleVoice;
+
+                    // Radiant next, must have battlevoice buff for it to fire
+                    if (canWeave && ActionReady(RadiantFinale) &&
+                        (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet)) &&
+                        HasEffect(Buffs.BattleVoice))
+                        return RadiantFinale;
+
+                    // Late weave Raging last, must have battle voice buff OR not be high enough level for Battlecoice
+                    if (canWeave && ActionReady(RagingStrikes) && (HasEffect(Buffs.BattleVoice) || !LevelChecked(BattleVoice)))
+                        return RagingStrikes;
+
+                    // Barrage Logic to check for raging for low level reasons and it doesn't really need to check for the other buffs
+                    if (canWeave && ActionReady(Barrage) && HasEffect(Buffs.RagingStrikes))
+                        return Barrage;
+
+                }
+
+                #endregion
+
+                #region OGCDS and Selfcare
+
+                if (canWeave)
+                {
+                    float battleVoiceCD = GetCooldownRemainingTime(BattleVoice);
+                    float empyrealCD = GetCooldownRemainingTime(EmpyrealArrow);
+                    float ragingCD = GetCooldownRemainingTime(RagingStrikes);
+                    float radiantCD = GetCooldownRemainingTime(RadiantFinale);
+
+                    if (ActionReady(EmpyrealArrow))
+                        return EmpyrealArrow;
+
+                    // Pitch Perfect logic to use when full or when Empy arrow can cause an overcap
+                    if (LevelChecked(PitchPerfect) && songWanderer &&
+                        (gauge.Repertoire == 3 || (LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && empyrealCD < 2)))
+                        return OriginalHook(PitchPerfect);
+
+                    // Sidewinder Logic to use in Window and on the 1 min
+                    if (ActionReady(Sidewinder))
+                    {
+                        if (songWanderer)
+                        {
+                            if ((HasEffect(Buffs.RagingStrikes) || ragingCD > 10) &&
+                                (HasEffect(Buffs.BattleVoice) || battleVoiceCD > 10) &&
+                                (HasEffect(Buffs.RadiantFinale) || radiantCD > 10 ||
+                                 !LevelChecked(RadiantFinale)))
+                                return Sidewinder;
+
+                        }
+                        else return Sidewinder;
+                    }
+
+                    // Interupt
+                    if (CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && canWeaveDelayed)
+                        return All.HeadGraze;
+
+                    // Pooling logic for rain of death basied on song
+                    if (LevelChecked(RainOfDeath) && !WasLastAction(RainOfDeath) && (empyrealCD > 1 || !LevelChecked(EmpyrealArrow)))
+                    {
+                        uint rainOfDeathCharges = LevelChecked(RainOfDeath) ? GetRemainingCharges(RainOfDeath) : 0;
+
+                        if (LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
+                        {
+                            if (songWanderer)
+                            {
+                                if (((HasEffect(Buffs.RagingStrikes) || ragingCD > 10) &&
+                                     (HasEffect(Buffs.BattleVoice) || battleVoiceCD > 10 ||
+                                      !LevelChecked(BattleVoice)) &&
+                                     (HasEffect(Buffs.RadiantFinale) || radiantCD > 10 ||
+                                      !LevelChecked(RadiantFinale)) &&
+                                     rainOfDeathCharges > 0) || rainOfDeathCharges > 2)
+                                    return OriginalHook(RainOfDeath);
+                            }
+
+                            if (songArmy && (rainOfDeathCharges == 3 || ((gauge.SongTimer / 1000) > 30 && rainOfDeathCharges > 0)))
+                                return OriginalHook(RainOfDeath);
+                            if (songMage && rainOfDeathCharges > 0)
+                                return OriginalHook(RainOfDeath);
+                            if (songNone && rainOfDeathCharges == 3)
+                                return OriginalHook(RainOfDeath);
+                        }
+                        else if (rainOfDeathCharges > 0)
+                            return OriginalHook(RainOfDeath);
+                    }
+
+                    if (!LevelChecked(RainOfDeath) && !(WasLastAction(Bloodletter) && GetRemainingCharges(Bloodletter) > 0))
+                        return OriginalHook(Bloodletter);
+
+                    // Self care section for healing and debuff removal
+
+                    if (PlayerHealthPercentageHp() <= 40 && ActionReady(All.SecondWind))
+                        return All.SecondWind;
+
+                    if (ActionReady(TheWardensPaeon) && HasCleansableDebuff(LocalPlayer))
+                        return OriginalHook(TheWardensPaeon);
+                }
+                #endregion
+
+                #region GCDS
+
+                if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))  //Ahead of other gcds because of higher risk of losing a proc than a ready buff
+                    return OriginalHook(WideVolley);
+
+                if (LevelChecked(ApexArrow) && gauge.SoulVoice == 100)
+                    return ApexArrow;
+
+                if (HasEffect(Buffs.BlastArrowReady))
+                    return BlastArrow;
+
+                if (HasEffect(Buffs.ResonantArrowReady))
+                    return ResonantArrow;
+
+                if (HasEffect(Buffs.RadiantEncoreReady))
+                    return OriginalHook(RadiantEncore);
+
+                #endregion
+
+                return actionID;
+            }
+        }
+        internal class BRD_ST_SimpleMode : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_ST_SimpleMode;
+            internal static bool usedStraightShotReady = false;
+            internal static bool usedPitchPerfect = false;
+            internal delegate bool DotRecast(int value);
+
+            protected override uint Invoke(uint actionID)
+            {
+                if (actionID is not (HeavyShot or BurstShot)) return actionID;
+
+                BRDGauge? gauge = GetJobGauge<BRDGauge>();
+                bool canWeave = CanWeave() && !ActionWatching.HasDoubleWeaved();
+                bool canWeaveDelayed = CanDelayedWeave(0.9) && !ActionWatching.HasDoubleWeaved();
+                bool songNone = gauge.Song == Song.NONE;
+                bool songWanderer = gauge.Song == Song.WANDERER;
+                bool songMage = gauge.Song == Song.MAGE;
+                bool songArmy = gauge.Song == Song.ARMY;
+                bool isEnemyHealthHigh = GetTargetHPPercent() > 1;
+                int songTimerInSeconds = gauge.SongTimer / 1000;
+                bool hasTarget = HasBattleTarget();
+
+                #region Variants
+                if (IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= 50)
+                    return Variant.VariantCure;
+
+                if (IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart) &&
+                    canWeave)
+                    return Variant.VariantRampart;
+                #endregion
+
+                #region Songs
+
+                // Limit optimisation to when you are high enough level to benefit from it.
+                if (LevelChecked(WanderersMinuet))
+                {
+                    // 43s of Wanderer's Minute, ~36s of Mage's Ballad, and ~43s of Army's Paeon
+
+                    if (ActionReady(EmpyrealArrow) && JustUsed(WanderersMinuet))
+                        return EmpyrealArrow;
+
+                    if (canWeave || !hasTarget)
+                    {
+                        if (songNone && InCombat())
+                        {
+                            // Logic to determine first song
+                            if (ActionReady(WanderersMinuet) && !(JustUsed(MagesBallad) || JustUsed(ArmysPaeon)))
+                                return WanderersMinuet;
+                            if (ActionReady(MagesBallad) && !(JustUsed(WanderersMinuet) || JustUsed(ArmysPaeon)))
+                                return MagesBallad;
+                            if (ActionReady(ArmysPaeon) && !(JustUsed(MagesBallad) || JustUsed(WanderersMinuet)))
+                                return ArmysPaeon;
+                        }
+
+                        if (songWanderer)
+                        {
+                            if (songTimerInSeconds <= 3 && gauge.Repertoire > 0 && hasTarget) // Spend any repertoire before switching to next song
+                                return OriginalHook(PitchPerfect);
+                            if (songTimerInSeconds <= 3 && ActionReady(MagesBallad))          // Move to Mage's Ballad if <= 3 seconds left on song
+                                return MagesBallad;
+                        }
+
+                        if (songMage)
+                        {
+
+                            // Move to Army's Paeon if <= 3 seconds left on song
+                            if (songTimerInSeconds <= 3 && ActionReady(ArmysPaeon))
+                            {
+                                // Special case for Empyreal Arrow: it must be cast before you change to it to avoid drift!
+                                if (ActionReady(EmpyrealArrow) && hasTarget)
+                                    return EmpyrealArrow;
+                                return ArmysPaeon;
+                            }
+                        }
+                    }
+
+                    if (songArmy && (canWeaveDelayed || !hasTarget))
+                    {
+                        // Move to Wanderer's Minuet if <= 12 seconds left on song or WM off CD and have 4 repertoires of AP
+                        if (songTimerInSeconds <= 12 || (ActionReady(WanderersMinuet) && gauge.Repertoire == 4))
+                            return WanderersMinuet;
+                    }
+                }
+                else if (songTimerInSeconds <= 3 && canWeaveDelayed)
+                {
+                    if (ActionReady(MagesBallad))
+                        return MagesBallad;
+                    if (ActionReady(ArmysPaeon))
+                        return ArmysPaeon;
+                }
+
+                #endregion
+
+                #region Buffs
+
+                if ((!songNone || !LevelChecked(MagesBallad)) && isEnemyHealthHigh)
+                {
+                    float ragingCD = GetCooldownRemainingTime(RagingStrikes);
+
+                    // Late weave Battle voice logic first, timed with raging strikes cd to keep buffs tight.
+                    if (canWeaveDelayed && ActionReady(BattleVoice) && songWanderer && (ragingCD < 3 || ActionReady(RagingStrikes)))
+                        return BattleVoice;
+
+                    // Radiant next, must have battlevoice buff for it to fire
+                    if (canWeave && ActionReady(RadiantFinale) &&
+                        (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet)) &&
+                        HasEffect(Buffs.BattleVoice))
+                        return RadiantFinale;
+
+                    // Late weave Raging last, must have battle voice buff OR not be high enough level for Battlecoice
+                    if (canWeave && ActionReady(RagingStrikes) && (HasEffect(Buffs.BattleVoice) || !LevelChecked(BattleVoice)))
+                        return RagingStrikes;
+
+                    // Barrage Logic to check for raging for low level reasons and it doesn't really need to check for the other buffs
+                    if (canWeave && ActionReady(Barrage) && HasEffect(Buffs.RagingStrikes))
+                        return Barrage;
+
+                }
+
+                #endregion
+
+                #region OGCDS
+
+                if (canWeave)
+                {
+                    float battleVoiceCD = GetCooldownRemainingTime(BattleVoice);
+                    float empyrealCD = GetCooldownRemainingTime(EmpyrealArrow);
+                    float ragingCD = GetCooldownRemainingTime(RagingStrikes);
+                    float radiantCD = GetCooldownRemainingTime(RadiantFinale);
+
+                    // Empyreal Arrow first to minimize drift
+                    if (ActionReady(EmpyrealArrow))
+                        return EmpyrealArrow;
+
+                    //Pitch Perfect Logic to not let Empyreal arrow overcap
+                    if (LevelChecked(PitchPerfect) && songWanderer &&
+                        (gauge.Repertoire == 3 || (LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && empyrealCD < 2)))
+                        return OriginalHook(PitchPerfect);
+
+                    // Sidewinder Logic for burst window and 1 min
+                    if (ActionReady(Sidewinder))
+                    {
+                        if (songWanderer)
+                        {
+                            if ((HasEffect(Buffs.RagingStrikes) || ragingCD > 10) &&
+                                (HasEffect(Buffs.BattleVoice) || battleVoiceCD > 10) &&
+                                (HasEffect(Buffs.RadiantFinale) || radiantCD > 10 ||
+                                 !LevelChecked(RadiantFinale)))
+                                return Sidewinder;
+                        }
+                        else return Sidewinder;
+                    }
+
+                    //Interupt delayered weave
+                    if (CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && canWeaveDelayed)
+                        return All.HeadGraze;
+
+                    // Bloodletter pooling logic
+                    if (ActionReady(Bloodletter) && !(WasLastAction(Bloodletter) || WasLastAction(HeartbreakShot)) && (empyrealCD > 1 || !LevelChecked(EmpyrealArrow)))
+                    {
+                        uint bloodletterCharges = GetRemainingCharges(Bloodletter);
+
+                        if (LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
+                        {
+                            if (songWanderer) // Stop pooling in burst window
+                            {
+                                if (((HasEffect(Buffs.RagingStrikes) || ragingCD > 10) &&
+                                     (HasEffect(Buffs.BattleVoice) || battleVoiceCD > 10 ||
+                                      !LevelChecked(BattleVoice)) &&
+                                     (HasEffect(Buffs.RadiantFinale) || radiantCD > 10 ||
+                                      !LevelChecked(RadiantFinale)) &&
+                                     bloodletterCharges > 0) || bloodletterCharges > 2)
+                                    return OriginalHook(Bloodletter);
+                            }
+
+                            if (songArmy && (bloodletterCharges == 3 || ((gauge.SongTimer / 1000) > 30 && bloodletterCharges > 0))) // Start pooling in army
+                                return OriginalHook(Bloodletter);
+                            if (songMage && bloodletterCharges > 0) // Dont pool in mages
+                                return OriginalHook(Bloodletter);
+                            if (songNone && bloodletterCharges == 3) // No song pooling
+                                return OriginalHook(Bloodletter);
+                        }
+                        else if (bloodletterCharges > 0)
+                            return OriginalHook(Bloodletter);
+                    }
+
+                    // Self Care
+
+                    if (PlayerHealthPercentageHp() <= 40 && ActionReady(All.SecondWind))
+                        return All.SecondWind;
+
+                    if (ActionReady(TheWardensPaeon) && HasCleansableDebuff(LocalPlayer))
+                        return OriginalHook(TheWardensPaeon);
+                }
+                #endregion
+
+                #region Dot Management
+
+                if (isEnemyHealthHigh)
+                {
+                    bool canIronJaws = LevelChecked(IronJaws);
+                    Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
+                    Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
+                    float purpleRemaining = purple?.RemainingTime ?? 0;
+                    float blueRemaining = blue?.RemainingTime ?? 0;
+                    float ragingStrikesDuration = GetBuffRemainingTime(Buffs.RagingStrikes);
+                    int ragingJawsRenewTime = 6;
+
+                    // Raging jaws dot snapshotting logic
+                    if (ActionReady(IronJaws) && HasEffect(Buffs.RagingStrikes) &&
+                        ragingStrikesDuration < ragingJawsRenewTime && // Raging Jaws
+                        purpleRemaining < 35 && blueRemaining < 35)    // Prevention of double refreshing dots
+                    {
+                        return IronJaws;
+                    }
+
+                    // Iron jaws Dot refresh, or low level manaul dot refresh
+                    if (purple is not null && purpleRemaining < 4)
+                        return canIronJaws ? IronJaws : VenomousBite;
+                    if (blue is not null && blueRemaining < 4)
+                        return canIronJaws ? IronJaws : Windbite;
+
+                    // Dot application
+                    if (blue is null && LevelChecked(Windbite))
+                        return OriginalHook(Windbite);
+                    if (purple is null && LevelChecked(VenomousBite))
+                        return OriginalHook(VenomousBite);
+
+
+                }
+                #endregion
+
+                #region GCDS
+
+                if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
+                    return OriginalHook(StraightShot);
+
+                if (LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady))
+                    return BlastArrow;
+
+                if (LevelChecked(ApexArrow)) //Apex Logic to use in the burst window and around the 1 min.
+                {
+                    if (songMage && gauge.SoulVoice == 100)
+                        return ApexArrow;
+                    if (songMage && gauge.SoulVoice >= 80 &&
+                        songTimerInSeconds > 18 && songTimerInSeconds < 22)
+                        return ApexArrow;
+                    if (songWanderer && HasEffect(Buffs.RagingStrikes) && HasEffect(Buffs.BattleVoice) &&
+                        (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale)) && gauge.SoulVoice >= 80)
+                        return ApexArrow;
+                }
+
+                if (HasEffect(Buffs.ResonantArrowReady))
+                    return ResonantArrow;
+
+                if (HasEffect(Buffs.RadiantEncoreReady) && !JustUsed(RadiantFinale) && GetCooldownElapsed(BattleVoice) >= 4.2f)
+                    return OriginalHook(RadiantEncore);
+                #endregion
                 return actionID;
             }
         }

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -1205,55 +1205,54 @@ internal partial class DNC
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Cascade)
+            if (actionID is not Cascade) return actionID;
+
+            #region Types
+
+            bool flow = HasEffect(Buffs.SilkenFlow) ||
+                        HasEffect(Buffs.FlourishingFlow);
+            bool symmetry = HasEffect(Buffs.SilkenSymmetry) ||
+                            HasEffect(Buffs.FlourishingSymmetry);
+
+            #endregion
+
+            // ST Esprit overcap protection
+            if (IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap) &&
+                LevelChecked(DanceOfTheDawn) &&
+                HasEffect(Buffs.DanceOfTheDawnReady) &&
+                Gauge.Esprit >= Config.DNCEspritThreshold_ST)
+                return OriginalHook(DanceOfTheDawn);
+            if (IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap) &&
+                LevelChecked(SaberDance) &&
+                Gauge.Esprit >= Config.DNCEspritThreshold_ST)
+                return SaberDance;
+
+            if (CanWeave())
             {
-                #region Types
+                // ST Fan Dance overcap protection
+                if (IsEnabled(CustomComboPreset.DNC_ST_FanDanceOvercap) &&
+                    LevelChecked(FanDance1) && Gauge.Feathers is 4 &&
+                    (HasEffect(Buffs.SilkenSymmetry) ||
+                     HasEffect(Buffs.SilkenFlow)))
+                    return FanDance1;
 
-                bool flow = HasEffect(Buffs.SilkenFlow) ||
-                            HasEffect(Buffs.FlourishingFlow);
-                bool symmetry = HasEffect(Buffs.SilkenSymmetry) ||
-                                HasEffect(Buffs.FlourishingSymmetry);
-
-                #endregion
-
-                // ST Esprit overcap protection
-                if (IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap) &&
-                    LevelChecked(DanceOfTheDawn) &&
-                    HasEffect(Buffs.DanceOfTheDawnReady) &&
-                    Gauge.Esprit >= Config.DNCEspritThreshold_ST)
-                    return OriginalHook(DanceOfTheDawn);
-                if (IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap) &&
-                    LevelChecked(SaberDance) &&
-                    Gauge.Esprit >= Config.DNCEspritThreshold_ST)
-                    return SaberDance;
-
-                if (CanWeave())
+                // ST Fan Dance 3/4 on combo
+                if (IsEnabled(CustomComboPreset.DNC_ST_FanDance34))
                 {
-                    // ST Fan Dance overcap protection
-                    if (IsEnabled(CustomComboPreset.DNC_ST_FanDanceOvercap) &&
-                        LevelChecked(FanDance1) && Gauge.Feathers is 4 &&
-                        (HasEffect(Buffs.SilkenSymmetry) ||
-                         HasEffect(Buffs.SilkenFlow)))
-                        return FanDance1;
-
-                    // ST Fan Dance 3/4 on combo
-                    if (IsEnabled(CustomComboPreset.DNC_ST_FanDance34))
-                    {
-                        if (HasEffect(Buffs.ThreeFoldFanDance))
-                            return FanDance3;
-                        if (HasEffect(Buffs.FourFoldFanDance))
-                            return FanDance4;
-                    }
+                    if (HasEffect(Buffs.ThreeFoldFanDance))
+                        return FanDance3;
+                    if (HasEffect(Buffs.FourFoldFanDance))
+                        return FanDance4;
                 }
-
-                // ST base combos
-                if (LevelChecked(Fountainfall) && flow)
-                    return Fountainfall;
-                if (LevelChecked(ReverseCascade) && symmetry)
-                    return ReverseCascade;
-                if (LevelChecked(Fountain) && ComboAction is Cascade)
-                    return Fountain;
             }
+
+            // ST base combos
+            if (LevelChecked(Fountainfall) && flow)
+                return Fountainfall;
+            if (LevelChecked(ReverseCascade) && symmetry)
+                return ReverseCascade;
+            if (LevelChecked(Fountain) && ComboAction is Cascade)
+                return Fountain;
 
             return actionID;
         }
@@ -1266,55 +1265,54 @@ internal partial class DNC
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Windmill)
+            if (actionID is not Windmill) return actionID;
+
+            #region Types
+
+            bool flow = HasEffect(Buffs.SilkenFlow) ||
+                        HasEffect(Buffs.FlourishingFlow);
+            bool symmetry = HasEffect(Buffs.SilkenSymmetry) ||
+                            HasEffect(Buffs.FlourishingSymmetry);
+
+            #endregion
+
+            // AoE Esprit overcap protection
+            if (IsEnabled(CustomComboPreset.DNC_AoE_EspritOvercap) &&
+                LevelChecked(DanceOfTheDawn) &&
+                HasEffect(Buffs.DanceOfTheDawnReady) &&
+                Gauge.Esprit >= Config.DNCEspritThreshold_ST)
+                return OriginalHook(DanceOfTheDawn);
+            if (IsEnabled(CustomComboPreset.DNC_AoE_EspritOvercap) &&
+                LevelChecked(SaberDance) &&
+                Gauge.Esprit >= Config.DNCEspritThreshold_AoE)
+                return SaberDance;
+
+            if (CanWeave())
             {
-                #region Types
+                // AoE Fan Dance overcap protection
+                if (IsEnabled(CustomComboPreset.DNC_AoE_FanDanceOvercap) &&
+                    LevelChecked(FanDance2) && Gauge.Feathers is 4 &&
+                    (HasEffect(Buffs.SilkenSymmetry) ||
+                     HasEffect(Buffs.SilkenFlow)))
+                    return FanDance2;
 
-                bool flow = HasEffect(Buffs.SilkenFlow) ||
-                            HasEffect(Buffs.FlourishingFlow);
-                bool symmetry = HasEffect(Buffs.SilkenSymmetry) ||
-                                HasEffect(Buffs.FlourishingSymmetry);
-
-                #endregion
-
-                // AoE Esprit overcap protection
-                if (IsEnabled(CustomComboPreset.DNC_AoE_EspritOvercap) &&
-                    LevelChecked(DanceOfTheDawn) &&
-                    HasEffect(Buffs.DanceOfTheDawnReady) &&
-                    Gauge.Esprit >= Config.DNCEspritThreshold_ST)
-                    return OriginalHook(DanceOfTheDawn);
-                if (IsEnabled(CustomComboPreset.DNC_AoE_EspritOvercap) &&
-                    LevelChecked(SaberDance) &&
-                    Gauge.Esprit >= Config.DNCEspritThreshold_AoE)
-                    return SaberDance;
-
-                if (CanWeave())
+                // AoE Fan Dance 3/4 on combo
+                if (IsEnabled(CustomComboPreset.DNC_AoE_FanDance34))
                 {
-                    // AoE Fan Dance overcap protection
-                    if (IsEnabled(CustomComboPreset.DNC_AoE_FanDanceOvercap) &&
-                        LevelChecked(FanDance2) && Gauge.Feathers is 4 &&
-                        (HasEffect(Buffs.SilkenSymmetry) ||
-                         HasEffect(Buffs.SilkenFlow)))
-                        return FanDance2;
-
-                    // AoE Fan Dance 3/4 on combo
-                    if (IsEnabled(CustomComboPreset.DNC_AoE_FanDance34))
-                    {
-                        if (HasEffect(Buffs.ThreeFoldFanDance))
-                            return FanDance3;
-                        if (HasEffect(Buffs.FourFoldFanDance))
-                            return FanDance4;
-                    }
+                    if (HasEffect(Buffs.ThreeFoldFanDance))
+                        return FanDance3;
+                    if (HasEffect(Buffs.FourFoldFanDance))
+                        return FanDance4;
                 }
-
-                // AoE base combos
-                if (LevelChecked(Bloodshower) && flow)
-                    return Bloodshower;
-                if (LevelChecked(RisingWindmill) && symmetry)
-                    return RisingWindmill;
-                if (LevelChecked(Bladeshower) && ComboAction is Windmill)
-                    return Bladeshower;
             }
+
+            // AoE base combos
+            if (LevelChecked(Bloodshower) && flow)
+                return Bloodshower;
+            if (LevelChecked(RisingWindmill) && symmetry)
+                return RisingWindmill;
+            if (LevelChecked(Bladeshower) && ComboAction is Windmill)
+                return Bladeshower;
 
             return actionID;
         }
@@ -1331,6 +1329,8 @@ internal partial class DNC
 
         protected override uint Invoke(uint actionID)
         {
+            if (actionID is not (StandardStep or TechnicalStep)) return actionID;
+
             // Standard Step
             if (actionID is StandardStep && Gauge.IsDancing &&
                 HasEffect(Buffs.StandardStep))
@@ -1412,29 +1412,26 @@ internal partial class DNC
 
         protected override uint Invoke(uint actionID)
         {
-            // FD 1 --> 3, FD 1 --> 4
-            if (actionID is FanDance1)
-            {
-                if (IsEnabled(CustomComboPreset.DNC_FanDance_1to3_Combo) &&
-                    HasEffect(Buffs.ThreeFoldFanDance))
-                    return FanDance3;
-                if (IsEnabled(CustomComboPreset.DNC_FanDance_1to4_Combo) &&
-                    HasEffect(Buffs.FourFoldFanDance))
-                    return FanDance4;
-            }
+            if (actionID is not (FanDance1 or FanDance2)) return actionID;
 
-            // FD 2 --> 3, FD 2 --> 4
-            if (actionID is FanDance2)
+            return actionID switch
             {
-                if (IsEnabled(CustomComboPreset.DNC_FanDance_2to3_Combo) &&
-                    HasEffect(Buffs.ThreeFoldFanDance))
-                    return FanDance3;
-                if (IsEnabled(CustomComboPreset.DNC_FanDance_2to4_Combo) &&
-                    HasEffect(Buffs.FourFoldFanDance))
-                    return FanDance4;
-            }
-
-            return actionID;
+                // FD 1 --> 3, FD 1 --> 4
+                FanDance1 when
+                    IsEnabled(CustomComboPreset.DNC_FanDance_1to3_Combo) &&
+                    HasEffect(Buffs.ThreeFoldFanDance) => FanDance3,
+                FanDance1 when
+                    IsEnabled(CustomComboPreset.DNC_FanDance_1to4_Combo) &&
+                    HasEffect(Buffs.FourFoldFanDance) => FanDance4,
+                // FD 2 --> 3, FD 2 --> 4
+                FanDance2 when
+                    IsEnabled(CustomComboPreset.DNC_FanDance_2to3_Combo) &&
+                    HasEffect(Buffs.ThreeFoldFanDance) => FanDance3,
+                FanDance2 when
+                    IsEnabled(CustomComboPreset.DNC_FanDance_2to4_Combo) &&
+                    HasEffect(Buffs.FourFoldFanDance) => FanDance4,
+                _ => actionID
+            };
         }
     }
 

--- a/WrathCombo/Combos/PvE/DOL/DOL.cs
+++ b/WrathCombo/Combos/PvE/DOL/DOL.cs
@@ -98,21 +98,20 @@ namespace WrathCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.FSH_Swim;
             protected override uint Invoke(uint actionID)
             {
-                if (HasCondition(ConditionFlag.Diving))
+                if (!HasCondition(ConditionFlag.Diving)) return actionID;
+
+                if (actionID is Cast && IsEnabled(CustomComboPreset.FSH_CastGig)) return Gig;
+                if (actionID is SurfaceSlap && IsEnabled(CustomComboPreset.FSH_SurfaceTrade)) return VeteranTrade;
+                if (actionID is PrizeCatch && IsEnabled(CustomComboPreset.FSH_PrizeBounty)) return NaturesBounty;
+                if (actionID is Snagging && IsEnabled(CustomComboPreset.FSH_SnaggingSalvage)) return Salvage;
+                if (actionID is CastLight && IsEnabled(CustomComboPreset.FSH_CastLight_ElectricCurrent)) return ElectricCurrent;
+                if (IsEnabled(CustomComboPreset.FSH_Mooch_SharkEye))
                 {
-                    if (actionID is Cast && IsEnabled(CustomComboPreset.FSH_CastGig)) return Gig;
-                    if (actionID is SurfaceSlap && IsEnabled(CustomComboPreset.FSH_SurfaceTrade)) return VeteranTrade;
-                    if (actionID is PrizeCatch && IsEnabled(CustomComboPreset.FSH_PrizeBounty)) return NaturesBounty;
-                    if (actionID is Snagging && IsEnabled(CustomComboPreset.FSH_SnaggingSalvage)) return Salvage;
-                    if (actionID is CastLight && IsEnabled(CustomComboPreset.FSH_CastLight_ElectricCurrent)) return ElectricCurrent;
-                    if (IsEnabled(CustomComboPreset.FSH_Mooch_SharkEye))
-                    {
-                        if (actionID is Mooch) return SharkEye;
-                        if (actionID is MoochII) return SharkEyeII;
-                    }
-                    if (actionID is FishEyes && IsEnabled(CustomComboPreset.FSH_FishEyes_VitalSight)) return VitalSight;
-                    if (actionID is Chum && IsEnabled(CustomComboPreset.FSH_Chum_BaitedBreath)) return BaitedBreath;
+                    if (actionID is Mooch) return SharkEye;
+                    if (actionID is MoochII) return SharkEyeII;
                 }
+                if (actionID is FishEyes && IsEnabled(CustomComboPreset.FSH_FishEyes_VitalSight)) return VitalSight;
+                if (actionID is Chum && IsEnabled(CustomComboPreset.FSH_Chum_BaitedBreath)) return BaitedBreath;
 
                 return actionID;
             }

--- a/WrathCombo/Combos/PvE/DRG/DRG.cs
+++ b/WrathCombo/Combos/PvE/DRG/DRG.cs
@@ -12,27 +12,25 @@ internal partial class DRG
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is FullThrust or HeavensThrust)
+            if (actionID is not (FullThrust or HeavensThrust)) return actionID;
+
+            if (ComboTimer > 0)
             {
-                if (ComboTimer > 0)
-                {
-                    if (ComboAction is TrueThrust or RaidenThrust && LevelChecked(VorpalThrust))
-                        return OriginalHook(VorpalThrust);
+                if (ComboAction is TrueThrust or RaidenThrust && LevelChecked(VorpalThrust))
+                    return OriginalHook(VorpalThrust);
 
-                    if (ComboAction == OriginalHook(VorpalThrust) && LevelChecked(FullThrust))
-                        return OriginalHook(FullThrust);
+                if (ComboAction == OriginalHook(VorpalThrust) && LevelChecked(FullThrust))
+                    return OriginalHook(FullThrust);
 
-                    if (ComboAction == OriginalHook(FullThrust) && LevelChecked(FangAndClaw))
-                        return FangAndClaw;
+                if (ComboAction == OriginalHook(FullThrust) && LevelChecked(FangAndClaw))
+                    return FangAndClaw;
 
-                    if (ComboAction is FangAndClaw && LevelChecked(Drakesbane))
-                        return Drakesbane;
-                }
-
-                return OriginalHook(TrueThrust);
+                if (ComboAction is FangAndClaw && LevelChecked(Drakesbane))
+                    return Drakesbane;
             }
 
-            return actionID;
+            return OriginalHook(TrueThrust);
+
         }
     }
 
@@ -42,27 +40,25 @@ internal partial class DRG
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is ChaosThrust or ChaoticSpring)
+            if (actionID is not (ChaosThrust or ChaoticSpring)) return actionID;
+
+            if (ComboTimer > 0)
             {
-                if (ComboTimer > 0)
-                {
-                    if (ComboAction is TrueThrust or RaidenThrust && LevelChecked(Disembowel))
-                        return OriginalHook(Disembowel);
+                if (ComboAction is TrueThrust or RaidenThrust && LevelChecked(Disembowel))
+                    return OriginalHook(Disembowel);
 
-                    if (ComboAction == OriginalHook(Disembowel) && LevelChecked(ChaosThrust))
-                        return OriginalHook(ChaosThrust);
+                if (ComboAction == OriginalHook(Disembowel) && LevelChecked(ChaosThrust))
+                    return OriginalHook(ChaosThrust);
 
-                    if (ComboAction == OriginalHook(ChaosThrust) && LevelChecked(WheelingThrust))
-                        return WheelingThrust;
+                if (ComboAction == OriginalHook(ChaosThrust) && LevelChecked(WheelingThrust))
+                    return WheelingThrust;
 
-                    if (ComboAction is WheelingThrust && LevelChecked(Drakesbane))
-                        return Drakesbane;
-                }
-
-                return OriginalHook(TrueThrust);
+                if (ComboAction is WheelingThrust && LevelChecked(Drakesbane))
+                    return Drakesbane;
             }
 
-            return actionID;
+            return OriginalHook(TrueThrust);
+
         }
     }
 

--- a/WrathCombo/Combos/PvE/DRK/DRK.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK.cs
@@ -6,6 +6,7 @@ using WrathCombo.Combos.PvE.Content;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Data;
 
+// ReSharper disable UnusedType.Global
 // ReSharper disable ClassNeverInstantiated.Global
 // ReSharper disable InconsistentNaming
 // ReSharper disable CheckNamespace
@@ -26,7 +27,7 @@ internal partial class DRK
         protected override uint Invoke(uint actionID)
         {
             // Bail if not looking at the replaced action
-            if (actionID != HardSlash) return actionID;
+            if (actionID is not HardSlash) return actionID;
 
             #region Variables
 
@@ -316,7 +317,7 @@ internal partial class DRK
         protected override uint Invoke(uint actionID)
         {
             // Bail if not looking at the replaced action
-            if (actionID != Unleash) return actionID;
+            if (actionID is not Unleash) return actionID;
 
             var hpRemainingShadow = Config.DRK_AoE_LivingShadowThreshold;
             var hpRemainingDelirium = Config.DRK_AoE_DeliriumThreshold;
@@ -490,33 +491,30 @@ internal partial class DRK
 
         protected override uint Invoke(uint actionID)
         {
-            var gauge = GetJobGauge<DRKGauge>();
+            if (actionID is not (CarveAndSpit or AbyssalDrain)) return actionID;
 
-            if (actionID == CarveAndSpit || actionID == AbyssalDrain)
-            {
-                if (IsOffCooldown(LivingShadow)
-                    && LevelChecked(LivingShadow))
-                    return LivingShadow;
+            if (IsOffCooldown(LivingShadow)
+                && LevelChecked(LivingShadow))
+                return LivingShadow;
 
-                if (IsOffCooldown(SaltedEarth)
-                    && LevelChecked(SaltedEarth))
-                    return SaltedEarth;
+            if (IsOffCooldown(SaltedEarth)
+                && LevelChecked(SaltedEarth))
+                return SaltedEarth;
 
-                if (IsOffCooldown(CarveAndSpit)
-                    && LevelChecked(AbyssalDrain))
-                    return actionID;
+            if (IsOffCooldown(CarveAndSpit)
+                && LevelChecked(AbyssalDrain))
+                return actionID;
 
-                if (IsOffCooldown(SaltAndDarkness)
-                    && HasEffect(Buffs.SaltedEarth)
-                    && LevelChecked(SaltAndDarkness))
-                    return SaltAndDarkness;
+            if (IsOffCooldown(SaltAndDarkness)
+                && HasEffect(Buffs.SaltedEarth)
+                && LevelChecked(SaltAndDarkness))
+                return SaltAndDarkness;
 
-                if (IsEnabled(CustomComboPreset.DRK_Shadowbringer_oGCD)
-                    && GetCooldownRemainingTime(Shadowbringer) < 60
-                    && LevelChecked(Shadowbringer)
-                    && gauge.DarksideTimeRemaining > 0)
-                    return Shadowbringer;
-            }
+            if (IsEnabled(CustomComboPreset.DRK_Shadowbringer_oGCD)
+                && GetCooldownRemainingTime(Shadowbringer) < 60
+                && LevelChecked(Shadowbringer)
+                && Gauge.DarksideTimeRemaining > 0)
+                return Shadowbringer;
 
             return actionID;
         }

--- a/WrathCombo/Combos/PvE/GNB/GNB.cs
+++ b/WrathCombo/Combos/PvE/GNB/GNB.cs
@@ -107,524 +107,522 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is KeenEdge) //Our button
+                if (actionID is not KeenEdge) return actionID; //Our button
+
+                #region Variables
+                //Gauge
+                var Ammo = GetJobGauge<GNBGauge>().Ammo; //Our cartridge count
+                var GunStep = GetJobGauge<GNBGauge>().AmmoComboStep; //For Gnashing Fang & Reign combo purposes
+                //Cooldown-related
+                var gfCD = GetCooldownRemainingTime(GnashingFang); //GnashingFang's cooldown; 30s total
+                var nmCD = GetCooldownRemainingTime(NoMercy); //NoMercy's cooldown; 60s total
+                var ddCD = GetCooldownRemainingTime(DoubleDown); //Double Down's cooldown; 60s total
+                var bfCD = GetCooldownRemainingTime(Bloodfest); //Bloodfest's cooldown; 120s total
+                var nmLeft = GetBuffRemainingTime(Buffs.NoMercy); //Remaining time for No Mercy buff (20s)
+                var hasNM = nmCD is >= 40 and <= 60; //Checks if No Mercy is active
+                var hasBreak = HasEffect(Buffs.ReadyToBreak); //Checks for Ready To Break buff
+                var hasReign = HasEffect(Buffs.ReadyToReign); //Checks for Ready To Reign buff
+                //Mitigations
+                //Misc
+                var inOdd = bfCD is < 90 and > 20; //Odd Minute
+                var canLateWeave = GetCooldownRemainingTime(actionID) < 1 && GetCooldownRemainingTime(actionID) > 0.6; //SkS purposes
+                var GCD = GetCooldown(KeenEdge).CooldownTotal; //2.5 is base SkS, but can work with 2.4x
+                var justMitted = JustUsed(OriginalHook(HeartOfStone), 4f) ||
+                                 JustUsed(OriginalHook(Nebula), 5f) ||
+                                 JustUsed(Camouflage, 5f) ||
+                                 JustUsed(All.Rampart, 5f) ||
+                                 JustUsed(Aurora, 5f) ||
+                                 JustUsed(Superbolide, 9f);
+
+                #region Minimal Requirements
+                //Ammo-relative
+                var canBS = LevelChecked(BurstStrike) && //Burst Strike is unlocked
+                            Ammo > 0; //Has Ammo
+                var canGF = LevelChecked(GnashingFang) && //GnashingFang is unlocked
+                            gfCD < 0.6f && //Gnashing Fang is off cooldown
+                            !HasEffect(Buffs.ReadyToBlast) && //to ensure Hypervelocity is spent in case Burst Strike is used before Gnashing Fang
+                            GunStep == 0 && //Gnashing Fang or Reign combo is not already active
+                            Ammo > 0; //Has Ammo
+                var canDD = LevelChecked(DoubleDown) && //Double Down is unlocked
+                            ddCD < 0.6f && //Double Down is off cooldown
+                            Ammo > 0; //Has Ammo
+                var canBF = LevelChecked(Bloodfest) && //Bloodfest is unlocked
+                            bfCD < 0.6f; //Bloodfest is off cooldown
+                //Cooldown-relative
+                var canZone = LevelChecked(DangerZone) && //Zone is unlocked
+                              GetCooldownRemainingTime(OriginalHook(DangerZone)) < 0.6f; //DangerZone is off cooldown
+                var canBreak = LevelChecked(SonicBreak) && //Sonic Break is unlocked
+                               hasBreak; //No Mercy or Ready To Break is active
+                var canBow = LevelChecked(BowShock) && //Bow Shock is unlocked
+                             GetCooldownRemainingTime(BowShock) < 0.6f; //BowShock is off cooldown
+                var canContinue = LevelChecked(Continuation); //Continuation is unlocked
+                var canReign = LevelChecked(ReignOfBeasts) && //Reign of Beasts is unlocked
+                               GunStep == 0 && //Gnashing Fang or Reign combo is not already active
+                               hasReign; //Ready To Reign is active
+                #endregion
+                #endregion
+
+                if (Opener().FullOpener(ref actionID))
+                    return actionID;
+
+                #region Mitigations
+                if (Config.GNB_ST_MitsOptions != 1)
                 {
-                    #region Variables
-                    //Gauge
-                    var Ammo = GetJobGauge<GNBGauge>().Ammo; //Our cartridge count
-                    var GunStep = GetJobGauge<GNBGauge>().AmmoComboStep; //For Gnashing Fang & Reign combo purposes
-                    //Cooldown-related
-                    var gfCD = GetCooldownRemainingTime(GnashingFang); //GnashingFang's cooldown; 30s total
-                    var nmCD = GetCooldownRemainingTime(NoMercy); //NoMercy's cooldown; 60s total
-                    var ddCD = GetCooldownRemainingTime(DoubleDown); //Double Down's cooldown; 60s total
-                    var bfCD = GetCooldownRemainingTime(Bloodfest); //Bloodfest's cooldown; 120s total
-                    var nmLeft = GetBuffRemainingTime(Buffs.NoMercy); //Remaining time for No Mercy buff (20s)
-                    var hasNM = nmCD is >= 40 and <= 60; //Checks if No Mercy is active
-                    var hasBreak = HasEffect(Buffs.ReadyToBreak); //Checks for Ready To Break buff
-                    var hasReign = HasEffect(Buffs.ReadyToReign); //Checks for Ready To Reign buff
-                    //Mitigations
-                    //Misc
-                    var inOdd = bfCD is < 90 and > 20; //Odd Minute
-                    var canLateWeave = GetCooldownRemainingTime(actionID) < 1 && GetCooldownRemainingTime(actionID) > 0.6; //SkS purposes
-                    var GCD = GetCooldown(KeenEdge).CooldownTotal; //2.5 is base SkS, but can work with 2.4x
-                    var justMitted = JustUsed(OriginalHook(HeartOfStone), 4f) ||
-                                      JustUsed(OriginalHook(Nebula), 5f) ||
-                                      JustUsed(Camouflage, 5f) ||
-                                      JustUsed(All.Rampart, 5f) ||
-                                      JustUsed(Aurora, 5f) ||
-                                      JustUsed(Superbolide, 9f);
-
-                    #region Minimal Requirements
-                    //Ammo-relative
-                    var canBS = LevelChecked(BurstStrike) && //Burst Strike is unlocked
-                                Ammo > 0; //Has Ammo
-                    var canGF = LevelChecked(GnashingFang) && //GnashingFang is unlocked
-                                gfCD < 0.6f && //Gnashing Fang is off cooldown
-                                !HasEffect(Buffs.ReadyToBlast) && //to ensure Hypervelocity is spent in case Burst Strike is used before Gnashing Fang
-                                GunStep == 0 && //Gnashing Fang or Reign combo is not already active
-                                Ammo > 0; //Has Ammo
-                    var canDD = LevelChecked(DoubleDown) && //Double Down is unlocked
-                                ddCD < 0.6f && //Double Down is off cooldown
-                                Ammo > 0; //Has Ammo
-                    var canBF = LevelChecked(Bloodfest) && //Bloodfest is unlocked
-                                bfCD < 0.6f; //Bloodfest is off cooldown
-                    //Cooldown-relative
-                    var canZone = LevelChecked(DangerZone) && //Zone is unlocked
-                                GetCooldownRemainingTime(OriginalHook(DangerZone)) < 0.6f; //DangerZone is off cooldown
-                    var canBreak = LevelChecked(SonicBreak) && //Sonic Break is unlocked
-                                hasBreak; //No Mercy or Ready To Break is active
-                    var canBow = LevelChecked(BowShock) && //Bow Shock is unlocked
-                                GetCooldownRemainingTime(BowShock) < 0.6f; //BowShock is off cooldown
-                    var canContinue = LevelChecked(Continuation); //Continuation is unlocked
-                    var canReign = LevelChecked(ReignOfBeasts) && //Reign of Beasts is unlocked
-                                GunStep == 0 && //Gnashing Fang or Reign combo is not already active
-                                hasReign; //Ready To Reign is active
-                    #endregion
-                    #endregion
-
-                    if (Opener().FullOpener(ref actionID))
-                        return actionID;
-
-                    #region Mitigations
-                    if (Config.GNB_ST_MitsOptions != 1)
-                    {
-                        if (InCombat() && //Player is in combat
+                    if (InCombat() && //Player is in combat
                         !justMitted) //Player has not used a mitigation ability in the last 4-9 seconds
-                        {
-                            //Superbolide
-                            if (ActionReady(Superbolide) && //Superbolide is ready
-                                PlayerHealthPercentageHp() < 30) //Player's health is below 30%
-                                return Superbolide;
-
-                            if (IsPlayerTargeted())
-                            {
-                                //Nebula
-                                if (ActionReady(OriginalHook(Nebula)) && //Nebula is ready
-                                    PlayerHealthPercentageHp() < 60) //Player's health is below 60%
-                                    return OriginalHook(Nebula);
-
-                                //Rampart
-                                if (ActionReady(All.Rampart) && //Rampart is ready
-                                    PlayerHealthPercentageHp() < 80) //Player's health is below 80%
-                                    return All.Rampart;
-
-                                //Reprisal
-                                if (ActionReady(All.Reprisal) && //Reprisal is ready
-                                    InActionRange(All.Reprisal) && //Player is in range of Reprisal
-                                    PlayerHealthPercentageHp() < 90) //Player's health is below 90%
-                                    return All.Reprisal;
-                            }
-
-                            //Camouflage
-                            if (ActionReady(Camouflage) && //Camouflage is ready
-                                PlayerHealthPercentageHp() < 70) //Player's health is below 80%
-                                return Camouflage;
-
-                            //Corundum
-                            if (ActionReady(OriginalHook(HeartOfStone)) && //Corundum
-                                PlayerHealthPercentageHp() < 90) //Player's health is below 95%
-                                return OriginalHook(HeartOfStone);
-
-                            //Aurora
-                            if (ActionReady(Aurora) && //Aurora is ready
-                                ((HasFriendlyTarget() && TargetHasEffectAny(Buffs.Aurora)) || (!HasFriendlyTarget() && HasEffectAny(Buffs.Aurora))) && //Aurora is not active on self or target
-                                PlayerHealthPercentageHp() < 85) //
-                                return Aurora;
-                        }
-
-                    }
-                    #endregion
-
-                    #region Variant
-                    //Variant Cure
-                    if (IsEnabled(CustomComboPreset.GNB_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure)
-                        && PlayerHealthPercentageHp() <= GetOptionValue(Config.GNB_VariantCure))
-                        return Variant.VariantCure;
-
-                    //Variant SpiritDart
-                    Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
-                    if (IsEnabled(CustomComboPreset.GNB_Variant_SpiritDart) &&
-                        IsEnabled(Variant.VariantSpiritDart) &&
-                        CanWeave() &&
-                        (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
-                        return Variant.VariantSpiritDart;
-
-                    //Variant Ultimatum
-                    if (IsEnabled(CustomComboPreset.GNB_Variant_Ultimatum) &&
-                        IsEnabled(Variant.VariantUltimatum) &&
-                        CanWeave() &&
-                        ActionReady(Variant.VariantUltimatum))
-                        return Variant.VariantUltimatum;
-                    #endregion
-
-                    #region Bozja
-                    if (Bozja.IsInBozja) //Checks if we're inside Bozja instances
                     {
-                        //oGCDs
-                        if (CanWeave())
+                        //Superbolide
+                        if (ActionReady(Superbolide) && //Superbolide is ready
+                            PlayerHealthPercentageHp() < 30) //Player's health is below 30%
+                            return Superbolide;
+
+                        if (IsPlayerTargeted())
                         {
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFocus) && //Lost Focus is enabled
-                                HasActionEquipped(Bozja.LostFocus) &&
-                                GetBuffStacks(Bozja.Buffs.Boost) < 16) //Boost stacks are below 16
-                                return Bozja.LostFocus;
+                            //Nebula
+                            if (ActionReady(OriginalHook(Nebula)) && //Nebula is ready
+                                PlayerHealthPercentageHp() < 60) //Player's health is below 60%
+                                return OriginalHook(Nebula);
 
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFontOfPower) && //Lost Font of Power is enabled
-                                HasActionEquipped(Bozja.LostFontOfPower) &&
-                                IsOffCooldown(Bozja.LostFontOfPower)) //Lost Focus was not just used within 30 seconds
-                                return Bozja.LostFontOfPower;
+                            //Rampart
+                            if (ActionReady(All.Rampart) && //Rampart is ready
+                                PlayerHealthPercentageHp() < 80) //Player's health is below 80%
+                                return All.Rampart;
 
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSlash) &&
-                                HasActionEquipped(Bozja.LostSlash) &&
-                                IsOffCooldown(Bozja.LostSlash))
-                                return Bozja.LostSlash;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfNobleEnds))
-                            {
-                                if (!IsEnabled(CustomComboPreset.GNB_Bozja_PowerEnds) &&
-                                    HasActionEquipped(Bozja.BannerOfNobleEnds) &&
-                                    IsOffCooldown(Bozja.BannerOfNobleEnds))
-                                    return Bozja.BannerOfNobleEnds;
-
-                                if (IsEnabled(CustomComboPreset.GNB_Bozja_PowerEnds) &&
-                                    HasActionEquipped(Bozja.BannerOfNobleEnds) &&
-                                    IsOffCooldown(Bozja.BannerOfNobleEnds) &&
-                                    JustUsed(Bozja.LostFontOfPower, 5f))
-                                    return Bozja.BannerOfNobleEnds;
-                            }
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfHonoredSacrifice))
-                            {
-                                if (!IsEnabled(CustomComboPreset.GNB_Bozja_PowerSacrifice) &&
-                                    HasActionEquipped(Bozja.BannerOfHonoredSacrifice) &&
-                                    IsOffCooldown(Bozja.BannerOfHonoredSacrifice))
-                                    return Bozja.BannerOfHonoredSacrifice;
-                                if (IsEnabled(CustomComboPreset.GNB_Bozja_PowerSacrifice) &&
-                                    HasActionEquipped(Bozja.BannerOfHonoredSacrifice) &&
-                                    IsOffCooldown(Bozja.BannerOfHonoredSacrifice) &&
-                                    JustUsed(Bozja.LostFontOfPower, 5f))
-                                    return Bozja.BannerOfHonoredSacrifice;
-                            }
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfHonedAcuity) &&
-                                HasActionEquipped(Bozja.BannerOfHonedAcuity) &&
-                                IsOffCooldown(Bozja.BannerOfHonedAcuity) &&
-                                !HasEffect(Bozja.Buffs.BannerOfTranscendentFinesse))
-                                return Bozja.BannerOfHonedAcuity;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFairTrade) &&
-                                HasActionEquipped(Bozja.LostFairTrade) &&
-                                IsOffCooldown(Bozja.LostFairTrade))
-                                return Bozja.LostFairTrade;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostAssassination) &&
-                                HasActionEquipped(Bozja.LostAssassination) &&
-                                IsOffCooldown(Bozja.LostAssassination))
-                                return Bozja.LostAssassination;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostManawall) &&
-                                HasActionEquipped(Bozja.LostManawall) &&
-                                IsOffCooldown(Bozja.LostManawall))
-                                return Bozja.LostManawall;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfTirelessConviction) &&
-                                HasActionEquipped(Bozja.BannerOfTirelessConviction) &&
-                                IsOffCooldown(Bozja.BannerOfTirelessConviction) &&
-                                !HasEffect(Bozja.Buffs.BannerOfUnyieldingDefense))
-                                return Bozja.BannerOfTirelessConviction;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBloodRage) &&
-                                HasActionEquipped(Bozja.LostBloodRage) &&
-                                IsOffCooldown(Bozja.LostBloodRage))
-                                return Bozja.LostBloodRage;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfSolemnClarity) &&
-                                HasActionEquipped(Bozja.BannerOfSolemnClarity) &&
-                                IsOffCooldown(Bozja.BannerOfSolemnClarity) &&
-                                !HasEffect(Bozja.Buffs.BannerOfLimitlessGrace))
-                                return Bozja.BannerOfSolemnClarity;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure2) &&
-                                HasActionEquipped(Bozja.LostCure2) &&
-                                IsOffCooldown(Bozja.LostCure2) &&
-                                PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure2_Health)
-                                return Bozja.LostCure2;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure4) &&
-                                HasActionEquipped(Bozja.LostCure4) &&
-                                IsOffCooldown(Bozja.LostCure4) &&
-                                PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure4_Health)
-                                return Bozja.LostCure4;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostReflect) &&
-                                HasActionEquipped(Bozja.LostReflect) &&
-                                IsOffCooldown(Bozja.LostReflect) &&
-                                !HasEffect(Bozja.Buffs.LostReflect))
-                                return Bozja.LostReflect;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostAethershield) &&
-                                HasActionEquipped(Bozja.LostAethershield) &&
-                                IsOffCooldown(Bozja.LostAethershield) &&
-                                !HasEffect(Bozja.Buffs.LostAethershield) &&
-                                PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostAethershield_Health)
-                                return Bozja.LostAethershield;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSwift) &&
-                                HasActionEquipped(Bozja.LostSwift) &&
-                                IsOffCooldown(Bozja.LostSwift) &&
-                                !HasEffect(Bozja.Buffs.LostSwift))
-                                return Bozja.LostSwift;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFontOfSkill) &&
-                                HasActionEquipped(Bozja.LostFontOfSkill) &&
-                                IsOffCooldown(Bozja.LostFontOfSkill))
-                                return Bozja.LostFontOfSkill;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostRampage) &&
-                                HasActionEquipped(Bozja.LostRampage) &&
-                                IsOffCooldown(Bozja.LostRampage))
-                                return Bozja.LostRampage;
+                            //Reprisal
+                            if (ActionReady(All.Reprisal) && //Reprisal is ready
+                                InActionRange(All.Reprisal) && //Player is in range of Reprisal
+                                PlayerHealthPercentageHp() < 90) //Player's health is below 90%
+                                return All.Reprisal;
                         }
 
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostStealth) &&
-                            HasActionEquipped(Bozja.LostStealth) &&
-                            !InCombat() &&
-                            IsOffCooldown(Bozja.LostStealth))
-                            return Bozja.LostStealth;
+                        //Camouflage
+                        if (ActionReady(Camouflage) && //Camouflage is ready
+                            PlayerHealthPercentageHp() < 70) //Player's health is below 80%
+                            return Camouflage;
 
-                        //GCDs
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostDeath) &&
-                            HasActionEquipped(Bozja.LostDeath) &&
-                            IsOffCooldown(Bozja.LostDeath))
-                            return Bozja.LostDeath;
+                        //Corundum
+                        if (ActionReady(OriginalHook(HeartOfStone)) && //Corundum
+                            PlayerHealthPercentageHp() < 90) //Player's health is below 95%
+                            return OriginalHook(HeartOfStone);
 
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure) &&
-                            HasActionEquipped(Bozja.LostCure) &&
-                            IsOffCooldown(Bozja.LostCure) &&
-                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure_Health)
-                            return Bozja.LostCure;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure3) &&
-                            HasActionEquipped(Bozja.LostCure3) &&
-                            IsOffCooldown(Bozja.LostCure3) &&
-                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure3_Health)
-                            return Bozja.LostCure3;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostArise) &&
-                            HasActionEquipped(Bozja.LostArise) &&
-                            IsOffCooldown(Bozja.LostArise) &&
-                            GetTargetHPPercent() == 0 &&
-                            !HasEffect(All.Debuffs.Raise))
-                            return Bozja.LostArise;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSacrifice) &&
-                            HasActionEquipped(Bozja.LostSacrifice) &&
-                            IsOffCooldown(Bozja.LostSacrifice) &&
-                            GetTargetHPPercent() == 0)
-                            return Bozja.LostSacrifice;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostReraise) &&
-                            HasActionEquipped(Bozja.LostReraise) &&
-                            IsOffCooldown(Bozja.LostReraise) &&
-                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostReraise_Health)
-                            return Bozja.LostReraise;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSpellforge) &&
-                            HasActionEquipped(Bozja.LostSpellforge) &&
-                            IsOffCooldown(Bozja.LostSpellforge) &&
-                            (!HasEffect(Bozja.Buffs.LostSpellforge) || !HasEffect(Bozja.Buffs.LostSteelsting)))
-                            return Bozja.LostSpellforge;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSteelsting) &&
-                            HasActionEquipped(Bozja.LostSteelsting) &&
-                            IsOffCooldown(Bozja.LostSteelsting) &&
-                            (!HasEffect(Bozja.Buffs.LostSpellforge) || !HasEffect(Bozja.Buffs.LostSteelsting)))
-                            return Bozja.LostSteelsting;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostProtect) &&
-                            HasActionEquipped(Bozja.LostProtect) &&
-                            IsOffCooldown(Bozja.LostProtect) &&
-                            !HasEffect(Bozja.Buffs.LostProtect))
-                            return Bozja.LostProtect;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostShell) &&
-                            HasActionEquipped(Bozja.LostShell) &&
-                            IsOffCooldown(Bozja.LostShell) &&
-                            !HasEffect(Bozja.Buffs.LostShell))
-                            return Bozja.LostShell;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBravery) &&
-                            HasActionEquipped(Bozja.LostBravery) &&
-                            IsOffCooldown(Bozja.LostBravery) &&
-                            !HasEffect(Bozja.Buffs.LostBravery))
-                            return Bozja.LostBravery;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostProtect2) &&
-                            HasActionEquipped(Bozja.LostProtect2) &&
-                            IsOffCooldown(Bozja.LostProtect2) &&
-                            !HasEffect(Bozja.Buffs.LostProtect2))
-                            return Bozja.LostProtect2;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostShell2) &&
-                            HasActionEquipped(Bozja.LostShell2) &&
-                            IsOffCooldown(Bozja.LostShell2) &&
-                            !HasEffect(Bozja.Buffs.LostShell2))
-                            return Bozja.LostShell2;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBubble) &&
-                            HasActionEquipped(Bozja.LostBubble) &&
-                            IsOffCooldown(Bozja.LostBubble) &&
-                            !HasEffect(Bozja.Buffs.LostBubble))
-                            return Bozja.LostBubble;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostParalyze3) &&
-                            HasActionEquipped(Bozja.LostParalyze3) &&
-                            IsOffCooldown(Bozja.LostParalyze3) &&
-                            !JustUsed(Bozja.LostParalyze3, 60f))
-                            return Bozja.LostParalyze3;
-                    }
-                    #endregion
-
-                    #region Rotation
-                    //Ranged Uptime
-                    if (LevelChecked(LightningShot) && //Lightning Shot is unlocked
-                        !InMeleeRange() && //Out of melee range
-                        HasBattleTarget()) //Has target
-                        return LightningShot; //Execute Lightning Shot if conditions are met
-
-                    //No Mercy
-                    if (ActionReady(NoMercy) && //No Mercy is ready
-                        InCombat() && //In combat
-                        HasTarget() && //Has target
-                        CanWeave()) //Able to weave
-                    {
-                        if (LevelChecked(DoubleDown)) //Lv90+
-                        {
-                            if ((inOdd && //Odd Minute window
-                                (Ammo >= 2 || (ComboAction is BrutalShell && Ammo == 1))) || //2 or 3 Ammo or 1 Ammo with Solid Barrel next in combo
-                                (!inOdd && //Even Minute window
-                                Ammo != 3)) //Ammo is not full (3)
-                                return NoMercy; //Execute No Mercy if conditions are met
-                        }
-                        if (!LevelChecked(DoubleDown)) //Lv1-89
-                        {
-                            if (canLateWeave && //Late-weaveable
-                                Ammo == MaxCartridges()) //Ammo is full
-                                return NoMercy; //Execute No Mercy if conditions are met
-                        }
+                        //Aurora
+                        if (ActionReady(Aurora) && //Aurora is ready
+                            ((HasFriendlyTarget() && TargetHasEffectAny(Buffs.Aurora)) || (!HasFriendlyTarget() && HasEffectAny(Buffs.Aurora))) && //Aurora is not active on self or target
+                            PlayerHealthPercentageHp() < 85) //
+                            return Aurora;
                     }
 
-                    //Hypervelocity - Forced to prevent loss
-                    if (JustUsed(BurstStrike, 5f) && //Burst Strike was just used within 5 seconds
-                        LevelChecked(Hypervelocity) && //Hypervelocity is unlocked
-                        HasEffect(Buffs.ReadyToBlast) && //Ready To Blast buff is active
-                        nmCD is > 1 or <= 0.1f) //Priority hack to prevent Hypervelocity from being used before No Mercy
-                        return Hypervelocity; //Execute Hypervelocity if conditions are met
+                }
+                #endregion
 
-                    //Continuation protection - Forced to prevent loss
-                    if (canContinue && //able to use Continuation
-                        (HasEffect(Buffs.ReadyToRip) || //after Gnashing Fang
-                        HasEffect(Buffs.ReadyToTear) || //after Savage Claw
-                        HasEffect(Buffs.ReadyToGouge) || //after Wicked Talon
-                        HasEffect(Buffs.ReadyToBlast) || //after Burst Strike
-                        HasEffect(Buffs.ReadyToRaze))) //after Fated Circle
-                        return OriginalHook(Continuation); //Execute appopriate Continuation action if conditions are met
+                #region Variant
+                //Variant Cure
+                if (IsEnabled(CustomComboPreset.GNB_Variant_Cure) &&
+                    IsEnabled(Variant.VariantCure)
+                    && PlayerHealthPercentageHp() <= GetOptionValue(Config.GNB_VariantCure))
+                    return Variant.VariantCure;
 
+                //Variant SpiritDart
+                Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+                if (IsEnabled(CustomComboPreset.GNB_Variant_SpiritDart) &&
+                    IsEnabled(Variant.VariantSpiritDart) &&
+                    CanWeave() &&
+                    (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
+                    return Variant.VariantSpiritDart;
+
+                //Variant Ultimatum
+                if (IsEnabled(CustomComboPreset.GNB_Variant_Ultimatum) &&
+                    IsEnabled(Variant.VariantUltimatum) &&
+                    CanWeave() &&
+                    ActionReady(Variant.VariantUltimatum))
+                    return Variant.VariantUltimatum;
+                #endregion
+
+                #region Bozja
+                if (Bozja.IsInBozja) //Checks if we're inside Bozja instances
+                {
                     //oGCDs
                     if (CanWeave())
                     {
-                        //Bloodfest
-                        if (InCombat() && //In combat
-                            HasTarget() && //Has target
-                            canBF && //able to use Bloodfest
-                            Ammo == 0) //Only when ammo is empty
-                            return Bloodfest; //Execute Bloodfest if conditions are met
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFocus) && //Lost Focus is enabled
+                            HasActionEquipped(Bozja.LostFocus) &&
+                            GetBuffStacks(Bozja.Buffs.Boost) < 16) //Boost stacks are below 16
+                            return Bozja.LostFocus;
 
-                        //Zone
-                        if (canZone && //able to use Zone
-                            (nmCD is < 57.5f and > 17f))//Optimal use; twice per minute, 1 in NM, 1 out of NM
-                            return OriginalHook(DangerZone); //Execute Zone if conditions are met
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFontOfPower) && //Lost Font of Power is enabled
+                            HasActionEquipped(Bozja.LostFontOfPower) &&
+                            IsOffCooldown(Bozja.LostFontOfPower)) //Lost Focus was not just used within 30 seconds
+                            return Bozja.LostFontOfPower;
 
-                        //Bow Shock
-                        if (canBow && //able to use Bow Shock
-                            nmCD is < 57.5f and >= 40) //No Mercy is up & was not just used within 1 GCD
-                            return BowShock;
-                    }
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSlash) &&
+                            HasActionEquipped(Bozja.LostSlash) &&
+                            IsOffCooldown(Bozja.LostSlash))
+                            return Bozja.LostSlash;
 
-                    //Lv90+ - every 3rd NM window
-                    if (LevelChecked(DoubleDown) &&
-                        HasEffect(Buffs.NoMercy) &&
-                        GunStep == 0 &&
-                        ComboAction is BrutalShell &&
-                        Ammo == 1)
-                        return SolidBarrel;
-
-                    //GnashingFang
-                    if (canGF && //able to use Gnashing Fang
-                        ((nmCD is > 17 and < 35) || //30s Optimal use
-                        (JustUsed(NoMercy, 6f)))) //No Mercy was just used within 4 seconds
-                        return GnashingFang;
-
-                    //Double Down
-                    if (canDD && //able to use Double Down
-                        IsOnCooldown(GnashingFang) && //Gnashing Fang is on cooldown
-                        hasNM) //No Mercy is active
-                        return DoubleDown;
-
-                    //Sonic Break
-                    if (canBreak && //able to use Sonic Break
-                        ((IsOnCooldown(GnashingFang) && IsOnCooldown(DoubleDown)) || //Gnashing Fang and Double Down are both on cooldown
-                        nmLeft <= GCD)) //No Mercy buff is about to expire
-                        return SonicBreak; //Execute Sonic Break if conditions are met
-
-                    //Reign of Beasts
-                    if (canReign && //able to use Reign of Beasts
-                        IsOnCooldown(GnashingFang) && //Gnashing Fang is on cooldown
-                        IsOnCooldown(DoubleDown) && //Double Down is on cooldown
-                        !HasEffect(Buffs.ReadyToBreak) && //Ready To Break is not active
-                        GunStep == 0) //Gnashing Fang or Reign combo is not active or finished
-                        return OriginalHook(ReignOfBeasts); //Execute Reign of Beasts if conditions are met
-
-                    //Burst Strike
-                    if (canBS && //able to use Burst Strike
-                        HasEffect(Buffs.NoMercy) && //No Mercy is active
-                        IsOnCooldown(GnashingFang) && //Gnashing Fang is on cooldown
-                        IsOnCooldown(DoubleDown) && //Double Down is on cooldown
-                        !HasEffect(Buffs.ReadyToBreak) && //Ready To Break is not active
-                        !HasEffect(Buffs.ReadyToReign) && //Ready To Reign is not active
-                        GunStep == 0) //Gnashing Fang or Reign combo is not active or finished
-                        return BurstStrike; //Execute Burst Strike if conditions are met
-
-                    //Lv90+ 2cart forced Opener
-                    if (LevelChecked(DoubleDown) && //Lv90+
-                        nmCD < 1 && //No Mercy is ready or about to be
-                        Ammo is 3 && //Ammo is full
-                        bfCD > 110 && //Bloodfest was just used, but not recently
-                        ComboAction is KeenEdge) //Just used Keen Edge
-                        return BurstStrike;
-                    //Lv100 2cart forced 2min starter
-                    if (LevelChecked(ReignOfBeasts) && //Lv100
-                        (nmCD < 1 && //No Mercy is ready or about to be
-                        Ammo is 3 && //Ammo is full
-                        bfCD < GCD * 12)) //Bloodfest is ready or about to be
-                        return BurstStrike;
-
-                    //Gauge Combo Steps
-                    if (GunStep is 1 or 2) //Gnashing Fang combo is only for 1 and 2
-                        return OriginalHook(GnashingFang); //Execute Gnashing Fang combo if conditions are met
-                    if (GunStep is 3 or 4) //Reign of Beasts combo is only for 3 and 4
-                        return OriginalHook(ReignOfBeasts); //Execute Reign of Beasts combo if conditions are met
-
-                    //123 (overcap included)
-                    if (ComboTimer > 0) //we're in combo
-                    {
-                        if (LevelChecked(BrutalShell) && //Brutal Shell is unlocked
-                            ComboAction == KeenEdge) //just used first action in combo
-                            return BrutalShell; //Execute Brutal Shell if conditions are met
-
-                        if (LevelChecked(SolidBarrel) && //Solid Barrel is unlocked
-                            ComboAction == BrutalShell) //just used second action in combo
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfNobleEnds))
                         {
-                            //holds Hypervelocity if NM comes up in time
-                            if (LevelChecked(Hypervelocity) && //Hypervelocity is unlocked
-                                HasEffect(Buffs.ReadyToBlast) && //Ready To Blast buff is active
-                                (nmCD is > 1 or <= 0.1f)) //Priority hack to prevent Hypervelocity from being used before No Mercy
-                                return Hypervelocity; //Execute Hypervelocity if conditions are met
+                            if (!IsEnabled(CustomComboPreset.GNB_Bozja_PowerEnds) &&
+                                HasActionEquipped(Bozja.BannerOfNobleEnds) &&
+                                IsOffCooldown(Bozja.BannerOfNobleEnds))
+                                return Bozja.BannerOfNobleEnds;
 
-                            //Overcap protection
-                            if (LevelChecked(BurstStrike) && //Burst Strike is unlocked
-                                Ammo == MaxCartridges()) //Ammo is full relaive to level
-                                return BurstStrike; //Execute Burst Strike if conditions are met
-
-                            return SolidBarrel; //Execute Solid Barrel if conditions are met
+                            if (IsEnabled(CustomComboPreset.GNB_Bozja_PowerEnds) &&
+                                HasActionEquipped(Bozja.BannerOfNobleEnds) &&
+                                IsOffCooldown(Bozja.BannerOfNobleEnds) &&
+                                JustUsed(Bozja.LostFontOfPower, 5f))
+                                return Bozja.BannerOfNobleEnds;
                         }
-                    }
-                    #endregion
 
-                    return KeenEdge; //Always default back to Keen Edge
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfHonoredSacrifice))
+                        {
+                            if (!IsEnabled(CustomComboPreset.GNB_Bozja_PowerSacrifice) &&
+                                HasActionEquipped(Bozja.BannerOfHonoredSacrifice) &&
+                                IsOffCooldown(Bozja.BannerOfHonoredSacrifice))
+                                return Bozja.BannerOfHonoredSacrifice;
+                            if (IsEnabled(CustomComboPreset.GNB_Bozja_PowerSacrifice) &&
+                                HasActionEquipped(Bozja.BannerOfHonoredSacrifice) &&
+                                IsOffCooldown(Bozja.BannerOfHonoredSacrifice) &&
+                                JustUsed(Bozja.LostFontOfPower, 5f))
+                                return Bozja.BannerOfHonoredSacrifice;
+                        }
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfHonedAcuity) &&
+                            HasActionEquipped(Bozja.BannerOfHonedAcuity) &&
+                            IsOffCooldown(Bozja.BannerOfHonedAcuity) &&
+                            !HasEffect(Bozja.Buffs.BannerOfTranscendentFinesse))
+                            return Bozja.BannerOfHonedAcuity;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFairTrade) &&
+                            HasActionEquipped(Bozja.LostFairTrade) &&
+                            IsOffCooldown(Bozja.LostFairTrade))
+                            return Bozja.LostFairTrade;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostAssassination) &&
+                            HasActionEquipped(Bozja.LostAssassination) &&
+                            IsOffCooldown(Bozja.LostAssassination))
+                            return Bozja.LostAssassination;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostManawall) &&
+                            HasActionEquipped(Bozja.LostManawall) &&
+                            IsOffCooldown(Bozja.LostManawall))
+                            return Bozja.LostManawall;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfTirelessConviction) &&
+                            HasActionEquipped(Bozja.BannerOfTirelessConviction) &&
+                            IsOffCooldown(Bozja.BannerOfTirelessConviction) &&
+                            !HasEffect(Bozja.Buffs.BannerOfUnyieldingDefense))
+                            return Bozja.BannerOfTirelessConviction;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBloodRage) &&
+                            HasActionEquipped(Bozja.LostBloodRage) &&
+                            IsOffCooldown(Bozja.LostBloodRage))
+                            return Bozja.LostBloodRage;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfSolemnClarity) &&
+                            HasActionEquipped(Bozja.BannerOfSolemnClarity) &&
+                            IsOffCooldown(Bozja.BannerOfSolemnClarity) &&
+                            !HasEffect(Bozja.Buffs.BannerOfLimitlessGrace))
+                            return Bozja.BannerOfSolemnClarity;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure2) &&
+                            HasActionEquipped(Bozja.LostCure2) &&
+                            IsOffCooldown(Bozja.LostCure2) &&
+                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure2_Health)
+                            return Bozja.LostCure2;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure4) &&
+                            HasActionEquipped(Bozja.LostCure4) &&
+                            IsOffCooldown(Bozja.LostCure4) &&
+                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure4_Health)
+                            return Bozja.LostCure4;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostReflect) &&
+                            HasActionEquipped(Bozja.LostReflect) &&
+                            IsOffCooldown(Bozja.LostReflect) &&
+                            !HasEffect(Bozja.Buffs.LostReflect))
+                            return Bozja.LostReflect;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostAethershield) &&
+                            HasActionEquipped(Bozja.LostAethershield) &&
+                            IsOffCooldown(Bozja.LostAethershield) &&
+                            !HasEffect(Bozja.Buffs.LostAethershield) &&
+                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostAethershield_Health)
+                            return Bozja.LostAethershield;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSwift) &&
+                            HasActionEquipped(Bozja.LostSwift) &&
+                            IsOffCooldown(Bozja.LostSwift) &&
+                            !HasEffect(Bozja.Buffs.LostSwift))
+                            return Bozja.LostSwift;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFontOfSkill) &&
+                            HasActionEquipped(Bozja.LostFontOfSkill) &&
+                            IsOffCooldown(Bozja.LostFontOfSkill))
+                            return Bozja.LostFontOfSkill;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostRampage) &&
+                            HasActionEquipped(Bozja.LostRampage) &&
+                            IsOffCooldown(Bozja.LostRampage))
+                            return Bozja.LostRampage;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostStealth) &&
+                        HasActionEquipped(Bozja.LostStealth) &&
+                        !InCombat() &&
+                        IsOffCooldown(Bozja.LostStealth))
+                        return Bozja.LostStealth;
+
+                    //GCDs
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostDeath) &&
+                        HasActionEquipped(Bozja.LostDeath) &&
+                        IsOffCooldown(Bozja.LostDeath))
+                        return Bozja.LostDeath;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure) &&
+                        HasActionEquipped(Bozja.LostCure) &&
+                        IsOffCooldown(Bozja.LostCure) &&
+                        PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure_Health)
+                        return Bozja.LostCure;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure3) &&
+                        HasActionEquipped(Bozja.LostCure3) &&
+                        IsOffCooldown(Bozja.LostCure3) &&
+                        PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure3_Health)
+                        return Bozja.LostCure3;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostArise) &&
+                        HasActionEquipped(Bozja.LostArise) &&
+                        IsOffCooldown(Bozja.LostArise) &&
+                        GetTargetHPPercent() == 0 &&
+                        !HasEffect(All.Debuffs.Raise))
+                        return Bozja.LostArise;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSacrifice) &&
+                        HasActionEquipped(Bozja.LostSacrifice) &&
+                        IsOffCooldown(Bozja.LostSacrifice) &&
+                        GetTargetHPPercent() == 0)
+                        return Bozja.LostSacrifice;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostReraise) &&
+                        HasActionEquipped(Bozja.LostReraise) &&
+                        IsOffCooldown(Bozja.LostReraise) &&
+                        PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostReraise_Health)
+                        return Bozja.LostReraise;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSpellforge) &&
+                        HasActionEquipped(Bozja.LostSpellforge) &&
+                        IsOffCooldown(Bozja.LostSpellforge) &&
+                        (!HasEffect(Bozja.Buffs.LostSpellforge) || !HasEffect(Bozja.Buffs.LostSteelsting)))
+                        return Bozja.LostSpellforge;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSteelsting) &&
+                        HasActionEquipped(Bozja.LostSteelsting) &&
+                        IsOffCooldown(Bozja.LostSteelsting) &&
+                        (!HasEffect(Bozja.Buffs.LostSpellforge) || !HasEffect(Bozja.Buffs.LostSteelsting)))
+                        return Bozja.LostSteelsting;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostProtect) &&
+                        HasActionEquipped(Bozja.LostProtect) &&
+                        IsOffCooldown(Bozja.LostProtect) &&
+                        !HasEffect(Bozja.Buffs.LostProtect))
+                        return Bozja.LostProtect;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostShell) &&
+                        HasActionEquipped(Bozja.LostShell) &&
+                        IsOffCooldown(Bozja.LostShell) &&
+                        !HasEffect(Bozja.Buffs.LostShell))
+                        return Bozja.LostShell;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBravery) &&
+                        HasActionEquipped(Bozja.LostBravery) &&
+                        IsOffCooldown(Bozja.LostBravery) &&
+                        !HasEffect(Bozja.Buffs.LostBravery))
+                        return Bozja.LostBravery;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostProtect2) &&
+                        HasActionEquipped(Bozja.LostProtect2) &&
+                        IsOffCooldown(Bozja.LostProtect2) &&
+                        !HasEffect(Bozja.Buffs.LostProtect2))
+                        return Bozja.LostProtect2;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostShell2) &&
+                        HasActionEquipped(Bozja.LostShell2) &&
+                        IsOffCooldown(Bozja.LostShell2) &&
+                        !HasEffect(Bozja.Buffs.LostShell2))
+                        return Bozja.LostShell2;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBubble) &&
+                        HasActionEquipped(Bozja.LostBubble) &&
+                        IsOffCooldown(Bozja.LostBubble) &&
+                        !HasEffect(Bozja.Buffs.LostBubble))
+                        return Bozja.LostBubble;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostParalyze3) &&
+                        HasActionEquipped(Bozja.LostParalyze3) &&
+                        IsOffCooldown(Bozja.LostParalyze3) &&
+                        !JustUsed(Bozja.LostParalyze3, 60f))
+                        return Bozja.LostParalyze3;
+                }
+                #endregion
+
+                #region Rotation
+                //Ranged Uptime
+                if (LevelChecked(LightningShot) && //Lightning Shot is unlocked
+                    !InMeleeRange() && //Out of melee range
+                    HasBattleTarget()) //Has target
+                    return LightningShot; //Execute Lightning Shot if conditions are met
+
+                //No Mercy
+                if (ActionReady(NoMercy) && //No Mercy is ready
+                    InCombat() && //In combat
+                    HasTarget() && //Has target
+                    CanWeave()) //Able to weave
+                {
+                    if (LevelChecked(DoubleDown)) //Lv90+
+                    {
+                        if ((inOdd && //Odd Minute window
+                             (Ammo >= 2 || (ComboAction is BrutalShell && Ammo == 1))) || //2 or 3 Ammo or 1 Ammo with Solid Barrel next in combo
+                            (!inOdd && //Even Minute window
+                             Ammo != 3)) //Ammo is not full (3)
+                            return NoMercy; //Execute No Mercy if conditions are met
+                    }
+                    if (!LevelChecked(DoubleDown)) //Lv1-89
+                    {
+                        if (canLateWeave && //Late-weaveable
+                            Ammo == MaxCartridges()) //Ammo is full
+                            return NoMercy; //Execute No Mercy if conditions are met
+                    }
                 }
 
-                return actionID;
+                //Hypervelocity - Forced to prevent loss
+                if (JustUsed(BurstStrike, 5f) && //Burst Strike was just used within 5 seconds
+                    LevelChecked(Hypervelocity) && //Hypervelocity is unlocked
+                    HasEffect(Buffs.ReadyToBlast) && //Ready To Blast buff is active
+                    nmCD is > 1 or <= 0.1f) //Priority hack to prevent Hypervelocity from being used before No Mercy
+                    return Hypervelocity; //Execute Hypervelocity if conditions are met
+
+                //Continuation protection - Forced to prevent loss
+                if (canContinue && //able to use Continuation
+                    (HasEffect(Buffs.ReadyToRip) || //after Gnashing Fang
+                     HasEffect(Buffs.ReadyToTear) || //after Savage Claw
+                     HasEffect(Buffs.ReadyToGouge) || //after Wicked Talon
+                     HasEffect(Buffs.ReadyToBlast) || //after Burst Strike
+                     HasEffect(Buffs.ReadyToRaze))) //after Fated Circle
+                    return OriginalHook(Continuation); //Execute appopriate Continuation action if conditions are met
+
+                //oGCDs
+                if (CanWeave())
+                {
+                    //Bloodfest
+                    if (InCombat() && //In combat
+                        HasTarget() && //Has target
+                        canBF && //able to use Bloodfest
+                        Ammo == 0) //Only when ammo is empty
+                        return Bloodfest; //Execute Bloodfest if conditions are met
+
+                    //Zone
+                    if (canZone && //able to use Zone
+                        (nmCD is < 57.5f and > 17f))//Optimal use; twice per minute, 1 in NM, 1 out of NM
+                        return OriginalHook(DangerZone); //Execute Zone if conditions are met
+
+                    //Bow Shock
+                    if (canBow && //able to use Bow Shock
+                        nmCD is < 57.5f and >= 40) //No Mercy is up & was not just used within 1 GCD
+                        return BowShock;
+                }
+
+                //Lv90+ - every 3rd NM window
+                if (LevelChecked(DoubleDown) &&
+                    HasEffect(Buffs.NoMercy) &&
+                    GunStep == 0 &&
+                    ComboAction is BrutalShell &&
+                    Ammo == 1)
+                    return SolidBarrel;
+
+                //GnashingFang
+                if (canGF && //able to use Gnashing Fang
+                    ((nmCD is > 17 and < 35) || //30s Optimal use
+                     (JustUsed(NoMercy, 6f)))) //No Mercy was just used within 4 seconds
+                    return GnashingFang;
+
+                //Double Down
+                if (canDD && //able to use Double Down
+                    IsOnCooldown(GnashingFang) && //Gnashing Fang is on cooldown
+                    hasNM) //No Mercy is active
+                    return DoubleDown;
+
+                //Sonic Break
+                if (canBreak && //able to use Sonic Break
+                    ((IsOnCooldown(GnashingFang) && IsOnCooldown(DoubleDown)) || //Gnashing Fang and Double Down are both on cooldown
+                     nmLeft <= GCD)) //No Mercy buff is about to expire
+                    return SonicBreak; //Execute Sonic Break if conditions are met
+
+                //Reign of Beasts
+                if (canReign && //able to use Reign of Beasts
+                    IsOnCooldown(GnashingFang) && //Gnashing Fang is on cooldown
+                    IsOnCooldown(DoubleDown) && //Double Down is on cooldown
+                    !HasEffect(Buffs.ReadyToBreak) && //Ready To Break is not active
+                    GunStep == 0) //Gnashing Fang or Reign combo is not active or finished
+                    return OriginalHook(ReignOfBeasts); //Execute Reign of Beasts if conditions are met
+
+                //Burst Strike
+                if (canBS && //able to use Burst Strike
+                    HasEffect(Buffs.NoMercy) && //No Mercy is active
+                    IsOnCooldown(GnashingFang) && //Gnashing Fang is on cooldown
+                    IsOnCooldown(DoubleDown) && //Double Down is on cooldown
+                    !HasEffect(Buffs.ReadyToBreak) && //Ready To Break is not active
+                    !HasEffect(Buffs.ReadyToReign) && //Ready To Reign is not active
+                    GunStep == 0) //Gnashing Fang or Reign combo is not active or finished
+                    return BurstStrike; //Execute Burst Strike if conditions are met
+
+                //Lv90+ 2cart forced Opener
+                if (LevelChecked(DoubleDown) && //Lv90+
+                    nmCD < 1 && //No Mercy is ready or about to be
+                    Ammo is 3 && //Ammo is full
+                    bfCD > 110 && //Bloodfest was just used, but not recently
+                    ComboAction is KeenEdge) //Just used Keen Edge
+                    return BurstStrike;
+                //Lv100 2cart forced 2min starter
+                if (LevelChecked(ReignOfBeasts) && //Lv100
+                    (nmCD < 1 && //No Mercy is ready or about to be
+                     Ammo is 3 && //Ammo is full
+                     bfCD < GCD * 12)) //Bloodfest is ready or about to be
+                    return BurstStrike;
+
+                //Gauge Combo Steps
+                if (GunStep is 1 or 2) //Gnashing Fang combo is only for 1 and 2
+                    return OriginalHook(GnashingFang); //Execute Gnashing Fang combo if conditions are met
+                if (GunStep is 3 or 4) //Reign of Beasts combo is only for 3 and 4
+                    return OriginalHook(ReignOfBeasts); //Execute Reign of Beasts combo if conditions are met
+
+                //123 (overcap included)
+                if (ComboTimer > 0) //we're in combo
+                {
+                    if (LevelChecked(BrutalShell) && //Brutal Shell is unlocked
+                        ComboAction == KeenEdge) //just used first action in combo
+                        return BrutalShell; //Execute Brutal Shell if conditions are met
+
+                    if (LevelChecked(SolidBarrel) && //Solid Barrel is unlocked
+                        ComboAction == BrutalShell) //just used second action in combo
+                    {
+                        //holds Hypervelocity if NM comes up in time
+                        if (LevelChecked(Hypervelocity) && //Hypervelocity is unlocked
+                            HasEffect(Buffs.ReadyToBlast) && //Ready To Blast buff is active
+                            (nmCD is > 1 or <= 0.1f)) //Priority hack to prevent Hypervelocity from being used before No Mercy
+                            return Hypervelocity; //Execute Hypervelocity if conditions are met
+
+                        //Overcap protection
+                        if (LevelChecked(BurstStrike) && //Burst Strike is unlocked
+                            Ammo == MaxCartridges()) //Ammo is full relaive to level
+                            return BurstStrike; //Execute Burst Strike if conditions are met
+
+                        return SolidBarrel; //Execute Solid Barrel if conditions are met
+                    }
+                }
+                #endregion
+
+                return KeenEdge; //Always default back to Keen Edge
+
             }
         }
         #endregion
@@ -636,549 +634,547 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is KeenEdge)
+                if (actionID is not KeenEdge) return actionID;
+
+                #region Variables
+                //Gauge
+                var Ammo = GetJobGauge<GNBGauge>().Ammo; //Our cartridge count
+                var GunStep = GetJobGauge<GNBGauge>().AmmoComboStep; //For Gnashing Fang & Reign combo purposes
+                //Cooldown-related
+                var gfCD = GetCooldownRemainingTime(GnashingFang); //GnashingFang's cooldown; 30s total
+                var nmCD = GetCooldownRemainingTime(NoMercy); //NoMercy's cooldown; 60s total
+                var ddCD = GetCooldownRemainingTime(DoubleDown); //Double Down's cooldown; 60s total
+                var bfCD = GetCooldownRemainingTime(Bloodfest); //Bloodfest's cooldown; 120s total
+                var nmLeft = GetBuffRemainingTime(Buffs.NoMercy); //Remaining time for No Mercy buff (20s)
+                var hasNM = nmCD is >= 40 and <= 60; //Checks if No Mercy is active
+                var hasBreak = HasEffect(Buffs.ReadyToBreak); //Checks for Ready To Break buff
+                var hasReign = HasEffect(Buffs.ReadyToReign); //Checks for Ready To Reign buff
+                //Misc
+                var inOdd = bfCD is < 90 and > 20; //Odd Minute
+                var canLateWeave = GetCooldownRemainingTime(actionID) < 1 && GetCooldownRemainingTime(actionID) > 0.6; //SkS purposes
+                var GCD = GetCooldown(KeenEdge).CooldownTotal; //2.5 is base SkS, but can work with 2.4x
+                var nmStop = PluginConfiguration.GetCustomIntValue(Config.GNB_ST_NoMercyStop);
+                var justMitted = JustUsed(OriginalHook(HeartOfStone), 4f) ||
+                                 JustUsed(OriginalHook(Nebula), 5f) ||
+                                 JustUsed(Camouflage, 5f) ||
+                                 JustUsed(All.Rampart, 5f) ||
+                                 JustUsed(Aurora, 5f) ||
+                                 JustUsed(Superbolide, 9f);
+                #region Minimal Requirements
+                //Ammo-relative
+                var canBS = LevelChecked(BurstStrike) && //Burst Strike is unlocked
+                            Ammo > 0; //Has Ammo
+                var canGF = LevelChecked(GnashingFang) && //GnashingFang is unlocked
+                            gfCD < 0.6f && //Gnashing Fang is off cooldown
+                            !HasEffect(Buffs.ReadyToBlast) && //to ensure Hypervelocity is spent in case Burst Strike is used before Gnashing Fang
+                            GunStep == 0 && //Gnashing Fang or Reign combo is not already active
+                            Ammo > 0; //Has Ammo
+                var canDD = LevelChecked(DoubleDown) && //Double Down is unlocked
+                            ddCD < 0.6f && //Double Down is off cooldown
+                            Ammo > 0; //Has Ammo
+                var canBF = LevelChecked(Bloodfest) && //Bloodfest is unlocked
+                            bfCD < 0.6f; //Bloodfest is off cooldown
+                //Cooldown-relative
+                var canZone = LevelChecked(DangerZone) && //Zone is unlocked
+                              GetCooldownRemainingTime(OriginalHook(DangerZone)) < 0.6f; //DangerZone is off cooldown
+                var canBreak = LevelChecked(SonicBreak) && //Sonic Break is unlocked
+                               hasBreak; //No Mercy or Ready To Break is active
+                var canBow = LevelChecked(BowShock) && //Bow Shock is unlocked
+                             GetCooldownRemainingTime(BowShock) < 0.6f; //BowShock is off cooldown
+                var canContinue = LevelChecked(Continuation); //Continuation is unlocked
+                var canReign = LevelChecked(ReignOfBeasts) && //Reign of Beasts is unlocked
+                               GunStep == 0 && //Gnashing Fang or Reign combo is not already active
+                               hasReign; //Ready To Reign is active
+                #endregion
+                #endregion
+
+                if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Opener) &&
+                    Opener().FullOpener(ref actionID))
+                    return actionID;
+
+                #region Mitigations
+                if (IsEnabled(CustomComboPreset.GNB_ST_Mitigation) && //Mitigation option is enabled
+                    InCombat() && //Player is in combat
+                    !justMitted) //Player has not used a mitigation ability in the last 4-9 seconds
                 {
-                    #region Variables
-                    //Gauge
-                    var Ammo = GetJobGauge<GNBGauge>().Ammo; //Our cartridge count
-                    var GunStep = GetJobGauge<GNBGauge>().AmmoComboStep; //For Gnashing Fang & Reign combo purposes
-                    //Cooldown-related
-                    var gfCD = GetCooldownRemainingTime(GnashingFang); //GnashingFang's cooldown; 30s total
-                    var nmCD = GetCooldownRemainingTime(NoMercy); //NoMercy's cooldown; 60s total
-                    var ddCD = GetCooldownRemainingTime(DoubleDown); //Double Down's cooldown; 60s total
-                    var bfCD = GetCooldownRemainingTime(Bloodfest); //Bloodfest's cooldown; 120s total
-                    var nmLeft = GetBuffRemainingTime(Buffs.NoMercy); //Remaining time for No Mercy buff (20s)
-                    var hasNM = nmCD is >= 40 and <= 60; //Checks if No Mercy is active
-                    var hasBreak = HasEffect(Buffs.ReadyToBreak); //Checks for Ready To Break buff
-                    var hasReign = HasEffect(Buffs.ReadyToReign); //Checks for Ready To Reign buff
-                    //Misc
-                    var inOdd = bfCD is < 90 and > 20; //Odd Minute
-                    var canLateWeave = GetCooldownRemainingTime(actionID) < 1 && GetCooldownRemainingTime(actionID) > 0.6; //SkS purposes
-                    var GCD = GetCooldown(KeenEdge).CooldownTotal; //2.5 is base SkS, but can work with 2.4x
-                    var nmStop = PluginConfiguration.GetCustomIntValue(Config.GNB_ST_NoMercyStop);
-                    var justMitted = JustUsed(OriginalHook(HeartOfStone), 4f) ||
-                                      JustUsed(OriginalHook(Nebula), 5f) ||
-                                      JustUsed(Camouflage, 5f) ||
-                                      JustUsed(All.Rampart, 5f) ||
-                                      JustUsed(Aurora, 5f) ||
-                                      JustUsed(Superbolide, 9f);
-                    #region Minimal Requirements
-                    //Ammo-relative
-                    var canBS = LevelChecked(BurstStrike) && //Burst Strike is unlocked
-                                Ammo > 0; //Has Ammo
-                    var canGF = LevelChecked(GnashingFang) && //GnashingFang is unlocked
-                                gfCD < 0.6f && //Gnashing Fang is off cooldown
-                                !HasEffect(Buffs.ReadyToBlast) && //to ensure Hypervelocity is spent in case Burst Strike is used before Gnashing Fang
-                                GunStep == 0 && //Gnashing Fang or Reign combo is not already active
-                                Ammo > 0; //Has Ammo
-                    var canDD = LevelChecked(DoubleDown) && //Double Down is unlocked
-                                ddCD < 0.6f && //Double Down is off cooldown
-                                Ammo > 0; //Has Ammo
-                    var canBF = LevelChecked(Bloodfest) && //Bloodfest is unlocked
-                                bfCD < 0.6f; //Bloodfest is off cooldown
-                    //Cooldown-relative
-                    var canZone = LevelChecked(DangerZone) && //Zone is unlocked
-                                GetCooldownRemainingTime(OriginalHook(DangerZone)) < 0.6f; //DangerZone is off cooldown
-                    var canBreak = LevelChecked(SonicBreak) && //Sonic Break is unlocked
-                                hasBreak; //No Mercy or Ready To Break is active
-                    var canBow = LevelChecked(BowShock) && //Bow Shock is unlocked
-                                GetCooldownRemainingTime(BowShock) < 0.6f; //BowShock is off cooldown
-                    var canContinue = LevelChecked(Continuation); //Continuation is unlocked
-                    var canReign = LevelChecked(ReignOfBeasts) && //Reign of Beasts is unlocked
-                                GunStep == 0 && //Gnashing Fang or Reign combo is not already active
-                                hasReign; //Ready To Reign is active
-                    #endregion
-                    #endregion
+                    //Superbolide
+                    if (IsEnabled(CustomComboPreset.GNB_ST_Superbolide) && //Superbolide option is enabled
+                        ActionReady(Superbolide) && //Superbolide is ready
+                        PlayerHealthPercentageHp() < Config.GNB_ST_Superbolide_Health && //Player's health is below selected threshold
+                        (Config.GNB_ST_Superbolide_SubOption == 0 || //Superbolide is enabled for all targets
+                         (TargetIsBoss() && Config.GNB_ST_Superbolide_SubOption == 1))) //Superbolide is enabled for bosses only
+                        return Superbolide;
 
-                    if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Opener) &&
-                        Opener().FullOpener(ref actionID))
-                        return actionID;
-
-                    #region Mitigations
-                    if (IsEnabled(CustomComboPreset.GNB_ST_Mitigation) && //Mitigation option is enabled
-                        InCombat() && //Player is in combat
-                        !justMitted) //Player has not used a mitigation ability in the last 4-9 seconds
+                    if (IsPlayerTargeted()) //Player is being targeted by current target
                     {
-                        //Superbolide
-                        if (IsEnabled(CustomComboPreset.GNB_ST_Superbolide) && //Superbolide option is enabled
-                            ActionReady(Superbolide) && //Superbolide is ready
-                            PlayerHealthPercentageHp() < Config.GNB_ST_Superbolide_Health && //Player's health is below selected threshold
-                            (Config.GNB_ST_Superbolide_SubOption == 0 || //Superbolide is enabled for all targets
-                            (TargetIsBoss() && Config.GNB_ST_Superbolide_SubOption == 1))) //Superbolide is enabled for bosses only
-                            return Superbolide;
+                        //Nebula
+                        if (IsEnabled(CustomComboPreset.GNB_ST_Nebula) && //Nebula option is enabled
+                            ActionReady(OriginalHook(Nebula)) && //Nebula is ready
+                            PlayerHealthPercentageHp() < Config.GNB_ST_Nebula_Health && //Player's health is below selected threshold
+                            (Config.GNB_ST_Nebula_SubOption == 0 || //Nebula is enabled for all targets
+                             (TargetIsBoss() && Config.GNB_ST_Nebula_SubOption == 1))) //Nebula is enabled for bosses only
+                            return OriginalHook(Nebula);
 
-                        if (IsPlayerTargeted()) //Player is being targeted by current target
-                        {
-                            //Nebula
-                            if (IsEnabled(CustomComboPreset.GNB_ST_Nebula) && //Nebula option is enabled
-                                ActionReady(OriginalHook(Nebula)) && //Nebula is ready
-                                PlayerHealthPercentageHp() < Config.GNB_ST_Nebula_Health && //Player's health is below selected threshold
-                                (Config.GNB_ST_Nebula_SubOption == 0 || //Nebula is enabled for all targets
-                                (TargetIsBoss() && Config.GNB_ST_Nebula_SubOption == 1))) //Nebula is enabled for bosses only
-                                return OriginalHook(Nebula);
+                        //Rampart
+                        if (IsEnabled(CustomComboPreset.GNB_ST_Rampart) && //Rampart option is enabled
+                            ActionReady(All.Rampart) && //Rampart is ready
+                            PlayerHealthPercentageHp() < Config.GNB_ST_Rampart_Health && //Player's health is below selected threshold
+                            (Config.GNB_ST_Rampart_SubOption == 0 || //Rampart is enabled for all targets
+                             (TargetIsBoss() && Config.GNB_ST_Rampart_SubOption == 1))) //Rampart is enabled for bosses only
+                            return All.Rampart;
 
-                            //Rampart
-                            if (IsEnabled(CustomComboPreset.GNB_ST_Rampart) && //Rampart option is enabled
-                                ActionReady(All.Rampart) && //Rampart is ready
-                                PlayerHealthPercentageHp() < Config.GNB_ST_Rampart_Health && //Player's health is below selected threshold
-                                (Config.GNB_ST_Rampart_SubOption == 0 || //Rampart is enabled for all targets
-                                (TargetIsBoss() && Config.GNB_ST_Rampart_SubOption == 1))) //Rampart is enabled for bosses only
-                                return All.Rampart;
+                        //Reprisal
+                        if (IsEnabled(CustomComboPreset.GNB_ST_Reprisal) && //Reprisal option is enabled
+                            ActionReady(All.Reprisal) && //Reprisal is ready
+                            InActionRange(All.Reprisal) && //Player is in range of Reprisal
+                            PlayerHealthPercentageHp() < Config.GNB_ST_Reprisal_Health && //Player's health is below selected threshold
+                            (Config.GNB_ST_Reprisal_SubOption == 0 || //Reprisal is enabled for all targets
+                             (TargetIsBoss() && Config.GNB_ST_Reprisal_SubOption == 1))) //Reprisal is enabled for bosses only
+                            return All.Reprisal;
 
-                            //Reprisal
-                            if (IsEnabled(CustomComboPreset.GNB_ST_Reprisal) && //Reprisal option is enabled
-                                ActionReady(All.Reprisal) && //Reprisal is ready
-                                InActionRange(All.Reprisal) && //Player is in range of Reprisal
-                                PlayerHealthPercentageHp() < Config.GNB_ST_Reprisal_Health && //Player's health is below selected threshold
-                                (Config.GNB_ST_Reprisal_SubOption == 0 || //Reprisal is enabled for all targets
-                                (TargetIsBoss() && Config.GNB_ST_Reprisal_SubOption == 1))) //Reprisal is enabled for bosses only
-                                return All.Reprisal;
-
-                            //Arms Length
-                            if (IsEnabled(CustomComboPreset.GNB_ST_ArmsLength) && //Arms Length option is enabled
-                                ActionReady(All.ArmsLength) && //Arms Length is ready
-                                PlayerHealthPercentageHp() < Config.GNB_ST_ArmsLength_Health && //Player's health is below selected threshold
-                                !InBossEncounter()) //Arms Length is enabled for bosses only
-                                return All.ArmsLength;
-                        }
-
-                        //Camouflage
-                        if (IsEnabled(CustomComboPreset.GNB_ST_Camouflage) && //Camouflage option is enabled
-                            ActionReady(Camouflage) && //Camouflage is ready
-                            PlayerHealthPercentageHp() < Config.GNB_ST_Camouflage_Health && //Player's health is below selected threshold
-                            (Config.GNB_ST_Camouflage_SubOption == 0 || //Camouflage is enabled for all targets
-                            (TargetIsBoss() && Config.GNB_ST_Camouflage_SubOption == 1))) //Camouflage is enabled for bosses only
-                            return Camouflage;
-
-                        //Corundum
-                        if (IsEnabled(CustomComboPreset.GNB_ST_Corundum) && //Corundum option is enabled
-                            ActionReady(OriginalHook(HeartOfStone)) && //Corundum is ready
-                            PlayerHealthPercentageHp() < Config.GNB_ST_Corundum_Health && //Player's health is below selected threshold
-                            (Config.GNB_ST_Corundum_SubOption == 0 || //Corundum is enabled for all targets
-                            (TargetIsBoss() && Config.GNB_ST_Corundum_SubOption == 1))) //Corundum is enabled for bosses only
-                            return OriginalHook(HeartOfStone);
-
-                        //Aurora
-                        if (IsEnabled(CustomComboPreset.GNB_ST_Aurora) && //Aurora option is enabled
-                            ActionReady(Aurora) && //Aurora is ready
-                            ((HasFriendlyTarget() && TargetHasEffectAny(Buffs.Aurora)) || (!HasFriendlyTarget() && HasEffectAny(Buffs.Aurora))) && //Aurora is not active on self or target
-                            GetRemainingCharges(Aurora) > Config.GNB_ST_Aurora_Charges && //Aurora has more charges than set threshold
-                            PlayerHealthPercentageHp() < Config.GNB_ST_Aurora_Health && //Player's health is below selected threshold
-                            (Config.GNB_ST_Aurora_SubOption == 0 || //Aurora is enabled for all targets
-                            (TargetIsBoss() && Config.GNB_ST_Aurora_SubOption == 1))) //Aurora is enabled for bosses only
-                            return Aurora;
-                    }
-                    #endregion
-
-                    #region Variant
-                    //Variant Cure
-                    if (IsEnabled(CustomComboPreset.GNB_Variant_Cure) && IsEnabled(Variant.VariantCure)
-                        && PlayerHealthPercentageHp() <= GetOptionValue(Config.GNB_VariantCure))
-                        return Variant.VariantCure;
-
-                    //Variant SpiritDart
-                    Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
-                    if (IsEnabled(CustomComboPreset.GNB_Variant_SpiritDart) &&
-                        IsEnabled(Variant.VariantSpiritDart) &&
-                        CanWeave() &&
-                        (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
-                        return Variant.VariantSpiritDart;
-
-                    //Variant Ultimatum
-                    if (IsEnabled(CustomComboPreset.GNB_Variant_Ultimatum) &&
-                        IsEnabled(Variant.VariantUltimatum) &&
-                        CanWeave() &&
-                        ActionReady(Variant.VariantUltimatum))
-                        return Variant.VariantUltimatum;
-                    #endregion 
-
-                    #region Bozja
-                    if (Bozja.IsInBozja) //Checks if we're inside Bozja instances
-                    {
-                        //oGCDs
-                        if (CanWeave())
-                        {
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFocus) && //Lost Focus is enabled
-                                GetBuffStacks(Bozja.Buffs.Boost) < 16) //Boost stacks are below 16
-                                return Bozja.LostFocus;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFontOfPower) && //Lost Font of Power is enabled
-                                IsOffCooldown(Bozja.LostFontOfPower)) //Lost Focus was not just used within 30 seconds
-                                return Bozja.LostFontOfPower;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSlash) &&
-                                IsOffCooldown(Bozja.LostSlash))
-                                return Bozja.LostSlash;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfNobleEnds))
-                            {
-                                if (!IsEnabled(CustomComboPreset.GNB_Bozja_PowerEnds) &&
-                                    IsOffCooldown(Bozja.BannerOfNobleEnds))
-                                    return Bozja.BannerOfNobleEnds;
-                                if (IsEnabled(CustomComboPreset.GNB_Bozja_PowerEnds) &&
-                                    IsOffCooldown(Bozja.BannerOfNobleEnds) &&
-                                    JustUsed(Bozja.LostFontOfPower, 5f))
-                                    return Bozja.BannerOfNobleEnds;
-                            }
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfHonoredSacrifice))
-                            {
-                                if (!IsEnabled(CustomComboPreset.GNB_Bozja_PowerSacrifice) &&
-                                    IsOffCooldown(Bozja.BannerOfHonoredSacrifice))
-                                    return Bozja.BannerOfHonoredSacrifice;
-                                if (IsEnabled(CustomComboPreset.GNB_Bozja_PowerSacrifice) &&
-                                    IsOffCooldown(Bozja.BannerOfHonoredSacrifice) &&
-                                    JustUsed(Bozja.LostFontOfPower, 5f))
-                                    return Bozja.BannerOfHonoredSacrifice;
-                            }
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfHonedAcuity) &&
-                                IsOffCooldown(Bozja.BannerOfHonedAcuity) &&
-                                !HasEffect(Bozja.Buffs.BannerOfTranscendentFinesse))
-                                return Bozja.BannerOfHonedAcuity;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFairTrade) &&
-                                IsOffCooldown(Bozja.LostFairTrade))
-                                return Bozja.LostFairTrade;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostAssassination) &&
-                                IsOffCooldown(Bozja.LostAssassination))
-                                return Bozja.LostAssassination;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostManawall) &&
-                                IsOffCooldown(Bozja.LostManawall))
-                                return Bozja.LostManawall;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfTirelessConviction) &&
-                                IsOffCooldown(Bozja.BannerOfTirelessConviction) &&
-                                !HasEffect(Bozja.Buffs.BannerOfUnyieldingDefense))
-                                return Bozja.BannerOfTirelessConviction;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBloodRage) &&
-                                IsOffCooldown(Bozja.LostBloodRage))
-                                return Bozja.LostBloodRage;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfSolemnClarity) &&
-                                IsOffCooldown(Bozja.BannerOfSolemnClarity) &&
-                                !HasEffect(Bozja.Buffs.BannerOfLimitlessGrace))
-                                return Bozja.BannerOfSolemnClarity;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure2) &&
-                                IsOffCooldown(Bozja.LostCure2) &&
-                                PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure2_Health)
-                                return Bozja.LostCure2;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure4) &&
-                                IsOffCooldown(Bozja.LostCure4) &&
-                                PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure4_Health)
-                                return Bozja.LostCure4;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostReflect) &&
-                                IsOffCooldown(Bozja.LostReflect) &&
-                                !HasEffect(Bozja.Buffs.LostReflect))
-                                return Bozja.LostReflect;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostAethershield) &&
-                                IsOffCooldown(Bozja.LostAethershield) &&
-                                !HasEffect(Bozja.Buffs.LostAethershield) &&
-                                PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostAethershield_Health)
-                                return Bozja.LostAethershield;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSwift) &&
-                                IsOffCooldown(Bozja.LostSwift) &&
-                                !HasEffect(Bozja.Buffs.LostSwift))
-                                return Bozja.LostSwift;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFontOfSkill) &&
-                                IsOffCooldown(Bozja.LostFontOfSkill))
-                                return Bozja.LostFontOfSkill;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostRampage) &&
-                                IsOffCooldown(Bozja.LostRampage))
-                                return Bozja.LostRampage;
-                        }
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostStealth) &&
-                            !InCombat() &&
-                            IsOffCooldown(Bozja.LostStealth))
-                            return Bozja.LostStealth;
-
-                        //GCDs
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostDeath) &&
-                            IsOffCooldown(Bozja.LostDeath))
-                            return Bozja.LostDeath;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure) &&
-                            IsOffCooldown(Bozja.LostCure) &&
-                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure_Health)
-                            return Bozja.LostCure;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure3) &&
-                            IsOffCooldown(Bozja.LostCure3) &&
-                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure3_Health)
-                            return Bozja.LostCure3;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostArise) &&
-                            IsOffCooldown(Bozja.LostArise) &&
-                            GetTargetHPPercent() == 0 &&
-                            !HasEffect(All.Debuffs.Raise))
-                            return Bozja.LostArise;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSacrifice) &&
-                            IsOffCooldown(Bozja.LostSacrifice) &&
-                            GetTargetHPPercent() == 0)
-                            return Bozja.LostSacrifice;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostReraise) &&
-                            IsOffCooldown(Bozja.LostReraise) &&
-                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostReraise_Health)
-                            return Bozja.LostReraise;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSpellforge) &&
-                            IsOffCooldown(Bozja.LostSpellforge) &&
-                            (!HasEffect(Bozja.Buffs.LostSpellforge) || !HasEffect(Bozja.Buffs.LostSteelsting)))
-                            return Bozja.LostSpellforge;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSteelsting) &&
-                            IsOffCooldown(Bozja.LostSteelsting) &&
-                            (!HasEffect(Bozja.Buffs.LostSpellforge) || !HasEffect(Bozja.Buffs.LostSteelsting)))
-                            return Bozja.LostSteelsting;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostProtect) &&
-                            IsOffCooldown(Bozja.LostProtect) &&
-                            !HasEffect(Bozja.Buffs.LostProtect))
-                            return Bozja.LostProtect;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostShell) &&
-                            IsOffCooldown(Bozja.LostShell) &&
-                            !HasEffect(Bozja.Buffs.LostShell))
-                            return Bozja.LostShell;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBravery) &&
-                            IsOffCooldown(Bozja.LostBravery) &&
-                            !HasEffect(Bozja.Buffs.LostBravery))
-                            return Bozja.LostBravery;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostProtect2) &&
-                            IsOffCooldown(Bozja.LostProtect2) &&
-                            !HasEffect(Bozja.Buffs.LostProtect2))
-                            return Bozja.LostProtect2;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostShell2) &&
-                            IsOffCooldown(Bozja.LostShell2) &&
-                            !HasEffect(Bozja.Buffs.LostShell2))
-                            return Bozja.LostShell2;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBubble) &&
-                            IsOffCooldown(Bozja.LostBubble) &&
-                            !HasEffect(Bozja.Buffs.LostBubble))
-                            return Bozja.LostBubble;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostParalyze3) &&
-                            IsOffCooldown(Bozja.LostParalyze3) &&
-                            !JustUsed(Bozja.LostParalyze3, 60f))
-                            return Bozja.LostParalyze3;
-                    }
-                    #endregion
-
-                    #region Rotation
-                    //Ranged Uptime
-                    if (IsEnabled(CustomComboPreset.GNB_ST_RangedUptime) && //Ranged Uptime option is enabled
-                        LevelChecked(LightningShot) && //Lightning Shot is unlocked
-                        !InMeleeRange() && //Out of melee range
-                        HasBattleTarget()) //Has target
-                        return LightningShot; //Execute Lightning Shot if conditions are met
-
-                    //No Mercy
-                    if (IsEnabled(CustomComboPreset.GNB_ST_NoMercy) && //No Mercy option is enabled
-                        ActionReady(NoMercy) && //No Mercy is ready
-                        InCombat() && //In combat
-                        HasTarget() && //Has target
-                        CanWeave() && //Able to weave
-                        GetTargetHPPercent() >= nmStop) //target HP is above threshold
-                    {
-                        if (LevelChecked(DoubleDown)) //Lv90+
-                        {
-                            if ((inOdd && //Odd Minute window
-                                (Ammo >= 2 || (ComboAction is BrutalShell && Ammo == 1))) || //2 or 3 Ammo or 1 Ammo with Solid Barrel next in combo
-                                (!inOdd && //Even Minute window
-                                Ammo != 3)) //Ammo is not full (3)
-                                return NoMercy; //Execute No Mercy if conditions are met
-                        }
-                        if (!LevelChecked(DoubleDown)) //Lv1-89
-                        {
-                            if (canLateWeave && //Late-weaveable
-                                Ammo == MaxCartridges()) //Ammo is full
-                                return NoMercy; //Execute No Mercy if conditions are met
-                        }
+                        //Arms Length
+                        if (IsEnabled(CustomComboPreset.GNB_ST_ArmsLength) && //Arms Length option is enabled
+                            ActionReady(All.ArmsLength) && //Arms Length is ready
+                            PlayerHealthPercentageHp() < Config.GNB_ST_ArmsLength_Health && //Player's health is below selected threshold
+                            !InBossEncounter()) //Arms Length is enabled for bosses only
+                            return All.ArmsLength;
                     }
 
-                    //Hypervelocity - Forced to prevent loss
-                    if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Cooldowns) && //Cooldowns option is enabled
-                        IsEnabled(CustomComboPreset.GNB_ST_Continuation) && //Continuation option is enabled
-                        JustUsed(BurstStrike, 5f) && //Burst Strike was just used within 5 seconds
-                        LevelChecked(Hypervelocity) && //Hypervelocity is unlocked
-                        HasEffect(Buffs.ReadyToBlast) && //Ready To Blast buff is active
-                        (IsEnabled(CustomComboPreset.GNB_ST_NoMercy) && //No Mercy option is enabled
-                        nmCD is > 1 or <= 0.1f)) //Priority hack to prevent Hypervelocity from being used before No Mercy
-                        return Hypervelocity; //Execute Hypervelocity if conditions are met
+                    //Camouflage
+                    if (IsEnabled(CustomComboPreset.GNB_ST_Camouflage) && //Camouflage option is enabled
+                        ActionReady(Camouflage) && //Camouflage is ready
+                        PlayerHealthPercentageHp() < Config.GNB_ST_Camouflage_Health && //Player's health is below selected threshold
+                        (Config.GNB_ST_Camouflage_SubOption == 0 || //Camouflage is enabled for all targets
+                         (TargetIsBoss() && Config.GNB_ST_Camouflage_SubOption == 1))) //Camouflage is enabled for bosses only
+                        return Camouflage;
 
-                    //Continuation protection - Forced to prevent loss
-                    if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Cooldowns) && //Cooldowns option is enabled
-                        IsEnabled(CustomComboPreset.GNB_ST_Continuation) && //Continuation option is enabled
-                        canContinue && //able to use Continuation
-                        (HasEffect(Buffs.ReadyToRip) || //after Gnashing Fang
-                        HasEffect(Buffs.ReadyToTear) || //after Savage Claw
-                        HasEffect(Buffs.ReadyToGouge) || //after Wicked Talon
-                        HasEffect(Buffs.ReadyToBlast) || //after Burst Strike
-                        HasEffect(Buffs.ReadyToRaze))) //after Fated Circle
-                        return OriginalHook(Continuation); //Execute appopriate Continuation action if conditions are met
+                    //Corundum
+                    if (IsEnabled(CustomComboPreset.GNB_ST_Corundum) && //Corundum option is enabled
+                        ActionReady(OriginalHook(HeartOfStone)) && //Corundum is ready
+                        PlayerHealthPercentageHp() < Config.GNB_ST_Corundum_Health && //Player's health is below selected threshold
+                        (Config.GNB_ST_Corundum_SubOption == 0 || //Corundum is enabled for all targets
+                         (TargetIsBoss() && Config.GNB_ST_Corundum_SubOption == 1))) //Corundum is enabled for bosses only
+                        return OriginalHook(HeartOfStone);
 
+                    //Aurora
+                    if (IsEnabled(CustomComboPreset.GNB_ST_Aurora) && //Aurora option is enabled
+                        ActionReady(Aurora) && //Aurora is ready
+                        ((HasFriendlyTarget() && TargetHasEffectAny(Buffs.Aurora)) || (!HasFriendlyTarget() && HasEffectAny(Buffs.Aurora))) && //Aurora is not active on self or target
+                        GetRemainingCharges(Aurora) > Config.GNB_ST_Aurora_Charges && //Aurora has more charges than set threshold
+                        PlayerHealthPercentageHp() < Config.GNB_ST_Aurora_Health && //Player's health is below selected threshold
+                        (Config.GNB_ST_Aurora_SubOption == 0 || //Aurora is enabled for all targets
+                         (TargetIsBoss() && Config.GNB_ST_Aurora_SubOption == 1))) //Aurora is enabled for bosses only
+                        return Aurora;
+                }
+                #endregion
+
+                #region Variant
+                //Variant Cure
+                if (IsEnabled(CustomComboPreset.GNB_Variant_Cure) && IsEnabled(Variant.VariantCure)
+                    && PlayerHealthPercentageHp() <= GetOptionValue(Config.GNB_VariantCure))
+                    return Variant.VariantCure;
+
+                //Variant SpiritDart
+                Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+                if (IsEnabled(CustomComboPreset.GNB_Variant_SpiritDart) &&
+                    IsEnabled(Variant.VariantSpiritDart) &&
+                    CanWeave() &&
+                    (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
+                    return Variant.VariantSpiritDart;
+
+                //Variant Ultimatum
+                if (IsEnabled(CustomComboPreset.GNB_Variant_Ultimatum) &&
+                    IsEnabled(Variant.VariantUltimatum) &&
+                    CanWeave() &&
+                    ActionReady(Variant.VariantUltimatum))
+                    return Variant.VariantUltimatum;
+                #endregion
+
+                #region Bozja
+                if (Bozja.IsInBozja) //Checks if we're inside Bozja instances
+                {
                     //oGCDs
                     if (CanWeave())
                     {
-                        //Cooldowns
-                        if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Cooldowns)) //Cooldowns option is enabled
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFocus) && //Lost Focus is enabled
+                            GetBuffStacks(Bozja.Buffs.Boost) < 16) //Boost stacks are below 16
+                            return Bozja.LostFocus;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFontOfPower) && //Lost Font of Power is enabled
+                            IsOffCooldown(Bozja.LostFontOfPower)) //Lost Focus was not just used within 30 seconds
+                            return Bozja.LostFontOfPower;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSlash) &&
+                            IsOffCooldown(Bozja.LostSlash))
+                            return Bozja.LostSlash;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfNobleEnds))
                         {
-                            //Bloodfest
-                            if (IsEnabled(CustomComboPreset.GNB_ST_Bloodfest) && //Bloodfest option is enabled
-                                InCombat() && //In combat
-                                HasTarget() && //Has target
-                                canBF && //able to use Bloodfest
-                                Ammo == 0) //Only when ammo is empty
-                                return Bloodfest; //Execute Bloodfest if conditions are met
-
-                            //Zone
-                            if (IsEnabled(CustomComboPreset.GNB_ST_Zone) && //Zone option is enabled
-                                canZone && //able to use Zone
-                                (nmCD is < 57.5f and > 17f))//Optimal use; twice per minute, 1 in NM, 1 out of NM
-                                return OriginalHook(DangerZone); //Execute Zone if conditions are met
-
-                            //Bow Shock
-                            if (IsEnabled(CustomComboPreset.GNB_ST_BowShock) && //Bow Shock option is enabled
-                                canBow && //able to use Bow Shock
-                                nmCD is < 57.5f and >= 40) //No Mercy is up & was not just used within 1 GCD
-                                return BowShock;
+                            if (!IsEnabled(CustomComboPreset.GNB_Bozja_PowerEnds) &&
+                                IsOffCooldown(Bozja.BannerOfNobleEnds))
+                                return Bozja.BannerOfNobleEnds;
+                            if (IsEnabled(CustomComboPreset.GNB_Bozja_PowerEnds) &&
+                                IsOffCooldown(Bozja.BannerOfNobleEnds) &&
+                                JustUsed(Bozja.LostFontOfPower, 5f))
+                                return Bozja.BannerOfNobleEnds;
                         }
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfHonoredSacrifice))
+                        {
+                            if (!IsEnabled(CustomComboPreset.GNB_Bozja_PowerSacrifice) &&
+                                IsOffCooldown(Bozja.BannerOfHonoredSacrifice))
+                                return Bozja.BannerOfHonoredSacrifice;
+                            if (IsEnabled(CustomComboPreset.GNB_Bozja_PowerSacrifice) &&
+                                IsOffCooldown(Bozja.BannerOfHonoredSacrifice) &&
+                                JustUsed(Bozja.LostFontOfPower, 5f))
+                                return Bozja.BannerOfHonoredSacrifice;
+                        }
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfHonedAcuity) &&
+                            IsOffCooldown(Bozja.BannerOfHonedAcuity) &&
+                            !HasEffect(Bozja.Buffs.BannerOfTranscendentFinesse))
+                            return Bozja.BannerOfHonedAcuity;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFairTrade) &&
+                            IsOffCooldown(Bozja.LostFairTrade))
+                            return Bozja.LostFairTrade;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostAssassination) &&
+                            IsOffCooldown(Bozja.LostAssassination))
+                            return Bozja.LostAssassination;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostManawall) &&
+                            IsOffCooldown(Bozja.LostManawall))
+                            return Bozja.LostManawall;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfTirelessConviction) &&
+                            IsOffCooldown(Bozja.BannerOfTirelessConviction) &&
+                            !HasEffect(Bozja.Buffs.BannerOfUnyieldingDefense))
+                            return Bozja.BannerOfTirelessConviction;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBloodRage) &&
+                            IsOffCooldown(Bozja.LostBloodRage))
+                            return Bozja.LostBloodRage;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfSolemnClarity) &&
+                            IsOffCooldown(Bozja.BannerOfSolemnClarity) &&
+                            !HasEffect(Bozja.Buffs.BannerOfLimitlessGrace))
+                            return Bozja.BannerOfSolemnClarity;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure2) &&
+                            IsOffCooldown(Bozja.LostCure2) &&
+                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure2_Health)
+                            return Bozja.LostCure2;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure4) &&
+                            IsOffCooldown(Bozja.LostCure4) &&
+                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure4_Health)
+                            return Bozja.LostCure4;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostReflect) &&
+                            IsOffCooldown(Bozja.LostReflect) &&
+                            !HasEffect(Bozja.Buffs.LostReflect))
+                            return Bozja.LostReflect;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostAethershield) &&
+                            IsOffCooldown(Bozja.LostAethershield) &&
+                            !HasEffect(Bozja.Buffs.LostAethershield) &&
+                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostAethershield_Health)
+                            return Bozja.LostAethershield;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSwift) &&
+                            IsOffCooldown(Bozja.LostSwift) &&
+                            !HasEffect(Bozja.Buffs.LostSwift))
+                            return Bozja.LostSwift;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFontOfSkill) &&
+                            IsOffCooldown(Bozja.LostFontOfSkill))
+                            return Bozja.LostFontOfSkill;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostRampage) &&
+                            IsOffCooldown(Bozja.LostRampage))
+                            return Bozja.LostRampage;
                     }
 
-                    //Lv90+ - every 3rd NM window
-                    if (LevelChecked(DoubleDown) &&
-                        HasEffect(Buffs.NoMercy) &&
-                        GunStep == 0 &&
-                        ComboAction is BrutalShell &&
-                        Ammo == 1)
-                        return SolidBarrel;
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostStealth) &&
+                        !InCombat() &&
+                        IsOffCooldown(Bozja.LostStealth))
+                        return Bozja.LostStealth;
 
                     //GCDs
-                    if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Cooldowns)) //Cooldowns option is enabled
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostDeath) &&
+                        IsOffCooldown(Bozja.LostDeath))
+                        return Bozja.LostDeath;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure) &&
+                        IsOffCooldown(Bozja.LostCure) &&
+                        PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure_Health)
+                        return Bozja.LostCure;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure3) &&
+                        IsOffCooldown(Bozja.LostCure3) &&
+                        PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure3_Health)
+                        return Bozja.LostCure3;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostArise) &&
+                        IsOffCooldown(Bozja.LostArise) &&
+                        GetTargetHPPercent() == 0 &&
+                        !HasEffect(All.Debuffs.Raise))
+                        return Bozja.LostArise;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSacrifice) &&
+                        IsOffCooldown(Bozja.LostSacrifice) &&
+                        GetTargetHPPercent() == 0)
+                        return Bozja.LostSacrifice;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostReraise) &&
+                        IsOffCooldown(Bozja.LostReraise) &&
+                        PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostReraise_Health)
+                        return Bozja.LostReraise;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSpellforge) &&
+                        IsOffCooldown(Bozja.LostSpellforge) &&
+                        (!HasEffect(Bozja.Buffs.LostSpellforge) || !HasEffect(Bozja.Buffs.LostSteelsting)))
+                        return Bozja.LostSpellforge;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSteelsting) &&
+                        IsOffCooldown(Bozja.LostSteelsting) &&
+                        (!HasEffect(Bozja.Buffs.LostSpellforge) || !HasEffect(Bozja.Buffs.LostSteelsting)))
+                        return Bozja.LostSteelsting;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostProtect) &&
+                        IsOffCooldown(Bozja.LostProtect) &&
+                        !HasEffect(Bozja.Buffs.LostProtect))
+                        return Bozja.LostProtect;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostShell) &&
+                        IsOffCooldown(Bozja.LostShell) &&
+                        !HasEffect(Bozja.Buffs.LostShell))
+                        return Bozja.LostShell;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBravery) &&
+                        IsOffCooldown(Bozja.LostBravery) &&
+                        !HasEffect(Bozja.Buffs.LostBravery))
+                        return Bozja.LostBravery;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostProtect2) &&
+                        IsOffCooldown(Bozja.LostProtect2) &&
+                        !HasEffect(Bozja.Buffs.LostProtect2))
+                        return Bozja.LostProtect2;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostShell2) &&
+                        IsOffCooldown(Bozja.LostShell2) &&
+                        !HasEffect(Bozja.Buffs.LostShell2))
+                        return Bozja.LostShell2;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBubble) &&
+                        IsOffCooldown(Bozja.LostBubble) &&
+                        !HasEffect(Bozja.Buffs.LostBubble))
+                        return Bozja.LostBubble;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostParalyze3) &&
+                        IsOffCooldown(Bozja.LostParalyze3) &&
+                        !JustUsed(Bozja.LostParalyze3, 60f))
+                        return Bozja.LostParalyze3;
+                }
+                #endregion
+
+                #region Rotation
+                //Ranged Uptime
+                if (IsEnabled(CustomComboPreset.GNB_ST_RangedUptime) && //Ranged Uptime option is enabled
+                    LevelChecked(LightningShot) && //Lightning Shot is unlocked
+                    !InMeleeRange() && //Out of melee range
+                    HasBattleTarget()) //Has target
+                    return LightningShot; //Execute Lightning Shot if conditions are met
+
+                //No Mercy
+                if (IsEnabled(CustomComboPreset.GNB_ST_NoMercy) && //No Mercy option is enabled
+                    ActionReady(NoMercy) && //No Mercy is ready
+                    InCombat() && //In combat
+                    HasTarget() && //Has target
+                    CanWeave() && //Able to weave
+                    GetTargetHPPercent() >= nmStop) //target HP is above threshold
+                {
+                    if (LevelChecked(DoubleDown)) //Lv90+
                     {
-                        //GnashingFang
-                        if (IsEnabled(CustomComboPreset.GNB_ST_GnashingFang) && //Gnashing Fang option is enabled
-                            canGF && //able to use Gnashing Fang
-                            ((nmCD is > 17 and < 35) || //30s Optimal use
-                            (JustUsed(NoMercy, 6f)))) //No Mercy was just used within 4 seconds
-                            return GnashingFang;
-
-                        //Double Down
-                        if (IsEnabled(CustomComboPreset.GNB_ST_DoubleDown) && //Double Down option is enabled
-                            canDD && //able to use Double Down
-                            IsOnCooldown(GnashingFang) && //Gnashing Fang is on cooldown
-                            hasNM) //No Mercy is active
-                            return DoubleDown;
-
-                        //Sonic Break
-                        if (IsEnabled(CustomComboPreset.GNB_ST_SonicBreak) && //Sonic Break option is enabled
-                            canBreak && //able to use Sonic Break
-                            ((IsOnCooldown(GnashingFang) && IsOnCooldown(DoubleDown)) || //Gnashing Fang and Double Down are both on cooldown
-                            nmLeft <= GCD)) //No Mercy buff is about to expire
-                            return SonicBreak; //Execute Sonic Break if conditions are met
-
-                        //Reign of Beasts
-                        if (IsEnabled(CustomComboPreset.GNB_ST_Reign) && //Reign of Beasts option is enabled
-                            canReign && //able to use Reign of Beasts
-                            IsOnCooldown(GnashingFang) && //Gnashing Fang is on cooldown
-                            IsOnCooldown(DoubleDown) && //Double Down is on cooldown
-                            !HasEffect(Buffs.ReadyToBreak) && //Ready To Break is not active
-                            GunStep == 0) //Gnashing Fang or Reign combo is not active or finished
-                            return OriginalHook(ReignOfBeasts); //Execute Reign of Beasts if conditions are met
-
-                        //Burst Strike
-                        if (IsEnabled(CustomComboPreset.GNB_ST_BurstStrike) && //Burst Strike option is enabled
-                            canBS && //able to use Burst Strike
-                            HasEffect(Buffs.NoMercy) && //No Mercy is active
-                            IsOnCooldown(GnashingFang) && //Gnashing Fang is on cooldown
-                            IsOnCooldown(DoubleDown) && //Double Down is on cooldown
-                            !HasEffect(Buffs.ReadyToBreak) && //Ready To Break is not active
-                            !HasEffect(Buffs.ReadyToReign) && //Ready To Reign is not active
-                            GunStep == 0) //Gnashing Fang or Reign combo is not active or finished
-                            return BurstStrike; //Execute Burst Strike if conditions are met
+                        if ((inOdd && //Odd Minute window
+                             (Ammo >= 2 || (ComboAction is BrutalShell && Ammo == 1))) || //2 or 3 Ammo or 1 Ammo with Solid Barrel next in combo
+                            (!inOdd && //Even Minute window
+                             Ammo != 3)) //Ammo is not full (3)
+                            return NoMercy; //Execute No Mercy if conditions are met
                     }
-
-                    //Lv90+ 2cart forced Opener
-                    if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Cooldowns) && //Cooldowns option is enabled
-                        IsEnabled(CustomComboPreset.GNB_ST_NoMercy) && //No Mercy option is enabled
-                        IsEnabled(CustomComboPreset.GNB_ST_BurstStrike) && //Burst Strike option is enabled
-                        GetTargetHPPercent() > nmStop && //target HP is above threshold
-                        LevelChecked(DoubleDown) && //Lv90+
-                        (nmCD < 1 && //No Mercy is ready or about to be
-                        Ammo is 3 && //Ammo is full
-                        bfCD > 110 && //Bloodfest was just used, but not recently
-                        ComboAction is KeenEdge)) //Just used Keen Edge
-                        return BurstStrike;
-                    //Lv100 2cart forced 2min starter
-                    if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Cooldowns) && //Cooldowns option is enabled
-                        IsEnabled(CustomComboPreset.GNB_ST_NoMercy) && //No Mercy option is enabled
-                        IsEnabled(CustomComboPreset.GNB_ST_BurstStrike) && //Burst Strike option is enabled
-                        GetTargetHPPercent() > nmStop && //target HP is above threshold
-                        LevelChecked(ReignOfBeasts) && //Lv100
-                        (nmCD < 1 && //No Mercy is ready or about to be
-                        Ammo is 3 && //Ammo is full
-                        bfCD < GCD * 12)) //Bloodfest is ready or about to be
-                        return BurstStrike;
-
-                    //Gauge Combo Steps
-                    if (IsEnabled(CustomComboPreset.GNB_ST_GnashingFang) && //Gnashing Fang option is enabled
-                        GunStep is 1 or 2) //Gnashing Fang combo is only for 1 and 2
-                        return OriginalHook(GnashingFang); //Execute Gnashing Fang combo if conditions are met
-                    if (IsEnabled(CustomComboPreset.GNB_ST_Reign) && //Reign of Beasts option is enabled
-                        GunStep is 3 or 4) //Reign of Beasts combo is only for 3 and 4
-                        return OriginalHook(ReignOfBeasts); //Execute Reign of Beasts combo if conditions are met
-
-                    //123 (overcap included)
-                    if (ComboTimer > 0) //we're in combo
+                    if (!LevelChecked(DoubleDown)) //Lv1-89
                     {
-                        if (LevelChecked(BrutalShell) && //Brutal Shell is unlocked
-                            ComboAction == KeenEdge) //just used first action in combo
-                            return BrutalShell; //Execute Brutal Shell if conditions are met
-
-                        if (LevelChecked(SolidBarrel) && //Solid Barrel is unlocked
-                            ComboAction == BrutalShell) //just used second action in combo
-                        {
-                            //holds Hypervelocity if NM comes up in time
-                            if (IsEnabled(CustomComboPreset.GNB_ST_Continuation) && //Continuation option is enabled
-                                IsEnabled(CustomComboPreset.GNB_ST_NoMercy) && //No Mercy option is enabled
-                                LevelChecked(Hypervelocity) && //Hypervelocity is unlocked
-                                HasEffect(Buffs.ReadyToBlast) && //Ready To Blast buff is active
-                                (nmCD is > 1 or <= 0.1f || //Priority hack to prevent Hypervelocity from being used before No Mercy
-                                GetTargetHPPercent() < nmStop)) //target HP is below threshold
-                                return Hypervelocity; //Execute Hypervelocity if conditions are met
-
-                            //Overcap protection
-                            if (IsEnabled(CustomComboPreset.GNB_ST_Overcap) && //Overcap option is enabled
-                                LevelChecked(BurstStrike) && //Burst Strike is unlocked
-                                Ammo == MaxCartridges()) //Ammo is full relaive to level
-                                return BurstStrike; //Execute Burst Strike if conditions are met
-
-                            return SolidBarrel; //Execute Solid Barrel if conditions are met
-                        }
+                        if (canLateWeave && //Late-weaveable
+                            Ammo == MaxCartridges()) //Ammo is full
+                            return NoMercy; //Execute No Mercy if conditions are met
                     }
-                    #endregion
-
-                    return KeenEdge; //Always default back to Keen Edge
                 }
 
-                return actionID;
+                //Hypervelocity - Forced to prevent loss
+                if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Cooldowns) && //Cooldowns option is enabled
+                    IsEnabled(CustomComboPreset.GNB_ST_Continuation) && //Continuation option is enabled
+                    JustUsed(BurstStrike, 5f) && //Burst Strike was just used within 5 seconds
+                    LevelChecked(Hypervelocity) && //Hypervelocity is unlocked
+                    HasEffect(Buffs.ReadyToBlast) && //Ready To Blast buff is active
+                    (IsEnabled(CustomComboPreset.GNB_ST_NoMercy) && //No Mercy option is enabled
+                     nmCD is > 1 or <= 0.1f)) //Priority hack to prevent Hypervelocity from being used before No Mercy
+                    return Hypervelocity; //Execute Hypervelocity if conditions are met
+
+                //Continuation protection - Forced to prevent loss
+                if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Cooldowns) && //Cooldowns option is enabled
+                    IsEnabled(CustomComboPreset.GNB_ST_Continuation) && //Continuation option is enabled
+                    canContinue && //able to use Continuation
+                    (HasEffect(Buffs.ReadyToRip) || //after Gnashing Fang
+                     HasEffect(Buffs.ReadyToTear) || //after Savage Claw
+                     HasEffect(Buffs.ReadyToGouge) || //after Wicked Talon
+                     HasEffect(Buffs.ReadyToBlast) || //after Burst Strike
+                     HasEffect(Buffs.ReadyToRaze))) //after Fated Circle
+                    return OriginalHook(Continuation); //Execute appopriate Continuation action if conditions are met
+
+                //oGCDs
+                if (CanWeave())
+                {
+                    //Cooldowns
+                    if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Cooldowns)) //Cooldowns option is enabled
+                    {
+                        //Bloodfest
+                        if (IsEnabled(CustomComboPreset.GNB_ST_Bloodfest) && //Bloodfest option is enabled
+                            InCombat() && //In combat
+                            HasTarget() && //Has target
+                            canBF && //able to use Bloodfest
+                            Ammo == 0) //Only when ammo is empty
+                            return Bloodfest; //Execute Bloodfest if conditions are met
+
+                        //Zone
+                        if (IsEnabled(CustomComboPreset.GNB_ST_Zone) && //Zone option is enabled
+                            canZone && //able to use Zone
+                            (nmCD is < 57.5f and > 17f))//Optimal use; twice per minute, 1 in NM, 1 out of NM
+                            return OriginalHook(DangerZone); //Execute Zone if conditions are met
+
+                        //Bow Shock
+                        if (IsEnabled(CustomComboPreset.GNB_ST_BowShock) && //Bow Shock option is enabled
+                            canBow && //able to use Bow Shock
+                            nmCD is < 57.5f and >= 40) //No Mercy is up & was not just used within 1 GCD
+                            return BowShock;
+                    }
+                }
+
+                //Lv90+ - every 3rd NM window
+                if (LevelChecked(DoubleDown) &&
+                    HasEffect(Buffs.NoMercy) &&
+                    GunStep == 0 &&
+                    ComboAction is BrutalShell &&
+                    Ammo == 1)
+                    return SolidBarrel;
+
+                //GCDs
+                if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Cooldowns)) //Cooldowns option is enabled
+                {
+                    //GnashingFang
+                    if (IsEnabled(CustomComboPreset.GNB_ST_GnashingFang) && //Gnashing Fang option is enabled
+                        canGF && //able to use Gnashing Fang
+                        ((nmCD is > 17 and < 35) || //30s Optimal use
+                         (JustUsed(NoMercy, 6f)))) //No Mercy was just used within 4 seconds
+                        return GnashingFang;
+
+                    //Double Down
+                    if (IsEnabled(CustomComboPreset.GNB_ST_DoubleDown) && //Double Down option is enabled
+                        canDD && //able to use Double Down
+                        IsOnCooldown(GnashingFang) && //Gnashing Fang is on cooldown
+                        hasNM) //No Mercy is active
+                        return DoubleDown;
+
+                    //Sonic Break
+                    if (IsEnabled(CustomComboPreset.GNB_ST_SonicBreak) && //Sonic Break option is enabled
+                        canBreak && //able to use Sonic Break
+                        ((IsOnCooldown(GnashingFang) && IsOnCooldown(DoubleDown)) || //Gnashing Fang and Double Down are both on cooldown
+                         nmLeft <= GCD)) //No Mercy buff is about to expire
+                        return SonicBreak; //Execute Sonic Break if conditions are met
+
+                    //Reign of Beasts
+                    if (IsEnabled(CustomComboPreset.GNB_ST_Reign) && //Reign of Beasts option is enabled
+                        canReign && //able to use Reign of Beasts
+                        IsOnCooldown(GnashingFang) && //Gnashing Fang is on cooldown
+                        IsOnCooldown(DoubleDown) && //Double Down is on cooldown
+                        !HasEffect(Buffs.ReadyToBreak) && //Ready To Break is not active
+                        GunStep == 0) //Gnashing Fang or Reign combo is not active or finished
+                        return OriginalHook(ReignOfBeasts); //Execute Reign of Beasts if conditions are met
+
+                    //Burst Strike
+                    if (IsEnabled(CustomComboPreset.GNB_ST_BurstStrike) && //Burst Strike option is enabled
+                        canBS && //able to use Burst Strike
+                        HasEffect(Buffs.NoMercy) && //No Mercy is active
+                        IsOnCooldown(GnashingFang) && //Gnashing Fang is on cooldown
+                        IsOnCooldown(DoubleDown) && //Double Down is on cooldown
+                        !HasEffect(Buffs.ReadyToBreak) && //Ready To Break is not active
+                        !HasEffect(Buffs.ReadyToReign) && //Ready To Reign is not active
+                        GunStep == 0) //Gnashing Fang or Reign combo is not active or finished
+                        return BurstStrike; //Execute Burst Strike if conditions are met
+                }
+
+                //Lv90+ 2cart forced Opener
+                if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Cooldowns) && //Cooldowns option is enabled
+                    IsEnabled(CustomComboPreset.GNB_ST_NoMercy) && //No Mercy option is enabled
+                    IsEnabled(CustomComboPreset.GNB_ST_BurstStrike) && //Burst Strike option is enabled
+                    GetTargetHPPercent() > nmStop && //target HP is above threshold
+                    LevelChecked(DoubleDown) && //Lv90+
+                    (nmCD < 1 && //No Mercy is ready or about to be
+                     Ammo is 3 && //Ammo is full
+                     bfCD > 110 && //Bloodfest was just used, but not recently
+                     ComboAction is KeenEdge)) //Just used Keen Edge
+                    return BurstStrike;
+                //Lv100 2cart forced 2min starter
+                if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Cooldowns) && //Cooldowns option is enabled
+                    IsEnabled(CustomComboPreset.GNB_ST_NoMercy) && //No Mercy option is enabled
+                    IsEnabled(CustomComboPreset.GNB_ST_BurstStrike) && //Burst Strike option is enabled
+                    GetTargetHPPercent() > nmStop && //target HP is above threshold
+                    LevelChecked(ReignOfBeasts) && //Lv100
+                    (nmCD < 1 && //No Mercy is ready or about to be
+                     Ammo is 3 && //Ammo is full
+                     bfCD < GCD * 12)) //Bloodfest is ready or about to be
+                    return BurstStrike;
+
+                //Gauge Combo Steps
+                if (IsEnabled(CustomComboPreset.GNB_ST_GnashingFang) && //Gnashing Fang option is enabled
+                    GunStep is 1 or 2) //Gnashing Fang combo is only for 1 and 2
+                    return OriginalHook(GnashingFang); //Execute Gnashing Fang combo if conditions are met
+                if (IsEnabled(CustomComboPreset.GNB_ST_Reign) && //Reign of Beasts option is enabled
+                    GunStep is 3 or 4) //Reign of Beasts combo is only for 3 and 4
+                    return OriginalHook(ReignOfBeasts); //Execute Reign of Beasts combo if conditions are met
+
+                //123 (overcap included)
+                if (ComboTimer > 0) //we're in combo
+                {
+                    if (LevelChecked(BrutalShell) && //Brutal Shell is unlocked
+                        ComboAction == KeenEdge) //just used first action in combo
+                        return BrutalShell; //Execute Brutal Shell if conditions are met
+
+                    if (LevelChecked(SolidBarrel) && //Solid Barrel is unlocked
+                        ComboAction == BrutalShell) //just used second action in combo
+                    {
+                        //holds Hypervelocity if NM comes up in time
+                        if (IsEnabled(CustomComboPreset.GNB_ST_Continuation) && //Continuation option is enabled
+                            IsEnabled(CustomComboPreset.GNB_ST_NoMercy) && //No Mercy option is enabled
+                            LevelChecked(Hypervelocity) && //Hypervelocity is unlocked
+                            HasEffect(Buffs.ReadyToBlast) && //Ready To Blast buff is active
+                            (nmCD is > 1 or <= 0.1f || //Priority hack to prevent Hypervelocity from being used before No Mercy
+                             GetTargetHPPercent() < nmStop)) //target HP is below threshold
+                            return Hypervelocity; //Execute Hypervelocity if conditions are met
+
+                        //Overcap protection
+                        if (IsEnabled(CustomComboPreset.GNB_ST_Overcap) && //Overcap option is enabled
+                            LevelChecked(BurstStrike) && //Burst Strike is unlocked
+                            Ammo == MaxCartridges()) //Ammo is full relaive to level
+                            return BurstStrike; //Execute Burst Strike if conditions are met
+
+                        return SolidBarrel; //Execute Solid Barrel if conditions are met
+                    }
+                }
+                #endregion
+
+                return KeenEdge; //Always default back to Keen Edge
+
             }
         }
         #endregion
@@ -1190,391 +1186,388 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == DemonSlice)
+                if (actionID is not DemonSlice) return actionID;
+
+                #region Variables
+                //Gauge
+                var Ammo = GetJobGauge<GNBGauge>().Ammo; //Our cartridge count
+                var GunStep = GetJobGauge<GNBGauge>().AmmoComboStep; //For Gnashing Fang & Reign combo purposes
+                //Cooldown-related
+                var nmCD = GetCooldownRemainingTime(NoMercy); //NoMercy's cooldown; 60s total
+                var bfCD = GetCooldownRemainingTime(Bloodfest); //Bloodfest's cooldown; 120s total
+                var hasBreak = HasEffect(Buffs.ReadyToBreak); //Checks for Ready To Break buff
+                var hasReign = HasEffect(Buffs.ReadyToReign); //Checks for Ready To Reign buff
+                bool justMitted = JustUsed(OriginalHook(HeartOfStone), 4f) ||
+                                  JustUsed(OriginalHook(Nebula), 5f) ||
+                                  JustUsed(Camouflage, 5f) ||
+                                  JustUsed(All.Rampart, 5f) ||
+                                  JustUsed(Aurora, 5f) ||
+                                  JustUsed(Superbolide, 9f);
+                #region Minimal Requirements
+                //Ammo-relative
+                var canFC = LevelChecked(FatedCircle) && //Fated Circle is unlocked
+                            Ammo > 0; //Has Ammo
+                var canDD = LevelChecked(DoubleDown) && //Double Down is unlocked
+                            GetCooldownRemainingTime(DoubleDown) < 0.6f && //Double Down is off cooldown
+                            Ammo > 0; //Has Ammo
+                var canBF = LevelChecked(Bloodfest) && //Bloodfest is unlocked
+                            GetCooldownRemainingTime(Bloodfest) < 0.6f; //Bloodfest is off cooldown
+                //Cooldown-relative
+                var canZone = LevelChecked(DangerZone) && //Zone is unlocked
+                              GetCooldownRemainingTime(OriginalHook(DangerZone)) < 0.6f; //DangerZone is off cooldown
+                var canBreak = LevelChecked(SonicBreak) && //Sonic Break is unlocked
+                               hasBreak; //No Mercy or Ready To Break is active
+                var canBow = LevelChecked(BowShock) && //Bow Shock is unlocked
+                             GetCooldownRemainingTime(BowShock) < 0.6f; //BowShock is off cooldown
+                var canReign = LevelChecked(ReignOfBeasts) && //Reign of Beasts is unlocked
+                               GunStep == 0 && //Gnashing Fang or Reign combo is not already active
+                               hasReign; //Ready To Reign is active
+                #endregion
+                #endregion
+
+                #region Mitigations
+                if (Config.GNB_AoE_MitsOptions != 1)
                 {
-
-                    #region Variables
-                    //Gauge
-                    var Ammo = GetJobGauge<GNBGauge>().Ammo; //Our cartridge count
-                    var GunStep = GetJobGauge<GNBGauge>().AmmoComboStep; //For Gnashing Fang & Reign combo purposes
-                    //Cooldown-related
-                    var nmCD = GetCooldownRemainingTime(NoMercy); //NoMercy's cooldown; 60s total
-                    var bfCD = GetCooldownRemainingTime(Bloodfest); //Bloodfest's cooldown; 120s total
-                    var hasBreak = HasEffect(Buffs.ReadyToBreak); //Checks for Ready To Break buff
-                    var hasReign = HasEffect(Buffs.ReadyToReign); //Checks for Ready To Reign buff
-                    bool justMitted = JustUsed(OriginalHook(HeartOfStone), 4f) ||
-                                      JustUsed(OriginalHook(Nebula), 5f) ||
-                                      JustUsed(Camouflage, 5f) ||
-                                      JustUsed(All.Rampart, 5f) ||
-                                      JustUsed(Aurora, 5f) ||
-                                      JustUsed(Superbolide, 9f);
-                    #region Minimal Requirements
-                    //Ammo-relative
-                    var canFC = LevelChecked(FatedCircle) && //Fated Circle is unlocked
-                                Ammo > 0; //Has Ammo
-                    var canDD = LevelChecked(DoubleDown) && //Double Down is unlocked
-                                GetCooldownRemainingTime(DoubleDown) < 0.6f && //Double Down is off cooldown
-                                Ammo > 0; //Has Ammo
-                    var canBF = LevelChecked(Bloodfest) && //Bloodfest is unlocked
-                                GetCooldownRemainingTime(Bloodfest) < 0.6f; //Bloodfest is off cooldown
-                    //Cooldown-relative
-                    var canZone = LevelChecked(DangerZone) && //Zone is unlocked
-                                GetCooldownRemainingTime(OriginalHook(DangerZone)) < 0.6f; //DangerZone is off cooldown
-                    var canBreak = LevelChecked(SonicBreak) && //Sonic Break is unlocked
-                                hasBreak; //No Mercy or Ready To Break is active
-                    var canBow = LevelChecked(BowShock) && //Bow Shock is unlocked
-                                GetCooldownRemainingTime(BowShock) < 0.6f; //BowShock is off cooldown
-                    var canReign = LevelChecked(ReignOfBeasts) && //Reign of Beasts is unlocked
-                                GunStep == 0 && //Gnashing Fang or Reign combo is not already active
-                                hasReign; //Ready To Reign is active
-                    #endregion
-                    #endregion
-
-                    #region Mitigations
-                    if (Config.GNB_AoE_MitsOptions != 1)
-                    {
-                        if (InCombat() && //Player is in combat
+                    if (InCombat() && //Player is in combat
                         !justMitted) //Player has not used a mitigation ability in the last 4-9 seconds
-                        {
-                            //Superbolide
-                            if (ActionReady(Superbolide) && //Superbolide is ready
-                                PlayerHealthPercentageHp() < 30) //Player's health is below 30%
-                                return Superbolide;
-
-                            if (IsPlayerTargeted())
-                            {
-                                //Nebula
-                                if (ActionReady(OriginalHook(Nebula)) && //Nebula is ready
-                                    PlayerHealthPercentageHp() < 60) //Player's health is below 60%
-                                    return OriginalHook(Nebula);
-
-                                //Rampart
-                                if (ActionReady(All.Rampart) && //Rampart is ready
-                                    PlayerHealthPercentageHp() < 80) //Player's health is below 80%
-                                    return All.Rampart;
-
-                                //Reprisal
-                                if (ActionReady(All.Reprisal) && //Reprisal is ready
-                                    InActionRange(All.Reprisal) && //Player is in range of Reprisal
-                                    PlayerHealthPercentageHp() < 90) //Player's health is below 90%
-                                    return All.Reprisal;
-                            }
-
-                            //Camouflage
-                            if (ActionReady(Camouflage) && //Camouflage is ready
-                                PlayerHealthPercentageHp() < 70) //Player's health is below 80%
-                                return Camouflage;
-
-                            //Corundum
-                            if (ActionReady(OriginalHook(HeartOfStone)) && //Corundum
-                                PlayerHealthPercentageHp() < 90) //Player's health is below 95%
-                                return OriginalHook(HeartOfStone);
-
-                            //Aurora
-                            if (ActionReady(Aurora) && //Aurora is ready
-                                ((HasFriendlyTarget() && TargetHasEffectAny(Buffs.Aurora)) || (!HasFriendlyTarget() && HasEffectAny(Buffs.Aurora))) && //Aurora is not active on self or target
-                                PlayerHealthPercentageHp() < 85) //
-                                return Aurora;
-                        }
-
-                    }
-                    #endregion
-
-                    #region Variant
-                    //Variant Cure
-                    if (IsEnabled(CustomComboPreset.GNB_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure)
-                        && PlayerHealthPercentageHp() <= GetOptionValue(Config.GNB_VariantCure))
-                        return Variant.VariantCure;
-
-                    //Variant SpiritDart
-                    Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
-                    if (IsEnabled(CustomComboPreset.GNB_Variant_SpiritDart) &&
-                        IsEnabled(Variant.VariantSpiritDart) &&
-                        CanWeave() &&
-                        (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
-                        return Variant.VariantSpiritDart;
-
-                    //Variant Ultimatum
-                    if (IsEnabled(CustomComboPreset.GNB_Variant_Ultimatum) &&
-                        IsEnabled(Variant.VariantUltimatum) &&
-                        CanWeave() &&
-                        ActionReady(Variant.VariantUltimatum))
-                        return Variant.VariantUltimatum;
-                    #endregion
-
-                    #region Bozja
-                    if (Bozja.IsInBozja) //Checks if we're inside Bozja instances
                     {
-                        //oGCDs
-                        if (CanWeave())
+                        //Superbolide
+                        if (ActionReady(Superbolide) && //Superbolide is ready
+                            PlayerHealthPercentageHp() < 30) //Player's health is below 30%
+                            return Superbolide;
+
+                        if (IsPlayerTargeted())
                         {
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFocus) && //Lost Focus is enabled
-                                GetBuffStacks(Bozja.Buffs.Boost) < 16) //Boost stacks are below 16
-                                return Bozja.LostFocus;
+                            //Nebula
+                            if (ActionReady(OriginalHook(Nebula)) && //Nebula is ready
+                                PlayerHealthPercentageHp() < 60) //Player's health is below 60%
+                                return OriginalHook(Nebula);
 
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFontOfPower) && //Lost Font of Power is enabled
-                                IsOffCooldown(Bozja.LostFontOfPower)) //Lost Focus was not just used within 30 seconds
-                                return Bozja.LostFontOfPower;
+                            //Rampart
+                            if (ActionReady(All.Rampart) && //Rampart is ready
+                                PlayerHealthPercentageHp() < 80) //Player's health is below 80%
+                                return All.Rampart;
 
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSlash) &&
-                                IsOffCooldown(Bozja.LostSlash))
-                                return Bozja.LostSlash;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfNobleEnds))
-                            {
-                                if (!IsEnabled(CustomComboPreset.GNB_Bozja_PowerEnds) &&
-                                    IsOffCooldown(Bozja.BannerOfNobleEnds))
-                                    return Bozja.BannerOfNobleEnds;
-                                if (IsEnabled(CustomComboPreset.GNB_Bozja_PowerEnds) &&
-                                    IsOffCooldown(Bozja.BannerOfNobleEnds) &&
-                                    JustUsed(Bozja.LostFontOfPower, 5f))
-                                    return Bozja.BannerOfNobleEnds;
-                            }
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfHonoredSacrifice))
-                            {
-                                if (!IsEnabled(CustomComboPreset.GNB_Bozja_PowerSacrifice) &&
-                                    IsOffCooldown(Bozja.BannerOfHonoredSacrifice))
-                                    return Bozja.BannerOfHonoredSacrifice;
-                                if (IsEnabled(CustomComboPreset.GNB_Bozja_PowerSacrifice) &&
-                                    IsOffCooldown(Bozja.BannerOfHonoredSacrifice) &&
-                                    JustUsed(Bozja.LostFontOfPower, 5f))
-                                    return Bozja.BannerOfHonoredSacrifice;
-                            }
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfHonedAcuity) &&
-                                IsOffCooldown(Bozja.BannerOfHonedAcuity) &&
-                                !HasEffect(Bozja.Buffs.BannerOfTranscendentFinesse))
-                                return Bozja.BannerOfHonedAcuity;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFairTrade) &&
-                                IsOffCooldown(Bozja.LostFairTrade))
-                                return Bozja.LostFairTrade;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostAssassination) &&
-                                IsOffCooldown(Bozja.LostAssassination))
-                                return Bozja.LostAssassination;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostManawall) &&
-                                IsOffCooldown(Bozja.LostManawall))
-                                return Bozja.LostManawall;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfTirelessConviction) &&
-                                IsOffCooldown(Bozja.BannerOfTirelessConviction) &&
-                                !HasEffect(Bozja.Buffs.BannerOfUnyieldingDefense))
-                                return Bozja.BannerOfTirelessConviction;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBloodRage) &&
-                                IsOffCooldown(Bozja.LostBloodRage))
-                                return Bozja.LostBloodRage;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfSolemnClarity) &&
-                                IsOffCooldown(Bozja.BannerOfSolemnClarity) &&
-                                !HasEffect(Bozja.Buffs.BannerOfLimitlessGrace))
-                                return Bozja.BannerOfSolemnClarity;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure2) &&
-                                IsOffCooldown(Bozja.LostCure2) &&
-                                PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure2_Health)
-                                return Bozja.LostCure2;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure4) &&
-                                IsOffCooldown(Bozja.LostCure4) &&
-                                PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure4_Health)
-                                return Bozja.LostCure4;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostReflect) &&
-                                IsOffCooldown(Bozja.LostReflect) &&
-                                !HasEffect(Bozja.Buffs.LostReflect))
-                                return Bozja.LostReflect;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostAethershield) &&
-                                IsOffCooldown(Bozja.LostAethershield) &&
-                                !HasEffect(Bozja.Buffs.LostAethershield) &&
-                                PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostAethershield_Health)
-                                return Bozja.LostAethershield;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSwift) &&
-                                IsOffCooldown(Bozja.LostSwift) &&
-                                !HasEffect(Bozja.Buffs.LostSwift))
-                                return Bozja.LostSwift;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFontOfSkill) &&
-                                IsOffCooldown(Bozja.LostFontOfSkill))
-                                return Bozja.LostFontOfSkill;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostRampage) &&
-                                IsOffCooldown(Bozja.LostRampage))
-                                return Bozja.LostRampage;
+                            //Reprisal
+                            if (ActionReady(All.Reprisal) && //Reprisal is ready
+                                InActionRange(All.Reprisal) && //Player is in range of Reprisal
+                                PlayerHealthPercentageHp() < 90) //Player's health is below 90%
+                                return All.Reprisal;
                         }
 
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostStealth) &&
-                            !InCombat() &&
-                            IsOffCooldown(Bozja.LostStealth))
-                            return Bozja.LostStealth;
+                        //Camouflage
+                        if (ActionReady(Camouflage) && //Camouflage is ready
+                            PlayerHealthPercentageHp() < 70) //Player's health is below 80%
+                            return Camouflage;
 
-                        //GCDs
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostDeath) &&
-                            IsOffCooldown(Bozja.LostDeath))
-                            return Bozja.LostDeath;
+                        //Corundum
+                        if (ActionReady(OriginalHook(HeartOfStone)) && //Corundum
+                            PlayerHealthPercentageHp() < 90) //Player's health is below 95%
+                            return OriginalHook(HeartOfStone);
 
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure) &&
-                            IsOffCooldown(Bozja.LostCure) &&
-                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure_Health)
-                            return Bozja.LostCure;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure3) &&
-                            IsOffCooldown(Bozja.LostCure3) &&
-                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure3_Health)
-                            return Bozja.LostCure3;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostArise) &&
-                            IsOffCooldown(Bozja.LostArise) &&
-                            GetTargetHPPercent() == 0 &&
-                            !HasEffect(All.Debuffs.Raise))
-                            return Bozja.LostArise;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSacrifice) &&
-                            IsOffCooldown(Bozja.LostSacrifice) &&
-                            GetTargetHPPercent() == 0)
-                            return Bozja.LostSacrifice;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostReraise) &&
-                            IsOffCooldown(Bozja.LostReraise) &&
-                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostReraise_Health)
-                            return Bozja.LostReraise;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSpellforge) &&
-                            IsOffCooldown(Bozja.LostSpellforge) &&
-                            (!HasEffect(Bozja.Buffs.LostSpellforge) || !HasEffect(Bozja.Buffs.LostSteelsting)))
-                            return Bozja.LostSpellforge;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSteelsting) &&
-                            IsOffCooldown(Bozja.LostSteelsting) &&
-                            (!HasEffect(Bozja.Buffs.LostSpellforge) || !HasEffect(Bozja.Buffs.LostSteelsting)))
-                            return Bozja.LostSteelsting;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostProtect) &&
-                            IsOffCooldown(Bozja.LostProtect) &&
-                            !HasEffect(Bozja.Buffs.LostProtect))
-                            return Bozja.LostProtect;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostShell) &&
-                            IsOffCooldown(Bozja.LostShell) &&
-                            !HasEffect(Bozja.Buffs.LostShell))
-                            return Bozja.LostShell;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBravery) &&
-                            IsOffCooldown(Bozja.LostBravery) &&
-                            !HasEffect(Bozja.Buffs.LostBravery))
-                            return Bozja.LostBravery;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostProtect2) &&
-                            IsOffCooldown(Bozja.LostProtect2) &&
-                            !HasEffect(Bozja.Buffs.LostProtect2))
-                            return Bozja.LostProtect2;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostShell2) &&
-                            IsOffCooldown(Bozja.LostShell2) &&
-                            !HasEffect(Bozja.Buffs.LostShell2))
-                            return Bozja.LostShell2;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBubble) &&
-                            IsOffCooldown(Bozja.LostBubble) &&
-                            !HasEffect(Bozja.Buffs.LostBubble))
-                            return Bozja.LostBubble;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostParalyze3) &&
-                            IsOffCooldown(Bozja.LostParalyze3) &&
-                            !JustUsed(Bozja.LostParalyze3, 60f))
-                            return Bozja.LostParalyze3;
+                        //Aurora
+                        if (ActionReady(Aurora) && //Aurora is ready
+                            ((HasFriendlyTarget() && TargetHasEffectAny(Buffs.Aurora)) || (!HasFriendlyTarget() && HasEffectAny(Buffs.Aurora))) && //Aurora is not active on self or target
+                            PlayerHealthPercentageHp() < 85) //
+                            return Aurora;
                     }
-                    #endregion
 
-                    #region Rotation
-                    if (InCombat()) //if already in combat
+                }
+                #endregion
+
+                #region Variant
+                //Variant Cure
+                if (IsEnabled(CustomComboPreset.GNB_Variant_Cure) &&
+                    IsEnabled(Variant.VariantCure)
+                    && PlayerHealthPercentageHp() <= GetOptionValue(Config.GNB_VariantCure))
+                    return Variant.VariantCure;
+
+                //Variant SpiritDart
+                Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+                if (IsEnabled(CustomComboPreset.GNB_Variant_SpiritDart) &&
+                    IsEnabled(Variant.VariantSpiritDart) &&
+                    CanWeave() &&
+                    (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
+                    return Variant.VariantSpiritDart;
+
+                //Variant Ultimatum
+                if (IsEnabled(CustomComboPreset.GNB_Variant_Ultimatum) &&
+                    IsEnabled(Variant.VariantUltimatum) &&
+                    CanWeave() &&
+                    ActionReady(Variant.VariantUltimatum))
+                    return Variant.VariantUltimatum;
+                #endregion
+
+                #region Bozja
+                if (Bozja.IsInBozja) //Checks if we're inside Bozja instances
+                {
+                    //oGCDs
+                    if (CanWeave())
                     {
-                        if (CanWeave()) //if we can weave
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFocus) && //Lost Focus is enabled
+                            GetBuffStacks(Bozja.Buffs.Boost) < 16) //Boost stacks are below 16
+                            return Bozja.LostFocus;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFontOfPower) && //Lost Font of Power is enabled
+                            IsOffCooldown(Bozja.LostFontOfPower)) //Lost Focus was not just used within 30 seconds
+                            return Bozja.LostFontOfPower;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSlash) &&
+                            IsOffCooldown(Bozja.LostSlash))
+                            return Bozja.LostSlash;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfNobleEnds))
                         {
-                            //NoMercy
-                            if (ActionReady(NoMercy) && //if No Mercy is ready
-                                GetTargetHPPercent() > 5) //if target HP is above threshold
-                                return NoMercy; //execute No Mercy
-                            //BowShock
-                            if (canBow && //if Bow Shock is ready
-                                HasEffect(Buffs.NoMercy)) //if No Mercy is active
-                                return BowShock; //execute Bow Shock
-                            //Zone
-                            if (canZone &&
-                                nmCD is < 57.5f and > 17) //use on CD after first usage in NM
-                                return OriginalHook(DangerZone); //execute Zone
-                            //Bloodfest
-                            if (canBF) //if Bloodfest is ready & gauge is empty
-                                return Bloodfest; //execute Bloodfest
-                            //Continuation
-                            if (LevelChecked(FatedBrand) && //if Fated Brand is unlocked
-                                HasEffect(Buffs.ReadyToRaze)) //if Ready To Raze is active
-                                return FatedBrand; //execute Fated Brand
+                            if (!IsEnabled(CustomComboPreset.GNB_Bozja_PowerEnds) &&
+                                IsOffCooldown(Bozja.BannerOfNobleEnds))
+                                return Bozja.BannerOfNobleEnds;
+                            if (IsEnabled(CustomComboPreset.GNB_Bozja_PowerEnds) &&
+                                IsOffCooldown(Bozja.BannerOfNobleEnds) &&
+                                JustUsed(Bozja.LostFontOfPower, 5f))
+                                return Bozja.BannerOfNobleEnds;
                         }
 
-                        //SonicBreak
-                        if (canBreak && //if Ready To Break is active & unlocked
-                            !HasEffect(Buffs.ReadyToRaze) && //if Ready To Raze is not active
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfHonoredSacrifice))
+                        {
+                            if (!IsEnabled(CustomComboPreset.GNB_Bozja_PowerSacrifice) &&
+                                IsOffCooldown(Bozja.BannerOfHonoredSacrifice))
+                                return Bozja.BannerOfHonoredSacrifice;
+                            if (IsEnabled(CustomComboPreset.GNB_Bozja_PowerSacrifice) &&
+                                IsOffCooldown(Bozja.BannerOfHonoredSacrifice) &&
+                                JustUsed(Bozja.LostFontOfPower, 5f))
+                                return Bozja.BannerOfHonoredSacrifice;
+                        }
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfHonedAcuity) &&
+                            IsOffCooldown(Bozja.BannerOfHonedAcuity) &&
+                            !HasEffect(Bozja.Buffs.BannerOfTranscendentFinesse))
+                            return Bozja.BannerOfHonedAcuity;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFairTrade) &&
+                            IsOffCooldown(Bozja.LostFairTrade))
+                            return Bozja.LostFairTrade;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostAssassination) &&
+                            IsOffCooldown(Bozja.LostAssassination))
+                            return Bozja.LostAssassination;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostManawall) &&
+                            IsOffCooldown(Bozja.LostManawall))
+                            return Bozja.LostManawall;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfTirelessConviction) &&
+                            IsOffCooldown(Bozja.BannerOfTirelessConviction) &&
+                            !HasEffect(Bozja.Buffs.BannerOfUnyieldingDefense))
+                            return Bozja.BannerOfTirelessConviction;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBloodRage) &&
+                            IsOffCooldown(Bozja.LostBloodRage))
+                            return Bozja.LostBloodRage;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfSolemnClarity) &&
+                            IsOffCooldown(Bozja.BannerOfSolemnClarity) &&
+                            !HasEffect(Bozja.Buffs.BannerOfLimitlessGrace))
+                            return Bozja.BannerOfSolemnClarity;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure2) &&
+                            IsOffCooldown(Bozja.LostCure2) &&
+                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure2_Health)
+                            return Bozja.LostCure2;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure4) &&
+                            IsOffCooldown(Bozja.LostCure4) &&
+                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure4_Health)
+                            return Bozja.LostCure4;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostReflect) &&
+                            IsOffCooldown(Bozja.LostReflect) &&
+                            !HasEffect(Bozja.Buffs.LostReflect))
+                            return Bozja.LostReflect;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostAethershield) &&
+                            IsOffCooldown(Bozja.LostAethershield) &&
+                            !HasEffect(Bozja.Buffs.LostAethershield) &&
+                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostAethershield_Health)
+                            return Bozja.LostAethershield;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSwift) &&
+                            IsOffCooldown(Bozja.LostSwift) &&
+                            !HasEffect(Bozja.Buffs.LostSwift))
+                            return Bozja.LostSwift;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFontOfSkill) &&
+                            IsOffCooldown(Bozja.LostFontOfSkill))
+                            return Bozja.LostFontOfSkill;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostRampage) &&
+                            IsOffCooldown(Bozja.LostRampage))
+                            return Bozja.LostRampage;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostStealth) &&
+                        !InCombat() &&
+                        IsOffCooldown(Bozja.LostStealth))
+                        return Bozja.LostStealth;
+
+                    //GCDs
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostDeath) &&
+                        IsOffCooldown(Bozja.LostDeath))
+                        return Bozja.LostDeath;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure) &&
+                        IsOffCooldown(Bozja.LostCure) &&
+                        PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure_Health)
+                        return Bozja.LostCure;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure3) &&
+                        IsOffCooldown(Bozja.LostCure3) &&
+                        PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure3_Health)
+                        return Bozja.LostCure3;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostArise) &&
+                        IsOffCooldown(Bozja.LostArise) &&
+                        GetTargetHPPercent() == 0 &&
+                        !HasEffect(All.Debuffs.Raise))
+                        return Bozja.LostArise;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSacrifice) &&
+                        IsOffCooldown(Bozja.LostSacrifice) &&
+                        GetTargetHPPercent() == 0)
+                        return Bozja.LostSacrifice;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostReraise) &&
+                        IsOffCooldown(Bozja.LostReraise) &&
+                        PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostReraise_Health)
+                        return Bozja.LostReraise;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSpellforge) &&
+                        IsOffCooldown(Bozja.LostSpellforge) &&
+                        (!HasEffect(Bozja.Buffs.LostSpellforge) || !HasEffect(Bozja.Buffs.LostSteelsting)))
+                        return Bozja.LostSpellforge;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSteelsting) &&
+                        IsOffCooldown(Bozja.LostSteelsting) &&
+                        (!HasEffect(Bozja.Buffs.LostSpellforge) || !HasEffect(Bozja.Buffs.LostSteelsting)))
+                        return Bozja.LostSteelsting;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostProtect) &&
+                        IsOffCooldown(Bozja.LostProtect) &&
+                        !HasEffect(Bozja.Buffs.LostProtect))
+                        return Bozja.LostProtect;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostShell) &&
+                        IsOffCooldown(Bozja.LostShell) &&
+                        !HasEffect(Bozja.Buffs.LostShell))
+                        return Bozja.LostShell;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBravery) &&
+                        IsOffCooldown(Bozja.LostBravery) &&
+                        !HasEffect(Bozja.Buffs.LostBravery))
+                        return Bozja.LostBravery;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostProtect2) &&
+                        IsOffCooldown(Bozja.LostProtect2) &&
+                        !HasEffect(Bozja.Buffs.LostProtect2))
+                        return Bozja.LostProtect2;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostShell2) &&
+                        IsOffCooldown(Bozja.LostShell2) &&
+                        !HasEffect(Bozja.Buffs.LostShell2))
+                        return Bozja.LostShell2;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBubble) &&
+                        IsOffCooldown(Bozja.LostBubble) &&
+                        !HasEffect(Bozja.Buffs.LostBubble))
+                        return Bozja.LostBubble;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostParalyze3) &&
+                        IsOffCooldown(Bozja.LostParalyze3) &&
+                        !JustUsed(Bozja.LostParalyze3, 60f))
+                        return Bozja.LostParalyze3;
+                }
+                #endregion
+
+                #region Rotation
+                if (InCombat()) //if already in combat
+                {
+                    if (CanWeave()) //if we can weave
+                    {
+                        //NoMercy
+                        if (ActionReady(NoMercy) && //if No Mercy is ready
+                            GetTargetHPPercent() > 5) //if target HP is above threshold
+                            return NoMercy; //execute No Mercy
+                        //BowShock
+                        if (canBow && //if Bow Shock is ready
                             HasEffect(Buffs.NoMercy)) //if No Mercy is active
-                            return SonicBreak;
-                        //DoubleDown
-                        if (canDD && //if Double Down is ready && gauge is not empty
-                            HasEffect(Buffs.NoMercy)) //if No Mercy is active
-                            return DoubleDown; //execute Double Down
-                        //Reign - because leaving this out anywhere is a waste
-                        if (LevelChecked(ReignOfBeasts)) //if Reign of Beasts is unlocked
-                        {
-                            if (canReign || //can execute Reign of Beasts
-                               (GunStep is 3 or 4)) //can execute Noble Blood or Lion Heart
-                                return OriginalHook(ReignOfBeasts);
-                        }
-                        //FatedCircle - if not LevelChecked, use BurstStrike
-                        if (canFC && //if Fated Circle is unlocked && gauge is not empty
-                                     //Normal
-                            ((HasEffect(Buffs.NoMercy) && //if No Mercy is active
-                            !ActionReady(DoubleDown) && //if Double Down is not ready
-                            GunStep == 0) || //if Gnashing Fang or Reign combo is not active
-                                             //Bloodfest prep
-                            (IsEnabled(CustomComboPreset.GNB_AoE_Bloodfest) && //if Bloodfest option is enabled
-                            bfCD < 6))) //if Bloodfest is about to be ready
-                            return FatedCircle;
-                        if (Ammo > 0 && //if gauge is not empty
-                            !LevelChecked(FatedCircle) && //if Fated Circle is not unlocked
-                            LevelChecked(BurstStrike) && //if Burst Strike is unlocked
-                            (HasEffect(Buffs.NoMercy) && //if No Mercy is active
-                            GunStep == 0)) //if Gnashing Fang or Reign combo is not active
-                            return BurstStrike;
+                            return BowShock; //execute Bow Shock
+                        //Zone
+                        if (canZone &&
+                            nmCD is < 57.5f and > 17) //use on CD after first usage in NM
+                            return OriginalHook(DangerZone); //execute Zone
+                        //Bloodfest
+                        if (canBF) //if Bloodfest is ready & gauge is empty
+                            return Bloodfest; //execute Bloodfest
+                        //Continuation
+                        if (LevelChecked(FatedBrand) && //if Fated Brand is unlocked
+                            HasEffect(Buffs.ReadyToRaze)) //if Ready To Raze is active
+                            return FatedBrand; //execute Fated Brand
                     }
 
-                    //1-2
-                    if (ComboTimer > 0) //if we're in combo
+                    //SonicBreak
+                    if (canBreak && //if Ready To Break is active & unlocked
+                        !HasEffect(Buffs.ReadyToRaze) && //if Ready To Raze is not active
+                        HasEffect(Buffs.NoMercy)) //if No Mercy is active
+                        return SonicBreak;
+                    //DoubleDown
+                    if (canDD && //if Double Down is ready && gauge is not empty
+                        HasEffect(Buffs.NoMercy)) //if No Mercy is active
+                        return DoubleDown; //execute Double Down
+                    //Reign - because leaving this out anywhere is a waste
+                    if (LevelChecked(ReignOfBeasts)) //if Reign of Beasts is unlocked
                     {
-                        if (ComboAction == DemonSlice && //if last action was Demon Slice
-                            LevelChecked(DemonSlaughter)) //if Demon Slaughter is unlocked
-                        {
-                            if (Ammo == MaxCartridges())
-                            {
-                                if (LevelChecked(FatedCircle)) //if Fated Circle is unlocked
-                                    return FatedCircle; //execute Fated Circle
-                                if (!LevelChecked(FatedCircle)) //if Fated Circle is not unlocked
-                                    return BurstStrike; //execute Burst Strike
-                            }
-                            if (Ammo != MaxCartridges()) //if gauge is full && if Fated Circle is not unlocked
-                                return DemonSlaughter; //execute Demon Slaughter
-                        }
+                        if (canReign || //can execute Reign of Beasts
+                            (GunStep is 3 or 4)) //can execute Noble Blood or Lion Heart
+                            return OriginalHook(ReignOfBeasts);
                     }
-                    #endregion
-
-                    return DemonSlice; //Always default back to Demon Slice
+                    //FatedCircle - if not LevelChecked, use BurstStrike
+                    if (canFC && //if Fated Circle is unlocked && gauge is not empty
+                        //Normal
+                        ((HasEffect(Buffs.NoMercy) && //if No Mercy is active
+                          !ActionReady(DoubleDown) && //if Double Down is not ready
+                          GunStep == 0) || //if Gnashing Fang or Reign combo is not active
+                         //Bloodfest prep
+                         (IsEnabled(CustomComboPreset.GNB_AoE_Bloodfest) && //if Bloodfest option is enabled
+                          bfCD < 6))) //if Bloodfest is about to be ready
+                        return FatedCircle;
+                    if (Ammo > 0 && //if gauge is not empty
+                        !LevelChecked(FatedCircle) && //if Fated Circle is not unlocked
+                        LevelChecked(BurstStrike) && //if Burst Strike is unlocked
+                        (HasEffect(Buffs.NoMercy) && //if No Mercy is active
+                         GunStep == 0)) //if Gnashing Fang or Reign combo is not active
+                        return BurstStrike;
                 }
 
-                return actionID;
+                //1-2
+                if (ComboTimer > 0) //if we're in combo
+                {
+                    if (ComboAction == DemonSlice && //if last action was Demon Slice
+                        LevelChecked(DemonSlaughter)) //if Demon Slaughter is unlocked
+                    {
+                        if (Ammo == MaxCartridges())
+                        {
+                            if (LevelChecked(FatedCircle)) //if Fated Circle is unlocked
+                                return FatedCircle; //execute Fated Circle
+                            if (!LevelChecked(FatedCircle)) //if Fated Circle is not unlocked
+                                return BurstStrike; //execute Burst Strike
+                        }
+                        if (Ammo != MaxCartridges()) //if gauge is full && if Fated Circle is not unlocked
+                            return DemonSlaughter; //execute Demon Slaughter
+                    }
+                }
+                #endregion
+
+                return DemonSlice; //Always default back to Demon Slice
+
             }
         }
         #endregion
@@ -1586,435 +1579,432 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == DemonSlice)
+                if (actionID is not DemonSlice) return actionID;
+
+                #region Variables
+                //Gauge
+                var Ammo = GetJobGauge<GNBGauge>().Ammo; //Our cartridge count
+                var GunStep = GetJobGauge<GNBGauge>().AmmoComboStep; //For Gnashing Fang & Reign combo purposes
+                //Cooldown-related
+                var nmCD = GetCooldownRemainingTime(NoMercy); //NoMercy's cooldown; 60s total
+                var bfCD = GetCooldownRemainingTime(Bloodfest); //Bloodfest's cooldown; 120s total
+                var hasBreak = HasEffect(Buffs.ReadyToBreak); //Checks for Ready To Break buff
+                var hasReign = HasEffect(Buffs.ReadyToReign); //Checks for Ready To Reign buff
+                bool justMitted = JustUsed(OriginalHook(HeartOfStone), 4f) ||
+                                  JustUsed(OriginalHook(Nebula), 5f) ||
+                                  JustUsed(Camouflage, 5f) ||
+                                  JustUsed(All.Rampart, 5f) ||
+                                  JustUsed(Aurora, 5f) ||
+                                  JustUsed(Superbolide, 9f);
+                //Misc
+                var nmStop = PluginConfiguration.GetCustomIntValue(Config.GNB_AoE_NoMercyStop);
+                #region Minimal Requirements
+                //Ammo-relative
+                var canFC = LevelChecked(FatedCircle) && //Fated Circle is unlocked
+                            Ammo > 0; //Has Ammo
+                var canDD = LevelChecked(DoubleDown) && //Double Down is unlocked
+                            GetCooldownRemainingTime(DoubleDown) < 0.6f && //Double Down is off cooldown
+                            Ammo > 0; //Has Ammo
+                var canBF = LevelChecked(Bloodfest) && //Bloodfest is unlocked
+                            GetCooldownRemainingTime(Bloodfest) < 0.6f; //Bloodfest is off cooldown
+                //Cooldown-relative
+                var canZone = LevelChecked(DangerZone) && //Zone is unlocked
+                              GetCooldownRemainingTime(OriginalHook(DangerZone)) < 0.6f; //DangerZone is off cooldown
+                var canBreak = LevelChecked(SonicBreak) && //Sonic Break is unlocked
+                               hasBreak; //No Mercy or Ready To Break is active
+                var canBow = LevelChecked(BowShock) && //Bow Shock is unlocked
+                             GetCooldownRemainingTime(BowShock) < 0.6f; //BowShock is off cooldown
+                var canReign = LevelChecked(ReignOfBeasts) && //Reign of Beasts is unlocked
+                               GunStep == 0 && //Gnashing Fang or Reign combo is not already active
+                               hasReign; //Ready To Reign is active
+                #endregion
+                #endregion
+
+                #region Mitigations
+                if (IsEnabled(CustomComboPreset.GNB_AoE_Mitigation) && //Mitigation option is enabled
+                    InCombat() && //Player is in combat
+                    !justMitted) //Player has not used a mitigation ability in the last 4-9 seconds
                 {
+                    //Superbolide
+                    if (IsEnabled(CustomComboPreset.GNB_AoE_Superbolide) && //Superbolide option is enabled
+                        ActionReady(Superbolide) && //Superbolide is ready
+                        PlayerHealthPercentageHp() < Config.GNB_AoE_Superbolide_Health && //Player's health is below selected threshold
+                        (Config.GNB_AoE_Superbolide_SubOption == 0 || //Superbolide is enabled for all targets
+                         (TargetIsBoss() && Config.GNB_AoE_Superbolide_SubOption == 1))) //Superbolide is enabled for bosses only
+                        return Superbolide;
 
-                    #region Variables
-                    //Gauge
-                    var Ammo = GetJobGauge<GNBGauge>().Ammo; //Our cartridge count
-                    var GunStep = GetJobGauge<GNBGauge>().AmmoComboStep; //For Gnashing Fang & Reign combo purposes
-                    //Cooldown-related
-                    var nmCD = GetCooldownRemainingTime(NoMercy); //NoMercy's cooldown; 60s total
-                    var bfCD = GetCooldownRemainingTime(Bloodfest); //Bloodfest's cooldown; 120s total
-                    var hasBreak = HasEffect(Buffs.ReadyToBreak); //Checks for Ready To Break buff
-                    var hasReign = HasEffect(Buffs.ReadyToReign); //Checks for Ready To Reign buff
-                    bool justMitted = JustUsed(OriginalHook(HeartOfStone), 4f) ||
-                                      JustUsed(OriginalHook(Nebula), 5f) ||
-                                      JustUsed(Camouflage, 5f) ||
-                                      JustUsed(All.Rampart, 5f) ||
-                                      JustUsed(Aurora, 5f) ||
-                                      JustUsed(Superbolide, 9f);
-                    //Misc
-                    var nmStop = PluginConfiguration.GetCustomIntValue(Config.GNB_AoE_NoMercyStop);
-                    #region Minimal Requirements
-                    //Ammo-relative
-                    var canFC = LevelChecked(FatedCircle) && //Fated Circle is unlocked
-                                Ammo > 0; //Has Ammo
-                    var canDD = LevelChecked(DoubleDown) && //Double Down is unlocked
-                                GetCooldownRemainingTime(DoubleDown) < 0.6f && //Double Down is off cooldown
-                                Ammo > 0; //Has Ammo
-                    var canBF = LevelChecked(Bloodfest) && //Bloodfest is unlocked
-                                GetCooldownRemainingTime(Bloodfest) < 0.6f; //Bloodfest is off cooldown
-                    //Cooldown-relative
-                    var canZone = LevelChecked(DangerZone) && //Zone is unlocked
-                                GetCooldownRemainingTime(OriginalHook(DangerZone)) < 0.6f; //DangerZone is off cooldown
-                    var canBreak = LevelChecked(SonicBreak) && //Sonic Break is unlocked
-                                hasBreak; //No Mercy or Ready To Break is active
-                    var canBow = LevelChecked(BowShock) && //Bow Shock is unlocked
-                                GetCooldownRemainingTime(BowShock) < 0.6f; //BowShock is off cooldown
-                    var canReign = LevelChecked(ReignOfBeasts) && //Reign of Beasts is unlocked
-                                GunStep == 0 && //Gnashing Fang or Reign combo is not already active
-                                hasReign; //Ready To Reign is active
-                    #endregion
-                    #endregion
-
-                    #region Mitigations
-                    if (IsEnabled(CustomComboPreset.GNB_AoE_Mitigation) && //Mitigation option is enabled
-                        InCombat() && //Player is in combat
-                        !justMitted) //Player has not used a mitigation ability in the last 4-9 seconds
+                    if (IsPlayerTargeted()) //Player is being targeted by current target
                     {
-                        //Superbolide
-                        if (IsEnabled(CustomComboPreset.GNB_AoE_Superbolide) && //Superbolide option is enabled
-                            ActionReady(Superbolide) && //Superbolide is ready
-                            PlayerHealthPercentageHp() < Config.GNB_AoE_Superbolide_Health && //Player's health is below selected threshold
-                            (Config.GNB_AoE_Superbolide_SubOption == 0 || //Superbolide is enabled for all targets
-                            (TargetIsBoss() && Config.GNB_AoE_Superbolide_SubOption == 1))) //Superbolide is enabled for bosses only
-                            return Superbolide;
+                        //Nebula
+                        if (IsEnabled(CustomComboPreset.GNB_AoE_Nebula) && //Nebula option is enabled
+                            ActionReady(OriginalHook(Nebula)) && //Nebula is ready
+                            PlayerHealthPercentageHp() < Config.GNB_AoE_Nebula_Health && //Player's health is below selected threshold
+                            (Config.GNB_AoE_Nebula_SubOption == 0 || //Nebula is enabled for all targets
+                             (TargetIsBoss() && Config.GNB_AoE_Nebula_SubOption == 1))) //Nebula is enabled for bosses only
+                            return OriginalHook(Nebula);
 
-                        if (IsPlayerTargeted()) //Player is being targeted by current target
-                        {
-                            //Nebula
-                            if (IsEnabled(CustomComboPreset.GNB_AoE_Nebula) && //Nebula option is enabled
-                                ActionReady(OriginalHook(Nebula)) && //Nebula is ready
-                                PlayerHealthPercentageHp() < Config.GNB_AoE_Nebula_Health && //Player's health is below selected threshold
-                                (Config.GNB_AoE_Nebula_SubOption == 0 || //Nebula is enabled for all targets
-                                (TargetIsBoss() && Config.GNB_AoE_Nebula_SubOption == 1))) //Nebula is enabled for bosses only
-                                return OriginalHook(Nebula);
+                        //Rampart
+                        if (IsEnabled(CustomComboPreset.GNB_AoE_Rampart) && //Rampart option is enabled
+                            ActionReady(All.Rampart) && //Rampart is ready
+                            PlayerHealthPercentageHp() < Config.GNB_AoE_Rampart_Health && //Player's health is below selected threshold
+                            (Config.GNB_AoE_Rampart_SubOption == 0 || //Rampart is enabled for all targets
+                             (TargetIsBoss() && Config.GNB_AoE_Rampart_SubOption == 1))) //Rampart is enabled for bosses only
+                            return All.Rampart;
 
-                            //Rampart
-                            if (IsEnabled(CustomComboPreset.GNB_AoE_Rampart) && //Rampart option is enabled
-                                ActionReady(All.Rampart) && //Rampart is ready
-                                PlayerHealthPercentageHp() < Config.GNB_AoE_Rampart_Health && //Player's health is below selected threshold
-                                (Config.GNB_AoE_Rampart_SubOption == 0 || //Rampart is enabled for all targets
-                                (TargetIsBoss() && Config.GNB_AoE_Rampart_SubOption == 1))) //Rampart is enabled for bosses only
-                                return All.Rampart;
+                        //Reprisal
+                        if (IsEnabled(CustomComboPreset.GNB_AoE_Reprisal) && //Reprisal option is enabled
+                            ActionReady(All.Reprisal) && //Reprisal is ready
+                            InActionRange(All.Reprisal) && //Player is in range of Reprisal
+                            PlayerHealthPercentageHp() < Config.GNB_AoE_Reprisal_Health && //Player's health is below selected threshold
+                            (Config.GNB_AoE_Reprisal_SubOption == 0 || //Reprisal is enabled for all targets
+                             (TargetIsBoss() && Config.GNB_AoE_Reprisal_SubOption == 1))) //Reprisal is enabled for bosses only
+                            return All.Reprisal;
 
-                            //Reprisal
-                            if (IsEnabled(CustomComboPreset.GNB_AoE_Reprisal) && //Reprisal option is enabled
-                                ActionReady(All.Reprisal) && //Reprisal is ready
-                                InActionRange(All.Reprisal) && //Player is in range of Reprisal
-                                PlayerHealthPercentageHp() < Config.GNB_AoE_Reprisal_Health && //Player's health is below selected threshold
-                                (Config.GNB_AoE_Reprisal_SubOption == 0 || //Reprisal is enabled for all targets
-                                (TargetIsBoss() && Config.GNB_AoE_Reprisal_SubOption == 1))) //Reprisal is enabled for bosses only
-                                return All.Reprisal;
-
-                            //Arm's Length
-                            if (IsEnabled(CustomComboPreset.GNB_AoE_ArmsLength) && //Arm's Length option is enabled
-                                ActionReady(All.ArmsLength) && //Arm's Length is ready
-                                PlayerHealthPercentageHp() < Config.GNB_AoE_ArmsLength_Health && //Player's health is below selected threshold
-                                !InBossEncounter()) //Arms Length is enabled for bosses only
-                                return All.ArmsLength;
-                        }
-
-                        //Camouflage
-                        if (IsEnabled(CustomComboPreset.GNB_AoE_Camouflage) && //Camouflage option is enabled
-                            ActionReady(Camouflage) && //Camouflage is ready
-                            PlayerHealthPercentageHp() < Config.GNB_AoE_Camouflage_Health && //Player's health is below selected threshold
-                            (Config.GNB_AoE_Camouflage_SubOption == 0 || //Camouflage is enabled for all targets
-                            (TargetIsBoss() && Config.GNB_AoE_Camouflage_SubOption == 1))) //Camouflage is enabled for bosses only
-                            return Camouflage;
-
-                        //Corundum
-                        if (IsEnabled(CustomComboPreset.GNB_AoE_Corundum) && //Corundum option is enabled
-                            ActionReady(OriginalHook(HeartOfStone)) && //Corundum is ready
-                            PlayerHealthPercentageHp() < Config.GNB_AoE_Corundum_Health && //Player's health is below selected threshold
-                            (Config.GNB_AoE_Corundum_SubOption == 0 || //Corundum is enabled for all targets
-                            (TargetIsBoss() && Config.GNB_AoE_Corundum_SubOption == 1))) //Corundum is enabled for bosses only
-                            return OriginalHook(HeartOfStone);
-
-                        //Aurora
-                        if (IsEnabled(CustomComboPreset.GNB_AoE_Aurora) && //Aurora option is enabled
-                            ActionReady(Aurora) && //Aurora is ready
-                            GetRemainingCharges(Aurora) > Config.GNB_AoE_Aurora_Charges && //Aurora has more charges than set threshold
-                            ((HasFriendlyTarget() && TargetHasEffectAny(Buffs.Aurora)) || (!HasFriendlyTarget() && HasEffectAny(Buffs.Aurora))) && //Aurora is not active on self or target
-                            PlayerHealthPercentageHp() < Config.GNB_AoE_Aurora_Health && //Player's health is below selected threshold
-                            (Config.GNB_AoE_Aurora_SubOption == 0 || //Aurora is enabled for all targets
-                            (TargetIsBoss() && Config.GNB_AoE_Aurora_SubOption == 1))) //Aurora is enabled for bosses only
-                            return Aurora;
+                        //Arm's Length
+                        if (IsEnabled(CustomComboPreset.GNB_AoE_ArmsLength) && //Arm's Length option is enabled
+                            ActionReady(All.ArmsLength) && //Arm's Length is ready
+                            PlayerHealthPercentageHp() < Config.GNB_AoE_ArmsLength_Health && //Player's health is below selected threshold
+                            !InBossEncounter()) //Arms Length is enabled for bosses only
+                            return All.ArmsLength;
                     }
-                    #endregion
 
-                    #region Variant
-                    //Variant Cure
-                    if (IsEnabled(CustomComboPreset.GNB_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure)
-                        && PlayerHealthPercentageHp() <= GetOptionValue(Config.GNB_VariantCure))
-                        return Variant.VariantCure;
+                    //Camouflage
+                    if (IsEnabled(CustomComboPreset.GNB_AoE_Camouflage) && //Camouflage option is enabled
+                        ActionReady(Camouflage) && //Camouflage is ready
+                        PlayerHealthPercentageHp() < Config.GNB_AoE_Camouflage_Health && //Player's health is below selected threshold
+                        (Config.GNB_AoE_Camouflage_SubOption == 0 || //Camouflage is enabled for all targets
+                         (TargetIsBoss() && Config.GNB_AoE_Camouflage_SubOption == 1))) //Camouflage is enabled for bosses only
+                        return Camouflage;
 
-                    //Variant SpiritDart
-                    Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
-                    if (IsEnabled(CustomComboPreset.GNB_Variant_SpiritDart) &&
-                        IsEnabled(Variant.VariantSpiritDart) &&
-                        CanWeave() &&
-                        (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
-                        return Variant.VariantSpiritDart;
+                    //Corundum
+                    if (IsEnabled(CustomComboPreset.GNB_AoE_Corundum) && //Corundum option is enabled
+                        ActionReady(OriginalHook(HeartOfStone)) && //Corundum is ready
+                        PlayerHealthPercentageHp() < Config.GNB_AoE_Corundum_Health && //Player's health is below selected threshold
+                        (Config.GNB_AoE_Corundum_SubOption == 0 || //Corundum is enabled for all targets
+                         (TargetIsBoss() && Config.GNB_AoE_Corundum_SubOption == 1))) //Corundum is enabled for bosses only
+                        return OriginalHook(HeartOfStone);
 
-                    //Variant Ultimatum
-                    if (IsEnabled(CustomComboPreset.GNB_Variant_Ultimatum) &&
-                        IsEnabled(Variant.VariantUltimatum) &&
-                        CanWeave() &&
-                        ActionReady(Variant.VariantUltimatum))
-                        return Variant.VariantUltimatum;
-                    #endregion
+                    //Aurora
+                    if (IsEnabled(CustomComboPreset.GNB_AoE_Aurora) && //Aurora option is enabled
+                        ActionReady(Aurora) && //Aurora is ready
+                        GetRemainingCharges(Aurora) > Config.GNB_AoE_Aurora_Charges && //Aurora has more charges than set threshold
+                        ((HasFriendlyTarget() && TargetHasEffectAny(Buffs.Aurora)) || (!HasFriendlyTarget() && HasEffectAny(Buffs.Aurora))) && //Aurora is not active on self or target
+                        PlayerHealthPercentageHp() < Config.GNB_AoE_Aurora_Health && //Player's health is below selected threshold
+                        (Config.GNB_AoE_Aurora_SubOption == 0 || //Aurora is enabled for all targets
+                         (TargetIsBoss() && Config.GNB_AoE_Aurora_SubOption == 1))) //Aurora is enabled for bosses only
+                        return Aurora;
+                }
+                #endregion
 
-                    #region Bozja
-                    if (Bozja.IsInBozja) //Checks if we're inside Bozja instances
+                #region Variant
+                //Variant Cure
+                if (IsEnabled(CustomComboPreset.GNB_Variant_Cure) &&
+                    IsEnabled(Variant.VariantCure)
+                    && PlayerHealthPercentageHp() <= GetOptionValue(Config.GNB_VariantCure))
+                    return Variant.VariantCure;
+
+                //Variant SpiritDart
+                Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+                if (IsEnabled(CustomComboPreset.GNB_Variant_SpiritDart) &&
+                    IsEnabled(Variant.VariantSpiritDart) &&
+                    CanWeave() &&
+                    (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
+                    return Variant.VariantSpiritDart;
+
+                //Variant Ultimatum
+                if (IsEnabled(CustomComboPreset.GNB_Variant_Ultimatum) &&
+                    IsEnabled(Variant.VariantUltimatum) &&
+                    CanWeave() &&
+                    ActionReady(Variant.VariantUltimatum))
+                    return Variant.VariantUltimatum;
+                #endregion
+
+                #region Bozja
+                if (Bozja.IsInBozja) //Checks if we're inside Bozja instances
+                {
+                    //oGCDs
+                    if (CanWeave())
                     {
-                        //oGCDs
-                        if (CanWeave())
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFocus) && //Lost Focus is enabled
+                            GetBuffStacks(Bozja.Buffs.Boost) < 16) //Boost stacks are below 16
+                            return Bozja.LostFocus;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFontOfPower) && //Lost Font of Power is enabled
+                            IsOffCooldown(Bozja.LostFontOfPower)) //Lost Focus was not just used within 30 seconds
+                            return Bozja.LostFontOfPower;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSlash) &&
+                            IsOffCooldown(Bozja.LostSlash))
+                            return Bozja.LostSlash;
+
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfNobleEnds))
                         {
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFocus) && //Lost Focus is enabled
-                                GetBuffStacks(Bozja.Buffs.Boost) < 16) //Boost stacks are below 16
-                                return Bozja.LostFocus;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFontOfPower) && //Lost Font of Power is enabled
-                                IsOffCooldown(Bozja.LostFontOfPower)) //Lost Focus was not just used within 30 seconds
-                                return Bozja.LostFontOfPower; 
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSlash) &&
-                                IsOffCooldown(Bozja.LostSlash))
-                                return Bozja.LostSlash;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfNobleEnds))
-                            {
-                                if (!IsEnabled(CustomComboPreset.GNB_Bozja_PowerEnds) &&
-                                    IsOffCooldown(Bozja.BannerOfNobleEnds))
-                                    return Bozja.BannerOfNobleEnds;
-                                if (IsEnabled(CustomComboPreset.GNB_Bozja_PowerEnds) &&
-                                    IsOffCooldown(Bozja.BannerOfNobleEnds) &&
-                                    JustUsed(Bozja.LostFontOfPower, 5f))
-                                    return Bozja.BannerOfNobleEnds;
-                            }
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfHonoredSacrifice))
-                            {
-                                if (!IsEnabled(CustomComboPreset.GNB_Bozja_PowerSacrifice) &&
-                                    IsOffCooldown(Bozja.BannerOfHonoredSacrifice))
-                                    return Bozja.BannerOfHonoredSacrifice;
-                                if (IsEnabled(CustomComboPreset.GNB_Bozja_PowerSacrifice) &&
-                                    IsOffCooldown(Bozja.BannerOfHonoredSacrifice) &&
-                                    JustUsed(Bozja.LostFontOfPower, 5f))
-                                    return Bozja.BannerOfHonoredSacrifice;
-                            }
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfHonedAcuity) &&
-                                IsOffCooldown(Bozja.BannerOfHonedAcuity) &&
-                                !HasEffect(Bozja.Buffs.BannerOfTranscendentFinesse))
-                                return Bozja.BannerOfHonedAcuity;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFairTrade) &&
-                                IsOffCooldown(Bozja.LostFairTrade))
-                                return Bozja.LostFairTrade;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostAssassination) &&
-                                IsOffCooldown(Bozja.LostAssassination))
-                                return Bozja.LostAssassination;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostManawall) &&
-                                IsOffCooldown(Bozja.LostManawall))
-                                return Bozja.LostManawall;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfTirelessConviction) &&
-                                IsOffCooldown(Bozja.BannerOfTirelessConviction) &&
-                                !HasEffect(Bozja.Buffs.BannerOfUnyieldingDefense))
-                                return Bozja.BannerOfTirelessConviction;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBloodRage) &&
-                                IsOffCooldown(Bozja.LostBloodRage))
-                                return Bozja.LostBloodRage;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfSolemnClarity) &&
-                                IsOffCooldown(Bozja.BannerOfSolemnClarity) &&
-                                !HasEffect(Bozja.Buffs.BannerOfLimitlessGrace))
-                                return Bozja.BannerOfSolemnClarity;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure2) &&
-                                IsOffCooldown(Bozja.LostCure2) &&
-                                PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure2_Health)
-                                return Bozja.LostCure2;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure4) &&
-                                IsOffCooldown(Bozja.LostCure4) &&
-                                PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure4_Health)
-                                return Bozja.LostCure4;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostReflect) &&
-                                IsOffCooldown(Bozja.LostReflect) &&
-                                !HasEffect(Bozja.Buffs.LostReflect))
-                                return Bozja.LostReflect;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostAethershield) &&
-                                IsOffCooldown(Bozja.LostAethershield) &&
-                                !HasEffect(Bozja.Buffs.LostAethershield) &&
-                                PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostAethershield_Health)
-                                return Bozja.LostAethershield;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSwift) &&
-                                IsOffCooldown(Bozja.LostSwift) &&
-                                !HasEffect(Bozja.Buffs.LostSwift))
-                                return Bozja.LostSwift;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFontOfSkill) &&
-                                IsOffCooldown(Bozja.LostFontOfSkill))
-                                return Bozja.LostFontOfSkill;
-
-                            if (IsEnabled(CustomComboPreset.GNB_Bozja_LostRampage) &&
-                                IsOffCooldown(Bozja.LostRampage))
-                                return Bozja.LostRampage;
+                            if (!IsEnabled(CustomComboPreset.GNB_Bozja_PowerEnds) &&
+                                IsOffCooldown(Bozja.BannerOfNobleEnds))
+                                return Bozja.BannerOfNobleEnds;
+                            if (IsEnabled(CustomComboPreset.GNB_Bozja_PowerEnds) &&
+                                IsOffCooldown(Bozja.BannerOfNobleEnds) &&
+                                JustUsed(Bozja.LostFontOfPower, 5f))
+                                return Bozja.BannerOfNobleEnds;
                         }
 
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostStealth) &&
-                            !InCombat() &&
-                            IsOffCooldown(Bozja.LostStealth))
-                            return Bozja.LostStealth;
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfHonoredSacrifice))
+                        {
+                            if (!IsEnabled(CustomComboPreset.GNB_Bozja_PowerSacrifice) &&
+                                IsOffCooldown(Bozja.BannerOfHonoredSacrifice))
+                                return Bozja.BannerOfHonoredSacrifice;
+                            if (IsEnabled(CustomComboPreset.GNB_Bozja_PowerSacrifice) &&
+                                IsOffCooldown(Bozja.BannerOfHonoredSacrifice) &&
+                                JustUsed(Bozja.LostFontOfPower, 5f))
+                                return Bozja.BannerOfHonoredSacrifice;
+                        }
 
-                        //GCDs
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostDeath) &&
-                            IsOffCooldown(Bozja.LostDeath))
-                            return Bozja.LostDeath;
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfHonedAcuity) &&
+                            IsOffCooldown(Bozja.BannerOfHonedAcuity) &&
+                            !HasEffect(Bozja.Buffs.BannerOfTranscendentFinesse))
+                            return Bozja.BannerOfHonedAcuity;
 
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure) &&
-                            IsOffCooldown(Bozja.LostCure) &&
-                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure_Health)
-                            return Bozja.LostCure;
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFairTrade) &&
+                            IsOffCooldown(Bozja.LostFairTrade))
+                            return Bozja.LostFairTrade;
 
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure3) &&
-                            IsOffCooldown(Bozja.LostCure3) &&
-                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure3_Health)
-                            return Bozja.LostCure3;
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostAssassination) &&
+                            IsOffCooldown(Bozja.LostAssassination))
+                            return Bozja.LostAssassination;
 
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostArise) &&
-                            IsOffCooldown(Bozja.LostArise) &&
-                            GetTargetHPPercent() == 0 &&
-                            !HasEffect(All.Debuffs.Raise))
-                            return Bozja.LostArise;
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostManawall) &&
+                            IsOffCooldown(Bozja.LostManawall))
+                            return Bozja.LostManawall;
 
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSacrifice) &&
-                            IsOffCooldown(Bozja.LostSacrifice) &&
-                            GetTargetHPPercent() == 0)
-                            return Bozja.LostSacrifice;
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfTirelessConviction) &&
+                            IsOffCooldown(Bozja.BannerOfTirelessConviction) &&
+                            !HasEffect(Bozja.Buffs.BannerOfUnyieldingDefense))
+                            return Bozja.BannerOfTirelessConviction;
 
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostReraise) &&
-                            IsOffCooldown(Bozja.LostReraise) &&
-                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostReraise_Health)
-                            return Bozja.LostReraise;
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBloodRage) &&
+                            IsOffCooldown(Bozja.LostBloodRage))
+                            return Bozja.LostBloodRage;
 
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSpellforge) &&
-                            IsOffCooldown(Bozja.LostSpellforge) &&
-                            (!HasEffect(Bozja.Buffs.LostSpellforge) || !HasEffect(Bozja.Buffs.LostSteelsting)))
-                            return Bozja.LostSpellforge;
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_BannerOfSolemnClarity) &&
+                            IsOffCooldown(Bozja.BannerOfSolemnClarity) &&
+                            !HasEffect(Bozja.Buffs.BannerOfLimitlessGrace))
+                            return Bozja.BannerOfSolemnClarity;
 
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSteelsting) &&
-                            IsOffCooldown(Bozja.LostSteelsting) &&
-                            (!HasEffect(Bozja.Buffs.LostSpellforge) || !HasEffect(Bozja.Buffs.LostSteelsting)))
-                            return Bozja.LostSteelsting;
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure2) &&
+                            IsOffCooldown(Bozja.LostCure2) &&
+                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure2_Health)
+                            return Bozja.LostCure2;
 
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostProtect) &&
-                            IsOffCooldown(Bozja.LostProtect) &&
-                            !HasEffect(Bozja.Buffs.LostProtect))
-                            return Bozja.LostProtect;
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure4) &&
+                            IsOffCooldown(Bozja.LostCure4) &&
+                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure4_Health)
+                            return Bozja.LostCure4;
 
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostShell) &&
-                            IsOffCooldown(Bozja.LostShell) &&
-                            !HasEffect(Bozja.Buffs.LostShell))
-                            return Bozja.LostShell;
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostReflect) &&
+                            IsOffCooldown(Bozja.LostReflect) &&
+                            !HasEffect(Bozja.Buffs.LostReflect))
+                            return Bozja.LostReflect;
 
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBravery) &&
-                            IsOffCooldown(Bozja.LostBravery) &&
-                            !HasEffect(Bozja.Buffs.LostBravery))
-                            return Bozja.LostBravery;
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostAethershield) &&
+                            IsOffCooldown(Bozja.LostAethershield) &&
+                            !HasEffect(Bozja.Buffs.LostAethershield) &&
+                            PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostAethershield_Health)
+                            return Bozja.LostAethershield;
 
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostProtect2) &&
-                            IsOffCooldown(Bozja.LostProtect2) &&
-                            !HasEffect(Bozja.Buffs.LostProtect2))
-                            return Bozja.LostProtect2;
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSwift) &&
+                            IsOffCooldown(Bozja.LostSwift) &&
+                            !HasEffect(Bozja.Buffs.LostSwift))
+                            return Bozja.LostSwift;
 
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostShell2) &&
-                            IsOffCooldown(Bozja.LostShell2) &&
-                            !HasEffect(Bozja.Buffs.LostShell2))
-                            return Bozja.LostShell2;
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostFontOfSkill) &&
+                            IsOffCooldown(Bozja.LostFontOfSkill))
+                            return Bozja.LostFontOfSkill;
 
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBubble) &&
-                            IsOffCooldown(Bozja.LostBubble) &&
-                            !HasEffect(Bozja.Buffs.LostBubble))
-                            return Bozja.LostBubble;
-
-                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostParalyze3) &&
-                            IsOffCooldown(Bozja.LostParalyze3) &&
-                            !JustUsed(Bozja.LostParalyze3, 60f))
-                            return Bozja.LostParalyze3;
+                        if (IsEnabled(CustomComboPreset.GNB_Bozja_LostRampage) &&
+                            IsOffCooldown(Bozja.LostRampage))
+                            return Bozja.LostRampage;
                     }
-                    #endregion
 
-                    #region Rotation
-                    if (InCombat()) //if already in combat
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostStealth) &&
+                        !InCombat() &&
+                        IsOffCooldown(Bozja.LostStealth))
+                        return Bozja.LostStealth;
+
+                    //GCDs
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostDeath) &&
+                        IsOffCooldown(Bozja.LostDeath))
+                        return Bozja.LostDeath;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure) &&
+                        IsOffCooldown(Bozja.LostCure) &&
+                        PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure_Health)
+                        return Bozja.LostCure;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostCure3) &&
+                        IsOffCooldown(Bozja.LostCure3) &&
+                        PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure3_Health)
+                        return Bozja.LostCure3;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostArise) &&
+                        IsOffCooldown(Bozja.LostArise) &&
+                        GetTargetHPPercent() == 0 &&
+                        !HasEffect(All.Debuffs.Raise))
+                        return Bozja.LostArise;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSacrifice) &&
+                        IsOffCooldown(Bozja.LostSacrifice) &&
+                        GetTargetHPPercent() == 0)
+                        return Bozja.LostSacrifice;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostReraise) &&
+                        IsOffCooldown(Bozja.LostReraise) &&
+                        PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostReraise_Health)
+                        return Bozja.LostReraise;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSpellforge) &&
+                        IsOffCooldown(Bozja.LostSpellforge) &&
+                        (!HasEffect(Bozja.Buffs.LostSpellforge) || !HasEffect(Bozja.Buffs.LostSteelsting)))
+                        return Bozja.LostSpellforge;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSteelsting) &&
+                        IsOffCooldown(Bozja.LostSteelsting) &&
+                        (!HasEffect(Bozja.Buffs.LostSpellforge) || !HasEffect(Bozja.Buffs.LostSteelsting)))
+                        return Bozja.LostSteelsting;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostProtect) &&
+                        IsOffCooldown(Bozja.LostProtect) &&
+                        !HasEffect(Bozja.Buffs.LostProtect))
+                        return Bozja.LostProtect;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostShell) &&
+                        IsOffCooldown(Bozja.LostShell) &&
+                        !HasEffect(Bozja.Buffs.LostShell))
+                        return Bozja.LostShell;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBravery) &&
+                        IsOffCooldown(Bozja.LostBravery) &&
+                        !HasEffect(Bozja.Buffs.LostBravery))
+                        return Bozja.LostBravery;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostProtect2) &&
+                        IsOffCooldown(Bozja.LostProtect2) &&
+                        !HasEffect(Bozja.Buffs.LostProtect2))
+                        return Bozja.LostProtect2;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostShell2) &&
+                        IsOffCooldown(Bozja.LostShell2) &&
+                        !HasEffect(Bozja.Buffs.LostShell2))
+                        return Bozja.LostShell2;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostBubble) &&
+                        IsOffCooldown(Bozja.LostBubble) &&
+                        !HasEffect(Bozja.Buffs.LostBubble))
+                        return Bozja.LostBubble;
+
+                    if (IsEnabled(CustomComboPreset.GNB_Bozja_LostParalyze3) &&
+                        IsOffCooldown(Bozja.LostParalyze3) &&
+                        !JustUsed(Bozja.LostParalyze3, 60f))
+                        return Bozja.LostParalyze3;
+                }
+                #endregion
+
+                #region Rotation
+                if (InCombat()) //if already in combat
+                {
+                    if (CanWeave()) //if we can weave
                     {
-                        if (CanWeave()) //if we can weave
-                        {
-                            //NoMercy
-                            if (IsEnabled(CustomComboPreset.GNB_AoE_NoMercy) && //if No Mercy option is enabled
-                                ActionReady(NoMercy) && //if No Mercy is ready
-                                GetTargetHPPercent() > nmStop) //if target HP is above threshold
-                                return NoMercy; //execute No Mercy
-                            //BowShock
-                            if (IsEnabled(CustomComboPreset.GNB_AoE_BowShock) && //if Bow Shock option is enabled
-                                canBow && //if Bow Shock is ready
-                                HasEffect(Buffs.NoMercy)) //if No Mercy is active
-                                return BowShock; //execute Bow Shock
-                            //Zone
-                            if (IsEnabled(CustomComboPreset.GNB_AoE_Zone) &&
-                                canZone &&
-                                nmCD is < 57.5f and > 17) //use on CD after first usage in NM
-                                return OriginalHook(DangerZone); //execute Zone
-                            //Bloodfest
-                            if (IsEnabled(CustomComboPreset.GNB_AoE_Bloodfest) && //if Bloodfest option is enabled
-                                canBF) //if Bloodfest is ready & gauge is empty
-                                return Bloodfest; //execute Bloodfest
-                            //Continuation
-                            if (LevelChecked(FatedBrand) && //if Fated Brand is unlocked
-                                HasEffect(Buffs.ReadyToRaze)) //if Ready To Raze is active
-                                return FatedBrand; //execute Fated Brand
-                        }
-
-                        //SonicBreak
-                        if (IsEnabled(CustomComboPreset.GNB_AoE_SonicBreak) && //if Sonic Break option is enabled
-                            canBreak && //if Ready To Break is active & unlocked
-                            !HasEffect(Buffs.ReadyToRaze) && //if Ready To Raze is not active
+                        //NoMercy
+                        if (IsEnabled(CustomComboPreset.GNB_AoE_NoMercy) && //if No Mercy option is enabled
+                            ActionReady(NoMercy) && //if No Mercy is ready
+                            GetTargetHPPercent() > nmStop) //if target HP is above threshold
+                            return NoMercy; //execute No Mercy
+                        //BowShock
+                        if (IsEnabled(CustomComboPreset.GNB_AoE_BowShock) && //if Bow Shock option is enabled
+                            canBow && //if Bow Shock is ready
                             HasEffect(Buffs.NoMercy)) //if No Mercy is active
-                            return SonicBreak;
-                        //DoubleDown
-                        if (IsEnabled(CustomComboPreset.GNB_AoE_DoubleDown) && //if Double Down option is enabled
-                            canDD && //if Double Down is ready && gauge is not empty
-                            HasEffect(Buffs.NoMercy)) //if No Mercy is active
-                            return DoubleDown; //execute Double Down
-                        //Reign - because leaving this out anywhere is a waste
-                        if (IsEnabled(CustomComboPreset.GNB_AoE_Reign) && //if Reign of Beasts option is enabled
-                            LevelChecked(ReignOfBeasts)) //if Reign of Beasts is unlocked
-                        {
-                            if (canReign || //can execute Reign of Beasts
-                               (GunStep is 3 or 4)) //can execute Noble Blood or Lion Heart
-                                return OriginalHook(ReignOfBeasts);
-                        }
-                        //FatedCircle - if not LevelChecked, use BurstStrike
-                        if (IsEnabled(CustomComboPreset.GNB_AoE_FatedCircle) && //if Fated Circle option is enabled
-                            canFC && //if Fated Circle is unlocked && gauge is not empty
-                                     //Normal
-                            ((HasEffect(Buffs.NoMercy) && //if No Mercy is active
-                            !ActionReady(DoubleDown) && //if Double Down is not ready
-                            GunStep == 0) || //if Gnashing Fang or Reign combo is not active
-                                             //Bloodfest prep
-                            (IsEnabled(CustomComboPreset.GNB_AoE_Bloodfest) && //if Bloodfest option is enabled
-                            bfCD < 6))) //if Bloodfest is about to be ready
-                            return FatedCircle;
-                        if (IsEnabled(CustomComboPreset.GNB_AoE_noFatedCircle) && //if Fated Circle Burst Strike option is disabled
-                            Ammo > 0 && //if gauge is not empty
-                            !LevelChecked(FatedCircle) && //if Fated Circle is not unlocked
-                            LevelChecked(BurstStrike) && //if Burst Strike is unlocked
-                            (HasEffect(Buffs.NoMercy) && //if No Mercy is active
-                            GunStep == 0)) //if Gnashing Fang or Reign combo is not active
-                            return BurstStrike;
+                            return BowShock; //execute Bow Shock
+                        //Zone
+                        if (IsEnabled(CustomComboPreset.GNB_AoE_Zone) &&
+                            canZone &&
+                            nmCD is < 57.5f and > 17) //use on CD after first usage in NM
+                            return OriginalHook(DangerZone); //execute Zone
+                        //Bloodfest
+                        if (IsEnabled(CustomComboPreset.GNB_AoE_Bloodfest) && //if Bloodfest option is enabled
+                            canBF) //if Bloodfest is ready & gauge is empty
+                            return Bloodfest; //execute Bloodfest
+                        //Continuation
+                        if (LevelChecked(FatedBrand) && //if Fated Brand is unlocked
+                            HasEffect(Buffs.ReadyToRaze)) //if Ready To Raze is active
+                            return FatedBrand; //execute Fated Brand
                     }
 
-                    //1-2
-                    if (ComboTimer > 0) //if we're in combo
+                    //SonicBreak
+                    if (IsEnabled(CustomComboPreset.GNB_AoE_SonicBreak) && //if Sonic Break option is enabled
+                        canBreak && //if Ready To Break is active & unlocked
+                        !HasEffect(Buffs.ReadyToRaze) && //if Ready To Raze is not active
+                        HasEffect(Buffs.NoMercy)) //if No Mercy is active
+                        return SonicBreak;
+                    //DoubleDown
+                    if (IsEnabled(CustomComboPreset.GNB_AoE_DoubleDown) && //if Double Down option is enabled
+                        canDD && //if Double Down is ready && gauge is not empty
+                        HasEffect(Buffs.NoMercy)) //if No Mercy is active
+                        return DoubleDown; //execute Double Down
+                    //Reign - because leaving this out anywhere is a waste
+                    if (IsEnabled(CustomComboPreset.GNB_AoE_Reign) && //if Reign of Beasts option is enabled
+                        LevelChecked(ReignOfBeasts)) //if Reign of Beasts is unlocked
                     {
-                        if (ComboAction == DemonSlice && //if last action was Demon Slice
-                            LevelChecked(DemonSlaughter)) //if Demon Slaughter is unlocked
-                        {
-                            if (Ammo == MaxCartridges())
-                            {
-                                if (IsEnabled(CustomComboPreset.GNB_AoE_Overcap) && //if Overcap option is enabled
-                                    LevelChecked(FatedCircle)) //if Fated Circle is unlocked
-                                    return FatedCircle; //execute Fated Circle
-                                if (IsEnabled(CustomComboPreset.GNB_AoE_BSOvercap) && //if Burst Strike Overcap option is enabled
-                                    !LevelChecked(FatedCircle)) //if Fated Circle is not unlocked
-                                    return BurstStrike; //execute Burst Strike
-                            }
-                            if (Ammo != MaxCartridges() || //if gauge is not full
-                                (Ammo == MaxCartridges() && //if gauge is full
-                                !LevelChecked(FatedCircle) && //if Fated Circle is not unlocked
-                                !IsEnabled(CustomComboPreset.GNB_AoE_BSOvercap))) //if Burst Strike Overcap option is disabled
-                            {
-                                return DemonSlaughter; //execute Demon Slaughter
-                            }
-                        }
+                        if (canReign || //can execute Reign of Beasts
+                            (GunStep is 3 or 4)) //can execute Noble Blood or Lion Heart
+                            return OriginalHook(ReignOfBeasts);
                     }
-                    #endregion
-
-                    return DemonSlice; //execute Demon Slice
+                    //FatedCircle - if not LevelChecked, use BurstStrike
+                    if (IsEnabled(CustomComboPreset.GNB_AoE_FatedCircle) && //if Fated Circle option is enabled
+                        canFC && //if Fated Circle is unlocked && gauge is not empty
+                        //Normal
+                        ((HasEffect(Buffs.NoMercy) && //if No Mercy is active
+                          !ActionReady(DoubleDown) && //if Double Down is not ready
+                          GunStep == 0) || //if Gnashing Fang or Reign combo is not active
+                         //Bloodfest prep
+                         (IsEnabled(CustomComboPreset.GNB_AoE_Bloodfest) && //if Bloodfest option is enabled
+                          bfCD < 6))) //if Bloodfest is about to be ready
+                        return FatedCircle;
+                    if (IsEnabled(CustomComboPreset.GNB_AoE_noFatedCircle) && //if Fated Circle Burst Strike option is disabled
+                        Ammo > 0 && //if gauge is not empty
+                        !LevelChecked(FatedCircle) && //if Fated Circle is not unlocked
+                        LevelChecked(BurstStrike) && //if Burst Strike is unlocked
+                        (HasEffect(Buffs.NoMercy) && //if No Mercy is active
+                         GunStep == 0)) //if Gnashing Fang or Reign combo is not active
+                        return BurstStrike;
                 }
 
-                return actionID;
+                //1-2
+                if (ComboTimer > 0) //if we're in combo
+                {
+                    if (ComboAction == DemonSlice && //if last action was Demon Slice
+                        LevelChecked(DemonSlaughter)) //if Demon Slaughter is unlocked
+                    {
+                        if (Ammo == MaxCartridges())
+                        {
+                            if (IsEnabled(CustomComboPreset.GNB_AoE_Overcap) && //if Overcap option is enabled
+                                LevelChecked(FatedCircle)) //if Fated Circle is unlocked
+                                return FatedCircle; //execute Fated Circle
+                            if (IsEnabled(CustomComboPreset.GNB_AoE_BSOvercap) && //if Burst Strike Overcap option is enabled
+                                !LevelChecked(FatedCircle)) //if Fated Circle is not unlocked
+                                return BurstStrike; //execute Burst Strike
+                        }
+                        if (Ammo != MaxCartridges() || //if gauge is not full
+                            (Ammo == MaxCartridges() && //if gauge is full
+                             !LevelChecked(FatedCircle) && //if Fated Circle is not unlocked
+                             !IsEnabled(CustomComboPreset.GNB_AoE_BSOvercap))) //if Burst Strike Overcap option is disabled
+                        {
+                            return DemonSlaughter; //execute Demon Slaughter
+                        }
+                    }
+                }
+                #endregion
+
+                return DemonSlice; //execute Demon Slice
+
             }
         }
         #endregion
@@ -2029,192 +2019,192 @@ namespace WrathCombo.Combos.PvE
                 var GFchoice = Config.GNB_GF_Features_Choice == 0; //Gnashing Fang as button
                 var NMchoice = Config.GNB_GF_Features_Choice == 1; //No Mercy as button
 
-                if ((GFchoice && actionID == GnashingFang) ||
-                    (NMchoice && actionID == NoMercy))
+                if (GFchoice && actionID is not GnashingFang ||
+                    NMchoice && actionID is not NoMercy)
+                    return actionID;
+
+                #region Variables
+                //Gauge
+                var Ammo = GetJobGauge<GNBGauge>().Ammo; //Our cartridge count
+                var GunStep = GetJobGauge<GNBGauge>().AmmoComboStep; //For Gnashing Fang & Reign combo purposes
+                //Cooldown-related
+                var gfCD = GetCooldownRemainingTime(GnashingFang); //GnashingFang's cooldown; 30s total
+                var nmCD = GetCooldownRemainingTime(NoMercy); //NoMercy's cooldown; 60s total
+                var ddCD = GetCooldownRemainingTime(DoubleDown); //Double Down's cooldown; 60s total
+                var bfCD = GetCooldownRemainingTime(Bloodfest); //Bloodfest's cooldown; 120s total
+                var nmLeft = GetBuffRemainingTime(Buffs.NoMercy); //Remaining time for No Mercy buff (20s)
+                var hasNM = nmCD is >= 40 and <= 60; //Checks if No Mercy is active
+                var hasBreak = HasEffect(Buffs.ReadyToBreak); //Checks for Ready To Break buff
+                var hasReign = HasEffect(Buffs.ReadyToReign); //Checks for Ready To Reign buff
+
+                //Misc
+                var inOdd = bfCD is < 90 and > 20; //Odd Minute
+                var canLateWeave = GetCooldownRemainingTime(actionID) < 1 && GetCooldownRemainingTime(actionID) > 0.6; //SkS purposes
+                var GCD = GetCooldown(KeenEdge).CooldownTotal; //2.5 is base SkS, but can work with 2.4x
+                #region Minimal Requirements
+                //Ammo-relative
+                var canBS = LevelChecked(BurstStrike) && //Burst Strike is unlocked
+                            Ammo > 0; //Has Ammo
+                var canGF = LevelChecked(GnashingFang) && //GnashingFang is unlocked
+                            gfCD < 0.6f && //Gnashing Fang is off cooldown
+                            !HasEffect(Buffs.ReadyToBlast) && //to ensure Hypervelocity is spent in case Burst Strike is used before Gnashing Fang
+                            GunStep == 0 && //Gnashing Fang or Reign combo is not already active
+                            Ammo > 0; //Has Ammo
+                var canDD = LevelChecked(DoubleDown) && //Double Down is unlocked
+                            ddCD < 0.6f && //Double Down is off cooldown
+                            Ammo > 0; //Has Ammo
+                var canBF = LevelChecked(Bloodfest) && //Bloodfest is unlocked
+                            bfCD < 0.6f; //Bloodfest is off cooldown
+                //Cooldown-relative
+                var canZone = LevelChecked(DangerZone) && //Zone is unlocked
+                              GetCooldownRemainingTime(OriginalHook(DangerZone)) < 0.6f; //DangerZone is off cooldown
+                var canBreak = LevelChecked(SonicBreak) && //Sonic Break is unlocked
+                               hasBreak; //No Mercy or Ready To Break is active
+                var canBow = LevelChecked(BowShock) && //Bow Shock is unlocked
+                             GetCooldownRemainingTime(BowShock) < 0.6f; //BowShock is off cooldown
+                var canContinue = LevelChecked(Continuation); //Continuation is unlocked
+                var canReign = LevelChecked(ReignOfBeasts) && //Reign of Beasts is unlocked
+                               GunStep == 0 && //Gnashing Fang or Reign combo is not already active
+                               hasReign; //Ready To Reign is active
+                #endregion
+                #endregion
+
+                //oGCDs
+                if (CanWeave())
                 {
-                    #region Variables
-                    //Gauge
-                    var Ammo = GetJobGauge<GNBGauge>().Ammo; //Our cartridge count
-                    var GunStep = GetJobGauge<GNBGauge>().AmmoComboStep; //For Gnashing Fang & Reign combo purposes
-                    //Cooldown-related
-                    var gfCD = GetCooldownRemainingTime(GnashingFang); //GnashingFang's cooldown; 30s total
-                    var nmCD = GetCooldownRemainingTime(NoMercy); //NoMercy's cooldown; 60s total
-                    var ddCD = GetCooldownRemainingTime(DoubleDown); //Double Down's cooldown; 60s total
-                    var bfCD = GetCooldownRemainingTime(Bloodfest); //Bloodfest's cooldown; 120s total
-                    var nmLeft = GetBuffRemainingTime(Buffs.NoMercy); //Remaining time for No Mercy buff (20s)
-                    var hasNM = nmCD is >= 40 and <= 60; //Checks if No Mercy is active
-                    var hasBreak = HasEffect(Buffs.ReadyToBreak); //Checks for Ready To Break buff
-                    var hasReign = HasEffect(Buffs.ReadyToReign); //Checks for Ready To Reign buff
-
-                    //Misc
-                    var inOdd = bfCD is < 90 and > 20; //Odd Minute
-                    var canLateWeave = GetCooldownRemainingTime(actionID) < 1 && GetCooldownRemainingTime(actionID) > 0.6; //SkS purposes
-                    var GCD = GetCooldown(KeenEdge).CooldownTotal; //2.5 is base SkS, but can work with 2.4x
-                    #region Minimal Requirements
-                    //Ammo-relative
-                    var canBS = LevelChecked(BurstStrike) && //Burst Strike is unlocked
-                                Ammo > 0; //Has Ammo
-                    var canGF = LevelChecked(GnashingFang) && //GnashingFang is unlocked
-                                gfCD < 0.6f && //Gnashing Fang is off cooldown
-                                !HasEffect(Buffs.ReadyToBlast) && //to ensure Hypervelocity is spent in case Burst Strike is used before Gnashing Fang
-                                GunStep == 0 && //Gnashing Fang or Reign combo is not already active
-                                Ammo > 0; //Has Ammo
-                    var canDD = LevelChecked(DoubleDown) && //Double Down is unlocked
-                                ddCD < 0.6f && //Double Down is off cooldown
-                                Ammo > 0; //Has Ammo
-                    var canBF = LevelChecked(Bloodfest) && //Bloodfest is unlocked
-                                bfCD < 0.6f; //Bloodfest is off cooldown
-                    //Cooldown-relative
-                    var canZone = LevelChecked(DangerZone) && //Zone is unlocked
-                                GetCooldownRemainingTime(OriginalHook(DangerZone)) < 0.6f; //DangerZone is off cooldown
-                    var canBreak = LevelChecked(SonicBreak) && //Sonic Break is unlocked
-                                hasBreak; //No Mercy or Ready To Break is active
-                    var canBow = LevelChecked(BowShock) && //Bow Shock is unlocked
-                                GetCooldownRemainingTime(BowShock) < 0.6f; //BowShock is off cooldown
-                    var canContinue = LevelChecked(Continuation); //Continuation is unlocked
-                    var canReign = LevelChecked(ReignOfBeasts) && //Reign of Beasts is unlocked
-                                GunStep == 0 && //Gnashing Fang or Reign combo is not already active
-                                hasReign; //Ready To Reign is active
-                    #endregion
-                    #endregion
-
-                    //oGCDs
-                    if (CanWeave())
+                    //No Mercy
+                    if (IsEnabled(CustomComboPreset.GNB_GF_NoMercy) && //No Mercy option is enabled
+                        ActionReady(NoMercy) && //No Mercy is ready
+                        InCombat() && //In combat
+                        HasTarget() && //Has target
+                        CanWeave()) //Able to weave
                     {
-                        //No Mercy
-                        if (IsEnabled(CustomComboPreset.GNB_GF_NoMercy) && //No Mercy option is enabled
-                            ActionReady(NoMercy) && //No Mercy is ready
-                            InCombat() && //In combat
-                            HasTarget() && //Has target
-                            CanWeave()) //Able to weave
+                        if (LevelChecked(DoubleDown)) //Lv90+
                         {
-                            if (LevelChecked(DoubleDown)) //Lv90+
-                            {
-                                if ((inOdd && //Odd Minute window
-                                    (Ammo >= 2 || (ComboAction is BrutalShell && Ammo == 1))) || //2 or 3 Ammo or 1 Ammo with Solid Barrel next in combo
-                                    (!inOdd && //Even Minute window
-                                    Ammo != 3)) //Ammo is not full (3)
-                                    return NoMercy; //Execute No Mercy if conditions are met
-                            }
-                            if (!LevelChecked(DoubleDown)) //Lv1-89
-                            {
-                                if (canLateWeave && //Late-weaveable
-                                    Ammo == MaxCartridges()) //Ammo is full
-                                    return NoMercy; //Execute No Mercy if conditions are met
-                            }
+                            if ((inOdd && //Odd Minute window
+                                 (Ammo >= 2 || (ComboAction is BrutalShell && Ammo == 1))) || //2 or 3 Ammo or 1 Ammo with Solid Barrel next in combo
+                                (!inOdd && //Even Minute window
+                                 Ammo != 3)) //Ammo is not full (3)
+                                return NoMercy; //Execute No Mercy if conditions are met
                         }
-
-                        //Cooldowns
-                        if (IsEnabled(CustomComboPreset.GNB_GF_Features)) //Features are enabled
+                        if (!LevelChecked(DoubleDown)) //Lv1-89
                         {
-                            //Hypervelocity
-                            if (IsEnabled(CustomComboPreset.GNB_GF_Continuation) && //Continuation option is enabled
-                                LevelChecked(Hypervelocity) && //Hypervelocity is unlocked
-                                (JustUsed(BurstStrike, 5f) || //Burst Strike was just used within 5 seconds
-                                HasEffect(Buffs.ReadyToBlast))) //Ready To Blast buff is active
-                                return Hypervelocity; //Execute Hypervelocity if conditions are met
-
-                            //Continuation
-                            if (IsEnabled(CustomComboPreset.GNB_GF_Continuation) && //Continuation option is enabled
-                                canContinue && //able to use Continuation
-                                (HasEffect(Buffs.ReadyToRip) || //after Gnashing Fang
-                                HasEffect(Buffs.ReadyToTear) || //after Savage Claw
-                                HasEffect(Buffs.ReadyToGouge) || //after Wicked Talon
-                                HasEffect(Buffs.ReadyToBlast))) //after Burst Strike
-                                return OriginalHook(Continuation); //Execute appopriate Continuation action if conditions are met
-
-                            //Bloodfest
-                            if (IsEnabled(CustomComboPreset.GNB_GF_Bloodfest) && //Bloodfest option is enabled
-                                InCombat() && //In combat
-                                HasTarget() && //Has target
-                                canBF && //able to use Bloodfest
-                                Ammo == 0) //Only when ammo is empty
-                                return Bloodfest; //Execute Bloodfest if conditions are met
-
-                            //Zone
-                            if (IsEnabled(CustomComboPreset.GNB_GF_Zone) && //Zone option is enabled
-                                canZone && //able to use Zone
-                                (nmCD is < 57.5f and > 17f))//Optimal use; twice per minute, 1 in NM, 1 out of NM
-                                return OriginalHook(DangerZone); //Execute Zone if conditions are met
-
-                            //Bow Shock
-                            if (IsEnabled(CustomComboPreset.GNB_GF_BowShock) && //Bow Shock option is enabled
-                                canBow && //able to use Bow Shock
-                                nmCD is < 57.5f and >= 40) //No Mercy is up & was not just used within 1 GCD
-                                return BowShock;
+                            if (canLateWeave && //Late-weaveable
+                                Ammo == MaxCartridges()) //Ammo is full
+                                return NoMercy; //Execute No Mercy if conditions are met
                         }
                     }
 
-                    //GCDs
+                    //Cooldowns
                     if (IsEnabled(CustomComboPreset.GNB_GF_Features)) //Features are enabled
                     {
-                        //GnashingFang
-                        if (canGF && //able to use Gnashing Fang
-                            ((nmCD is > 17 and < 35) || //30s Optimal use
-                            (JustUsed(NoMercy, 6f)))) //No Mercy was just used within 4 seconds
-                            return GnashingFang;
+                        //Hypervelocity
+                        if (IsEnabled(CustomComboPreset.GNB_GF_Continuation) && //Continuation option is enabled
+                            LevelChecked(Hypervelocity) && //Hypervelocity is unlocked
+                            (JustUsed(BurstStrike, 5f) || //Burst Strike was just used within 5 seconds
+                             HasEffect(Buffs.ReadyToBlast))) //Ready To Blast buff is active
+                            return Hypervelocity; //Execute Hypervelocity if conditions are met
 
-                        //Double Down
-                        if (IsEnabled(CustomComboPreset.GNB_GF_DoubleDown) && //Double Down option is enabled
-                            canDD && //able to use Double Down
-                            IsOnCooldown(GnashingFang) && //Gnashing Fang is on cooldown
-                            hasNM) //No Mercy is active
-                            return DoubleDown;
+                        //Continuation
+                        if (IsEnabled(CustomComboPreset.GNB_GF_Continuation) && //Continuation option is enabled
+                            canContinue && //able to use Continuation
+                            (HasEffect(Buffs.ReadyToRip) || //after Gnashing Fang
+                             HasEffect(Buffs.ReadyToTear) || //after Savage Claw
+                             HasEffect(Buffs.ReadyToGouge) || //after Wicked Talon
+                             HasEffect(Buffs.ReadyToBlast))) //after Burst Strike
+                            return OriginalHook(Continuation); //Execute appopriate Continuation action if conditions are met
 
-                        //Sonic Break
-                        if (IsEnabled(CustomComboPreset.GNB_GF_SonicBreak) && //Sonic Break option is enabled
-                            canBreak && //able to use Sonic Break
-                            ((IsOnCooldown(GnashingFang) && IsOnCooldown(DoubleDown)) || //Gnashing Fang and Double Down are both on cooldown
-                            nmLeft <= GCD)) //No Mercy buff is about to expire
-                            return SonicBreak; //Execute Sonic Break if conditions are met
+                        //Bloodfest
+                        if (IsEnabled(CustomComboPreset.GNB_GF_Bloodfest) && //Bloodfest option is enabled
+                            InCombat() && //In combat
+                            HasTarget() && //Has target
+                            canBF && //able to use Bloodfest
+                            Ammo == 0) //Only when ammo is empty
+                            return Bloodfest; //Execute Bloodfest if conditions are met
 
-                        //Reign of Beasts
-                        if (IsEnabled(CustomComboPreset.GNB_GF_Reign) && //Reign of Beasts option is enabled
-                            canReign && //able to use Reign of Beasts
-                            IsOnCooldown(GnashingFang) && //Gnashing Fang is on cooldown
-                            IsOnCooldown(DoubleDown) && //Double Down is on cooldown
-                            !HasEffect(Buffs.ReadyToBreak) && //Ready To Break is not active
-                            GunStep == 0) //Gnashing Fang or Reign combo is not active or finished
-                            return OriginalHook(ReignOfBeasts); //Execute Reign of Beasts if conditions are met
+                        //Zone
+                        if (IsEnabled(CustomComboPreset.GNB_GF_Zone) && //Zone option is enabled
+                            canZone && //able to use Zone
+                            (nmCD is < 57.5f and > 17f))//Optimal use; twice per minute, 1 in NM, 1 out of NM
+                            return OriginalHook(DangerZone); //Execute Zone if conditions are met
 
-                        //Burst Strike
-                        if (IsEnabled(CustomComboPreset.GNB_GF_BurstStrike) && //Burst Strike option is enabled
-                            canBS && //able to use Burst Strike
-                            HasEffect(Buffs.NoMercy) && //No Mercy is active
-                            IsOnCooldown(GnashingFang) && //Gnashing Fang is on cooldown
-                            IsOnCooldown(DoubleDown) && //Double Down is on cooldown
-                            !HasEffect(Buffs.ReadyToBreak) && //Ready To Break is not active
-                            !HasEffect(Buffs.ReadyToReign) && //Ready To Reign is not active
-                            GunStep == 0) //Gnashing Fang or Reign combo is not active or finished
-                            return BurstStrike; //Execute Burst Strike if conditions are met
+                        //Bow Shock
+                        if (IsEnabled(CustomComboPreset.GNB_GF_BowShock) && //Bow Shock option is enabled
+                            canBow && //able to use Bow Shock
+                            nmCD is < 57.5f and >= 40) //No Mercy is up & was not just used within 1 GCD
+                            return BowShock;
                     }
-
-                    //Lv90+ 2cart forced Reopener
-                    if (IsEnabled(CustomComboPreset.GNB_GF_Features) && //Cooldowns option is enabled
-                        IsEnabled(CustomComboPreset.GNB_GF_NoMercy) && //No Mercy option is enabled
-                        IsEnabled(CustomComboPreset.GNB_GF_BurstStrike) && //Burst Strike option is enabled
-                        LevelChecked(DoubleDown) && //Lv90+
-                        nmCD < 1 && //No Mercy is ready or about to be
-                        Ammo is 3 && //Ammo is full
-                        bfCD > 110 && //Bloodfest was recently used, but not just used
-                        ComboAction is KeenEdge) //Just used Keen Edge
-                        return BurstStrike;
-                    //Lv100 2cart forced 2min starter
-                    if (IsEnabled(CustomComboPreset.GNB_GF_Features) && //Cooldowns option is enabled
-                        IsEnabled(CustomComboPreset.GNB_GF_NoMercy) && //No Mercy option is enabled
-                        IsEnabled(CustomComboPreset.GNB_GF_BurstStrike) && //Burst Strike option is enabled
-                        LevelChecked(ReignOfBeasts) && //Lv100
-                        (nmCD < 1 && //No Mercy is ready or about to be
-                        Ammo is 3 && //Ammo is full
-                        bfCD < GCD * 12)) //Bloodfest is ready or about to be
-                        return BurstStrike;
-
-                    //Gauge Combo Steps
-                    if (GunStep is 1 or 2) //Gnashing Fang combo is only for 1 and 2
-                        return OriginalHook(GnashingFang); //Execute Gnashing Fang combo if conditions are met
-                    if (GunStep is 3 or 4) //Reign of Beasts combo is only for 3 and 4
-                        return OriginalHook(ReignOfBeasts); //Execute Reign of Beasts combo if conditions are met
                 }
+
+                //GCDs
+                if (IsEnabled(CustomComboPreset.GNB_GF_Features)) //Features are enabled
+                {
+                    //GnashingFang
+                    if (canGF && //able to use Gnashing Fang
+                        ((nmCD is > 17 and < 35) || //30s Optimal use
+                         (JustUsed(NoMercy, 6f)))) //No Mercy was just used within 4 seconds
+                        return GnashingFang;
+
+                    //Double Down
+                    if (IsEnabled(CustomComboPreset.GNB_GF_DoubleDown) && //Double Down option is enabled
+                        canDD && //able to use Double Down
+                        IsOnCooldown(GnashingFang) && //Gnashing Fang is on cooldown
+                        hasNM) //No Mercy is active
+                        return DoubleDown;
+
+                    //Sonic Break
+                    if (IsEnabled(CustomComboPreset.GNB_GF_SonicBreak) && //Sonic Break option is enabled
+                        canBreak && //able to use Sonic Break
+                        ((IsOnCooldown(GnashingFang) && IsOnCooldown(DoubleDown)) || //Gnashing Fang and Double Down are both on cooldown
+                         nmLeft <= GCD)) //No Mercy buff is about to expire
+                        return SonicBreak; //Execute Sonic Break if conditions are met
+
+                    //Reign of Beasts
+                    if (IsEnabled(CustomComboPreset.GNB_GF_Reign) && //Reign of Beasts option is enabled
+                        canReign && //able to use Reign of Beasts
+                        IsOnCooldown(GnashingFang) && //Gnashing Fang is on cooldown
+                        IsOnCooldown(DoubleDown) && //Double Down is on cooldown
+                        !HasEffect(Buffs.ReadyToBreak) && //Ready To Break is not active
+                        GunStep == 0) //Gnashing Fang or Reign combo is not active or finished
+                        return OriginalHook(ReignOfBeasts); //Execute Reign of Beasts if conditions are met
+
+                    //Burst Strike
+                    if (IsEnabled(CustomComboPreset.GNB_GF_BurstStrike) && //Burst Strike option is enabled
+                        canBS && //able to use Burst Strike
+                        HasEffect(Buffs.NoMercy) && //No Mercy is active
+                        IsOnCooldown(GnashingFang) && //Gnashing Fang is on cooldown
+                        IsOnCooldown(DoubleDown) && //Double Down is on cooldown
+                        !HasEffect(Buffs.ReadyToBreak) && //Ready To Break is not active
+                        !HasEffect(Buffs.ReadyToReign) && //Ready To Reign is not active
+                        GunStep == 0) //Gnashing Fang or Reign combo is not active or finished
+                        return BurstStrike; //Execute Burst Strike if conditions are met
+                }
+
+                //Lv90+ 2cart forced Reopener
+                if (IsEnabled(CustomComboPreset.GNB_GF_Features) && //Cooldowns option is enabled
+                    IsEnabled(CustomComboPreset.GNB_GF_NoMercy) && //No Mercy option is enabled
+                    IsEnabled(CustomComboPreset.GNB_GF_BurstStrike) && //Burst Strike option is enabled
+                    LevelChecked(DoubleDown) && //Lv90+
+                    nmCD < 1 && //No Mercy is ready or about to be
+                    Ammo is 3 && //Ammo is full
+                    bfCD > 110 && //Bloodfest was recently used, but not just used
+                    ComboAction is KeenEdge) //Just used Keen Edge
+                    return BurstStrike;
+                //Lv100 2cart forced 2min starter
+                if (IsEnabled(CustomComboPreset.GNB_GF_Features) && //Cooldowns option is enabled
+                    IsEnabled(CustomComboPreset.GNB_GF_NoMercy) && //No Mercy option is enabled
+                    IsEnabled(CustomComboPreset.GNB_GF_BurstStrike) && //Burst Strike option is enabled
+                    LevelChecked(ReignOfBeasts) && //Lv100
+                    (nmCD < 1 && //No Mercy is ready or about to be
+                     Ammo is 3 && //Ammo is full
+                     bfCD < GCD * 12)) //Bloodfest is ready or about to be
+                    return BurstStrike;
+
+                //Gauge Combo Steps
+                if (GunStep is 1 or 2) //Gnashing Fang combo is only for 1 and 2
+                    return OriginalHook(GnashingFang); //Execute Gnashing Fang combo if conditions are met
+                if (GunStep is 3 or 4) //Reign of Beasts combo is only for 3 and 4
+                    return OriginalHook(ReignOfBeasts); //Execute Reign of Beasts combo if conditions are met
 
                 return actionID;
             }
@@ -2228,85 +2218,84 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is BurstStrike)
-                {
-                    #region Variables
-                    //Gauge
-                    var Ammo = GetJobGauge<GNBGauge>().Ammo; //Our cartridge count
-                    var GunStep = GetJobGauge<GNBGauge>().AmmoComboStep; //For Gnashing Fang & Reign combo purposes
-                    //Cooldown-related
-                    var gfCD = GetCooldownRemainingTime(GnashingFang); //GnashingFang's cooldown; 30s total
-                    var ddCD = GetCooldownRemainingTime(DoubleDown); //Double Down's cooldown; 60s total
-                    var bfCD = GetCooldownRemainingTime(Bloodfest); //Bloodfest's cooldown; 120s total
-                    var hasReign = HasEffect(Buffs.ReadyToReign); //Checks for Ready To Reign buff
+                if (actionID is not BurstStrike) return actionID;
 
-                    #region Minimal Requirements
-                    //Ammo-relative
-                    var canGF = LevelChecked(GnashingFang) && //GnashingFang is unlocked
-                                gfCD < 0.6f && //Gnashing Fang is off cooldown
-                                !HasEffect(Buffs.ReadyToBlast) && //to ensure Hypervelocity is spent in case Burst Strike is used before Gnashing Fang
-                                GunStep == 0 && //Gnashing Fang or Reign combo is not already active
-                                Ammo > 0; //Has Ammo
-                    var canDD = LevelChecked(DoubleDown) && //Double Down is unlocked
-                                ddCD < 0.6f && //Double Down is off cooldown
-                                Ammo > 0; //Has Ammo
-                    var canBF = LevelChecked(Bloodfest) && //Bloodfest is unlocked
-                                bfCD < 0.6f; //Bloodfest is off cooldown
-                    //Cooldown-relative
-                    var canContinue = LevelChecked(Continuation); //Continuation is unlocked
-                    var canReign = LevelChecked(ReignOfBeasts) && //Reign of Beasts is unlocked
-                                GunStep == 0 && //Gnashing Fang or Reign combo is not already active
-                                hasReign; //Ready To Reign is active
-                    #endregion
-                    #endregion
+                #region Variables
+                //Gauge
+                var Ammo = GetJobGauge<GNBGauge>().Ammo; //Our cartridge count
+                var GunStep = GetJobGauge<GNBGauge>().AmmoComboStep; //For Gnashing Fang & Reign combo purposes
+                //Cooldown-related
+                var gfCD = GetCooldownRemainingTime(GnashingFang); //GnashingFang's cooldown; 30s total
+                var ddCD = GetCooldownRemainingTime(DoubleDown); //Double Down's cooldown; 60s total
+                var bfCD = GetCooldownRemainingTime(Bloodfest); //Bloodfest's cooldown; 120s total
+                var hasReign = HasEffect(Buffs.ReadyToReign); //Checks for Ready To Reign buff
 
-                    //Hypervelocity
-                    if (IsEnabled(CustomComboPreset.GNB_BS_Continuation) && //Continuation option is enabled
-                        IsEnabled(CustomComboPreset.GNB_BS_Hypervelocity) && //Continuation option is enabled
-                        LevelChecked(Hypervelocity) && //Hypervelocity is unlocked
-                        (JustUsed(BurstStrike, 5f) || //Burst Strike was just used within 5 seconds
-                        HasEffect(Buffs.ReadyToBlast))) //Ready To Blast buff is active
-                        return Hypervelocity; //Execute Hypervelocity if conditions are met
+                #region Minimal Requirements
+                //Ammo-relative
+                var canGF = LevelChecked(GnashingFang) && //GnashingFang is unlocked
+                            gfCD < 0.6f && //Gnashing Fang is off cooldown
+                            !HasEffect(Buffs.ReadyToBlast) && //to ensure Hypervelocity is spent in case Burst Strike is used before Gnashing Fang
+                            GunStep == 0 && //Gnashing Fang or Reign combo is not already active
+                            Ammo > 0; //Has Ammo
+                var canDD = LevelChecked(DoubleDown) && //Double Down is unlocked
+                            ddCD < 0.6f && //Double Down is off cooldown
+                            Ammo > 0; //Has Ammo
+                var canBF = LevelChecked(Bloodfest) && //Bloodfest is unlocked
+                            bfCD < 0.6f; //Bloodfest is off cooldown
+                //Cooldown-relative
+                var canContinue = LevelChecked(Continuation); //Continuation is unlocked
+                var canReign = LevelChecked(ReignOfBeasts) && //Reign of Beasts is unlocked
+                               GunStep == 0 && //Gnashing Fang or Reign combo is not already active
+                               hasReign; //Ready To Reign is active
+                #endregion
+                #endregion
 
-                    //Continuation
-                    if (IsEnabled(CustomComboPreset.GNB_BS_Continuation) && //Continuation option is enabled
-                        !IsEnabled(CustomComboPreset.GNB_BS_Hypervelocity) && //Hypervelocity Only option is disabled
-                        canContinue && //able to use Continuation
-                        (HasEffect(Buffs.ReadyToRip) || //after Gnashing Fang
-                        HasEffect(Buffs.ReadyToTear) || //after Savage Claw
-                        HasEffect(Buffs.ReadyToGouge) || //after Wicked Talon
-                        HasEffect(Buffs.ReadyToBlast))) //after Burst Strike
-                        return OriginalHook(Continuation); //Execute appopriate Continuation action if conditions are met
+                //Hypervelocity
+                if (IsEnabled(CustomComboPreset.GNB_BS_Continuation) && //Continuation option is enabled
+                    IsEnabled(CustomComboPreset.GNB_BS_Hypervelocity) && //Continuation option is enabled
+                    LevelChecked(Hypervelocity) && //Hypervelocity is unlocked
+                    (JustUsed(BurstStrike, 5f) || //Burst Strike was just used within 5 seconds
+                     HasEffect(Buffs.ReadyToBlast))) //Ready To Blast buff is active
+                    return Hypervelocity; //Execute Hypervelocity if conditions are met
 
-                    //Bloodfest
-                    if (IsEnabled(CustomComboPreset.GNB_BS_Bloodfest) && //Bloodfest option is enabled
-                        HasTarget() && //Has target
-                        canBF && //able to use Bloodfest
-                        Ammo == 0) //Only when ammo is empty
-                        return Bloodfest; //Execute Bloodfest if conditions are met
+                //Continuation
+                if (IsEnabled(CustomComboPreset.GNB_BS_Continuation) && //Continuation option is enabled
+                    !IsEnabled(CustomComboPreset.GNB_BS_Hypervelocity) && //Hypervelocity Only option is disabled
+                    canContinue && //able to use Continuation
+                    (HasEffect(Buffs.ReadyToRip) || //after Gnashing Fang
+                     HasEffect(Buffs.ReadyToTear) || //after Savage Claw
+                     HasEffect(Buffs.ReadyToGouge) || //after Wicked Talon
+                     HasEffect(Buffs.ReadyToBlast))) //after Burst Strike
+                    return OriginalHook(Continuation); //Execute appopriate Continuation action if conditions are met
 
-                    //Double Down higher prio if only 1 cartridge
-                    if (IsEnabled(CustomComboPreset.GNB_BS_DoubleDown) && //Double Down option is enabled
-                        LevelChecked(DoubleDown) && //Double Down is unlocked
-                        ddCD < 0.6f && //Double Down is off cooldown
-                        Ammo == 1) //Has Ammo
-                        return DoubleDown; //Execute Double Down if conditions are met
+                //Bloodfest
+                if (IsEnabled(CustomComboPreset.GNB_BS_Bloodfest) && //Bloodfest option is enabled
+                    HasTarget() && //Has target
+                    canBF && //able to use Bloodfest
+                    Ammo == 0) //Only when ammo is empty
+                    return Bloodfest; //Execute Bloodfest if conditions are met
 
-                    //Gnashing Fang
-                    if (IsEnabled(CustomComboPreset.GNB_BS_GnashingFang) && //Double Down option is enabled
-                        canGF) //able to use Gnashing Fang
-                        return GnashingFang; //Execute Gnashing Fang if conditions are met
+                //Double Down higher prio if only 1 cartridge
+                if (IsEnabled(CustomComboPreset.GNB_BS_DoubleDown) && //Double Down option is enabled
+                    LevelChecked(DoubleDown) && //Double Down is unlocked
+                    ddCD < 0.6f && //Double Down is off cooldown
+                    Ammo == 1) //Has Ammo
+                    return DoubleDown; //Execute Double Down if conditions are met
 
-                    //Double Down
-                    if (IsEnabled(CustomComboPreset.GNB_BS_DoubleDown) && //Double Down option is enabled
-                        canDD) //able to use Double Down
-                        return DoubleDown; //Execute Double Down if conditions are met
+                //Gnashing Fang
+                if (IsEnabled(CustomComboPreset.GNB_BS_GnashingFang) && //Double Down option is enabled
+                    canGF) //able to use Gnashing Fang
+                    return GnashingFang; //Execute Gnashing Fang if conditions are met
 
-                    //Reign
-                    if (IsEnabled(CustomComboPreset.GNB_BS_Reign) && //Reign of Beasts option is enabled
-                        (canReign || GunStep is 3 or 4)) //able to use Reign of Beasts
-                        return OriginalHook(ReignOfBeasts); //Execute Reign combo if conditions are met
-                }
+                //Double Down
+                if (IsEnabled(CustomComboPreset.GNB_BS_DoubleDown) && //Double Down option is enabled
+                    canDD) //able to use Double Down
+                    return DoubleDown; //Execute Double Down if conditions are met
+
+                //Reign
+                if (IsEnabled(CustomComboPreset.GNB_BS_Reign) && //Reign of Beasts option is enabled
+                    (canReign || GunStep is 3 or 4)) //able to use Reign of Beasts
+                    return OriginalHook(ReignOfBeasts); //Execute Reign combo if conditions are met
 
                 return actionID;
             }
@@ -2320,70 +2309,69 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is FatedCircle)
-                {
-                    #region Variables
-                    //Gauge
-                    var Ammo = GetJobGauge<GNBGauge>().Ammo; //Our cartridge count
-                    var GunStep = GetJobGauge<GNBGauge>().AmmoComboStep; //For Gnashing Fang & Reign combo purposes
-                    //Cooldown-related
-                    var nmCD = GetCooldownRemainingTime(NoMercy); //NoMercy's cooldown; 60s total
-                    var ddCD = GetCooldownRemainingTime(DoubleDown); //Double Down's cooldown; 60s total
-                    var bfCD = GetCooldownRemainingTime(Bloodfest); //Bloodfest's cooldown; 120s total
-                    var hasNM = nmCD is >= 40 and <= 60; //Checks if No Mercy is active
-                    var hasReign = HasEffect(Buffs.ReadyToReign); //Checks for Ready To Reign buff
-                    #region Minimal Requirements
-                    //Ammo-relative
-                    var canDD = LevelChecked(DoubleDown) && //Double Down is unlocked
-                                ddCD < 0.6f && //Double Down is off cooldown
-                                Ammo > 0; //Has Ammo
-                    var canBF = LevelChecked(Bloodfest) && //Bloodfest is unlocked
-                                bfCD < 0.6f; //Bloodfest is off cooldown
-                    //Cooldown-relative
-                    var canBow = LevelChecked(BowShock) && //Bow Shock is unlocked
-                                GetCooldownRemainingTime(BowShock) < 0.6f; //BowShock is off cooldown
-                    var canReign = LevelChecked(ReignOfBeasts) && //Reign of Beasts is unlocked
-                                GunStep == 0 && //Gnashing Fang or Reign combo is not already active
-                                hasReign; //Ready To Reign is active
-                    #endregion
-                    #endregion
+                if (actionID is not FatedCircle) return actionID;
 
-                    //Fated Brand
-                    if (IsEnabled(CustomComboPreset.GNB_FC_Continuation) && //Continuation option is enabled
-                        HasEffect(Buffs.ReadyToRaze) &&
-                        LevelChecked(FatedBrand))
-                        return FatedBrand;
+                #region Variables
+                //Gauge
+                var Ammo = GetJobGauge<GNBGauge>().Ammo; //Our cartridge count
+                var GunStep = GetJobGauge<GNBGauge>().AmmoComboStep; //For Gnashing Fang & Reign combo purposes
+                //Cooldown-related
+                var nmCD = GetCooldownRemainingTime(NoMercy); //NoMercy's cooldown; 60s total
+                var ddCD = GetCooldownRemainingTime(DoubleDown); //Double Down's cooldown; 60s total
+                var bfCD = GetCooldownRemainingTime(Bloodfest); //Bloodfest's cooldown; 120s total
+                var hasNM = nmCD is >= 40 and <= 60; //Checks if No Mercy is active
+                var hasReign = HasEffect(Buffs.ReadyToReign); //Checks for Ready To Reign buff
+                #region Minimal Requirements
+                //Ammo-relative
+                var canDD = LevelChecked(DoubleDown) && //Double Down is unlocked
+                            ddCD < 0.6f && //Double Down is off cooldown
+                            Ammo > 0; //Has Ammo
+                var canBF = LevelChecked(Bloodfest) && //Bloodfest is unlocked
+                            bfCD < 0.6f; //Bloodfest is off cooldown
+                //Cooldown-relative
+                var canBow = LevelChecked(BowShock) && //Bow Shock is unlocked
+                             GetCooldownRemainingTime(BowShock) < 0.6f; //BowShock is off cooldown
+                var canReign = LevelChecked(ReignOfBeasts) && //Reign of Beasts is unlocked
+                               GunStep == 0 && //Gnashing Fang or Reign combo is not already active
+                               hasReign; //Ready To Reign is active
+                #endregion
+                #endregion
 
-                    //Double Down under NM only
-                    if (IsEnabled(CustomComboPreset.GNB_FC_DoubleDown) && //Double Down option is enabled
-                        IsEnabled(CustomComboPreset.GNB_FC_DoubleDown_NM) && //Double Down No Mercy option is enabled
-                        canDD && //able to use Double Down
-                        hasNM) //No Mercy is active
-                        return DoubleDown; //Execute Double Down if conditions are met
+                //Fated Brand
+                if (IsEnabled(CustomComboPreset.GNB_FC_Continuation) && //Continuation option is enabled
+                    HasEffect(Buffs.ReadyToRaze) &&
+                    LevelChecked(FatedBrand))
+                    return FatedBrand;
 
-                    //Bloodfest
-                    if (IsEnabled(CustomComboPreset.GNB_FC_Bloodfest) && //Bloodfest option is enabled
-                        HasTarget() && //Has target
-                        canBF && //able to use Bloodfest
-                        Ammo == 0) //Only when ammo is empty
-                        return Bloodfest; //Execute Bloodfest if conditions are met
+                //Double Down under NM only
+                if (IsEnabled(CustomComboPreset.GNB_FC_DoubleDown) && //Double Down option is enabled
+                    IsEnabled(CustomComboPreset.GNB_FC_DoubleDown_NM) && //Double Down No Mercy option is enabled
+                    canDD && //able to use Double Down
+                    hasNM) //No Mercy is active
+                    return DoubleDown; //Execute Double Down if conditions are met
 
-                    //Bow Shock
-                    if (IsEnabled(CustomComboPreset.GNB_FC_BowShock) && //Double Down option is enabled
-                        canBow) //able to use Double Down
-                        return BowShock; //Execute Double Down if conditions are met
+                //Bloodfest
+                if (IsEnabled(CustomComboPreset.GNB_FC_Bloodfest) && //Bloodfest option is enabled
+                    HasTarget() && //Has target
+                    canBF && //able to use Bloodfest
+                    Ammo == 0) //Only when ammo is empty
+                    return Bloodfest; //Execute Bloodfest if conditions are met
 
-                    //Double Down
-                    if (IsEnabled(CustomComboPreset.GNB_FC_DoubleDown) && //Double Down option is enabled
-                        !IsEnabled(CustomComboPreset.GNB_FC_DoubleDown_NM) && //Double Down No Mercy option is disabled
-                        canDD) //able to use Double Down
-                        return DoubleDown; //Execute Double Down if conditions are met
+                //Bow Shock
+                if (IsEnabled(CustomComboPreset.GNB_FC_BowShock) && //Double Down option is enabled
+                    canBow) //able to use Double Down
+                    return BowShock; //Execute Double Down if conditions are met
 
-                    //Reign
-                    if (IsEnabled(CustomComboPreset.GNB_FC_Reign) && //Reign of Beasts option is enabled
-                        (canReign || GunStep is 3 or 4)) //able to use Reign of Beasts
-                        return OriginalHook(ReignOfBeasts); //Execute Reign combo if conditions are met
-                }
+                //Double Down
+                if (IsEnabled(CustomComboPreset.GNB_FC_DoubleDown) && //Double Down option is enabled
+                    !IsEnabled(CustomComboPreset.GNB_FC_DoubleDown_NM) && //Double Down No Mercy option is disabled
+                    canDD) //able to use Double Down
+                    return DoubleDown; //Execute Double Down if conditions are met
+
+                //Reign
+                if (IsEnabled(CustomComboPreset.GNB_FC_Reign) && //Reign of Beasts option is enabled
+                    (canReign || GunStep is 3 or 4)) //able to use Reign of Beasts
+                    return OriginalHook(ReignOfBeasts); //Execute Reign combo if conditions are met
 
                 return actionID;
             }
@@ -2397,76 +2385,41 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is NoMercy)
+                if (actionID is not NoMercy) return actionID;
+
+                #region Variables
+                //Gauge
+                var Ammo = GetJobGauge<GNBGauge>().Ammo; //Our cartridge count
+                //Cooldown-related
+                var nmCD = GetCooldownRemainingTime(NoMercy); //NoMercy's cooldown; 60s total
+                var bfCD = GetCooldownRemainingTime(Bloodfest); //Bloodfest's cooldown; 120s total
+
+                #region Minimal Requirements
+                //Ammo-relative
+                var canBF = LevelChecked(Bloodfest) && //Bloodfest is unlocked
+                            bfCD < 0.6f; //Bloodfest is off cooldown
+                //Cooldown-relative
+                var canZone = LevelChecked(DangerZone) && //Zone is unlocked
+                              GetCooldownRemainingTime(OriginalHook(DangerZone)) < 0.6f; //DangerZone is off cooldown
+                var canBow = LevelChecked(BowShock) && //Bow Shock is unlocked
+                             GetCooldownRemainingTime(BowShock) < 0.6f; //BowShock is off cooldown
+                var canContinue = LevelChecked(Continuation); //Continuation is unlocked
+                #endregion
+                #endregion
+
+                //oGCDs
+                if (Config.GNB_NM_Features_Weave == 1) //Weave option is enabled
                 {
-                    #region Variables
-                    //Gauge
-                    var Ammo = GetJobGauge<GNBGauge>().Ammo; //Our cartridge count
-                    //Cooldown-related
-                    var nmCD = GetCooldownRemainingTime(NoMercy); //NoMercy's cooldown; 60s total
-                    var bfCD = GetCooldownRemainingTime(Bloodfest); //Bloodfest's cooldown; 120s total
-
-                    #region Minimal Requirements
-                    //Ammo-relative
-                    var canBF = LevelChecked(Bloodfest) && //Bloodfest is unlocked
-                                bfCD < 0.6f; //Bloodfest is off cooldown
-                    //Cooldown-relative
-                    var canZone = LevelChecked(DangerZone) && //Zone is unlocked
-                                GetCooldownRemainingTime(OriginalHook(DangerZone)) < 0.6f; //DangerZone is off cooldown
-                    var canBow = LevelChecked(BowShock) && //Bow Shock is unlocked
-                                GetCooldownRemainingTime(BowShock) < 0.6f; //BowShock is off cooldown
-                    var canContinue = LevelChecked(Continuation); //Continuation is unlocked
-                    #endregion
-                    #endregion
-
-                    //oGCDs
-                    if (Config.GNB_NM_Features_Weave == 1) //Weave option is enabled
-                    {
-                        if (CanWeave())
-                        {
-                            //Continuation
-                            if (IsEnabled(CustomComboPreset.GNB_NM_Continuation) && //Continuation option is enabled
-                                canContinue && //able to use Continuation
-                                (HasEffect(Buffs.ReadyToRip) || //after Gnashing Fang
-                                HasEffect(Buffs.ReadyToTear) || //after Savage Claw
-                                HasEffect(Buffs.ReadyToGouge) || //after Wicked Talon
-                                HasEffect(Buffs.ReadyToBlast) || //after Burst Strike
-                                HasEffect(Buffs.ReadyToRaze))) //after Fated Circle
-                                return OriginalHook(Continuation); //Execute appopriate Continuation action if conditions are met
-
-                            //Bloodfest
-                            if (IsEnabled(CustomComboPreset.GNB_NM_Bloodfest) && //Bloodfest option is enabled
-                                InCombat() && //In combat
-                                HasTarget() && //Has target
-                                canBF && //able to use Bloodfest
-                                Ammo == 0) //Only when ammo is empty
-                                return Bloodfest; //Execute Bloodfest if conditions are met
-
-                            //Bow Shock
-                            if (IsEnabled(CustomComboPreset.GNB_NM_BowShock) && //Bow Shock option is enabled
-                                canBow && //able to use Bow Shock
-                                nmCD is < 57.5f and >= 40) //No Mercy is up & was not just used within 1 GCD
-                                return BowShock;
-
-                            //Zone
-                            if (IsEnabled(CustomComboPreset.GNB_NM_Zone) && //Zone option is enabled
-                                canZone && //able to use Zone
-                                (nmCD is < 57.5f and > 17f))//Optimal use; twice per minute, 1 in NM, 1 out of NM
-                                return OriginalHook(DangerZone); //Execute Zone if conditions are met
-                        }
-
-                    }
-
-                    if (Config.GNB_NM_Features_Weave == 2) //Force option is enabled
+                    if (CanWeave())
                     {
                         //Continuation
                         if (IsEnabled(CustomComboPreset.GNB_NM_Continuation) && //Continuation option is enabled
                             canContinue && //able to use Continuation
                             (HasEffect(Buffs.ReadyToRip) || //after Gnashing Fang
-                            HasEffect(Buffs.ReadyToTear) || //after Savage Claw
-                            HasEffect(Buffs.ReadyToGouge) || //after Wicked Talon
-                            HasEffect(Buffs.ReadyToBlast) || //after Burst Strike
-                            HasEffect(Buffs.ReadyToRaze))) //after Fated Circle
+                             HasEffect(Buffs.ReadyToTear) || //after Savage Claw
+                             HasEffect(Buffs.ReadyToGouge) || //after Wicked Talon
+                             HasEffect(Buffs.ReadyToBlast) || //after Burst Strike
+                             HasEffect(Buffs.ReadyToRaze))) //after Fated Circle
                             return OriginalHook(Continuation); //Execute appopriate Continuation action if conditions are met
 
                         //Bloodfest
@@ -2489,6 +2442,40 @@ namespace WrathCombo.Combos.PvE
                             (nmCD is < 57.5f and > 17f))//Optimal use; twice per minute, 1 in NM, 1 out of NM
                             return OriginalHook(DangerZone); //Execute Zone if conditions are met
                     }
+
+                }
+
+                if (Config.GNB_NM_Features_Weave == 2) //Force option is enabled
+                {
+                    //Continuation
+                    if (IsEnabled(CustomComboPreset.GNB_NM_Continuation) && //Continuation option is enabled
+                        canContinue && //able to use Continuation
+                        (HasEffect(Buffs.ReadyToRip) || //after Gnashing Fang
+                         HasEffect(Buffs.ReadyToTear) || //after Savage Claw
+                         HasEffect(Buffs.ReadyToGouge) || //after Wicked Talon
+                         HasEffect(Buffs.ReadyToBlast) || //after Burst Strike
+                         HasEffect(Buffs.ReadyToRaze))) //after Fated Circle
+                        return OriginalHook(Continuation); //Execute appopriate Continuation action if conditions are met
+
+                    //Bloodfest
+                    if (IsEnabled(CustomComboPreset.GNB_NM_Bloodfest) && //Bloodfest option is enabled
+                        InCombat() && //In combat
+                        HasTarget() && //Has target
+                        canBF && //able to use Bloodfest
+                        Ammo == 0) //Only when ammo is empty
+                        return Bloodfest; //Execute Bloodfest if conditions are met
+
+                    //Bow Shock
+                    if (IsEnabled(CustomComboPreset.GNB_NM_BowShock) && //Bow Shock option is enabled
+                        canBow && //able to use Bow Shock
+                        nmCD is < 57.5f and >= 40) //No Mercy is up & was not just used within 1 GCD
+                        return BowShock;
+
+                    //Zone
+                    if (IsEnabled(CustomComboPreset.GNB_NM_Zone) && //Zone option is enabled
+                        canZone && //able to use Zone
+                        (nmCD is < 57.5f and > 17f))//Optimal use; twice per minute, 1 in NM, 1 out of NM
+                        return OriginalHook(DangerZone); //Execute Zone if conditions are met
                 }
 
                 return actionID;
@@ -2503,12 +2490,10 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is Aurora)
-                {
-                    if ((HasFriendlyTarget() && TargetHasEffectAny(Buffs.Aurora)) ||
-                        (!HasFriendlyTarget() && HasEffectAny(Buffs.Aurora)))
-                        return OriginalHook(11);
-                }
+                if (actionID is not Aurora) return actionID;
+                if ((HasFriendlyTarget() && TargetHasEffectAny(Buffs.Aurora)) ||
+                    (!HasFriendlyTarget() && HasEffectAny(Buffs.Aurora)))
+                    return OriginalHook(11);
                 return actionID;
             }
         }

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -13,138 +13,137 @@ internal static partial class MCH
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is SplitShot or HeatedSplitShot)
-            {
-                if (IsEnabled(CustomComboPreset.MCH_Variant_Cure) &&
+            if (actionID is not (SplitShot or HeatedSplitShot)) return actionID;
+
+            if (IsEnabled(CustomComboPreset.MCH_Variant_Cure) &&
                 IsEnabled(Variant.VariantCure) &&
                 PlayerHealthPercentageHp() <= Config.MCH_VariantCure)
-                    return Variant.VariantCure;
+                return Variant.VariantCure;
 
-                if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
-                    IsEnabled(Variant.VariantRampart) &&
-                    IsOffCooldown(Variant.VariantRampart) &&
-                    CanWeave())
-                    return Variant.VariantRampart;
+            if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
+                IsEnabled(Variant.VariantRampart) &&
+                IsOffCooldown(Variant.VariantRampart) &&
+                CanWeave())
+                return Variant.VariantRampart;
 
-                // Opener
-                if (TargetIsHostile())
-                    if (Opener().FullOpener(ref actionID))
-                        return actionID;
-
-                //Reassemble to start before combat
-                if (!HasEffect(Buffs.Reassembled) && ActionReady(Reassemble) &&
-                    !InCombat() && TargetIsHostile())
-                    return Reassemble;
-
-                // Interrupt
-                if (InterruptReady)
-                    return All.HeadGraze;
-
-                // All weaves
-                if (CanWeave())
-                {
-                    if (!ActionWatching.HasDoubleWeaved())
-                    {
-                        // Wildfire
-                        if (JustUsed(Hypercharge) && ActionReady(Wildfire))
-                            return Wildfire;
-
-                        if (!Gauge.IsOverheated)
-                        {
-                            // BarrelStabilizer
-                            if (ActionReady(BarrelStabilizer))
-                                return BarrelStabilizer;
-
-                            // Hypercharge
-                            if ((Gauge.Heat >= 50 || HasEffect(Buffs.Hypercharged)) && !IsComboExpiring(6) &&
-                                LevelChecked(Hypercharge))
-                            {
-                                // Ensures Hypercharge is double weaved with WF
-                                if ((LevelChecked(FullMetalField) && JustUsed(FullMetalField) &&
-                                     (GetCooldownRemainingTime(Wildfire) < GCD || ActionReady(Wildfire))) ||
-                                    (!LevelChecked(FullMetalField) && ActionReady(Wildfire)) ||
-                                    !LevelChecked(Wildfire))
-                                    return Hypercharge;
-
-                                // Only Hypercharge when tools are on cooldown
-                                if (DrillCD && AnchorCD && SawCD &&
-                                    ((GetCooldownRemainingTime(Wildfire) > 40 && LevelChecked(Wildfire)) ||
-                                     !LevelChecked(Wildfire)))
-                                    return Hypercharge;
-                            }
-
-                            //Queen
-                            if (UseQueen(Gauge) &&
-                                (GetCooldownRemainingTime(Wildfire) > GCD || !LevelChecked(Wildfire)))
-                                return OriginalHook(RookAutoturret);
-
-                            // Reassemble
-                            if (Reassembled(Gauge))
-                                return Reassemble;
-
-                            // Gauss Round and Ricochet outside HC
-                            if (JustUsed(OriginalHook(AirAnchor), 2f) ||
-                                JustUsed(Chainsaw, 2f) ||
-                                JustUsed(Drill, 2f) ||
-                                JustUsed(Excavator, 2f))
-                            {
-                                if (ActionReady(OriginalHook(GaussRound)) &&
-                                    !JustUsed(OriginalHook(GaussRound), 2f))
-                                    return OriginalHook(GaussRound);
-
-                                if (ActionReady(OriginalHook(Ricochet)) &&
-                                    !JustUsed(OriginalHook(Ricochet), 2f))
-                                    return OriginalHook(Ricochet);
-                            }
-
-                            // Healing
-                            if (PlayerHealthPercentageHp() <= 25 && ActionReady(All.SecondWind))
-                                return All.SecondWind;
-                        }
-                    }
-
-                    // Gauss Round and Ricochet during HC
-                    if (JustUsed(OriginalHook(Heatblast), 1f) && HasNotWeaved)
-                    {
-                        if (ActionReady(OriginalHook(GaussRound)) &&
-                            GetRemainingCharges(OriginalHook(GaussRound)) >=
-                            GetRemainingCharges(OriginalHook(Ricochet)))
-                            return OriginalHook(GaussRound);
-
-                        if (ActionReady(OriginalHook(Ricochet)) &&
-                            GetRemainingCharges(OriginalHook(Ricochet)) > GetRemainingCharges(OriginalHook(GaussRound)))
-                            return OriginalHook(Ricochet);
-                    }
-                }
-
-                // Full Metal Field
-                if (HasEffect(Buffs.FullMetalMachinist) &&
-                    (GetCooldownRemainingTime(Wildfire) <= GCD || ActionReady(Wildfire) ||
-                     GetBuffRemainingTime(Buffs.FullMetalMachinist) <= 6) &&
-                    LevelChecked(FullMetalField))
-                    return FullMetalField;
-
-                // Heatblast
-                if (Gauge.IsOverheated && LevelChecked(OriginalHook(Heatblast)))
-                    return OriginalHook(Heatblast);
-
-                //Tools
-                if (Tools(ref actionID))
+            // Opener
+            if (TargetIsHostile())
+                if (Opener().FullOpener(ref actionID))
                     return actionID;
 
-                // 1-2-3 Combo
-                if (ComboTimer > 0)
+            //Reassemble to start before combat
+            if (!HasEffect(Buffs.Reassembled) && ActionReady(Reassemble) &&
+                !InCombat() && TargetIsHostile())
+                return Reassemble;
+
+            // Interrupt
+            if (InterruptReady)
+                return All.HeadGraze;
+
+            // All weaves
+            if (CanWeave())
+            {
+                if (!ActionWatching.HasDoubleWeaved())
                 {
-                    if (ComboAction is SplitShot && LevelChecked(OriginalHook(SlugShot)))
-                        return OriginalHook(SlugShot);
+                    // Wildfire
+                    if (JustUsed(Hypercharge) && ActionReady(Wildfire))
+                        return Wildfire;
 
-                    if (ComboAction == OriginalHook(SlugShot) &&
-                        !LevelChecked(Drill) && !HasEffect(Buffs.Reassembled) && ActionReady(Reassemble))
-                        return Reassemble;
+                    if (!Gauge.IsOverheated)
+                    {
+                        // BarrelStabilizer
+                        if (ActionReady(BarrelStabilizer))
+                            return BarrelStabilizer;
 
-                    if (ComboAction is SlugShot && LevelChecked(OriginalHook(CleanShot)))
-                        return OriginalHook(CleanShot);
+                        // Hypercharge
+                        if ((Gauge.Heat >= 50 || HasEffect(Buffs.Hypercharged)) && !IsComboExpiring(6) &&
+                            LevelChecked(Hypercharge))
+                        {
+                            // Ensures Hypercharge is double weaved with WF
+                            if ((LevelChecked(FullMetalField) && JustUsed(FullMetalField) &&
+                                 (GetCooldownRemainingTime(Wildfire) < GCD || ActionReady(Wildfire))) ||
+                                (!LevelChecked(FullMetalField) && ActionReady(Wildfire)) ||
+                                !LevelChecked(Wildfire))
+                                return Hypercharge;
+
+                            // Only Hypercharge when tools are on cooldown
+                            if (DrillCD && AnchorCD && SawCD &&
+                                ((GetCooldownRemainingTime(Wildfire) > 40 && LevelChecked(Wildfire)) ||
+                                 !LevelChecked(Wildfire)))
+                                return Hypercharge;
+                        }
+
+                        //Queen
+                        if (UseQueen(Gauge) &&
+                            (GetCooldownRemainingTime(Wildfire) > GCD || !LevelChecked(Wildfire)))
+                            return OriginalHook(RookAutoturret);
+
+                        // Reassemble
+                        if (Reassembled(Gauge))
+                            return Reassemble;
+
+                        // Gauss Round and Ricochet outside HC
+                        if (JustUsed(OriginalHook(AirAnchor), 2f) ||
+                            JustUsed(Chainsaw, 2f) ||
+                            JustUsed(Drill, 2f) ||
+                            JustUsed(Excavator, 2f))
+                        {
+                            if (ActionReady(OriginalHook(GaussRound)) &&
+                                !JustUsed(OriginalHook(GaussRound), 2f))
+                                return OriginalHook(GaussRound);
+
+                            if (ActionReady(OriginalHook(Ricochet)) &&
+                                !JustUsed(OriginalHook(Ricochet), 2f))
+                                return OriginalHook(Ricochet);
+                        }
+
+                        // Healing
+                        if (PlayerHealthPercentageHp() <= 25 && ActionReady(All.SecondWind))
+                            return All.SecondWind;
+                    }
                 }
+
+                // Gauss Round and Ricochet during HC
+                if (JustUsed(OriginalHook(Heatblast), 1f) && HasNotWeaved)
+                {
+                    if (ActionReady(OriginalHook(GaussRound)) &&
+                        GetRemainingCharges(OriginalHook(GaussRound)) >=
+                        GetRemainingCharges(OriginalHook(Ricochet)))
+                        return OriginalHook(GaussRound);
+
+                    if (ActionReady(OriginalHook(Ricochet)) &&
+                        GetRemainingCharges(OriginalHook(Ricochet)) > GetRemainingCharges(OriginalHook(GaussRound)))
+                        return OriginalHook(Ricochet);
+                }
+            }
+
+            // Full Metal Field
+            if (HasEffect(Buffs.FullMetalMachinist) &&
+                (GetCooldownRemainingTime(Wildfire) <= GCD || ActionReady(Wildfire) ||
+                 GetBuffRemainingTime(Buffs.FullMetalMachinist) <= 6) &&
+                LevelChecked(FullMetalField))
+                return FullMetalField;
+
+            // Heatblast
+            if (Gauge.IsOverheated && LevelChecked(OriginalHook(Heatblast)))
+                return OriginalHook(Heatblast);
+
+            //Tools
+            if (Tools(ref actionID))
+                return actionID;
+
+            // 1-2-3 Combo
+            if (ComboTimer > 0)
+            {
+                if (ComboAction is SplitShot && LevelChecked(OriginalHook(SlugShot)))
+                    return OriginalHook(SlugShot);
+
+                if (ComboAction == OriginalHook(SlugShot) &&
+                    !LevelChecked(Drill) && !HasEffect(Buffs.Reassembled) && ActionReady(Reassemble))
+                    return Reassemble;
+
+                if (ComboAction is SlugShot && LevelChecked(OriginalHook(CleanShot)))
+                    return OriginalHook(CleanShot);
             }
             return actionID;
         }
@@ -156,162 +155,161 @@ internal static partial class MCH
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is SplitShot or HeatedSplitShot)
-            {
-                if (IsEnabled(CustomComboPreset.MCH_Variant_Cure) &&
-                    IsEnabled(Variant.VariantCure) &&
-                    PlayerHealthPercentageHp() <= Config.MCH_VariantCure)
-                    return Variant.VariantCure;
+            if (actionID is not (SplitShot or HeatedSplitShot)) return actionID;
 
-                if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
-                    IsEnabled(Variant.VariantRampart) &&
-                    IsOffCooldown(Variant.VariantRampart) &&
-                    CanWeave())
-                    return Variant.VariantRampart;
+            if (IsEnabled(CustomComboPreset.MCH_Variant_Cure) &&
+                IsEnabled(Variant.VariantCure) &&
+                PlayerHealthPercentageHp() <= Config.MCH_VariantCure)
+                return Variant.VariantCure;
 
-                // Opener
-                if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Opener) && TargetIsHostile())
-                    if (Opener().FullOpener(ref actionID))
-                        return actionID;
+            if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
+                IsEnabled(Variant.VariantRampart) &&
+                IsOffCooldown(Variant.VariantRampart) &&
+                CanWeave())
+                return Variant.VariantRampart;
 
-                //Reassemble to start before combat
-                if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble) &&
-                    !HasEffect(Buffs.Reassembled) && ActionReady(Reassemble) &&
-                    !InCombat() && TargetIsHostile())
-                    return Reassemble;
-
-                // Interrupt
-                if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Interrupt) &&
-                    InterruptReady)
-                    return All.HeadGraze;
-
-                // All weaves
-                if (CanWeave())
-                {
-                    if (!ActionWatching.HasDoubleWeaved())
-                    {
-                        if (IsEnabled(CustomComboPreset.MCH_ST_Adv_QueenOverdrive) &&
-                            Gauge.IsRobotActive && GetTargetHPPercent() <= Config.MCH_ST_QueenOverDrive &&
-                            ActionReady(OriginalHook(RookOverdrive)))
-                            return OriginalHook(RookOverdrive);
-
-                        // Wildfire
-                        if (IsEnabled(CustomComboPreset.MCH_ST_Adv_WildFire) &&
-                            JustUsed(Hypercharge) && ActionReady(Wildfire) &&
-                            GetTargetHPPercent() >= Config.MCH_ST_WildfireHP)
-                            return Wildfire;
-
-                        if (!Gauge.IsOverheated)
-                        {
-                            // BarrelStabilizer
-                            if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Stabilizer) &&
-                                ActionReady(BarrelStabilizer))
-                                return BarrelStabilizer;
-
-                            // Hypercharge
-                            if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Hypercharge) &&
-                                (Gauge.Heat >= 50 || HasEffect(Buffs.Hypercharged)) &&
-                                !IsComboExpiring(6) &&
-                                LevelChecked(Hypercharge) &&
-                                GetTargetHPPercent() >= Config.MCH_ST_HyperchargeHP)
-                            {
-                                // Ensures Hypercharge is double weaved with WF
-                                if ((LevelChecked(FullMetalField) && JustUsed(FullMetalField) &&
-                                     (GetCooldownRemainingTime(Wildfire) < GCD || ActionReady(Wildfire))) ||
-                                    (!LevelChecked(FullMetalField) && ActionReady(Wildfire)) ||
-                                    !LevelChecked(Wildfire))
-                                    return Hypercharge;
-
-                                // Only Hypercharge when tools are on cooldown
-                                if (DrillCD && AnchorCD && SawCD &&
-                                    ((GetCooldownRemainingTime(Wildfire) > 40 && LevelChecked(Wildfire)) ||
-                                     !LevelChecked(Wildfire)))
-                                    return Hypercharge;
-                            }
-
-                            // Queen
-                            if (IsEnabled(CustomComboPreset.MCH_Adv_TurretQueen) &&
-                                UseQueen(Gauge) &&
-                                (GetCooldownRemainingTime(Wildfire) > GCD || !LevelChecked(Wildfire)))
-                                return OriginalHook(RookAutoturret);
-
-                            // Reassemble
-                            if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble) &&
-                                GetRemainingCharges(Reassemble) > Config.MCH_ST_ReassemblePool &&
-                                Reassembled(Gauge))
-                                return Reassemble;
-
-                            // Gauss Round and Ricochet outside HC
-                            if (IsEnabled(CustomComboPreset.MCH_ST_Adv_GaussRicochet) &&
-                                (JustUsed(OriginalHook(AirAnchor), 2f) ||
-                                 JustUsed(Chainsaw, 2f) ||
-                                 JustUsed(Drill, 2f) ||
-                                 JustUsed(Excavator, 2f)))
-                            {
-                                if (ActionReady(OriginalHook(GaussRound)) &&
-                                    !JustUsed(OriginalHook(GaussRound), 2f))
-                                    return OriginalHook(GaussRound);
-
-                                if (ActionReady(OriginalHook(Ricochet)) &&
-                                    !JustUsed(OriginalHook(Ricochet), 2f))
-                                    return OriginalHook(Ricochet);
-                            }
-
-                            // Healing
-                            if (IsEnabled(CustomComboPreset.MCH_ST_Adv_SecondWind) &&
-                                PlayerHealthPercentageHp() <= Config.MCH_ST_SecondWindThreshold &&
-                                ActionReady(All.SecondWind))
-                                return All.SecondWind;
-                        }
-                    }
-
-                    // Gauss Round and Ricochet during HC
-                    if (IsEnabled(CustomComboPreset.MCH_ST_Adv_GaussRicochet) &&
-                        JustUsed(OriginalHook(Heatblast), 1f) && HasNotWeaved)
-                    {
-                        if (ActionReady(OriginalHook(GaussRound)) &&
-                            GetRemainingCharges(OriginalHook(GaussRound)) >=
-                            GetRemainingCharges(OriginalHook(Ricochet)))
-                            return OriginalHook(GaussRound);
-
-                        if (ActionReady(OriginalHook(Ricochet)) &&
-                            GetRemainingCharges(OriginalHook(Ricochet)) >
-                            GetRemainingCharges(OriginalHook(GaussRound)))
-                            return OriginalHook(Ricochet);
-                    }
-                }
-
-                // Full Metal Field
-                if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Stabilizer_FullMetalField) &&
-                    HasEffect(Buffs.FullMetalMachinist) &&
-                    (GetCooldownRemainingTime(Wildfire) <= GCD || ActionReady(Wildfire) ||
-                     GetBuffRemainingTime(Buffs.FullMetalMachinist) <= 6) &&
-                    LevelChecked(FullMetalField))
-                    return FullMetalField;
-
-                // Heatblast
-                if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Heatblast) &&
-                    Gauge.IsOverheated && LevelChecked(OriginalHook(Heatblast)))
-                    return OriginalHook(Heatblast);
-
-                //Tools
-                if (Tools(ref actionID))
+            // Opener
+            if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Opener) && TargetIsHostile())
+                if (Opener().FullOpener(ref actionID))
                     return actionID;
 
-                // 1-2-3 Combo
-                if (ComboTimer > 0)
+            //Reassemble to start before combat
+            if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble) &&
+                !HasEffect(Buffs.Reassembled) && ActionReady(Reassemble) &&
+                !InCombat() && TargetIsHostile())
+                return Reassemble;
+
+            // Interrupt
+            if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Interrupt) &&
+                InterruptReady)
+                return All.HeadGraze;
+
+            // All weaves
+            if (CanWeave())
+            {
+                if (!ActionWatching.HasDoubleWeaved())
                 {
-                    if (ComboAction is SplitShot && LevelChecked(OriginalHook(SlugShot)))
-                        return OriginalHook(SlugShot);
+                    if (IsEnabled(CustomComboPreset.MCH_ST_Adv_QueenOverdrive) &&
+                        Gauge.IsRobotActive && GetTargetHPPercent() <= Config.MCH_ST_QueenOverDrive &&
+                        ActionReady(OriginalHook(RookOverdrive)))
+                        return OriginalHook(RookOverdrive);
 
-                    if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble) && Config.MCH_ST_Reassembled [4] &&
-                        ComboAction == OriginalHook(SlugShot) &&
-                        !LevelChecked(Drill) && !HasEffect(Buffs.Reassembled) && ActionReady(Reassemble))
-                        return Reassemble;
+                    // Wildfire
+                    if (IsEnabled(CustomComboPreset.MCH_ST_Adv_WildFire) &&
+                        JustUsed(Hypercharge) && ActionReady(Wildfire) &&
+                        GetTargetHPPercent() >= Config.MCH_ST_WildfireHP)
+                        return Wildfire;
 
-                    if (ComboAction is SlugShot && LevelChecked(OriginalHook(CleanShot)))
-                        return OriginalHook(CleanShot);
+                    if (!Gauge.IsOverheated)
+                    {
+                        // BarrelStabilizer
+                        if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Stabilizer) &&
+                            ActionReady(BarrelStabilizer))
+                            return BarrelStabilizer;
+
+                        // Hypercharge
+                        if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Hypercharge) &&
+                            (Gauge.Heat >= 50 || HasEffect(Buffs.Hypercharged)) &&
+                            !IsComboExpiring(6) &&
+                            LevelChecked(Hypercharge) &&
+                            GetTargetHPPercent() >= Config.MCH_ST_HyperchargeHP)
+                        {
+                            // Ensures Hypercharge is double weaved with WF
+                            if ((LevelChecked(FullMetalField) && JustUsed(FullMetalField) &&
+                                 (GetCooldownRemainingTime(Wildfire) < GCD || ActionReady(Wildfire))) ||
+                                (!LevelChecked(FullMetalField) && ActionReady(Wildfire)) ||
+                                !LevelChecked(Wildfire))
+                                return Hypercharge;
+
+                            // Only Hypercharge when tools are on cooldown
+                            if (DrillCD && AnchorCD && SawCD &&
+                                ((GetCooldownRemainingTime(Wildfire) > 40 && LevelChecked(Wildfire)) ||
+                                 !LevelChecked(Wildfire)))
+                                return Hypercharge;
+                        }
+
+                        // Queen
+                        if (IsEnabled(CustomComboPreset.MCH_Adv_TurretQueen) &&
+                            UseQueen(Gauge) &&
+                            (GetCooldownRemainingTime(Wildfire) > GCD || !LevelChecked(Wildfire)))
+                            return OriginalHook(RookAutoturret);
+
+                        // Reassemble
+                        if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble) &&
+                            GetRemainingCharges(Reassemble) > Config.MCH_ST_ReassemblePool &&
+                            Reassembled(Gauge))
+                            return Reassemble;
+
+                        // Gauss Round and Ricochet outside HC
+                        if (IsEnabled(CustomComboPreset.MCH_ST_Adv_GaussRicochet) &&
+                            (JustUsed(OriginalHook(AirAnchor), 2f) ||
+                             JustUsed(Chainsaw, 2f) ||
+                             JustUsed(Drill, 2f) ||
+                             JustUsed(Excavator, 2f)))
+                        {
+                            if (ActionReady(OriginalHook(GaussRound)) &&
+                                !JustUsed(OriginalHook(GaussRound), 2f))
+                                return OriginalHook(GaussRound);
+
+                            if (ActionReady(OriginalHook(Ricochet)) &&
+                                !JustUsed(OriginalHook(Ricochet), 2f))
+                                return OriginalHook(Ricochet);
+                        }
+
+                        // Healing
+                        if (IsEnabled(CustomComboPreset.MCH_ST_Adv_SecondWind) &&
+                            PlayerHealthPercentageHp() <= Config.MCH_ST_SecondWindThreshold &&
+                            ActionReady(All.SecondWind))
+                            return All.SecondWind;
+                    }
                 }
+
+                // Gauss Round and Ricochet during HC
+                if (IsEnabled(CustomComboPreset.MCH_ST_Adv_GaussRicochet) &&
+                    JustUsed(OriginalHook(Heatblast), 1f) && HasNotWeaved)
+                {
+                    if (ActionReady(OriginalHook(GaussRound)) &&
+                        GetRemainingCharges(OriginalHook(GaussRound)) >=
+                        GetRemainingCharges(OriginalHook(Ricochet)))
+                        return OriginalHook(GaussRound);
+
+                    if (ActionReady(OriginalHook(Ricochet)) &&
+                        GetRemainingCharges(OriginalHook(Ricochet)) >
+                        GetRemainingCharges(OriginalHook(GaussRound)))
+                        return OriginalHook(Ricochet);
+                }
+            }
+
+            // Full Metal Field
+            if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Stabilizer_FullMetalField) &&
+                HasEffect(Buffs.FullMetalMachinist) &&
+                (GetCooldownRemainingTime(Wildfire) <= GCD || ActionReady(Wildfire) ||
+                 GetBuffRemainingTime(Buffs.FullMetalMachinist) <= 6) &&
+                LevelChecked(FullMetalField))
+                return FullMetalField;
+
+            // Heatblast
+            if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Heatblast) &&
+                Gauge.IsOverheated && LevelChecked(OriginalHook(Heatblast)))
+                return OriginalHook(Heatblast);
+
+            //Tools
+            if (Tools(ref actionID))
+                return actionID;
+
+            // 1-2-3 Combo
+            if (ComboTimer > 0)
+            {
+                if (ComboAction is SplitShot && LevelChecked(OriginalHook(SlugShot)))
+                    return OriginalHook(SlugShot);
+
+                if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble) && Config.MCH_ST_Reassembled [4] &&
+                    ComboAction == OriginalHook(SlugShot) &&
+                    !LevelChecked(Drill) && !HasEffect(Buffs.Reassembled) && ActionReady(Reassemble))
+                    return Reassemble;
+
+                if (ComboAction is SlugShot && LevelChecked(OriginalHook(CleanShot)))
+                    return OriginalHook(CleanShot);
             }
             return actionID;
         }
@@ -323,105 +321,104 @@ internal static partial class MCH
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is SpreadShot or Scattergun)
+            if (actionID is not (SpreadShot or Scattergun)) return actionID;
+
+            if (IsEnabled(CustomComboPreset.MCH_Variant_Cure) &&
+                IsEnabled(Variant.VariantCure) &&
+                PlayerHealthPercentageHp() <= Config.MCH_VariantCure)
+                return Variant.VariantCure;
+
+            if (HasEffect(Buffs.Flamethrower) || JustUsed(Flamethrower, 10f))
+                return OriginalHook(11);
+
+            if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
+                IsEnabled(Variant.VariantRampart) &&
+                IsOffCooldown(Variant.VariantRampart) &&
+                CanWeave())
+                return Variant.VariantRampart;
+
+            // Interrupt
+            if (InterruptReady)
+                return All.HeadGraze;
+
+            // All weaves
+            if (CanWeave())
             {
-                if (IsEnabled(CustomComboPreset.MCH_Variant_Cure) &&
-                    IsEnabled(Variant.VariantCure) &&
-                    PlayerHealthPercentageHp() <= Config.MCH_VariantCure)
-                    return Variant.VariantCure;
-
-                if (HasEffect(Buffs.Flamethrower) || JustUsed(Flamethrower, 10f))
-                    return OriginalHook(11);
-
-                if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
-                    IsEnabled(Variant.VariantRampart) &&
-                    IsOffCooldown(Variant.VariantRampart) &&
-                    CanWeave())
-                    return Variant.VariantRampart;
-
-                // Interrupt
-                if (InterruptReady)
-                    return All.HeadGraze;
-
-                // All weaves
-                if (CanWeave())
+                if (!ActionWatching.HasDoubleWeaved() && !Gauge.IsOverheated)
                 {
-                    if (!ActionWatching.HasDoubleWeaved() && !Gauge.IsOverheated)
-                    {
-                        // BarrelStabilizer 
-                        if (ActionReady(BarrelStabilizer))
-                            return BarrelStabilizer;
+                    // BarrelStabilizer
+                    if (ActionReady(BarrelStabilizer))
+                        return BarrelStabilizer;
 
-                        if (Gauge.Battery == 100)
-                            return OriginalHook(RookAutoturret);
+                    if (Gauge.Battery == 100)
+                        return OriginalHook(RookAutoturret);
 
-                        // Hypercharge        
-                        if ((Gauge.Heat >= 50 || HasEffect(Buffs.Hypercharged)) && LevelChecked(Hypercharge) &&
-                            LevelChecked(AutoCrossbow) &&
-                            ((BioBlaster.LevelChecked() && GetCooldownRemainingTime(BioBlaster) > 10) ||
-                             !BioBlaster.LevelChecked()) &&
-                            ((Flamethrower.LevelChecked() && GetCooldownRemainingTime(Flamethrower) > 10) ||
-                             !Flamethrower.LevelChecked()))
-                            return Hypercharge;
+                    // Hypercharge
+                    if ((Gauge.Heat >= 50 || HasEffect(Buffs.Hypercharged)) && LevelChecked(Hypercharge) &&
+                        LevelChecked(AutoCrossbow) &&
+                        ((BioBlaster.LevelChecked() && GetCooldownRemainingTime(BioBlaster) > 10) ||
+                         !BioBlaster.LevelChecked()) &&
+                        ((Flamethrower.LevelChecked() && GetCooldownRemainingTime(Flamethrower) > 10) ||
+                         !Flamethrower.LevelChecked()))
+                        return Hypercharge;
 
-                        if (!HasEffect(Buffs.Wildfire) &&
-                            !HasEffect(Buffs.Reassembled) && HasCharges(Reassemble) &&
-                            !JustUsed(Flamethrower, 10f) &&
-                            ((HasEffect(Buffs.ExcavatorReady) && Excavator.LevelChecked()) ||
-                             (GetCooldownRemainingTime(Chainsaw) < 1 && Chainsaw.LevelChecked()) ||
-                             (GetCooldownRemainingTime(AirAnchor) < 1 && AirAnchor.LevelChecked()) ||
-                             Scattergun.LevelChecked()))
-                            return Reassemble;
+                    if (!HasEffect(Buffs.Wildfire) &&
+                        !HasEffect(Buffs.Reassembled) && HasCharges(Reassemble) &&
+                        !JustUsed(Flamethrower, 10f) &&
+                        ((HasEffect(Buffs.ExcavatorReady) && Excavator.LevelChecked()) ||
+                         (GetCooldownRemainingTime(Chainsaw) < 1 && Chainsaw.LevelChecked()) ||
+                         (GetCooldownRemainingTime(AirAnchor) < 1 && AirAnchor.LevelChecked()) ||
+                         Scattergun.LevelChecked()))
+                        return Reassemble;
 
-                        if (PlayerHealthPercentageHp() <= 25 && ActionReady(All.SecondWind))
-                            return All.SecondWind;
-                    }
-
-                    //AutoCrossbow, Gauss, Rico
-                    if ((JustUsed(OriginalHook(AutoCrossbow), 1f) ||
-                         JustUsed(OriginalHook(Heatblast), 1f)) && HasNotWeaved)
-                    {
-                        if (ActionReady(OriginalHook(GaussRound)) &&
-                            GetRemainingCharges(OriginalHook(GaussRound)) >=
-                            GetRemainingCharges(OriginalHook(Ricochet)))
-                            return OriginalHook(GaussRound);
-
-                        if (ActionReady(OriginalHook(Ricochet)) &&
-                            GetRemainingCharges(OriginalHook(Ricochet)) >
-                            GetRemainingCharges(OriginalHook(GaussRound)))
-                            return OriginalHook(Ricochet);
-                    }
+                    if (PlayerHealthPercentageHp() <= 25 && ActionReady(All.SecondWind))
+                        return All.SecondWind;
                 }
 
-                //Full Metal Field
-                if (HasEffect(Buffs.FullMetalMachinist) && LevelChecked(FullMetalField))
-                    return FullMetalField;
+                //AutoCrossbow, Gauss, Rico
+                if ((JustUsed(OriginalHook(AutoCrossbow), 1f) ||
+                     JustUsed(OriginalHook(Heatblast), 1f)) && HasNotWeaved)
+                {
+                    if (ActionReady(OriginalHook(GaussRound)) &&
+                        GetRemainingCharges(OriginalHook(GaussRound)) >=
+                        GetRemainingCharges(OriginalHook(Ricochet)))
+                        return OriginalHook(GaussRound);
 
-                if (ActionReady(BioBlaster) && !TargetHasEffect(Debuffs.Bioblaster) && !Gauge.IsOverheated)
-                    return OriginalHook(BioBlaster);
-
-                if (ActionReady(Flamethrower) && !IsMoving())
-                    return OriginalHook(Flamethrower);
-
-                if (LevelChecked(Excavator) && HasEffect(Buffs.ExcavatorReady))
-                    return OriginalHook(Chainsaw);
-
-                if (LevelChecked(Chainsaw) &&
-                    (GetCooldownRemainingTime(Chainsaw) <= GetCooldownRemainingTime(OriginalHook(Scattergun)) + 0.25 ||
-                     ActionReady(Chainsaw)))
-                    return Chainsaw;
-
-                if (LevelChecked(AirAnchor) &&
-                    (GetCooldownRemainingTime(AirAnchor) <= GetCooldownRemainingTime(OriginalHook(Scattergun)) + 0.25 ||
-                    ActionReady(AirAnchor)))
-                    return AirAnchor;
-
-                if (LevelChecked(AutoCrossbow) && Gauge.IsOverheated && !LevelChecked(CheckMate))
-                    return AutoCrossbow;
-
-                if (Gauge.IsOverheated && LevelChecked(CheckMate))
-                    return BlazingShot;
+                    if (ActionReady(OriginalHook(Ricochet)) &&
+                        GetRemainingCharges(OriginalHook(Ricochet)) >
+                        GetRemainingCharges(OriginalHook(GaussRound)))
+                        return OriginalHook(Ricochet);
+                }
             }
+
+            //Full Metal Field
+            if (HasEffect(Buffs.FullMetalMachinist) && LevelChecked(FullMetalField))
+                return FullMetalField;
+
+            if (ActionReady(BioBlaster) && !TargetHasEffect(Debuffs.Bioblaster) && !Gauge.IsOverheated)
+                return OriginalHook(BioBlaster);
+
+            if (ActionReady(Flamethrower) && !IsMoving())
+                return OriginalHook(Flamethrower);
+
+            if (LevelChecked(Excavator) && HasEffect(Buffs.ExcavatorReady))
+                return OriginalHook(Chainsaw);
+
+            if (LevelChecked(Chainsaw) &&
+                (GetCooldownRemainingTime(Chainsaw) <= GetCooldownRemainingTime(OriginalHook(Scattergun)) + 0.25 ||
+                 ActionReady(Chainsaw)))
+                return Chainsaw;
+
+            if (LevelChecked(AirAnchor) &&
+                (GetCooldownRemainingTime(AirAnchor) <= GetCooldownRemainingTime(OriginalHook(Scattergun)) + 0.25 ||
+                 ActionReady(AirAnchor)))
+                return AirAnchor;
+
+            if (LevelChecked(AutoCrossbow) && Gauge.IsOverheated && !LevelChecked(CheckMate))
+                return AutoCrossbow;
+
+            if (Gauge.IsOverheated && LevelChecked(CheckMate))
+                return BlazingShot;
 
             return actionID;
         }
@@ -433,159 +430,158 @@ internal static partial class MCH
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is SpreadShot or Scattergun)
-            {
-                bool reassembledScattergunAoE = IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) &&
+            if (actionID is not (SpreadShot or Scattergun)) return actionID;
+
+            bool reassembledScattergunAoE = IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) &&
                                             Config.MCH_AoE_Reassembled [0] && HasEffect(Buffs.Reassembled);
 
-                bool reassembledChainsawAoE =
-                    (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && Config.MCH_AoE_Reassembled [2] && HasEffect(Buffs.Reassembled)) ||
-                    (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && !Config.MCH_AoE_Reassembled [2] && !HasEffect(Buffs.Reassembled)) ||
-                    (!HasEffect(Buffs.Reassembled) && GetRemainingCharges(Reassemble) <= Config.MCH_AoE_ReassemblePool) ||
-                    !IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble);
+            bool reassembledChainsawAoE =
+                (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && Config.MCH_AoE_Reassembled [2] && HasEffect(Buffs.Reassembled)) ||
+                (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && !Config.MCH_AoE_Reassembled [2] && !HasEffect(Buffs.Reassembled)) ||
+                (!HasEffect(Buffs.Reassembled) && GetRemainingCharges(Reassemble) <= Config.MCH_AoE_ReassemblePool) ||
+                !IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble);
 
-                bool reassembledExcavatorAoE =
-                    (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && Config.MCH_AoE_Reassembled [3] && HasEffect(Buffs.Reassembled)) ||
-                    (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && !Config.MCH_AoE_Reassembled [3] && !HasEffect(Buffs.Reassembled)) ||
-                    (!HasEffect(Buffs.Reassembled) && GetRemainingCharges(Reassemble) <= Config.MCH_AoE_ReassemblePool) ||
-                    !IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble);
+            bool reassembledExcavatorAoE =
+                (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && Config.MCH_AoE_Reassembled [3] && HasEffect(Buffs.Reassembled)) ||
+                (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && !Config.MCH_AoE_Reassembled [3] && !HasEffect(Buffs.Reassembled)) ||
+                (!HasEffect(Buffs.Reassembled) && GetRemainingCharges(Reassemble) <= Config.MCH_AoE_ReassemblePool) ||
+                !IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble);
 
-                bool reassembledAirAnchorAoE =
-                    (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && Config.MCH_AoE_Reassembled [1] && HasEffect(Buffs.Reassembled)) ||
-                    (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && !Config.MCH_AoE_Reassembled [1] && !HasEffect(Buffs.Reassembled)) ||
-                    (!HasEffect(Buffs.Reassembled) && GetRemainingCharges(Reassemble) <= Config.MCH_AoE_ReassemblePool) ||
-                    !IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble);
+            bool reassembledAirAnchorAoE =
+                (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && Config.MCH_AoE_Reassembled [1] && HasEffect(Buffs.Reassembled)) ||
+                (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && !Config.MCH_AoE_Reassembled [1] && !HasEffect(Buffs.Reassembled)) ||
+                (!HasEffect(Buffs.Reassembled) && GetRemainingCharges(Reassemble) <= Config.MCH_AoE_ReassemblePool) ||
+                !IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble);
 
-                if (IsEnabled(CustomComboPreset.MCH_Variant_Cure) &&
-                    IsEnabled(Variant.VariantCure) &&
-                    PlayerHealthPercentageHp() <= Config.MCH_VariantCure)
-                    return Variant.VariantCure;
+            if (IsEnabled(CustomComboPreset.MCH_Variant_Cure) &&
+                IsEnabled(Variant.VariantCure) &&
+                PlayerHealthPercentageHp() <= Config.MCH_VariantCure)
+                return Variant.VariantCure;
 
-                if (HasEffect(Buffs.Flamethrower) || JustUsed(Flamethrower, 10f))
-                    return OriginalHook(11);
+            if (HasEffect(Buffs.Flamethrower) || JustUsed(Flamethrower, 10f))
+                return OriginalHook(11);
 
-                if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
-                    IsEnabled(Variant.VariantRampart) &&
-                    IsOffCooldown(Variant.VariantRampart) &&
-                    CanWeave())
-                    return Variant.VariantRampart;
+            if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
+                IsEnabled(Variant.VariantRampart) &&
+                IsOffCooldown(Variant.VariantRampart) &&
+                CanWeave())
+                return Variant.VariantRampart;
 
-                // Interrupt
-                if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Interrupt) && InterruptReady)
-                    return All.HeadGraze;
+            // Interrupt
+            if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Interrupt) && InterruptReady)
+                return All.HeadGraze;
 
-                // All weaves
-                if (CanWeave())
+            // All weaves
+            if (CanWeave())
+            {
+                if (!ActionWatching.HasDoubleWeaved() && !Gauge.IsOverheated)
                 {
-                    if (!ActionWatching.HasDoubleWeaved() && !Gauge.IsOverheated)
-                    {
-                        // BarrelStabilizer
-                        if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Stabilizer) &&
-                            ActionReady(BarrelStabilizer))
-                            return BarrelStabilizer;
+                    // BarrelStabilizer
+                    if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Stabilizer) &&
+                        ActionReady(BarrelStabilizer))
+                        return BarrelStabilizer;
 
-                        if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Queen) &&
-                            Gauge.Battery >= Config.MCH_AoE_TurretUsage)
-                            return OriginalHook(RookAutoturret);
+                    if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Queen) &&
+                        Gauge.Battery >= Config.MCH_AoE_TurretUsage)
+                        return OriginalHook(RookAutoturret);
 
-                        // Hypercharge        
-                        if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Hypercharge) &&
-                            (Gauge.Heat >= 50 || HasEffect(Buffs.Hypercharged)) && LevelChecked(Hypercharge) &&
-                            LevelChecked(AutoCrossbow) &&
-                            ((BioBlaster.LevelChecked() && GetCooldownRemainingTime(BioBlaster) > 10) ||
-                             !BioBlaster.LevelChecked() || IsNotEnabled(CustomComboPreset.MCH_AoE_Adv_Bioblaster)) &&
-                            ((Flamethrower.LevelChecked() && GetCooldownRemainingTime(Flamethrower) > 10) ||
-                             !Flamethrower.LevelChecked() || IsNotEnabled(CustomComboPreset.MCH_AoE_Adv_FlameThrower)))
-                            return Hypercharge;
+                    // Hypercharge
+                    if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Hypercharge) &&
+                        (Gauge.Heat >= 50 || HasEffect(Buffs.Hypercharged)) && LevelChecked(Hypercharge) &&
+                        LevelChecked(AutoCrossbow) &&
+                        ((BioBlaster.LevelChecked() && GetCooldownRemainingTime(BioBlaster) > 10) ||
+                         !BioBlaster.LevelChecked() || IsNotEnabled(CustomComboPreset.MCH_AoE_Adv_Bioblaster)) &&
+                        ((Flamethrower.LevelChecked() && GetCooldownRemainingTime(Flamethrower) > 10) ||
+                         !Flamethrower.LevelChecked() || IsNotEnabled(CustomComboPreset.MCH_AoE_Adv_FlameThrower)))
+                        return Hypercharge;
 
-                        if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && !HasEffect(Buffs.Wildfire) &&
-                            !HasEffect(Buffs.Reassembled) && HasCharges(Reassemble) && !JustUsed(Flamethrower, 10f) &&
-                            GetRemainingCharges(Reassemble) > Config.MCH_AoE_ReassemblePool &&
-                            ((Config.MCH_AoE_Reassembled [0] && Scattergun.LevelChecked()) ||
-                             (Gauge.IsOverheated && Config.MCH_AoE_Reassembled [1] && AutoCrossbow.LevelChecked()) ||
-                             (GetCooldownRemainingTime(Chainsaw) < 1 && Config.MCH_AoE_Reassembled [2] && Chainsaw.LevelChecked()) ||
-                             (GetCooldownRemainingTime(OriginalHook(Chainsaw)) < 1 && Config.MCH_AoE_Reassembled [3] &&
-                              Excavator.LevelChecked())))
-                            return Reassemble;
+                    if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && !HasEffect(Buffs.Wildfire) &&
+                        !HasEffect(Buffs.Reassembled) && HasCharges(Reassemble) && !JustUsed(Flamethrower, 10f) &&
+                        GetRemainingCharges(Reassemble) > Config.MCH_AoE_ReassemblePool &&
+                        ((Config.MCH_AoE_Reassembled [0] && Scattergun.LevelChecked()) ||
+                         (Gauge.IsOverheated && Config.MCH_AoE_Reassembled [1] && AutoCrossbow.LevelChecked()) ||
+                         (GetCooldownRemainingTime(Chainsaw) < 1 && Config.MCH_AoE_Reassembled [2] && Chainsaw.LevelChecked()) ||
+                         (GetCooldownRemainingTime(OriginalHook(Chainsaw)) < 1 && Config.MCH_AoE_Reassembled [3] &&
+                          Excavator.LevelChecked())))
+                        return Reassemble;
 
-                        //gauss and ricochet outside HC
-                        if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_GaussRicochet) &&
-                            Config.MCH_AoE_Hypercharge)
-                        {
-                            if (ActionReady(OriginalHook(GaussRound)) &&
-                                !JustUsed(OriginalHook(GaussRound), 2.5f))
-                                return OriginalHook(GaussRound);
-
-                            if (ActionReady(OriginalHook(Ricochet)) &&
-                                !JustUsed(OriginalHook(Ricochet), 2.5f))
-                                return OriginalHook(Ricochet);
-                        }
-
-                        if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_SecondWind) &&
-                            PlayerHealthPercentageHp() <= Config.MCH_AoE_SecondWindThreshold &&
-                            ActionReady(All.SecondWind))
-                            return All.SecondWind;
-                    }
-
-                    //AutoCrossbow, Gauss, Rico
+                    //gauss and ricochet outside HC
                     if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_GaussRicochet) &&
-                        !Config.MCH_AoE_Hypercharge &&
-                        (JustUsed(OriginalHook(AutoCrossbow), 1f) ||
-                         JustUsed(OriginalHook(Heatblast), 1f)) && HasNotWeaved)
+                        Config.MCH_AoE_Hypercharge)
                     {
                         if (ActionReady(OriginalHook(GaussRound)) &&
-                            GetRemainingCharges(OriginalHook(GaussRound)) >=
-                            GetRemainingCharges(OriginalHook(Ricochet)))
+                            !JustUsed(OriginalHook(GaussRound), 2.5f))
                             return OriginalHook(GaussRound);
 
                         if (ActionReady(OriginalHook(Ricochet)) &&
-                            GetRemainingCharges(OriginalHook(Ricochet)) >
-                            GetRemainingCharges(OriginalHook(GaussRound)))
+                            !JustUsed(OriginalHook(Ricochet), 2.5f))
                             return OriginalHook(Ricochet);
                     }
+
+                    if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_SecondWind) &&
+                        PlayerHealthPercentageHp() <= Config.MCH_AoE_SecondWindThreshold &&
+                        ActionReady(All.SecondWind))
+                        return All.SecondWind;
                 }
 
-                //Full Metal Field
-                if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Stabilizer_FullMetalField) &&
-                    HasEffect(Buffs.FullMetalMachinist) && LevelChecked(FullMetalField))
-                    return FullMetalField;
+                //AutoCrossbow, Gauss, Rico
+                if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_GaussRicochet) &&
+                    !Config.MCH_AoE_Hypercharge &&
+                    (JustUsed(OriginalHook(AutoCrossbow), 1f) ||
+                     JustUsed(OriginalHook(Heatblast), 1f)) && HasNotWeaved)
+                {
+                    if (ActionReady(OriginalHook(GaussRound)) &&
+                        GetRemainingCharges(OriginalHook(GaussRound)) >=
+                        GetRemainingCharges(OriginalHook(Ricochet)))
+                        return OriginalHook(GaussRound);
 
-                if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Bioblaster) &&
-                    ActionReady(BioBlaster) && !TargetHasEffect(Debuffs.Bioblaster) && !Gauge.IsOverheated)
-                    return OriginalHook(BioBlaster);
-
-                if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_FlameThrower) &&
-                    ActionReady(Flamethrower) && !IsMoving())
-                    return OriginalHook(Flamethrower);
-
-                if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Excavator) &&
-                    reassembledExcavatorAoE &&
-                    LevelChecked(Excavator) && HasEffect(Buffs.ExcavatorReady))
-                    return OriginalHook(Chainsaw);
-
-                if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Chainsaw) &&
-                    reassembledChainsawAoE &&
-                    LevelChecked(Chainsaw) &&
-                    (GetCooldownRemainingTime(Chainsaw) <= GCD + 0.25 || ActionReady(Chainsaw)))
-                    return Chainsaw;
-
-                if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_AirAnchor) &&
-                    reassembledAirAnchorAoE &&
-                    LevelChecked(AirAnchor) &&
-                    (GetCooldownRemainingTime(AirAnchor) <= GCD + 0.25 || ActionReady(AirAnchor)))
-                    return AirAnchor;
-
-                if (reassembledScattergunAoE)
-                    return OriginalHook(Scattergun);
-
-                if (LevelChecked(AutoCrossbow) && Gauge.IsOverheated &&
-                    (!LevelChecked(CheckMate) || IsNotEnabled(CustomComboPreset.MCH_AoE_Adv_BlazingShot)))
-                    return AutoCrossbow;
-
-                if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_BlazingShot) &&
-                    Gauge.IsOverheated && LevelChecked(CheckMate))
-                    return BlazingShot;
+                    if (ActionReady(OriginalHook(Ricochet)) &&
+                        GetRemainingCharges(OriginalHook(Ricochet)) >
+                        GetRemainingCharges(OriginalHook(GaussRound)))
+                        return OriginalHook(Ricochet);
+                }
             }
+
+            //Full Metal Field
+            if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Stabilizer_FullMetalField) &&
+                HasEffect(Buffs.FullMetalMachinist) && LevelChecked(FullMetalField))
+                return FullMetalField;
+
+            if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Bioblaster) &&
+                ActionReady(BioBlaster) && !TargetHasEffect(Debuffs.Bioblaster) && !Gauge.IsOverheated)
+                return OriginalHook(BioBlaster);
+
+            if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_FlameThrower) &&
+                ActionReady(Flamethrower) && !IsMoving())
+                return OriginalHook(Flamethrower);
+
+            if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Excavator) &&
+                reassembledExcavatorAoE &&
+                LevelChecked(Excavator) && HasEffect(Buffs.ExcavatorReady))
+                return OriginalHook(Chainsaw);
+
+            if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Chainsaw) &&
+                reassembledChainsawAoE &&
+                LevelChecked(Chainsaw) &&
+                (GetCooldownRemainingTime(Chainsaw) <= GCD + 0.25 || ActionReady(Chainsaw)))
+                return Chainsaw;
+
+            if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_AirAnchor) &&
+                reassembledAirAnchorAoE &&
+                LevelChecked(AirAnchor) &&
+                (GetCooldownRemainingTime(AirAnchor) <= GCD + 0.25 || ActionReady(AirAnchor)))
+                return AirAnchor;
+
+            if (reassembledScattergunAoE)
+                return OriginalHook(Scattergun);
+
+            if (LevelChecked(AutoCrossbow) && Gauge.IsOverheated &&
+                (!LevelChecked(CheckMate) || IsNotEnabled(CustomComboPreset.MCH_AoE_Adv_BlazingShot)))
+                return AutoCrossbow;
+
+            if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_BlazingShot) &&
+                Gauge.IsOverheated && LevelChecked(CheckMate))
+                return BlazingShot;
 
             return actionID;
         }
@@ -597,91 +593,24 @@ internal static partial class MCH
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Heatblast or BlazingShot)
-            {
-                if (IsEnabled(CustomComboPreset.MCH_Heatblast_AutoBarrel) &&
-                    ActionReady(BarrelStabilizer) && !Gauge.IsOverheated)
-                    return BarrelStabilizer;
+            if (actionID is not (Heatblast or BlazingShot)) return actionID;
 
-                if (IsEnabled(CustomComboPreset.MCH_Heatblast_Wildfire) &&
-                    ActionReady(Wildfire) && JustUsed(Hypercharge))
-                    return Wildfire;
+            if (IsEnabled(CustomComboPreset.MCH_Heatblast_AutoBarrel) &&
+                ActionReady(BarrelStabilizer) && !Gauge.IsOverheated)
+                return BarrelStabilizer;
 
-                if (!Gauge.IsOverheated && LevelChecked(Hypercharge) &&
-                    (Gauge.Heat >= 50 || HasEffect(Buffs.Hypercharged)))
-                    return Hypercharge;
+            if (IsEnabled(CustomComboPreset.MCH_Heatblast_Wildfire) &&
+                ActionReady(Wildfire) && JustUsed(Hypercharge))
+                return Wildfire;
 
-                if (IsEnabled(CustomComboPreset.MCH_Heatblast_GaussRound) &&
-                    CanWeave() &&
-                    JustUsed(OriginalHook(Heatblast), 1f) &&
-                    HasNotWeaved)
-                {
-                    if (ActionReady(OriginalHook(GaussRound)) &&
-                        GetRemainingCharges(OriginalHook(GaussRound)) >=
-                        GetRemainingCharges(OriginalHook(Ricochet)))
-                        return OriginalHook(GaussRound);
+            if (!Gauge.IsOverheated && LevelChecked(Hypercharge) &&
+                (Gauge.Heat >= 50 || HasEffect(Buffs.Hypercharged)))
+                return Hypercharge;
 
-                    if (ActionReady(OriginalHook(Ricochet)) &&
-                        GetRemainingCharges(OriginalHook(Ricochet)) >
-                        GetRemainingCharges(OriginalHook(GaussRound)))
-                        return OriginalHook(Ricochet);
-                }
-
-                if (Gauge.IsOverheated && LevelChecked(OriginalHook(Heatblast)))
-                    return OriginalHook(Heatblast);
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class MCH_AutoCrossbowGaussRicochet : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MCH_AutoCrossbow;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is AutoCrossbow)
-            {
-                if (IsEnabled(CustomComboPreset.MCH_AutoCrossbow_AutoBarrel) &&
-                    ActionReady(BarrelStabilizer) && !Gauge.IsOverheated)
-                    return BarrelStabilizer;
-
-                if (!Gauge.IsOverheated && LevelChecked(Hypercharge) &&
-                    (Gauge.Heat >= 50 || HasEffect(Buffs.Hypercharged)))
-                    return Hypercharge;
-
-                if (IsEnabled(CustomComboPreset.MCH_AutoCrossbow_GaussRound) &&
-                    CanWeave() &&
-                    JustUsed(OriginalHook(AutoCrossbow), 1f) &&
-                    HasNotWeaved)
-                {
-                    if (ActionReady(OriginalHook(GaussRound)) &&
-                        GetRemainingCharges(OriginalHook(GaussRound)) >=
-                        GetRemainingCharges(OriginalHook(Ricochet)))
-                        return OriginalHook(GaussRound);
-
-                    if (ActionReady(OriginalHook(Ricochet)) &&
-                        GetRemainingCharges(OriginalHook(Ricochet)) >
-                        GetRemainingCharges(OriginalHook(GaussRound)))
-                        return OriginalHook(Ricochet);
-                }
-
-                if (Gauge.IsOverheated && LevelChecked(OriginalHook(AutoCrossbow)))
-                    return OriginalHook(AutoCrossbow);
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class MCH_GaussRoundRicochet : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MCH_GaussRoundRicochet;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is GaussRound or Ricochet or CheckMate or DoubleCheck)
+            if (IsEnabled(CustomComboPreset.MCH_Heatblast_GaussRound) &&
+                CanWeave() &&
+                JustUsed(OriginalHook(Heatblast), 1f) &&
+                HasNotWeaved)
             {
                 if (ActionReady(OriginalHook(GaussRound)) &&
                     GetRemainingCharges(OriginalHook(GaussRound)) >=
@@ -693,6 +622,70 @@ internal static partial class MCH
                     GetRemainingCharges(OriginalHook(GaussRound)))
                     return OriginalHook(Ricochet);
             }
+
+            if (Gauge.IsOverheated && LevelChecked(OriginalHook(Heatblast)))
+                return OriginalHook(Heatblast);
+
+            return actionID;
+        }
+    }
+
+    internal class MCH_AutoCrossbowGaussRicochet : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MCH_AutoCrossbow;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not AutoCrossbow) return actionID;
+
+            if (IsEnabled(CustomComboPreset.MCH_AutoCrossbow_AutoBarrel) &&
+                ActionReady(BarrelStabilizer) && !Gauge.IsOverheated)
+                return BarrelStabilizer;
+
+            if (!Gauge.IsOverheated && LevelChecked(Hypercharge) &&
+                (Gauge.Heat >= 50 || HasEffect(Buffs.Hypercharged)))
+                return Hypercharge;
+
+            if (IsEnabled(CustomComboPreset.MCH_AutoCrossbow_GaussRound) &&
+                CanWeave() &&
+                JustUsed(OriginalHook(AutoCrossbow), 1f) &&
+                HasNotWeaved)
+            {
+                if (ActionReady(OriginalHook(GaussRound)) &&
+                    GetRemainingCharges(OriginalHook(GaussRound)) >=
+                    GetRemainingCharges(OriginalHook(Ricochet)))
+                    return OriginalHook(GaussRound);
+
+                if (ActionReady(OriginalHook(Ricochet)) &&
+                    GetRemainingCharges(OriginalHook(Ricochet)) >
+                    GetRemainingCharges(OriginalHook(GaussRound)))
+                    return OriginalHook(Ricochet);
+            }
+
+            if (Gauge.IsOverheated && LevelChecked(OriginalHook(AutoCrossbow)))
+                return OriginalHook(AutoCrossbow);
+
+            return actionID;
+        }
+    }
+
+    internal class MCH_GaussRoundRicochet : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MCH_GaussRoundRicochet;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not (GaussRound or Ricochet or CheckMate or DoubleCheck)) return actionID;
+
+            if (ActionReady(OriginalHook(GaussRound)) &&
+                GetRemainingCharges(OriginalHook(GaussRound)) >=
+                GetRemainingCharges(OriginalHook(Ricochet)))
+                return OriginalHook(GaussRound);
+
+            if (ActionReady(OriginalHook(Ricochet)) &&
+                GetRemainingCharges(OriginalHook(Ricochet)) >
+                GetRemainingCharges(OriginalHook(GaussRound)))
+                return OriginalHook(Ricochet);
 
             return actionID;
         }
@@ -712,18 +705,27 @@ internal static partial class MCH
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MCH_HotShotDrillChainsawExcavator;
 
-        protected override uint Invoke(uint actionID) =>
-            actionID is Drill or HotShot or AirAnchor or Chainsaw
-                ? LevelChecked(Excavator) && HasEffect(Buffs.ExcavatorReady)
-                    ? CalcBestAction(actionID, Excavator, Chainsaw, AirAnchor, Drill)
-                    : LevelChecked(Chainsaw)
-                        ? CalcBestAction(actionID, Chainsaw, AirAnchor, Drill)
-                        : LevelChecked(AirAnchor)
-                            ? CalcBestAction(actionID, AirAnchor, Drill)
-                            : LevelChecked(Drill)
-                                ? CalcBestAction(actionID, Drill, HotShot)
-                                : HotShot
-                : actionID;
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not (Drill or HotShot or AirAnchor or Chainsaw)) return actionID;
+
+            if (LevelChecked(Excavator) && HasEffect(Buffs.ExcavatorReady))
+                return CalcBestAction(actionID, Excavator, Chainsaw, AirAnchor, Drill);
+
+            if (LevelChecked(Chainsaw))
+                return CalcBestAction(actionID, Chainsaw, AirAnchor, Drill);
+
+            if (LevelChecked(AirAnchor))
+                return CalcBestAction(actionID, AirAnchor, Drill);
+
+            if (LevelChecked(Drill))
+                return CalcBestAction(actionID, Drill, HotShot);
+
+            if (!LevelChecked(Drill))
+                return HotShot;
+
+            return actionID;
+        }
     }
 
     internal class MCH_DismantleTactician : CustomCombo

--- a/WrathCombo/Combos/PvE/MNK/MNK.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK.cs
@@ -11,18 +11,155 @@ internal static partial class MNK
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Bootshine or LeapingOpo)
+            if (actionID is not (Bootshine or LeapingOpo)) return actionID;
+
+            if ((!InCombat() || !InMeleeRange()) &&
+                Gauge.Chakra < 5 &&
+                !HasEffect(Buffs.RiddleOfFire) &&
+                LevelChecked(SteeledMeditation))
+                return OriginalHook(SteeledMeditation);
+
+            if (!InCombat() && LevelChecked(FormShift) &&
+                !HasEffect(Buffs.FormlessFist) && !HasEffect(Buffs.PerfectBalance))
+                return FormShift;
+
+            if (Opener().FullOpener(ref actionID))
             {
-                if ((!InCombat() || !InMeleeRange()) &&
-                    Gauge.Chakra < 5 &&
-                    !HasEffect(Buffs.RiddleOfFire) &&
-                    LevelChecked(SteeledMeditation))
+                if (IsOnCooldown(RiddleOfWind) &&
+                    CanWeave() &&
+                    Gauge.Chakra >= 5)
+                    return TheForbiddenChakra;
+
+                return actionID;
+            }
+
+            //Variant Cure
+            if (IsEnabled(CustomComboPreset.MNK_Variant_Cure) &&
+                IsEnabled(Variant.VariantCure) &&
+                PlayerHealthPercentageHp() <= Config.MNK_VariantCure)
+                return Variant.VariantCure;
+
+            if (ActionReady(RiddleOfFire) &&
+                CanDelayedWeave())
+                return RiddleOfFire;
+
+            // OGCDs
+            if (CanWeave())
+            {
+                //Variant Rampart
+                if (IsEnabled(CustomComboPreset.MNK_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart))
+                    return Variant.VariantRampart;
+
+                if (ActionReady(Brotherhood))
+                    return Brotherhood;
+
+                if (ActionReady(RiddleOfWind))
+                    return RiddleOfWind;
+
+                //Perfect Balance
+                if (UsePerfectBalance())
+                    return PerfectBalance;
+
+                if (PlayerHealthPercentageHp() <= 25 && ActionReady(All.SecondWind))
+                    return All.SecondWind;
+
+                if (PlayerHealthPercentageHp() <= 40 && ActionReady(All.Bloodbath))
+                    return All.Bloodbath;
+
+                if (Gauge.Chakra >= 5 && InCombat() && LevelChecked(SteeledMeditation))
                     return OriginalHook(SteeledMeditation);
+            }
 
-                if (!InCombat() && LevelChecked(FormShift) &&
-                    !HasEffect(Buffs.FormlessFist) && !HasEffect(Buffs.PerfectBalance))
-                    return FormShift;
+            // GCDs
+            if (HasEffect(Buffs.FormlessFist))
+                return Gauge.OpoOpoFury == 0
+                    ? DragonKick
+                    : OriginalHook(Bootshine);
 
+            // Masterful Blitz
+            if (LevelChecked(MasterfulBlitz) &&
+                !HasEffect(Buffs.PerfectBalance) &&
+                !IsOriginal(MasterfulBlitz))
+                return OriginalHook(MasterfulBlitz);
+
+            // Perfect Balance
+            if (HasEffect(Buffs.PerfectBalance))
+            {
+                #region Open Lunar
+
+                if (!LunarNadi || BothNadisOpen || (!SolarNadi && !LunarNadi))
+                    return Gauge.OpoOpoFury == 0
+                        ? DragonKick
+                        : OriginalHook(Bootshine);
+
+                #endregion
+
+                #region Open Solar
+
+                if (!SolarNadi && !BothNadisOpen)
+                {
+                    if (CoeurlChakra == 0)
+                        return Gauge.CoeurlFury == 0
+                            ? Demolish
+                            : OriginalHook(SnapPunch);
+
+                    if (RaptorChakra == 0)
+                        return Gauge.RaptorFury == 0
+                            ? TwinSnakes
+                            : OriginalHook(TrueStrike);
+
+                    if (OpoOpoChakra == 0)
+                        return Gauge.OpoOpoFury == 0
+                            ? DragonKick
+                            : OriginalHook(Bootshine);
+                }
+
+                #endregion
+            }
+
+            if (HasEffect(Buffs.FiresRumination) &&
+                !HasEffect(Buffs.PerfectBalance) &&
+                !HasEffect(Buffs.FormlessFist) &&
+                (JustUsed(OriginalHook(Bootshine)) ||
+                 JustUsed(DragonKick) ||
+                 GetBuffRemainingTime(Buffs.FiresRumination) < 4))
+                return FiresReply;
+
+            if (HasEffect(Buffs.WindsRumination) &&
+                LevelChecked(WindsReply) &&
+                HasEffect(Buffs.RiddleOfWind) &&
+                GetBuffRemainingTime(Buffs.WindsRumination) < 4)
+                return WindsReply;
+
+            // Standard Beast Chakras
+            return DetermineCoreAbility(actionID, true);
+
+        }
+    }
+
+    internal class MNK_ST_AdvancedMode : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MNK_ST_AdvancedMode;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not (Bootshine or LeapingOpo)) return actionID;
+
+            if (IsEnabled(CustomComboPreset.MNK_STUseMeditation) &&
+                (!InCombat() || !InMeleeRange()) &&
+                Gauge.Chakra < 5 &&
+                !HasEffect(Buffs.RiddleOfFire) &&
+                LevelChecked(SteeledMeditation))
+                return OriginalHook(SteeledMeditation);
+
+            if (IsEnabled(CustomComboPreset.MNK_STUseFormShift) &&
+                !InCombat() && LevelChecked(FormShift) &&
+                !HasEffect(Buffs.FormlessFist) && !HasEffect(Buffs.PerfectBalance))
+                return FormShift;
+
+            if (IsEnabled(CustomComboPreset.MNK_STUseOpener))
                 if (Opener().FullOpener(ref actionID))
                 {
                     if (IsOnCooldown(RiddleOfWind) &&
@@ -33,93 +170,113 @@ internal static partial class MNK
                     return actionID;
                 }
 
-                //Variant Cure
-                if (IsEnabled(CustomComboPreset.MNK_Variant_Cure) &&
-                    IsEnabled(Variant.VariantCure) &&
-                    PlayerHealthPercentageHp() <= Config.MNK_VariantCure)
-                    return Variant.VariantCure;
+            //Variant Cure
+            if (IsEnabled(CustomComboPreset.MNK_Variant_Cure) &&
+                IsEnabled(Variant.VariantCure) &&
+                PlayerHealthPercentageHp() <= Config.MNK_VariantCure)
+                return Variant.VariantCure;
 
-                if (ActionReady(RiddleOfFire) &&
-                    CanDelayedWeave())
-                    return RiddleOfFire;
+            if (IsEnabled(CustomComboPreset.MNK_STUseBuffs) &&
+                IsEnabled(CustomComboPreset.MNK_STUseROF) &&
+                ActionReady(RiddleOfFire) &&
+                CanDelayedWeave() &&
+                GetTargetHPPercent() >= Config.MNK_ST_RiddleOfFire_HP)
+                return RiddleOfFire;
 
-                // OGCDs
-                if (CanWeave())
+            // OGCDs
+            if (CanWeave())
+            {
+                //Variant Rampart
+                if (IsEnabled(CustomComboPreset.MNK_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart))
+                    return Variant.VariantRampart;
+
+                if (IsEnabled(CustomComboPreset.MNK_STUseBuffs))
                 {
-                    //Variant Rampart
-                    if (IsEnabled(CustomComboPreset.MNK_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart))
-                        return Variant.VariantRampart;
-
-                    if (ActionReady(Brotherhood))
+                    if (IsEnabled(CustomComboPreset.MNK_STUseBrotherhood) &&
+                        ActionReady(Brotherhood) &&
+                        GetTargetHPPercent() >= Config.MNK_ST_Brotherhood_HP)
                         return Brotherhood;
 
-                    if (ActionReady(RiddleOfWind))
+                    if (IsEnabled(CustomComboPreset.MNK_STUseROW) &&
+                        ActionReady(RiddleOfWind) &&
+                        GetTargetHPPercent() >= Config.MNK_ST_RiddleOfWind_HP)
                         return RiddleOfWind;
-
-                    //Perfect Balance
-                    if (UsePerfectBalance())
-                        return PerfectBalance;
-
-                    if (PlayerHealthPercentageHp() <= 25 && ActionReady(All.SecondWind))
-                        return All.SecondWind;
-
-                    if (PlayerHealthPercentageHp() <= 40 && ActionReady(All.Bloodbath))
-                        return All.Bloodbath;
-
-                    if (Gauge.Chakra >= 5 && InCombat() && LevelChecked(SteeledMeditation))
-                        return OriginalHook(SteeledMeditation);
                 }
 
-                // GCDs
-                if (HasEffect(Buffs.FormlessFist))
+                //Perfect Balance
+                if (IsEnabled(CustomComboPreset.MNK_STUsePerfectBalance) &&
+                    UsePerfectBalance())
+                    return PerfectBalance;
+
+                if (IsEnabled(CustomComboPreset.MNK_ST_ComboHeals))
+                {
+                    if (PlayerHealthPercentageHp() <= Config.MNK_ST_SecondWind_Threshold && ActionReady(All.SecondWind))
+                        return All.SecondWind;
+
+                    if (PlayerHealthPercentageHp() <= Config.MNK_ST_Bloodbath_Threshold && ActionReady(All.Bloodbath))
+                        return All.Bloodbath;
+                }
+
+                if (IsEnabled(CustomComboPreset.MNK_STUseTheForbiddenChakra) &&
+                    Gauge.Chakra >= 5 && InCombat() &&
+                    LevelChecked(SteeledMeditation))
+                    return OriginalHook(SteeledMeditation);
+            }
+
+            // GCDs
+            if (HasEffect(Buffs.FormlessFist))
+                return Gauge.OpoOpoFury == 0
+                    ? DragonKick
+                    : OriginalHook(Bootshine);
+
+            // Masterful Blitz
+            if (LevelChecked(MasterfulBlitz) &&
+                !HasEffect(Buffs.PerfectBalance) &&
+                !IsOriginal(MasterfulBlitz))
+                return OriginalHook(MasterfulBlitz);
+
+            // Perfect Balance
+            if (HasEffect(Buffs.PerfectBalance))
+            {
+                #region Open Lunar
+
+                if (!LunarNadi || BothNadisOpen || (!SolarNadi && !LunarNadi))
                     return Gauge.OpoOpoFury == 0
                         ? DragonKick
                         : OriginalHook(Bootshine);
 
-                // Masterful Blitz
-                if (LevelChecked(MasterfulBlitz) &&
-                    !HasEffect(Buffs.PerfectBalance) &&
-                    !IsOriginal(MasterfulBlitz))
-                    return OriginalHook(MasterfulBlitz);
+                #endregion
 
-                // Perfect Balance
-                if (HasEffect(Buffs.PerfectBalance))
+                #region Open Solar
+
+                if (!SolarNadi && !BothNadisOpen)
                 {
-                    #region Open Lunar
+                    if (CoeurlChakra == 0)
+                        return Gauge.CoeurlFury == 0
+                            ? Demolish
+                            : OriginalHook(SnapPunch);
 
-                    if (!LunarNadi || BothNadisOpen || (!SolarNadi && !LunarNadi))
+                    if (RaptorChakra == 0)
+                        return Gauge.RaptorFury == 0
+                            ? TwinSnakes
+                            : OriginalHook(TrueStrike);
+
+                    if (OpoOpoChakra == 0)
                         return Gauge.OpoOpoFury == 0
                             ? DragonKick
                             : OriginalHook(Bootshine);
-
-                    #endregion
-
-                    #region Open Solar
-
-                    if (!SolarNadi && !BothNadisOpen)
-                    {
-                        if (CoeurlChakra == 0)
-                            return Gauge.CoeurlFury == 0
-                                ? Demolish
-                                : OriginalHook(SnapPunch);
-
-                        if (RaptorChakra == 0)
-                            return Gauge.RaptorFury == 0
-                                ? TwinSnakes
-                                : OriginalHook(TrueStrike);
-
-                        if (OpoOpoChakra == 0)
-                            return Gauge.OpoOpoFury == 0
-                                ? DragonKick
-                                : OriginalHook(Bootshine);
-                    }
-
-                    #endregion
                 }
 
-                if (HasEffect(Buffs.FiresRumination) &&
+                #endregion
+            }
+
+            if (IsEnabled(CustomComboPreset.MNK_STUseBuffs))
+            {
+                if (IsEnabled(CustomComboPreset.MNK_STUseROF) &&
+                    IsEnabled(CustomComboPreset.MNK_STUseFiresReply) &&
+                    HasEffect(Buffs.FiresRumination) &&
                     !HasEffect(Buffs.PerfectBalance) &&
                     !HasEffect(Buffs.FormlessFist) &&
                     (JustUsed(OriginalHook(Bootshine)) ||
@@ -127,178 +284,17 @@ internal static partial class MNK
                      GetBuffRemainingTime(Buffs.FiresRumination) < 4))
                     return FiresReply;
 
-                if (HasEffect(Buffs.WindsRumination) &&
+                if (IsEnabled(CustomComboPreset.MNK_STUseROW) &&
+                    IsEnabled(CustomComboPreset.MNK_STUseWindsReply) &&
+                    HasEffect(Buffs.WindsRumination) &&
                     LevelChecked(WindsReply) &&
                     HasEffect(Buffs.RiddleOfWind) &&
                     GetBuffRemainingTime(Buffs.WindsRumination) < 4)
                     return WindsReply;
-
-                // Standard Beast Chakras
-                return DetermineCoreAbility(actionID, true);
             }
 
-            return actionID;
-        }
-    }
-
-    internal class MNK_ST_AdvancedMode : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MNK_ST_AdvancedMode;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is Bootshine or LeapingOpo)
-            {
-                if (IsEnabled(CustomComboPreset.MNK_STUseMeditation) &&
-                    (!InCombat() || !InMeleeRange()) &&
-                    Gauge.Chakra < 5 &&
-                    !HasEffect(Buffs.RiddleOfFire) &&
-                    LevelChecked(SteeledMeditation))
-                    return OriginalHook(SteeledMeditation);
-
-                if (IsEnabled(CustomComboPreset.MNK_STUseFormShift) &&
-                    !InCombat() && LevelChecked(FormShift) &&
-                    !HasEffect(Buffs.FormlessFist) && !HasEffect(Buffs.PerfectBalance))
-                    return FormShift;
-
-                if (IsEnabled(CustomComboPreset.MNK_STUseOpener))
-                    if (Opener().FullOpener(ref actionID))
-                    {
-                        if (IsOnCooldown(RiddleOfWind) &&
-                            CanWeave() &&
-                            Gauge.Chakra >= 5)
-                            return TheForbiddenChakra;
-
-                        return actionID;
-                    }
-
-                //Variant Cure
-                if (IsEnabled(CustomComboPreset.MNK_Variant_Cure) &&
-                    IsEnabled(Variant.VariantCure) &&
-                    PlayerHealthPercentageHp() <= Config.MNK_VariantCure)
-                    return Variant.VariantCure;
-
-                if (IsEnabled(CustomComboPreset.MNK_STUseBuffs) &&
-                    IsEnabled(CustomComboPreset.MNK_STUseROF) &&
-                    ActionReady(RiddleOfFire) &&
-                    CanDelayedWeave() &&
-                    GetTargetHPPercent() >= Config.MNK_ST_RiddleOfFire_HP)
-                    return RiddleOfFire;
-
-                // OGCDs
-                if (CanWeave())
-                {
-                    //Variant Rampart
-                    if (IsEnabled(CustomComboPreset.MNK_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart))
-                        return Variant.VariantRampart;
-
-                    if (IsEnabled(CustomComboPreset.MNK_STUseBuffs))
-                    {
-                        if (IsEnabled(CustomComboPreset.MNK_STUseBrotherhood) &&
-                            ActionReady(Brotherhood) &&
-                            GetTargetHPPercent() >= Config.MNK_ST_Brotherhood_HP)
-                            return Brotherhood;
-
-                        if (IsEnabled(CustomComboPreset.MNK_STUseROW) &&
-                            ActionReady(RiddleOfWind) &&
-                            GetTargetHPPercent() >= Config.MNK_ST_RiddleOfWind_HP)
-                            return RiddleOfWind;
-                    }
-
-                    //Perfect Balance
-                    if (IsEnabled(CustomComboPreset.MNK_STUsePerfectBalance) &&
-                        UsePerfectBalance())
-                        return PerfectBalance;
-
-                    if (IsEnabled(CustomComboPreset.MNK_ST_ComboHeals))
-                    {
-                        if (PlayerHealthPercentageHp() <= Config.MNK_ST_SecondWind_Threshold && ActionReady(All.SecondWind))
-                            return All.SecondWind;
-
-                        if (PlayerHealthPercentageHp() <= Config.MNK_ST_Bloodbath_Threshold && ActionReady(All.Bloodbath))
-                            return All.Bloodbath;
-                    }
-
-                    if (IsEnabled(CustomComboPreset.MNK_STUseTheForbiddenChakra) &&
-                        Gauge.Chakra >= 5 && InCombat() &&
-                        LevelChecked(SteeledMeditation))
-                        return OriginalHook(SteeledMeditation);
-                }
-
-                // GCDs
-                if (HasEffect(Buffs.FormlessFist))
-                    return Gauge.OpoOpoFury == 0
-                        ? DragonKick
-                        : OriginalHook(Bootshine);
-
-                // Masterful Blitz
-                if (LevelChecked(MasterfulBlitz) &&
-                    !HasEffect(Buffs.PerfectBalance) &&
-                    !IsOriginal(MasterfulBlitz))
-                    return OriginalHook(MasterfulBlitz);
-
-                // Perfect Balance
-                if (HasEffect(Buffs.PerfectBalance))
-                {
-                    #region Open Lunar
-
-                    if (!LunarNadi || BothNadisOpen || (!SolarNadi && !LunarNadi))
-                        return Gauge.OpoOpoFury == 0
-                            ? DragonKick
-                            : OriginalHook(Bootshine);
-
-                    #endregion
-
-                    #region Open Solar
-
-                    if (!SolarNadi && !BothNadisOpen)
-                    {
-                        if (CoeurlChakra == 0)
-                            return Gauge.CoeurlFury == 0
-                                ? Demolish
-                                : OriginalHook(SnapPunch);
-
-                        if (RaptorChakra == 0)
-                            return Gauge.RaptorFury == 0
-                                ? TwinSnakes
-                                : OriginalHook(TrueStrike);
-
-                        if (OpoOpoChakra == 0)
-                            return Gauge.OpoOpoFury == 0
-                                ? DragonKick
-                                : OriginalHook(Bootshine);
-                    }
-
-                    #endregion
-                }
-
-                if (IsEnabled(CustomComboPreset.MNK_STUseBuffs))
-                {
-                    if (IsEnabled(CustomComboPreset.MNK_STUseROF) &&
-                        IsEnabled(CustomComboPreset.MNK_STUseFiresReply) &&
-                        HasEffect(Buffs.FiresRumination) &&
-                        !HasEffect(Buffs.PerfectBalance) &&
-                        !HasEffect(Buffs.FormlessFist) &&
-                        (JustUsed(OriginalHook(Bootshine)) ||
-                         JustUsed(DragonKick) ||
-                         GetBuffRemainingTime(Buffs.FiresRumination) < 4))
-                        return FiresReply;
-
-                    if (IsEnabled(CustomComboPreset.MNK_STUseROW) &&
-                        IsEnabled(CustomComboPreset.MNK_STUseWindsReply) &&
-                        HasEffect(Buffs.WindsRumination) &&
-                        LevelChecked(WindsReply) &&
-                        HasEffect(Buffs.RiddleOfWind) &&
-                        GetBuffRemainingTime(Buffs.WindsRumination) < 4)
-                        return WindsReply;
-                }
-
-                // Standard Beast Chakras
-                return DetermineCoreAbility(actionID, IsEnabled(CustomComboPreset.MNK_STUseTrueNorth));
-            }
-            return actionID;
+            // Standard Beast Chakras
+            return DetermineCoreAbility(actionID, IsEnabled(CustomComboPreset.MNK_STUseTrueNorth));
         }
     }
 
@@ -308,126 +304,125 @@ internal static partial class MNK
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is ArmOfTheDestroyer or ShadowOfTheDestroyer)
+            if (actionID is not (ArmOfTheDestroyer or ShadowOfTheDestroyer)) return actionID;
+
+            if (!InCombat() && Gauge.Chakra < 5 &&
+                LevelChecked(InspiritedMeditation))
+                return OriginalHook(InspiritedMeditation);
+
+            if (!InCombat() && LevelChecked(FormShift) &&
+                !HasEffect(Buffs.FormlessFist) &&
+                !HasEffect(Buffs.PerfectBalance))
+                return FormShift;
+
+            //Variant Cure
+            if (IsEnabled(CustomComboPreset.MNK_Variant_Cure) &&
+                IsEnabled(Variant.VariantCure) &&
+                PlayerHealthPercentageHp() <= Config.MNK_VariantCure)
+                return Variant.VariantCure;
+
+            if (ActionReady(RiddleOfFire) &&
+                CanDelayedWeave())
+                return RiddleOfFire;
+
+            // Buffs
+            if (CanWeave())
             {
-                if (!InCombat() && Gauge.Chakra < 5 &&
-                    LevelChecked(InspiritedMeditation))
+                //Variant Rampart
+                if (IsEnabled(CustomComboPreset.MNK_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart))
+                    return Variant.VariantRampart;
+
+                if (ActionReady(Brotherhood))
+                    return Brotherhood;
+
+                if (ActionReady(RiddleOfWind))
+                    return RiddleOfWind;
+
+                if (ActionReady(PerfectBalance) &&
+                    !HasEffect(Buffs.PerfectBalance) &&
+                    (GetRemainingCharges(PerfectBalance) == GetMaxCharges(PerfectBalance) ||
+                     GetCooldownRemainingTime(PerfectBalance) <= 4 ||
+                     HasEffect(Buffs.Brotherhood) ||
+                     (HasEffect(Buffs.RiddleOfFire) && GetBuffRemainingTime(Buffs.RiddleOfFire) < 10) ||
+                     (GetCooldownRemainingTime(RiddleOfFire) < 4 && GetCooldownRemainingTime(Brotherhood) < 8)))
+                    return PerfectBalance;
+
+                if (Gauge.Chakra >= 5 &&
+                    LevelChecked(InspiritedMeditation) &&
+                    HasBattleTarget() && InCombat())
                     return OriginalHook(InspiritedMeditation);
 
-                if (!InCombat() && LevelChecked(FormShift) &&
-                    !HasEffect(Buffs.FormlessFist) &&
-                    !HasEffect(Buffs.PerfectBalance))
-                    return FormShift;
+                if (PlayerHealthPercentageHp() <= 25 && ActionReady(All.SecondWind))
+                    return All.SecondWind;
 
-                //Variant Cure
-                if (IsEnabled(CustomComboPreset.MNK_Variant_Cure) &&
-                    IsEnabled(Variant.VariantCure) &&
-                    PlayerHealthPercentageHp() <= Config.MNK_VariantCure)
-                    return Variant.VariantCure;
-
-                if (ActionReady(RiddleOfFire) &&
-                    CanDelayedWeave())
-                    return RiddleOfFire;
-
-                // Buffs
-                if (CanWeave())
-                {
-                    //Variant Rampart
-                    if (IsEnabled(CustomComboPreset.MNK_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart))
-                        return Variant.VariantRampart;
-
-                    if (ActionReady(Brotherhood))
-                        return Brotherhood;
-
-                    if (ActionReady(RiddleOfWind))
-                        return RiddleOfWind;
-
-                    if (ActionReady(PerfectBalance) &&
-                        !HasEffect(Buffs.PerfectBalance) &&
-                        (GetRemainingCharges(PerfectBalance) == GetMaxCharges(PerfectBalance) ||
-                         GetCooldownRemainingTime(PerfectBalance) <= 4 ||
-                         HasEffect(Buffs.Brotherhood) ||
-                         (HasEffect(Buffs.RiddleOfFire) && GetBuffRemainingTime(Buffs.RiddleOfFire) < 10) ||
-                         (GetCooldownRemainingTime(RiddleOfFire) < 4 && GetCooldownRemainingTime(Brotherhood) < 8)))
-                        return PerfectBalance;
-
-                    if (Gauge.Chakra >= 5 &&
-                        LevelChecked(InspiritedMeditation) &&
-                        HasBattleTarget() && InCombat())
-                        return OriginalHook(InspiritedMeditation);
-
-                    if (PlayerHealthPercentageHp() <= 25 && ActionReady(All.SecondWind))
-                        return All.SecondWind;
-
-                    if (PlayerHealthPercentageHp() <= 40 && ActionReady(All.Bloodbath))
-                        return All.Bloodbath;
-                }
-
-                if (LevelChecked(FiresReply) &&
-                    HasEffect(Buffs.FiresRumination) &&
-                    !HasEffect(Buffs.PerfectBalance) &&
-                    !HasEffect(Buffs.FormlessFist))
-                    return FiresReply;
-
-                if (HasEffect(Buffs.WindsRumination) &&
-                    LevelChecked(WindsReply) &&
-                    HasEffect(Buffs.RiddleOfWind) &&
-                    GetBuffRemainingTime(Buffs.WindsRumination) < 4)
-                    return WindsReply;
-
-                // Masterful Blitz
-                if (LevelChecked(MasterfulBlitz) && !HasEffect(Buffs.PerfectBalance) &&
-                    OriginalHook(MasterfulBlitz) != MasterfulBlitz)
-                    return OriginalHook(MasterfulBlitz);
-
-                // Perfect Balance
-                if (HasEffect(Buffs.PerfectBalance))
-                {
-                    #region Open Lunar
-
-                    if (!LunarNadi || BothNadisOpen || (!SolarNadi && !LunarNadi))
-                        return LevelChecked(ShadowOfTheDestroyer)
-                            ? ShadowOfTheDestroyer
-                            : Rockbreaker;
-
-                    #endregion
-
-                    #region Open Solar
-
-                    if (!SolarNadi && !BothNadisOpen)
-                        switch (GetBuffStacks(Buffs.PerfectBalance))
-                        {
-                            case 3:
-                                return OriginalHook(ArmOfTheDestroyer);
-
-                            case 2:
-                                return FourPointFury;
-
-                            case 1:
-                                return Rockbreaker;
-                        }
-
-                    #endregion
-                }
-
-                // Monk Rotation
-                if (HasEffect(Buffs.OpoOpoForm))
-                    return OriginalHook(ArmOfTheDestroyer);
-
-                if (HasEffect(Buffs.RaptorForm))
-                {
-                    if (LevelChecked(FourPointFury))
-                        return FourPointFury;
-
-                    if (LevelChecked(TwinSnakes))
-                        return TwinSnakes;
-                }
-
-                if (HasEffect(Buffs.CoeurlForm) && LevelChecked(Rockbreaker))
-                    return Rockbreaker;
+                if (PlayerHealthPercentageHp() <= 40 && ActionReady(All.Bloodbath))
+                    return All.Bloodbath;
             }
+
+            if (LevelChecked(FiresReply) &&
+                HasEffect(Buffs.FiresRumination) &&
+                !HasEffect(Buffs.PerfectBalance) &&
+                !HasEffect(Buffs.FormlessFist))
+                return FiresReply;
+
+            if (HasEffect(Buffs.WindsRumination) &&
+                LevelChecked(WindsReply) &&
+                HasEffect(Buffs.RiddleOfWind) &&
+                GetBuffRemainingTime(Buffs.WindsRumination) < 4)
+                return WindsReply;
+
+            // Masterful Blitz
+            if (LevelChecked(MasterfulBlitz) && !HasEffect(Buffs.PerfectBalance) &&
+                OriginalHook(MasterfulBlitz) != MasterfulBlitz)
+                return OriginalHook(MasterfulBlitz);
+
+            // Perfect Balance
+            if (HasEffect(Buffs.PerfectBalance))
+            {
+                #region Open Lunar
+
+                if (!LunarNadi || BothNadisOpen || (!SolarNadi && !LunarNadi))
+                    return LevelChecked(ShadowOfTheDestroyer)
+                        ? ShadowOfTheDestroyer
+                        : Rockbreaker;
+
+                #endregion
+
+                #region Open Solar
+
+                if (!SolarNadi && !BothNadisOpen)
+                    switch (GetBuffStacks(Buffs.PerfectBalance))
+                    {
+                        case 3:
+                            return OriginalHook(ArmOfTheDestroyer);
+
+                        case 2:
+                            return FourPointFury;
+
+                        case 1:
+                            return Rockbreaker;
+                    }
+
+                #endregion
+            }
+
+            // Monk Rotation
+            if (HasEffect(Buffs.OpoOpoForm))
+                return OriginalHook(ArmOfTheDestroyer);
+
+            if (HasEffect(Buffs.RaptorForm))
+            {
+                if (LevelChecked(FourPointFury))
+                    return FourPointFury;
+
+                if (LevelChecked(TwinSnakes))
+                    return TwinSnakes;
+            }
+
+            if (HasEffect(Buffs.CoeurlForm) && LevelChecked(Rockbreaker))
+                return Rockbreaker;
             return actionID;
         }
     }
@@ -438,151 +433,150 @@ internal static partial class MNK
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is ArmOfTheDestroyer or ShadowOfTheDestroyer)
+            if (actionID is not (ArmOfTheDestroyer or ShadowOfTheDestroyer)) return actionID;
+
+            if (IsEnabled(CustomComboPreset.MNK_AoEUseMeditation) &&
+                !InCombat() && Gauge.Chakra < 5 &&
+                LevelChecked(InspiritedMeditation))
+                return OriginalHook(InspiritedMeditation);
+
+            if (IsEnabled(CustomComboPreset.MNK_AoEUseFormShift) &&
+                !InCombat() && LevelChecked(FormShift) &&
+                !HasEffect(Buffs.FormlessFist) && !HasEffect(Buffs.PerfectBalance))
+                return FormShift;
+
+            //Variant Cure
+            if (IsEnabled(CustomComboPreset.MNK_Variant_Cure) &&
+                IsEnabled(Variant.VariantCure) &&
+                PlayerHealthPercentageHp() <= Config.MNK_VariantCure)
+                return Variant.VariantCure;
+
+            if (IsEnabled(CustomComboPreset.MNK_AoEUseBuffs) &&
+                IsEnabled(CustomComboPreset.MNK_AoEUseROF) &&
+                ActionReady(RiddleOfFire) &&
+                CanDelayedWeave() &&
+                GetTargetHPPercent() >= Config.MNK_AoE_RiddleOfFire_HP)
+                return RiddleOfFire;
+
+            // Buffs
+            if (CanWeave())
             {
-                if (IsEnabled(CustomComboPreset.MNK_AoEUseMeditation) &&
-                    !InCombat() && Gauge.Chakra < 5 &&
-                    LevelChecked(InspiritedMeditation))
-                    return OriginalHook(InspiritedMeditation);
-
-                if (IsEnabled(CustomComboPreset.MNK_AoEUseFormShift) &&
-                    !InCombat() && LevelChecked(FormShift) &&
-                    !HasEffect(Buffs.FormlessFist) && !HasEffect(Buffs.PerfectBalance))
-                    return FormShift;
-
-                //Variant Cure
-                if (IsEnabled(CustomComboPreset.MNK_Variant_Cure) &&
-                    IsEnabled(Variant.VariantCure) &&
-                    PlayerHealthPercentageHp() <= Config.MNK_VariantCure)
-                    return Variant.VariantCure;
-
-                if (IsEnabled(CustomComboPreset.MNK_AoEUseBuffs) &&
-                    IsEnabled(CustomComboPreset.MNK_AoEUseROF) &&
-                    ActionReady(RiddleOfFire) &&
-                    CanDelayedWeave() &&
-                    GetTargetHPPercent() >= Config.MNK_AoE_RiddleOfFire_HP)
-                    return RiddleOfFire;
-
-                // Buffs
-                if (CanWeave())
-                {
-                    //Variant Rampart
-                    if (IsEnabled(CustomComboPreset.MNK_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart))
-                        return Variant.VariantRampart;
-
-                    if (IsEnabled(CustomComboPreset.MNK_AoEUseBuffs))
-                    {
-                        if (IsEnabled(CustomComboPreset.MNK_AoEUseBrotherhood) &&
-                            ActionReady(Brotherhood) &&
-                            GetTargetHPPercent() >= Config.MNK_AoE_Brotherhood_HP)
-                            return Brotherhood;
-
-                        if (IsEnabled(CustomComboPreset.MNK_AoEUseROW) &&
-                            ActionReady(RiddleOfWind) &&
-                            GetTargetHPPercent() >= Config.MNK_AoE_RiddleOfWind_HP)
-                            return RiddleOfWind;
-                    }
-
-                    if (IsEnabled(CustomComboPreset.MNK_AoEUsePerfectBalance) &&
-                        ActionReady(PerfectBalance) &&
-                        !HasEffect(Buffs.PerfectBalance) &&
-                        (GetRemainingCharges(PerfectBalance) == GetMaxCharges(PerfectBalance) ||
-                         GetCooldownRemainingTime(PerfectBalance) <= 4 ||
-                         HasEffect(Buffs.Brotherhood) ||
-                         (HasEffect(Buffs.RiddleOfFire) && GetBuffRemainingTime(Buffs.RiddleOfFire) < 10) ||
-                         (GetCooldownRemainingTime(RiddleOfFire) < 4 && GetCooldownRemainingTime(Brotherhood) < 8)))
-                        return PerfectBalance;
-
-                    if (IsEnabled(CustomComboPreset.MNK_AoEUseHowlingFist) &&
-                        Gauge.Chakra >= 5 && HasBattleTarget() && InCombat() &&
-                        LevelChecked(InspiritedMeditation))
-                        return OriginalHook(InspiritedMeditation);
-
-                    if (IsEnabled(CustomComboPreset.MNK_AoE_ComboHeals))
-                    {
-                        if (PlayerHealthPercentageHp() <= Config.MNK_AoE_SecondWind_Threshold &&
-                            ActionReady(All.SecondWind))
-                            return All.SecondWind;
-
-                        if (PlayerHealthPercentageHp() <= Config.MNK_AoE_Bloodbath_Threshold &&
-                            ActionReady(All.Bloodbath))
-                            return All.Bloodbath;
-                    }
-                }
+                //Variant Rampart
+                if (IsEnabled(CustomComboPreset.MNK_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart))
+                    return Variant.VariantRampart;
 
                 if (IsEnabled(CustomComboPreset.MNK_AoEUseBuffs))
                 {
-                    if (IsEnabled(CustomComboPreset.MNK_AoEUseROF) &&
-                        IsEnabled(CustomComboPreset.MNK_AoEUseFiresReply) &&
-                        LevelChecked(FiresReply) &&
-                        HasEffect(Buffs.FiresRumination) &&
-                        !HasEffect(Buffs.PerfectBalance) &&
-                        !HasEffect(Buffs.FormlessFist))
-                        return FiresReply;
+                    if (IsEnabled(CustomComboPreset.MNK_AoEUseBrotherhood) &&
+                        ActionReady(Brotherhood) &&
+                        GetTargetHPPercent() >= Config.MNK_AoE_Brotherhood_HP)
+                        return Brotherhood;
 
                     if (IsEnabled(CustomComboPreset.MNK_AoEUseROW) &&
-                        IsEnabled(CustomComboPreset.MNK_AoEUseWindsReply) &&
-                        HasEffect(Buffs.WindsRumination) &&
-                        LevelChecked(WindsReply) &&
-                        HasEffect(Buffs.RiddleOfWind) &&
-                        GetBuffRemainingTime(Buffs.WindsRumination) < 4)
-                        return WindsReply;
+                        ActionReady(RiddleOfWind) &&
+                        GetTargetHPPercent() >= Config.MNK_AoE_RiddleOfWind_HP)
+                        return RiddleOfWind;
                 }
 
-                // Masterful Blitz
-                if (LevelChecked(MasterfulBlitz) &&
+                if (IsEnabled(CustomComboPreset.MNK_AoEUsePerfectBalance) &&
+                    ActionReady(PerfectBalance) &&
                     !HasEffect(Buffs.PerfectBalance) &&
-                    OriginalHook(MasterfulBlitz) != MasterfulBlitz)
-                    return OriginalHook(MasterfulBlitz);
+                    (GetRemainingCharges(PerfectBalance) == GetMaxCharges(PerfectBalance) ||
+                     GetCooldownRemainingTime(PerfectBalance) <= 4 ||
+                     HasEffect(Buffs.Brotherhood) ||
+                     (HasEffect(Buffs.RiddleOfFire) && GetBuffRemainingTime(Buffs.RiddleOfFire) < 10) ||
+                     (GetCooldownRemainingTime(RiddleOfFire) < 4 && GetCooldownRemainingTime(Brotherhood) < 8)))
+                    return PerfectBalance;
 
-                // Perfect Balance
-                if (HasEffect(Buffs.PerfectBalance))
+                if (IsEnabled(CustomComboPreset.MNK_AoEUseHowlingFist) &&
+                    Gauge.Chakra >= 5 && HasBattleTarget() && InCombat() &&
+                    LevelChecked(InspiritedMeditation))
+                    return OriginalHook(InspiritedMeditation);
+
+                if (IsEnabled(CustomComboPreset.MNK_AoE_ComboHeals))
                 {
-                    #region Open Lunar
+                    if (PlayerHealthPercentageHp() <= Config.MNK_AoE_SecondWind_Threshold &&
+                        ActionReady(All.SecondWind))
+                        return All.SecondWind;
 
-                    if (!LunarNadi || BothNadisOpen || (!SolarNadi && !LunarNadi))
-                        return LevelChecked(ShadowOfTheDestroyer)
-                            ? ShadowOfTheDestroyer
-                            : Rockbreaker;
-
-                    #endregion
-
-                    #region Open Solar
-
-                    if (!SolarNadi && !BothNadisOpen)
-                        switch (GetBuffStacks(Buffs.PerfectBalance))
-                        {
-                            case 3:
-                                return OriginalHook(ArmOfTheDestroyer);
-
-                            case 2:
-                                return FourPointFury;
-
-                            case 1:
-                                return Rockbreaker;
-                        }
-
-                    #endregion
+                    if (PlayerHealthPercentageHp() <= Config.MNK_AoE_Bloodbath_Threshold &&
+                        ActionReady(All.Bloodbath))
+                        return All.Bloodbath;
                 }
-
-                // Monk Rotation
-                if (HasEffect(Buffs.OpoOpoForm))
-                    return OriginalHook(ArmOfTheDestroyer);
-
-                if (HasEffect(Buffs.RaptorForm))
-                {
-                    if (LevelChecked(FourPointFury))
-                        return FourPointFury;
-
-                    if (LevelChecked(TwinSnakes))
-                        return TwinSnakes;
-                }
-
-                if (HasEffect(Buffs.CoeurlForm) && LevelChecked(Rockbreaker))
-                    return Rockbreaker;
             }
+
+            if (IsEnabled(CustomComboPreset.MNK_AoEUseBuffs))
+            {
+                if (IsEnabled(CustomComboPreset.MNK_AoEUseROF) &&
+                    IsEnabled(CustomComboPreset.MNK_AoEUseFiresReply) &&
+                    LevelChecked(FiresReply) &&
+                    HasEffect(Buffs.FiresRumination) &&
+                    !HasEffect(Buffs.PerfectBalance) &&
+                    !HasEffect(Buffs.FormlessFist))
+                    return FiresReply;
+
+                if (IsEnabled(CustomComboPreset.MNK_AoEUseROW) &&
+                    IsEnabled(CustomComboPreset.MNK_AoEUseWindsReply) &&
+                    HasEffect(Buffs.WindsRumination) &&
+                    LevelChecked(WindsReply) &&
+                    HasEffect(Buffs.RiddleOfWind) &&
+                    GetBuffRemainingTime(Buffs.WindsRumination) < 4)
+                    return WindsReply;
+            }
+
+            // Masterful Blitz
+            if (LevelChecked(MasterfulBlitz) &&
+                !HasEffect(Buffs.PerfectBalance) &&
+                OriginalHook(MasterfulBlitz) != MasterfulBlitz)
+                return OriginalHook(MasterfulBlitz);
+
+            // Perfect Balance
+            if (HasEffect(Buffs.PerfectBalance))
+            {
+                #region Open Lunar
+
+                if (!LunarNadi || BothNadisOpen || (!SolarNadi && !LunarNadi))
+                    return LevelChecked(ShadowOfTheDestroyer)
+                        ? ShadowOfTheDestroyer
+                        : Rockbreaker;
+
+                #endregion
+
+                #region Open Solar
+
+                if (!SolarNadi && !BothNadisOpen)
+                    switch (GetBuffStacks(Buffs.PerfectBalance))
+                    {
+                        case 3:
+                            return OriginalHook(ArmOfTheDestroyer);
+
+                        case 2:
+                            return FourPointFury;
+
+                        case 1:
+                            return Rockbreaker;
+                    }
+
+                #endregion
+            }
+
+            // Monk Rotation
+            if (HasEffect(Buffs.OpoOpoForm))
+                return OriginalHook(ArmOfTheDestroyer);
+
+            if (HasEffect(Buffs.RaptorForm))
+            {
+                if (LevelChecked(FourPointFury))
+                    return FourPointFury;
+
+                if (LevelChecked(TwinSnakes))
+                    return TwinSnakes;
+            }
+
+            if (HasEffect(Buffs.CoeurlForm) && LevelChecked(Rockbreaker))
+                return Rockbreaker;
             return actionID;
         }
     }

--- a/WrathCombo/Combos/PvE/NIN/NIN.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN.cs
@@ -124,267 +124,277 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == SpinningEdge)
+                if (actionID is not SpinningEdge) return actionID;
+
+                NINGauge gauge = GetJobGauge<NINGauge>();
+                bool canWeave = CanWeave();
+                var canDelayedWeave = CanDelayedWeave();
+                bool inTrickBurstSaveWindow = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrickAttack_Cooldowns) && IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrickAttack) && GetCooldownRemainingTime(TrickAttack) <= GetOptionValue(Config.Advanced_Trick_Cooldown);
+                bool useBhakaBeforeTrickWindow = GetCooldownRemainingTime(TrickAttack) >= 3;
+                bool setupSuitonWindow = GetCooldownRemainingTime(OriginalHook(TrickAttack)) <= GetOptionValue(Config.Trick_CooldownRemaining) && !HasEffect(Buffs.ShadowWalker);
+                bool setupKassatsuWindow = GetCooldownRemainingTime(TrickAttack) <= 10 && HasEffect(Buffs.ShadowWalker);
+                bool chargeCheck = IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_ChargeHold) || (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_ChargeHold) && (InMudra || GetRemainingCharges(Ten) == 2 || (GetRemainingCharges(Ten) == 1 && GetCooldownChargeRemainingTime(Ten) < 3)));
+                bool poolCharges = !GetOptionBool(Config.Advanced_ChargePool) || (GetRemainingCharges(Ten) == 1 && GetCooldownChargeRemainingTime(Ten) < 2) || TrickDebuff || InMudra;
+                bool raitonUptime = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Raiton_Uptime);
+                bool suitonUptime = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Suiton_Uptime);
+                int bhavaPool = GetOptionValue(Config.Ninki_BhavaPooling);
+                int bunshinPool = GetOptionValue(Config.Ninki_BunshinPoolingST);
+                int burnKazematoi = GetOptionValue(Config.BurnKazematoi);
+                int SecondWindThreshold = PluginConfiguration.GetCustomIntValue(Config.SecondWindThresholdST);
+                int ShadeShiftThreshold = PluginConfiguration.GetCustomIntValue(Config.ShadeShiftThresholdST);
+                int BloodbathThreshold = PluginConfiguration.GetCustomIntValue(Config.BloodbathThresholdST);
+                double playerHP = PlayerHealthPercentageHp();
+                bool phantomUptime = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Phantom_Uptime);
+                var comboLength = GetCooldown(GustSlash).CooldownTotal * 3;
+                bool trueNorthArmor = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth) && TargetNeedsPositionals() && !OnTargetsFlank() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canDelayedWeave;
+                bool trueNorthEdge = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth) && TargetNeedsPositionals() && Config.Advanced_TrueNorth == 0 && !OnTargetsRear() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canDelayedWeave;
+                bool dynamic = Config.Advanced_TrueNorth == 0;
+
+                if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_BalanceOpener) && Opener().FullOpener(ref actionID))
+                    return actionID;
+
+                if (IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus) || (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat()))
+                    mudraState.CurrentMudra = MudraCasting.MudraState.None;
+
+                if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_Suiton) && IsOnCooldown(TrickAttack) && mudraState.CurrentMudra == MudraCasting.MudraState.CastingSuiton && !setupSuitonWindow)
+                    mudraState.CurrentMudra = MudraCasting.MudraState.None;
+
+                if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_Suiton) && IsOnCooldown(TrickAttack) && mudraState.CurrentMudra != MudraCasting.MudraState.CastingSuiton && setupSuitonWindow)
+                    mudraState.CurrentMudra = MudraCasting.MudraState.CastingSuiton;
+
+                if (OriginalHook(Ninjutsu) is Rabbit)
+                    return OriginalHook(Ninjutsu);
+
+                if (InMudra)
                 {
-                    NINGauge gauge = GetJobGauge<NINGauge>();
-                    bool canWeave = CanWeave();
-                    var canDelayedWeave = CanDelayedWeave();
-                    bool inTrickBurstSaveWindow = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrickAttack_Cooldowns) && IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrickAttack) && GetCooldownRemainingTime(TrickAttack) <= GetOptionValue(Config.Advanced_Trick_Cooldown);
-                    bool useBhakaBeforeTrickWindow = GetCooldownRemainingTime(TrickAttack) >= 3;
-                    bool setupSuitonWindow = GetCooldownRemainingTime(OriginalHook(TrickAttack)) <= GetOptionValue(Config.Trick_CooldownRemaining) && !HasEffect(Buffs.ShadowWalker);
-                    bool setupKassatsuWindow = GetCooldownRemainingTime(TrickAttack) <= 10 && HasEffect(Buffs.ShadowWalker);
-                    bool chargeCheck = IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_ChargeHold) || (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_ChargeHold) && (InMudra || GetRemainingCharges(Ten) == 2 || (GetRemainingCharges(Ten) == 1 && GetCooldownChargeRemainingTime(Ten) < 3)));
-                    bool poolCharges = !GetOptionBool(Config.Advanced_ChargePool) || (GetRemainingCharges(Ten) == 1 && GetCooldownChargeRemainingTime(Ten) < 2) || TrickDebuff || InMudra;
-                    bool raitonUptime = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Raiton_Uptime);
-                    bool suitonUptime = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Suiton_Uptime);
-                    int bhavaPool = GetOptionValue(Config.Ninki_BhavaPooling);
-                    int bunshinPool = GetOptionValue(Config.Ninki_BunshinPoolingST);
-                    int burnKazematoi = GetOptionValue(Config.BurnKazematoi);
-                    int SecondWindThreshold = PluginConfiguration.GetCustomIntValue(Config.SecondWindThresholdST);
-                    int ShadeShiftThreshold = PluginConfiguration.GetCustomIntValue(Config.ShadeShiftThresholdST);
-                    int BloodbathThreshold = PluginConfiguration.GetCustomIntValue(Config.BloodbathThresholdST);
-                    double playerHP = PlayerHealthPercentageHp();
-                    bool phantomUptime = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Phantom_Uptime);
-                    var comboLength = GetCooldown(GustSlash).CooldownTotal * 3;
-                    bool trueNorthArmor = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth) && TargetNeedsPositionals() && !OnTargetsFlank() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canDelayedWeave;
-                    bool trueNorthEdge = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth) && TargetNeedsPositionals() && Config.Advanced_TrueNorth == 0 && !OnTargetsRear() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canDelayedWeave;
-                    bool dynamic = Config.Advanced_TrueNorth == 0;
-
-                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_BalanceOpener) && Opener().FullOpener(ref actionID))
+                    if (mudraState.ContinueCurrentMudra(ref actionID))
                         return actionID;
+                }
 
-                    if (IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus) || (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat()))
-                        mudraState.CurrentMudra = MudraCasting.MudraState.None;
-
-                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_Suiton) && IsOnCooldown(TrickAttack) && mudraState.CurrentMudra == MudraCasting.MudraState.CastingSuiton && !setupSuitonWindow)
-                        mudraState.CurrentMudra = MudraCasting.MudraState.None;
-
-                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_Suiton) && IsOnCooldown(TrickAttack) && mudraState.CurrentMudra != MudraCasting.MudraState.CastingSuiton && setupSuitonWindow)
-                        mudraState.CurrentMudra = MudraCasting.MudraState.CastingSuiton;
-
-                    if (OriginalHook(Ninjutsu) is Rabbit)
-                        return OriginalHook(Ninjutsu);
-
-                    if (InMudra)
+                if (!Suiton.LevelChecked()) //For low level
+                {
+                    if (Raiton.LevelChecked() && IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_Raiton)) //under 45 will only use Raiton
                     {
-                        if (mudraState.ContinueCurrentMudra(ref actionID))
+                        if (mudraState.CastRaiton(ref actionID))
                             return actionID;
                     }
-
-                    if (!Suiton.LevelChecked()) //For low level
-                    {
-                        if (Raiton.LevelChecked() && IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_Raiton)) //under 45 will only use Raiton
-                        {
-                            if (mudraState.CastRaiton(ref actionID))
-                                return actionID;
-                        }
-                        else if (!Raiton.LevelChecked() && mudraState.CastFumaShuriken(ref actionID) && IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_FumaShuriken)) // 30-35 will use only fuma
-                            return actionID;
-                    }
-
-                    if (HasEffect(Buffs.TenChiJin))
-                    {
-                        if (OriginalHook(Ten) == TCJFumaShurikenTen) return OriginalHook(Ten);
-                        if (OriginalHook(Chi) == TCJRaiton) return OriginalHook(Chi);
-                        if (OriginalHook(Jin) == TCJSuiton) return OriginalHook(Jin);
-                    }
-
-                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Kassatsu_HyoshoRaynryu) &&
-                        HasEffect(Buffs.Kassatsu) &&
-                        TrickDebuff &&
-                        mudraState.CastHyoshoRanryu(ref actionID))
+                    else if (!Raiton.LevelChecked() && mudraState.CastFumaShuriken(ref actionID) && IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_FumaShuriken)) // 30-35 will use only fuma
                         return actionID;
+                }
 
-                    if (IsEnabled(CustomComboPreset.NIN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.NIN_VariantCure))
-                        return Variant.VariantCure;
+                if (HasEffect(Buffs.TenChiJin))
+                {
+                    if (OriginalHook(Ten) == TCJFumaShurikenTen) return OriginalHook(Ten);
+                    if (OriginalHook(Chi) == TCJRaiton) return OriginalHook(Chi);
+                    if (OriginalHook(Jin) == TCJSuiton) return OriginalHook(Jin);
+                }
 
-                    if (InCombat() && !InMeleeRange())
-                    {
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Bunshin_Phantom) &&
-                            HasEffect(Buffs.PhantomReady) &&
-                           ((GetCooldownRemainingTime(TrickAttack) > GetBuffRemainingTime(Buffs.PhantomReady)) || TrickDebuff || (HasEffect(Buffs.Bunshin) && MugDebuff)) &&
-                            PhantomKamaitachi.LevelChecked()
-                            && phantomUptime)
-                            return OriginalHook(PhantomKamaitachi);
+                if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Kassatsu_HyoshoRaynryu) &&
+                    HasEffect(Buffs.Kassatsu) &&
+                    TrickDebuff &&
+                    mudraState.CastHyoshoRanryu(ref actionID))
+                    return actionID;
 
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_Suiton) &&
-                            setupSuitonWindow &&
-                            TrickAttack.LevelChecked() &&
-                            !HasEffect(Buffs.ShadowWalker) &&
-                            chargeCheck &&
-                            suitonUptime &&
-                            mudraState.CastSuiton(ref actionID))
-                            return actionID;
+                if (IsEnabled(CustomComboPreset.NIN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.NIN_VariantCure))
+                    return Variant.VariantCure;
 
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_Raiton) &&
-                            !inTrickBurstSaveWindow &&
-                            chargeCheck &&
-                            poolCharges &&
-                            raitonUptime &&
-                            mudraState.CastRaiton(ref actionID))
-                            return actionID;
-
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_RangedUptime) && ThrowingDaggers.LevelChecked() && HasTarget() && !HasEffect(Buffs.RaijuReady))
-                            return OriginalHook(ThrowingDaggers);
-                    }
-
-                    if (canWeave && !InMudra)
-                    {
-                        if (IsEnabled(CustomComboPreset.NIN_Variant_Rampart) &&
-                            IsEnabled(Variant.VariantRampart) &&
-                            IsOffCooldown(Variant.VariantRampart))
-                            return Variant.VariantRampart;
-
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug) &&
-                            IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug_AlignBefore) &&
-                            HasEffect(Buffs.ShadowWalker) &&
-                            GetCooldownRemainingTime(TrickAttack) <= 3 &&
-                            ((IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrickAttack_Delayed) && InCombat() &&
-                              CombatEngageDuration().TotalSeconds > 6) ||
-                             IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrickAttack_Delayed)) &&
-                            IsOffCooldown(Mug) &&
-                            canDelayedWeave &&
-                            Mug.LevelChecked())
-                        {
-                            if (Dokumori.LevelChecked() && gauge.Ninki >= 60)
-                                return OriginalHook(Bhavacakra);
-                            return OriginalHook(Mug);
-                        }
-
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrickAttack) &&
-                            HasEffect(Buffs.ShadowWalker) &&
-                            IsOffCooldown(TrickAttack) &&
-                            canDelayedWeave &&
-                            ((IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrickAttack_Delayed) && InCombat() && CombatEngageDuration().TotalSeconds > 8) ||
-                            IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrickAttack_Delayed)))
-                            return OriginalHook(TrickAttack);
-
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TenriJindo) && HasEffect(Buffs.TenriJendo) && ((TrickDebuff && MugDebuff) || GetBuffRemainingTime(Buffs.TenriJendo) <= 3))
-                            return OriginalHook(TenriJendo);
-
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Bunshin) && Bunshin.LevelChecked() && IsOffCooldown(Bunshin) && gauge.Ninki >= bunshinPool)
-                            return OriginalHook(Bunshin);
-
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Kassatsu) && (TrickDebuff || setupKassatsuWindow) && IsOffCooldown(Kassatsu) && Kassatsu.LevelChecked())
-                            return OriginalHook(Kassatsu);
-
-                        //healing - please move if not appropriate priority
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_SecondWind) && All.SecondWind.LevelChecked() && playerHP <= SecondWindThreshold && IsOffCooldown(All.SecondWind))
-                            return All.SecondWind;
-
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_ShadeShift) && ShadeShift.LevelChecked() && playerHP <= ShadeShiftThreshold && IsOffCooldown(ShadeShift))
-                            return ShadeShift;
-
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Bloodbath) && All.Bloodbath.LevelChecked() && playerHP <= BloodbathThreshold && IsOffCooldown(All.Bloodbath))
-                            return All.Bloodbath;
-
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Bhavacakra) &&
-                            ((TrickDebuff && gauge.Ninki >= 50) || (useBhakaBeforeTrickWindow && gauge.Ninki >= 85)) &&
-                            (IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug) || (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug) && IsOnCooldown(Mug))) &&
-                            Bhavacakra.LevelChecked())
-                            return OriginalHook(Bhavacakra);
-
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Bhavacakra) &&
-                            ((TrickDebuff && gauge.Ninki >= 50) || (useBhakaBeforeTrickWindow && gauge.Ninki >= 60)) &&
-                            (IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug) || (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug) && IsOnCooldown(Mug))) &&
-                            !Bhavacakra.LevelChecked() && Hellfrog.LevelChecked())
-                            return OriginalHook(Hellfrog);
-
-                        if (!inTrickBurstSaveWindow)
-                        {
-                            if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug) && IsOffCooldown(Mug) && Mug.LevelChecked())
-                            {
-                                if (IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug_AlignAfter) || (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug_AlignAfter) && TrickDebuff))
-                                    return OriginalHook(Mug);
-                            }
-
-                            if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Meisui) && HasEffect(Buffs.ShadowWalker) && gauge.Ninki <= 50 && IsOffCooldown(Meisui) && Meisui.LevelChecked())
-                                return OriginalHook(Meisui);
-
-                            if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Bhavacakra) && gauge.Ninki >= bhavaPool && Bhavacakra.LevelChecked())
-                                return OriginalHook(Bhavacakra);
-
-                            if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Bhavacakra) && gauge.Ninki >= bhavaPool && !Bhavacakra.LevelChecked() && Hellfrog.LevelChecked())
-                                return OriginalHook(Hellfrog);
-
-                            if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_AssassinateDWAD) && IsOffCooldown(OriginalHook(Assassinate)) && Assassinate.LevelChecked())
-                                return OriginalHook(Assassinate);
-
-                            if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TCJ) && IsOffCooldown(TenChiJin) && TenChiJin.LevelChecked())
-                                return OriginalHook(TenChiJin);
-                        }
-
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_SecondWind) && All.SecondWind.LevelChecked() && playerHP <= SecondWindThreshold && IsOffCooldown(All.SecondWind))
-                            return All.SecondWind;
-
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_ShadeShift) && ShadeShift.LevelChecked() && playerHP <= ShadeShiftThreshold && IsOffCooldown(ShadeShift))
-                            return ShadeShift;
-
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Bloodbath) && All.Bloodbath.LevelChecked() && playerHP <= BloodbathThreshold && IsOffCooldown(All.Bloodbath))
-                            return All.Bloodbath;
-                    }
-
-
-                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Raiju) && HasEffect(Buffs.RaijuReady))
-                    {
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Raiju_Forked) && !InMeleeRange())
-                            return OriginalHook(ForkedRaiju);
-                        return OriginalHook(FleetingRaiju);
-                    }
-
-
-                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Kassatsu_HyoshoRaynryu) &&
-                        !inTrickBurstSaveWindow &&
-                        (IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug) || (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug) && IsOnCooldown(Mug))) &&
-                        mudraState.CastHyoshoRanryu(ref actionID))
-                        return actionID;
-
-                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus))
-                    {
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_Suiton) &&
-                            setupSuitonWindow &&
-                            TrickAttack.LevelChecked() &&
-                            !HasEffect(Buffs.ShadowWalker) &&
-                            chargeCheck &&
-                            mudraState.CastSuiton(ref actionID))
-                            return actionID;
-
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_Raiton) &&
-                            !inTrickBurstSaveWindow &&
-                            chargeCheck &&
-                            poolCharges &&
-                            mudraState.CastRaiton(ref actionID))
-                            return actionID;
-
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_FumaShuriken) &&
-                            !Raiton.LevelChecked() &&
-                            chargeCheck &&
-                            mudraState.CastFumaShuriken(ref actionID))
-                            return actionID;
-                    }
-
+                if (InCombat() && !InMeleeRange())
+                {
                     if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Bunshin_Phantom) &&
                         HasEffect(Buffs.PhantomReady) &&
-                        ((GetCooldownRemainingTime(TrickAttack) > GetBuffRemainingTime(Buffs.PhantomReady)) || TrickDebuff || (HasEffect(Buffs.Bunshin) && MugDebuff) || GetBuffRemainingTime(Buffs.PhantomReady) < 6) &&
-                        PhantomKamaitachi.LevelChecked())
+                        ((GetCooldownRemainingTime(TrickAttack) > GetBuffRemainingTime(Buffs.PhantomReady)) || TrickDebuff || (HasEffect(Buffs.Bunshin) && MugDebuff)) &&
+                        PhantomKamaitachi.LevelChecked()
+                        && phantomUptime)
                         return OriginalHook(PhantomKamaitachi);
 
-                    if (ComboTimer > 1f)
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_Suiton) &&
+                        setupSuitonWindow &&
+                        TrickAttack.LevelChecked() &&
+                        !HasEffect(Buffs.ShadowWalker) &&
+                        chargeCheck &&
+                        suitonUptime &&
+                        mudraState.CastSuiton(ref actionID))
+                        return actionID;
+
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_Raiton) &&
+                        !inTrickBurstSaveWindow &&
+                        chargeCheck &&
+                        poolCharges &&
+                        raitonUptime &&
+                        mudraState.CastRaiton(ref actionID))
+                        return actionID;
+
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_RangedUptime) && ThrowingDaggers.LevelChecked() && HasTarget() && !HasEffect(Buffs.RaijuReady))
+                        return OriginalHook(ThrowingDaggers);
+                }
+
+                if (canWeave && !InMudra)
+                {
+                    if (IsEnabled(CustomComboPreset.NIN_Variant_Rampart) &&
+                        IsEnabled(Variant.VariantRampart) &&
+                        IsOffCooldown(Variant.VariantRampart))
+                        return Variant.VariantRampart;
+
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug) &&
+                        IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug_AlignBefore) &&
+                        HasEffect(Buffs.ShadowWalker) &&
+                        GetCooldownRemainingTime(TrickAttack) <= 3 &&
+                        ((IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrickAttack_Delayed) && InCombat() &&
+                          CombatEngageDuration().TotalSeconds > 6) ||
+                         IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrickAttack_Delayed)) &&
+                        IsOffCooldown(Mug) &&
+                        canDelayedWeave &&
+                        Mug.LevelChecked())
                     {
-                        if (ComboAction == SpinningEdge && GustSlash.LevelChecked())
-                            return OriginalHook(GustSlash);
+                        if (Dokumori.LevelChecked() && gauge.Ninki >= 60)
+                            return OriginalHook(Bhavacakra);
+                        return OriginalHook(Mug);
+                    }
 
-                        if (ComboAction == GustSlash && ArmorCrush.LevelChecked())
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrickAttack) &&
+                        HasEffect(Buffs.ShadowWalker) &&
+                        IsOffCooldown(TrickAttack) &&
+                        canDelayedWeave &&
+                        ((IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrickAttack_Delayed) && InCombat() && CombatEngageDuration().TotalSeconds > 8) ||
+                         IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrickAttack_Delayed)))
+                        return OriginalHook(TrickAttack);
+
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TenriJindo) && HasEffect(Buffs.TenriJendo) && ((TrickDebuff && MugDebuff) || GetBuffRemainingTime(Buffs.TenriJendo) <= 3))
+                        return OriginalHook(TenriJendo);
+
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Bunshin) && Bunshin.LevelChecked() && IsOffCooldown(Bunshin) && gauge.Ninki >= bunshinPool)
+                        return OriginalHook(Bunshin);
+
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Kassatsu) && (TrickDebuff || setupKassatsuWindow) && IsOffCooldown(Kassatsu) && Kassatsu.LevelChecked())
+                        return OriginalHook(Kassatsu);
+
+                    //healing - please move if not appropriate priority
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_SecondWind) && All.SecondWind.LevelChecked() && playerHP <= SecondWindThreshold && IsOffCooldown(All.SecondWind))
+                        return All.SecondWind;
+
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_ShadeShift) && ShadeShift.LevelChecked() && playerHP <= ShadeShiftThreshold && IsOffCooldown(ShadeShift))
+                        return ShadeShift;
+
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Bloodbath) && All.Bloodbath.LevelChecked() && playerHP <= BloodbathThreshold && IsOffCooldown(All.Bloodbath))
+                        return All.Bloodbath;
+
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Bhavacakra) &&
+                        ((TrickDebuff && gauge.Ninki >= 50) || (useBhakaBeforeTrickWindow && gauge.Ninki >= 85)) &&
+                        (IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug) || (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug) && IsOnCooldown(Mug))) &&
+                        Bhavacakra.LevelChecked())
+                        return OriginalHook(Bhavacakra);
+
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Bhavacakra) &&
+                        ((TrickDebuff && gauge.Ninki >= 50) || (useBhakaBeforeTrickWindow && gauge.Ninki >= 60)) &&
+                        (IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug) || (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug) && IsOnCooldown(Mug))) &&
+                        !Bhavacakra.LevelChecked() && Hellfrog.LevelChecked())
+                        return OriginalHook(Hellfrog);
+
+                    if (!inTrickBurstSaveWindow)
+                    {
+                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug) && IsOffCooldown(Mug) && Mug.LevelChecked())
                         {
-                            if (gauge.Kazematoi == 0)
-                            {
-                                if (trueNorthArmor)
-                                    return All.TrueNorth;
+                            if (IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug_AlignAfter) || (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug_AlignAfter) && TrickDebuff))
+                                return OriginalHook(Mug);
+                        }
 
-                                return ArmorCrush;
-                            }
+                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Meisui) && HasEffect(Buffs.ShadowWalker) && gauge.Ninki <= 50 && IsOffCooldown(Meisui) && Meisui.LevelChecked())
+                            return OriginalHook(Meisui);
 
-                            if (GetTargetHPPercent() <= burnKazematoi && gauge.Kazematoi > 0)
+                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Bhavacakra) && gauge.Ninki >= bhavaPool && Bhavacakra.LevelChecked())
+                            return OriginalHook(Bhavacakra);
+
+                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Bhavacakra) && gauge.Ninki >= bhavaPool && !Bhavacakra.LevelChecked() && Hellfrog.LevelChecked())
+                            return OriginalHook(Hellfrog);
+
+                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_AssassinateDWAD) && IsOffCooldown(OriginalHook(Assassinate)) && Assassinate.LevelChecked())
+                            return OriginalHook(Assassinate);
+
+                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TCJ) && IsOffCooldown(TenChiJin) && TenChiJin.LevelChecked())
+                            return OriginalHook(TenChiJin);
+                    }
+
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_SecondWind) && All.SecondWind.LevelChecked() && playerHP <= SecondWindThreshold && IsOffCooldown(All.SecondWind))
+                        return All.SecondWind;
+
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_ShadeShift) && ShadeShift.LevelChecked() && playerHP <= ShadeShiftThreshold && IsOffCooldown(ShadeShift))
+                        return ShadeShift;
+
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Bloodbath) && All.Bloodbath.LevelChecked() && playerHP <= BloodbathThreshold && IsOffCooldown(All.Bloodbath))
+                        return All.Bloodbath;
+                }
+
+
+                if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Raiju) && HasEffect(Buffs.RaijuReady))
+                {
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Raiju_Forked) && !InMeleeRange())
+                        return OriginalHook(ForkedRaiju);
+                    return OriginalHook(FleetingRaiju);
+                }
+
+
+                if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Kassatsu_HyoshoRaynryu) &&
+                    !inTrickBurstSaveWindow &&
+                    (IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug) || (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug) && IsOnCooldown(Mug))) &&
+                    mudraState.CastHyoshoRanryu(ref actionID))
+                    return actionID;
+
+                if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus))
+                {
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_Suiton) &&
+                        setupSuitonWindow &&
+                        TrickAttack.LevelChecked() &&
+                        !HasEffect(Buffs.ShadowWalker) &&
+                        chargeCheck &&
+                        mudraState.CastSuiton(ref actionID))
+                        return actionID;
+
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_Raiton) &&
+                        !inTrickBurstSaveWindow &&
+                        chargeCheck &&
+                        poolCharges &&
+                        mudraState.CastRaiton(ref actionID))
+                        return actionID;
+
+                    if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_FumaShuriken) &&
+                        !Raiton.LevelChecked() &&
+                        chargeCheck &&
+                        mudraState.CastFumaShuriken(ref actionID))
+                        return actionID;
+                }
+
+                if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Bunshin_Phantom) &&
+                    HasEffect(Buffs.PhantomReady) &&
+                    ((GetCooldownRemainingTime(TrickAttack) > GetBuffRemainingTime(Buffs.PhantomReady)) || TrickDebuff || (HasEffect(Buffs.Bunshin) && MugDebuff) || GetBuffRemainingTime(Buffs.PhantomReady) < 6) &&
+                    PhantomKamaitachi.LevelChecked())
+                    return OriginalHook(PhantomKamaitachi);
+
+                if (ComboTimer > 1f)
+                {
+                    if (ComboAction == SpinningEdge && GustSlash.LevelChecked())
+                        return OriginalHook(GustSlash);
+
+                    if (ComboAction == GustSlash && ArmorCrush.LevelChecked())
+                    {
+                        if (gauge.Kazematoi == 0)
+                        {
+                            if (trueNorthArmor)
+                                return All.TrueNorth;
+
+                            return ArmorCrush;
+                        }
+
+                        if (GetTargetHPPercent() <= burnKazematoi && gauge.Kazematoi > 0)
+                        {
+                            if (trueNorthEdge)
+                                return All.TrueNorth;
+
+                            return AeolianEdge;
+                        }
+
+                        if (dynamic)
+                        {
+                            if (gauge.Kazematoi >= 4)
                             {
                                 if (trueNorthEdge)
                                     return All.TrueNorth;
@@ -392,46 +402,34 @@ namespace WrathCombo.Combos.PvE
                                 return AeolianEdge;
                             }
 
-                            if (dynamic)
-                            {
-                                if (gauge.Kazematoi >= 4)
-                                {
-                                    if (trueNorthEdge)
-                                        return All.TrueNorth;
-
-                                    return AeolianEdge;
-                                }
-
-                                if (OnTargetsFlank())
-                                    return ArmorCrush;
-                                else
-                                    return AeolianEdge;
-
-                            }
+                            if (OnTargetsFlank())
+                                return ArmorCrush;
                             else
-                            {
-                                if (gauge.Kazematoi < 3)
-                                {
-                                    if (trueNorthArmor)
-                                        return All.TrueNorth;
-
-                                    return ArmorCrush;
-                                }
-
                                 return AeolianEdge;
-                            }
+
                         }
-                        if (ComboAction == GustSlash && !ArmorCrush.LevelChecked() && AeolianEdge.LevelChecked())
+                        else
                         {
-                            if (trueNorthEdge)
-                                return OriginalHook(All.TrueNorth);
-                            else
-                                return OriginalHook(AeolianEdge);
+                            if (gauge.Kazematoi < 3)
+                            {
+                                if (trueNorthArmor)
+                                    return All.TrueNorth;
+
+                                return ArmorCrush;
+                            }
+
+                            return AeolianEdge;
                         }
                     }
-                    return OriginalHook(SpinningEdge);
+                    if (ComboAction == GustSlash && !ArmorCrush.LevelChecked() && AeolianEdge.LevelChecked())
+                    {
+                        if (trueNorthEdge)
+                            return OriginalHook(All.TrueNorth);
+                        else
+                            return OriginalHook(AeolianEdge);
+                    }
                 }
-                return actionID;
+                return OriginalHook(SpinningEdge);
             }
         }
 
@@ -443,165 +441,163 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == DeathBlossom)
+                if (actionID is not DeathBlossom) return actionID;
+
+                Status? dotonBuff = FindEffect(Buffs.Doton);
+                NINGauge? gauge = GetJobGauge<NINGauge>();
+                bool canWeave = CanWeave();
+                bool chargeCheck = IsNotEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus_ChargeHold) || (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus_ChargeHold) && GetRemainingCharges(Ten) == 2);
+                bool inMudraState = InMudra;
+                int hellfrogPool = GetOptionValue(Config.Ninki_HellfrogPooling);
+                int dotonTimer = GetOptionValue(Config.Advanced_DotonTimer);
+                int dotonThreshold = GetOptionValue(Config.Advanced_DotonHP);
+                int tcjPath = GetOptionValue(Config.Advanced_TCJEnderAoE);
+                int bunshingPool = GetOptionValue(Config.Ninki_BunshinPoolingAoE);
+                int SecondWindThreshold = PluginConfiguration.GetCustomIntValue(Config.SecondWindThresholdAoE);
+                int ShadeShiftThreshold = PluginConfiguration.GetCustomIntValue(Config.ShadeShiftThresholdAoE);
+                int BloodbathThreshold = PluginConfiguration.GetCustomIntValue(Config.BloodbathThresholdAoE);
+                double playerHP = PlayerHealthPercentageHp();
+
+                if (IsNotEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus) || (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat()))
+                    mudraState.CurrentMudra = MudraCasting.MudraState.None;
+
+                if (OriginalHook(Ninjutsu) is Rabbit)
+                    return OriginalHook(Ninjutsu);
+
+                if (InMudra)
                 {
-                    Status? dotonBuff = FindEffect(Buffs.Doton);
-                    NINGauge? gauge = GetJobGauge<NINGauge>();
-                    bool canWeave = CanWeave();
-                    bool chargeCheck = IsNotEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus_ChargeHold) || (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus_ChargeHold) && GetRemainingCharges(Ten) == 2);
-                    bool inMudraState = InMudra;
-                    int hellfrogPool = GetOptionValue(Config.Ninki_HellfrogPooling);
-                    int dotonTimer = GetOptionValue(Config.Advanced_DotonTimer);
-                    int dotonThreshold = GetOptionValue(Config.Advanced_DotonHP);
-                    int tcjPath = GetOptionValue(Config.Advanced_TCJEnderAoE);
-                    int bunshingPool = GetOptionValue(Config.Ninki_BunshinPoolingAoE);
-                    int SecondWindThreshold = PluginConfiguration.GetCustomIntValue(Config.SecondWindThresholdAoE);
-                    int ShadeShiftThreshold = PluginConfiguration.GetCustomIntValue(Config.ShadeShiftThresholdAoE);
-                    int BloodbathThreshold = PluginConfiguration.GetCustomIntValue(Config.BloodbathThresholdAoE);
-                    double playerHP = PlayerHealthPercentageHp();
+                    if (mudraState.ContinueCurrentMudra(ref actionID))
+                        return actionID;
+                }
 
-                    if (IsNotEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus) || (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat()))
-                        mudraState.CurrentMudra = MudraCasting.MudraState.None;
-
-                    if (OriginalHook(Ninjutsu) is Rabbit)
-                        return OriginalHook(Ninjutsu);
-
-                    if (InMudra)
+                if (HasEffect(Buffs.TenChiJin))
+                {
+                    if (tcjPath == 0)
                     {
-                        if (mudraState.ContinueCurrentMudra(ref actionID))
-                            return actionID;
+                        if (OriginalHook(Chi) == TCJFumaShurikenChi) return OriginalHook(Chi);
+                        if (OriginalHook(Ten) == TCJKaton) return OriginalHook(Ten);
+                        if (OriginalHook(Jin) == TCJSuiton) return OriginalHook(Jin);
+                    }
+                    else
+                    {
+                        if (OriginalHook(Jin) == TCJFumaShurikenJin) return OriginalHook(Jin);
+                        if (OriginalHook(Ten) == TCJKaton) return OriginalHook(Ten);
+                        if (OriginalHook(Chi) == TCJDoton) return OriginalHook(Chi);
                     }
 
-                    if (HasEffect(Buffs.TenChiJin))
-                    {
-                        if (tcjPath == 0)
-                        {
-                            if (OriginalHook(Chi) == TCJFumaShurikenChi) return OriginalHook(Chi);
-                            if (OriginalHook(Ten) == TCJKaton) return OriginalHook(Ten);
-                            if (OriginalHook(Jin) == TCJSuiton) return OriginalHook(Jin);
-                        }
-                        else
-                        {
-                            if (OriginalHook(Jin) == TCJFumaShurikenJin) return OriginalHook(Jin);
-                            if (OriginalHook(Ten) == TCJKaton) return OriginalHook(Ten);
-                            if (OriginalHook(Chi) == TCJDoton) return OriginalHook(Chi);
-                        }
+                }
 
-                    }
-
-                    if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_GokaMekkyaku) && HasEffect(Buffs.Kassatsu))
-                        mudraState.CurrentMudra = MudraCasting.MudraState.CastingGokaMekkyaku;
+                if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_GokaMekkyaku) && HasEffect(Buffs.Kassatsu))
+                    mudraState.CurrentMudra = MudraCasting.MudraState.CastingGokaMekkyaku;
 
 
-                    if (IsEnabled(CustomComboPreset.NIN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.NIN_VariantCure))
-                        return Variant.VariantCure;
+                if (IsEnabled(CustomComboPreset.NIN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.NIN_VariantCure))
+                    return Variant.VariantCure;
 
-                    if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_KunaisBane))
-                    {
-                        if (!HasEffect(Buffs.ShadowWalker) && KunaisBane.LevelChecked() && GetCooldownRemainingTime(KunaisBane) < 5 && mudraState.CastHuton(ref actionID))
-                            return actionID;
-
-                        if (HasEffect(Buffs.ShadowWalker) && KunaisBane.LevelChecked() && IsOffCooldown(KunaisBane) && canWeave)
-                            return KunaisBane;
-                    }
-
-                    if (canWeave && !inMudraState)
-                    {
-                        if (IsEnabled(CustomComboPreset.NIN_Variant_Rampart) &&
-                            IsEnabled(Variant.VariantRampart) &&
-                            IsOffCooldown(Variant.VariantRampart))
-                            return Variant.VariantRampart;
-
-                        if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_TenriJindo) && HasEffect(Buffs.TenriJendo))
-                            return OriginalHook(TenriJendo);
-
-                        if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Bunshin) && Bunshin.LevelChecked() && IsOffCooldown(Bunshin) && gauge.Ninki >= bunshingPool)
-                            return OriginalHook(Bunshin);
-
-                        if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_HellfrogMedium) && gauge.Ninki >= hellfrogPool && Hellfrog.LevelChecked())
-                        {
-                            if (HasEffect(Buffs.Meisui) && TraitLevelChecked(440))
-                                return OriginalHook(Bhavacakra);
-
-                            return OriginalHook(Hellfrog);
-                        }
-
-                        if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_HellfrogMedium) && gauge.Ninki >= hellfrogPool && !Hellfrog.LevelChecked() && Bhavacakra.LevelChecked())
-                        {
-                            return OriginalHook(Bhavacakra);
-                        }
-
-                        if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Kassatsu) &&
-                            IsOffCooldown(Kassatsu) &&
-                            Kassatsu.LevelChecked() &&
-                            ((IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus_Doton) && (dotonBuff != null || GetTargetHPPercent() < dotonThreshold)) ||
-                            IsNotEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus_Doton)))
-                            return OriginalHook(Kassatsu);
-
-                        if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Meisui) && HasEffect(Buffs.ShadowWalker) && gauge.Ninki <= 50 && IsOffCooldown(Meisui) && Meisui.LevelChecked())
-                            return OriginalHook(Meisui);
-
-                        if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_AssassinateDWAD) && IsOffCooldown(OriginalHook(Assassinate)) && Assassinate.LevelChecked())
-                            return OriginalHook(Assassinate);
-
-                        // healing - please move if not appropriate priority
-                        if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_SecondWind) && All.SecondWind.LevelChecked() && playerHP <= SecondWindThreshold && IsOffCooldown(All.SecondWind))
-                            return All.SecondWind;
-
-                        if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_ShadeShift) && ShadeShift.LevelChecked() && playerHP <= ShadeShiftThreshold && IsOffCooldown(ShadeShift))
-                            return ShadeShift;
-
-                        if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Bloodbath) && All.Bloodbath.LevelChecked() && playerHP <= BloodbathThreshold && IsOffCooldown(All.Bloodbath))
-                            return All.Bloodbath;
-
-                        if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_TCJ) &&
-                            IsOffCooldown(TenChiJin) &&
-                            TenChiJin.LevelChecked())
-                        {
-                            if ((IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus_Doton) && tcjPath == 1 &&
-                               (dotonBuff?.RemainingTime <= dotonTimer || dotonBuff is null) &&
-                               GetTargetHPPercent() >= dotonThreshold &&
-                               !WasLastAction(Doton)) ||
-                               tcjPath == 0)
-                                return OriginalHook(TenChiJin);
-                        }
-
-                    }
-
-                    if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_GokaMekkyaku) &&
-                        mudraState.CastGokaMekkyaku(ref actionID))
+                if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_KunaisBane))
+                {
+                    if (!HasEffect(Buffs.ShadowWalker) && KunaisBane.LevelChecked() && GetCooldownRemainingTime(KunaisBane) < 5 && mudraState.CastHuton(ref actionID))
                         return actionID;
 
-                    if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus))
-                    {
-                        if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus_Doton) &&
-                            (dotonBuff?.RemainingTime <= dotonTimer || dotonBuff is null) &&
-                            GetTargetHPPercent() >= dotonThreshold &&
-                            chargeCheck &&
-                            !(WasLastAction(Doton) || WasLastAction(TCJDoton) || dotonBuff is not null) &&
-                            mudraState.CastDoton(ref actionID))
-                            return actionID;
-
-                        if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus_Katon) &&
-                            chargeCheck &&
-                            ((IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus_Doton) && (dotonBuff != null || GetTargetHPPercent() < dotonThreshold)) ||
-                            IsNotEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus_Doton)) &&
-                            mudraState.CastKaton(ref actionID))
-                            return actionID;
-                    }
-
-                    if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Bunshin_Phantom) && HasEffect(Buffs.PhantomReady) && PhantomKamaitachi.LevelChecked())
-                        return OriginalHook(PhantomKamaitachi);
-
-                    if (ComboTimer > 1f)
-                    {
-                        if (ComboAction is DeathBlossom && HakkeMujinsatsu.LevelChecked())
-                            return OriginalHook(HakkeMujinsatsu);
-                    }
-
-                    return OriginalHook(DeathBlossom);
+                    if (HasEffect(Buffs.ShadowWalker) && KunaisBane.LevelChecked() && IsOffCooldown(KunaisBane) && canWeave)
+                        return KunaisBane;
                 }
-                return actionID;
+
+                if (canWeave && !inMudraState)
+                {
+                    if (IsEnabled(CustomComboPreset.NIN_Variant_Rampart) &&
+                        IsEnabled(Variant.VariantRampart) &&
+                        IsOffCooldown(Variant.VariantRampart))
+                        return Variant.VariantRampart;
+
+                    if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_TenriJindo) && HasEffect(Buffs.TenriJendo))
+                        return OriginalHook(TenriJendo);
+
+                    if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Bunshin) && Bunshin.LevelChecked() && IsOffCooldown(Bunshin) && gauge.Ninki >= bunshingPool)
+                        return OriginalHook(Bunshin);
+
+                    if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_HellfrogMedium) && gauge.Ninki >= hellfrogPool && Hellfrog.LevelChecked())
+                    {
+                        if (HasEffect(Buffs.Meisui) && TraitLevelChecked(440))
+                            return OriginalHook(Bhavacakra);
+
+                        return OriginalHook(Hellfrog);
+                    }
+
+                    if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_HellfrogMedium) && gauge.Ninki >= hellfrogPool && !Hellfrog.LevelChecked() && Bhavacakra.LevelChecked())
+                    {
+                        return OriginalHook(Bhavacakra);
+                    }
+
+                    if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Kassatsu) &&
+                        IsOffCooldown(Kassatsu) &&
+                        Kassatsu.LevelChecked() &&
+                        ((IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus_Doton) && (dotonBuff != null || GetTargetHPPercent() < dotonThreshold)) ||
+                         IsNotEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus_Doton)))
+                        return OriginalHook(Kassatsu);
+
+                    if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Meisui) && HasEffect(Buffs.ShadowWalker) && gauge.Ninki <= 50 && IsOffCooldown(Meisui) && Meisui.LevelChecked())
+                        return OriginalHook(Meisui);
+
+                    if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_AssassinateDWAD) && IsOffCooldown(OriginalHook(Assassinate)) && Assassinate.LevelChecked())
+                        return OriginalHook(Assassinate);
+
+                    // healing - please move if not appropriate priority
+                    if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_SecondWind) && All.SecondWind.LevelChecked() && playerHP <= SecondWindThreshold && IsOffCooldown(All.SecondWind))
+                        return All.SecondWind;
+
+                    if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_ShadeShift) && ShadeShift.LevelChecked() && playerHP <= ShadeShiftThreshold && IsOffCooldown(ShadeShift))
+                        return ShadeShift;
+
+                    if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Bloodbath) && All.Bloodbath.LevelChecked() && playerHP <= BloodbathThreshold && IsOffCooldown(All.Bloodbath))
+                        return All.Bloodbath;
+
+                    if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_TCJ) &&
+                        IsOffCooldown(TenChiJin) &&
+                        TenChiJin.LevelChecked())
+                    {
+                        if ((IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus_Doton) && tcjPath == 1 &&
+                             (dotonBuff?.RemainingTime <= dotonTimer || dotonBuff is null) &&
+                             GetTargetHPPercent() >= dotonThreshold &&
+                             !WasLastAction(Doton)) ||
+                            tcjPath == 0)
+                            return OriginalHook(TenChiJin);
+                    }
+
+                }
+
+                if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_GokaMekkyaku) &&
+                    mudraState.CastGokaMekkyaku(ref actionID))
+                    return actionID;
+
+                if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus))
+                {
+                    if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus_Doton) &&
+                        (dotonBuff?.RemainingTime <= dotonTimer || dotonBuff is null) &&
+                        GetTargetHPPercent() >= dotonThreshold &&
+                        chargeCheck &&
+                        !(WasLastAction(Doton) || WasLastAction(TCJDoton) || dotonBuff is not null) &&
+                        mudraState.CastDoton(ref actionID))
+                        return actionID;
+
+                    if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus_Katon) &&
+                        chargeCheck &&
+                        ((IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus_Doton) && (dotonBuff != null || GetTargetHPPercent() < dotonThreshold)) ||
+                         IsNotEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Ninjitsus_Doton)) &&
+                        mudraState.CastKaton(ref actionID))
+                        return actionID;
+                }
+
+                if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Bunshin_Phantom) && HasEffect(Buffs.PhantomReady) && PhantomKamaitachi.LevelChecked())
+                    return OriginalHook(PhantomKamaitachi);
+
+                if (ComboTimer > 1f)
+                {
+                    if (ComboAction is DeathBlossom && HakkeMujinsatsu.LevelChecked())
+                        return OriginalHook(HakkeMujinsatsu);
+                }
+
+                return OriginalHook(DeathBlossom);
             }
         }
 
@@ -616,216 +612,242 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == SpinningEdge)
+                if (actionID is not SpinningEdge) return actionID;
+
+                NINGauge gauge = GetJobGauge<NINGauge>();
+                bool canWeave = CanWeave();
+                var canDelayedWeave = CanDelayedWeave();
+                bool inTrickBurstSaveWindow = GetCooldownRemainingTime(TrickAttack) <= 20;
+                bool useBhakaBeforeTrickWindow = GetCooldownRemainingTime(TrickAttack) >= 3;
+                bool setupSuitonWindow = GetCooldownRemainingTime(OriginalHook(TrickAttack)) <= 18 && !HasEffect(Buffs.ShadowWalker);
+                bool setupKassatsuWindow = GetCooldownRemainingTime(TrickAttack) <= 10 && HasEffect(Buffs.ShadowWalker);
+                bool poolCharges = (GetRemainingCharges(Ten) == 1 && GetCooldownChargeRemainingTime(Ten) < 2) || TrickDebuff || InMudra;
+                bool raitonUptime = true;
+                int bhavaPool = 50;
+                int bunshinPool = 50;
+                int SecondWindThreshold = 50;
+                int ShadeShiftThreshold = 50;
+                int BloodbathThreshold = 50;
+                double playerHP = PlayerHealthPercentageHp();
+                bool phantomUptime = true;
+                var comboLength = GetCooldown(GustSlash).CooldownTotal * 3;
+                bool trueNorthArmor = TargetNeedsPositionals() && !OnTargetsFlank() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canDelayedWeave;
+                bool trueNorthEdge = TargetNeedsPositionals() && !OnTargetsRear() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canDelayedWeave;
+                bool dynamic = true;
+
+                if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat())
+                    mudraState.CurrentMudra = MudraCasting.MudraState.None;
+
+                if (IsOnCooldown(TrickAttack) && mudraState.CurrentMudra == MudraCasting.MudraState.CastingSuiton && !setupSuitonWindow)
+                    mudraState.CurrentMudra = MudraCasting.MudraState.None;
+
+                if (IsOnCooldown(TrickAttack) && mudraState.CurrentMudra != MudraCasting.MudraState.CastingSuiton && setupSuitonWindow)
+                    mudraState.CurrentMudra = MudraCasting.MudraState.CastingSuiton;
+
+                if (OriginalHook(Ninjutsu) is Rabbit)
+                    return OriginalHook(Ninjutsu);
+
+                if (InMudra)
                 {
-                    NINGauge gauge = GetJobGauge<NINGauge>();
-                    bool canWeave = CanWeave();
-                    var canDelayedWeave = CanDelayedWeave();
-                    bool inTrickBurstSaveWindow = GetCooldownRemainingTime(TrickAttack) <= 20;
-                    bool useBhakaBeforeTrickWindow = GetCooldownRemainingTime(TrickAttack) >= 3;
-                    bool setupSuitonWindow = GetCooldownRemainingTime(OriginalHook(TrickAttack)) <= 18 && !HasEffect(Buffs.ShadowWalker);
-                    bool setupKassatsuWindow = GetCooldownRemainingTime(TrickAttack) <= 10 && HasEffect(Buffs.ShadowWalker);
-                    bool poolCharges = (GetRemainingCharges(Ten) == 1 && GetCooldownChargeRemainingTime(Ten) < 2) || TrickDebuff || InMudra;
-                    bool raitonUptime = true;
-                    int bhavaPool = 50;
-                    int bunshinPool = 50;
-                    int SecondWindThreshold = 50;
-                    int ShadeShiftThreshold = 50;
-                    int BloodbathThreshold = 50;
-                    double playerHP = PlayerHealthPercentageHp();
-                    bool phantomUptime = true;
-                    var comboLength = GetCooldown(GustSlash).CooldownTotal * 3;
-                    bool trueNorthArmor = TargetNeedsPositionals() && !OnTargetsFlank() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canDelayedWeave;
-                    bool trueNorthEdge = TargetNeedsPositionals() && !OnTargetsRear() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canDelayedWeave;
-                    bool dynamic = true;
-
-                    if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat())
-                        mudraState.CurrentMudra = MudraCasting.MudraState.None;
-
-                    if (IsOnCooldown(TrickAttack) && mudraState.CurrentMudra == MudraCasting.MudraState.CastingSuiton && !setupSuitonWindow)
-                        mudraState.CurrentMudra = MudraCasting.MudraState.None;
-
-                    if (IsOnCooldown(TrickAttack) && mudraState.CurrentMudra != MudraCasting.MudraState.CastingSuiton && setupSuitonWindow)
-                        mudraState.CurrentMudra = MudraCasting.MudraState.CastingSuiton;
-
-                    if (OriginalHook(Ninjutsu) is Rabbit)
-                        return OriginalHook(Ninjutsu);
-
-                    if (InMudra)
-                    {
-                        if (mudraState.ContinueCurrentMudra(ref actionID))
-                            return actionID;
-                    }
-
-                    if (IsOffCooldown(Mug) && Mug.LevelChecked())
-                    {
-                        if ((GetCooldown(TrickAttack).CooldownRemaining < 3 || TrickDebuff) &&
-                            CombatEngageDuration().TotalSeconds > 5 &&
-                            canDelayedWeave)
-                            return OriginalHook(Mug);
-                    }
-
-                    if (HasEffect(Buffs.Kassatsu) &&
-                        TrickDebuff &&
-                        mudraState.CastHyoshoRanryu(ref actionID))
+                    if (mudraState.ContinueCurrentMudra(ref actionID))
                         return actionID;
+                }
 
-                    if (!Suiton.LevelChecked()) //For low level
+                if (IsOffCooldown(Mug) && Mug.LevelChecked())
+                {
+                    if ((GetCooldown(TrickAttack).CooldownRemaining < 3 || TrickDebuff) &&
+                        CombatEngageDuration().TotalSeconds > 5 &&
+                        canDelayedWeave)
+                        return OriginalHook(Mug);
+                }
+
+                if (HasEffect(Buffs.Kassatsu) &&
+                    TrickDebuff &&
+                    mudraState.CastHyoshoRanryu(ref actionID))
+                    return actionID;
+
+                if (!Suiton.LevelChecked()) //For low level
+                {
+                    if (Raiton.LevelChecked()) //under 45 will only use Raiton
                     {
-                        if (Raiton.LevelChecked()) //under 45 will only use Raiton
-                        {
-                            if (mudraState.CastRaiton(ref actionID))
-                                return actionID;
-                        }
-                        else if (!Raiton.LevelChecked() && mudraState.CastFumaShuriken(ref actionID)) // 30-35 will use only fuma
+                        if (mudraState.CastRaiton(ref actionID))
                             return actionID;
                     }
-
-                    if (HasEffect(Buffs.TenChiJin))
-                    {
-                        if (OriginalHook(Ten) == TCJFumaShurikenTen) return OriginalHook(Ten);
-                        if (OriginalHook(Chi) == TCJRaiton) return OriginalHook(Chi);
-                        if (OriginalHook(Jin) == TCJSuiton) return OriginalHook(Jin);
-                    }
-
-                    if (IsEnabled(CustomComboPreset.NIN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.NIN_VariantCure))
-                        return Variant.VariantCure;
-
-                    if (InCombat() && !InMeleeRange())
-                    {
-                        if (HasEffect(Buffs.PhantomReady) &&
-                            ((GetCooldownRemainingTime(TrickAttack) > GetBuffRemainingTime(Buffs.PhantomReady) && GetBuffRemainingTime(Buffs.PhantomReady) < 5) || TrickDebuff || (HasEffect(Buffs.Bunshin) && MugDebuff)) &&
-                            PhantomKamaitachi.LevelChecked()
-                            && phantomUptime)
-                            return OriginalHook(PhantomKamaitachi);
-
-                        if (setupSuitonWindow &&
-                            TrickAttack.LevelChecked() &&
-                            !HasEffect(Buffs.ShadowWalker) &&
-                            mudraState.CastSuiton(ref actionID))
-                            return actionID;
-
-                        if (!inTrickBurstSaveWindow &&
-                            poolCharges &&
-                            raitonUptime &&
-                            mudraState.CastRaiton(ref actionID))
-                            return actionID;
-
-                        if (ThrowingDaggers.LevelChecked() && HasTarget() && !HasEffect(Buffs.RaijuReady))
-                            return OriginalHook(ThrowingDaggers);
-                    }
-
-                    if (canWeave && !InMudra)
-                    {
-                        if (IsEnabled(CustomComboPreset.NIN_Variant_Rampart) &&
-                            IsEnabled(Variant.VariantRampart) &&
-                            IsOffCooldown(Variant.VariantRampart))
-                            return Variant.VariantRampart;
-
-                        if (HasEffect(Buffs.ShadowWalker) &&
-                            IsOffCooldown(TrickAttack) &&
-                            InCombat() && CombatEngageDuration().TotalSeconds > 8 &&
-                            canDelayedWeave)
-                            return OriginalHook(TrickAttack);
-
-                        if (HasEffect(Buffs.TenriJendo) && (TrickDebuff || GetBuffRemainingTime(Buffs.TenriJendo) <= 3))
-                            return OriginalHook(TenriJendo);
-
-                        if (Bunshin.LevelChecked() && IsOffCooldown(Bunshin) && gauge.Ninki >= bunshinPool)
-                            return OriginalHook(Bunshin);
-
-                        if ((TrickDebuff || setupKassatsuWindow) && IsOffCooldown(Kassatsu) && Kassatsu.LevelChecked())
-                            return OriginalHook(Kassatsu);
-
-                        //healing - please move if not appropriate priority
-                        if (All.SecondWind.LevelChecked() && playerHP <= SecondWindThreshold && IsOffCooldown(All.SecondWind))
-                            return All.SecondWind;
-
-                        if (ShadeShift.LevelChecked() && playerHP <= ShadeShiftThreshold && IsOffCooldown(ShadeShift))
-                            return ShadeShift;
-
-                        if (All.Bloodbath.LevelChecked() && playerHP <= BloodbathThreshold && IsOffCooldown(All.Bloodbath))
-                            return All.Bloodbath;
-
-                        if (((TrickDebuff && gauge.Ninki >= 50) || (useBhakaBeforeTrickWindow && gauge.Ninki >= 85)) &&
-                            Bhavacakra.LevelChecked())
-                            return OriginalHook(Bhavacakra);
-
-                        if (((TrickDebuff && gauge.Ninki >= 50) || (useBhakaBeforeTrickWindow && gauge.Ninki >= 60)) &&
-                            !Bhavacakra.LevelChecked() && Hellfrog.LevelChecked())
-                            return OriginalHook(Hellfrog);
-
-                        if (!inTrickBurstSaveWindow)
-                        {
-                            if (HasEffect(Buffs.ShadowWalker) && gauge.Ninki <= 50 && IsOffCooldown(Meisui) && Meisui.LevelChecked())
-                                return OriginalHook(Meisui);
-
-                            if (gauge.Ninki >= bhavaPool && Bhavacakra.LevelChecked())
-                                return OriginalHook(Bhavacakra);
-
-                            if (gauge.Ninki >= bhavaPool && !Bhavacakra.LevelChecked() && Hellfrog.LevelChecked())
-                                return OriginalHook(Hellfrog);
-
-                            if (IsOffCooldown(OriginalHook(Assassinate)) && Assassinate.LevelChecked())
-                                return OriginalHook(Assassinate);
-
-                            if (IsOffCooldown(TenChiJin) && TenChiJin.LevelChecked())
-                                return OriginalHook(TenChiJin);
-                        }
-
-                        if (All.SecondWind.LevelChecked() && playerHP <= SecondWindThreshold && IsOffCooldown(All.SecondWind))
-                            return All.SecondWind;
-
-                        if (ShadeShift.LevelChecked() && playerHP <= ShadeShiftThreshold && IsOffCooldown(ShadeShift))
-                            return ShadeShift;
-
-                        if (All.Bloodbath.LevelChecked() && playerHP <= BloodbathThreshold && IsOffCooldown(All.Bloodbath))
-                            return All.Bloodbath;
-                    }
-
-
-                    if (HasEffect(Buffs.RaijuReady) && InMeleeRange())
-                    {
-                        return OriginalHook(FleetingRaiju);
-                    }
-
-                    if (!inTrickBurstSaveWindow &&
-                        IsOnCooldown(Mug) &&
-                        mudraState.CastHyoshoRanryu(ref actionID))
+                    else if (!Raiton.LevelChecked() && mudraState.CastFumaShuriken(ref actionID)) // 30-35 will use only fuma
                         return actionID;
+                }
 
+                if (HasEffect(Buffs.TenChiJin))
+                {
+                    if (OriginalHook(Ten) == TCJFumaShurikenTen) return OriginalHook(Ten);
+                    if (OriginalHook(Chi) == TCJRaiton) return OriginalHook(Chi);
+                    if (OriginalHook(Jin) == TCJSuiton) return OriginalHook(Jin);
+                }
+
+                if (IsEnabled(CustomComboPreset.NIN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.NIN_VariantCure))
+                    return Variant.VariantCure;
+
+                if (InCombat() && !InMeleeRange())
+                {
+                    if (HasEffect(Buffs.PhantomReady) &&
+                        ((GetCooldownRemainingTime(TrickAttack) > GetBuffRemainingTime(Buffs.PhantomReady) && GetBuffRemainingTime(Buffs.PhantomReady) < 5) || TrickDebuff || (HasEffect(Buffs.Bunshin) && MugDebuff)) &&
+                        PhantomKamaitachi.LevelChecked()
+                        && phantomUptime)
+                        return OriginalHook(PhantomKamaitachi);
 
                     if (setupSuitonWindow &&
                         TrickAttack.LevelChecked() &&
-                        !HasEffect(Buffs.ShadowWalker) &&                      
+                        !HasEffect(Buffs.ShadowWalker) &&
                         mudraState.CastSuiton(ref actionID))
                         return actionID;
 
-                    if (
-                        !inTrickBurstSaveWindow &&
+                    if (!inTrickBurstSaveWindow &&
                         poolCharges &&
+                        raitonUptime &&
                         mudraState.CastRaiton(ref actionID))
                         return actionID;
 
-                    if (HasEffect(Buffs.PhantomReady) &&
-                        ((GetCooldownRemainingTime(TrickAttack) > GetBuffRemainingTime(Buffs.PhantomReady) && GetBuffRemainingTime(Buffs.PhantomReady) < 5) || TrickDebuff || (HasEffect(Buffs.Bunshin) && TargetHasEffect(Debuffs.Mug))) &&
-                        PhantomKamaitachi.LevelChecked())
-                        return OriginalHook(PhantomKamaitachi);
+                    if (ThrowingDaggers.LevelChecked() && HasTarget() && !HasEffect(Buffs.RaijuReady))
+                        return OriginalHook(ThrowingDaggers);
+                }
 
+                if (canWeave && !InMudra)
+                {
+                    if (IsEnabled(CustomComboPreset.NIN_Variant_Rampart) &&
+                        IsEnabled(Variant.VariantRampart) &&
+                        IsOffCooldown(Variant.VariantRampart))
+                        return Variant.VariantRampart;
 
-                    if (!Raiton.LevelChecked() &&
-                        mudraState.CastFumaShuriken(ref actionID))
-                        return actionID;
+                    if (HasEffect(Buffs.ShadowWalker) &&
+                        IsOffCooldown(TrickAttack) &&
+                        InCombat() && CombatEngageDuration().TotalSeconds > 8 &&
+                        canDelayedWeave)
+                        return OriginalHook(TrickAttack);
 
+                    if (HasEffect(Buffs.TenriJendo) && (TrickDebuff || GetBuffRemainingTime(Buffs.TenriJendo) <= 3))
+                        return OriginalHook(TenriJendo);
 
-                    if (ComboTimer > 1f)
+                    if (Bunshin.LevelChecked() && IsOffCooldown(Bunshin) && gauge.Ninki >= bunshinPool)
+                        return OriginalHook(Bunshin);
+
+                    if ((TrickDebuff || setupKassatsuWindow) && IsOffCooldown(Kassatsu) && Kassatsu.LevelChecked())
+                        return OriginalHook(Kassatsu);
+
+                    //healing - please move if not appropriate priority
+                    if (All.SecondWind.LevelChecked() && playerHP <= SecondWindThreshold && IsOffCooldown(All.SecondWind))
+                        return All.SecondWind;
+
+                    if (ShadeShift.LevelChecked() && playerHP <= ShadeShiftThreshold && IsOffCooldown(ShadeShift))
+                        return ShadeShift;
+
+                    if (All.Bloodbath.LevelChecked() && playerHP <= BloodbathThreshold && IsOffCooldown(All.Bloodbath))
+                        return All.Bloodbath;
+
+                    if (((TrickDebuff && gauge.Ninki >= 50) || (useBhakaBeforeTrickWindow && gauge.Ninki >= 85)) &&
+                        Bhavacakra.LevelChecked())
+                        return OriginalHook(Bhavacakra);
+
+                    if (((TrickDebuff && gauge.Ninki >= 50) || (useBhakaBeforeTrickWindow && gauge.Ninki >= 60)) &&
+                        !Bhavacakra.LevelChecked() && Hellfrog.LevelChecked())
+                        return OriginalHook(Hellfrog);
+
+                    if (!inTrickBurstSaveWindow)
                     {
-                        if (ComboAction == SpinningEdge && GustSlash.LevelChecked())
-                            return OriginalHook(GustSlash);
+                        if (HasEffect(Buffs.ShadowWalker) && gauge.Ninki <= 50 && IsOffCooldown(Meisui) && Meisui.LevelChecked())
+                            return OriginalHook(Meisui);
 
-                        if (ComboAction == GustSlash && ArmorCrush.LevelChecked())
+                        if (gauge.Ninki >= bhavaPool && Bhavacakra.LevelChecked())
+                            return OriginalHook(Bhavacakra);
+
+                        if (gauge.Ninki >= bhavaPool && !Bhavacakra.LevelChecked() && Hellfrog.LevelChecked())
+                            return OriginalHook(Hellfrog);
+
+                        if (IsOffCooldown(OriginalHook(Assassinate)) && Assassinate.LevelChecked())
+                            return OriginalHook(Assassinate);
+
+                        if (IsOffCooldown(TenChiJin) && TenChiJin.LevelChecked())
+                            return OriginalHook(TenChiJin);
+                    }
+
+                    if (All.SecondWind.LevelChecked() && playerHP <= SecondWindThreshold && IsOffCooldown(All.SecondWind))
+                        return All.SecondWind;
+
+                    if (ShadeShift.LevelChecked() && playerHP <= ShadeShiftThreshold && IsOffCooldown(ShadeShift))
+                        return ShadeShift;
+
+                    if (All.Bloodbath.LevelChecked() && playerHP <= BloodbathThreshold && IsOffCooldown(All.Bloodbath))
+                        return All.Bloodbath;
+                }
+
+
+                if (HasEffect(Buffs.RaijuReady) && InMeleeRange())
+                {
+                    return OriginalHook(FleetingRaiju);
+                }
+
+                if (!inTrickBurstSaveWindow &&
+                    IsOnCooldown(Mug) &&
+                    mudraState.CastHyoshoRanryu(ref actionID))
+                    return actionID;
+
+
+                if (setupSuitonWindow &&
+                    TrickAttack.LevelChecked() &&
+                    !HasEffect(Buffs.ShadowWalker) &&
+                    mudraState.CastSuiton(ref actionID))
+                    return actionID;
+
+                if (
+                    !inTrickBurstSaveWindow &&
+                    poolCharges &&
+                    mudraState.CastRaiton(ref actionID))
+                    return actionID;
+
+                if (HasEffect(Buffs.PhantomReady) &&
+                    ((GetCooldownRemainingTime(TrickAttack) > GetBuffRemainingTime(Buffs.PhantomReady) && GetBuffRemainingTime(Buffs.PhantomReady) < 5) || TrickDebuff || (HasEffect(Buffs.Bunshin) && TargetHasEffect(Debuffs.Mug))) &&
+                    PhantomKamaitachi.LevelChecked())
+                    return OriginalHook(PhantomKamaitachi);
+
+
+                if (!Raiton.LevelChecked() &&
+                    mudraState.CastFumaShuriken(ref actionID))
+                    return actionID;
+
+
+                if (ComboTimer > 1f)
+                {
+                    if (ComboAction == SpinningEdge && GustSlash.LevelChecked())
+                        return OriginalHook(GustSlash);
+
+                    if (ComboAction == GustSlash && ArmorCrush.LevelChecked())
+                    {
+                        if (gauge.Kazematoi == 0)
                         {
-                            if (gauge.Kazematoi == 0)
+                            if (trueNorthArmor)
+                                return All.TrueNorth;
+
+                            return ArmorCrush;
+                        }
+
+                        if (dynamic)
+                        {
+                            if (gauge.Kazematoi >= 4)
+                            {
+                                if (trueNorthEdge)
+                                    return All.TrueNorth;
+
+                                return AeolianEdge;
+                            }
+
+                            if (OnTargetsFlank())
+                                return ArmorCrush;
+                            else
+                                return AeolianEdge;
+
+                        }
+                        else
+                        {
+                            if (gauge.Kazematoi < 3)
                             {
                                 if (trueNorthArmor)
                                     return All.TrueNorth;
@@ -833,46 +855,18 @@ namespace WrathCombo.Combos.PvE
                                 return ArmorCrush;
                             }
 
-                            if (dynamic)
-                            {
-                                if (gauge.Kazematoi >= 4)
-                                {
-                                    if (trueNorthEdge)
-                                        return All.TrueNorth;
-
-                                    return AeolianEdge;
-                                }
-
-                                if (OnTargetsFlank())
-                                    return ArmorCrush;
-                                else
-                                    return AeolianEdge;
-
-                            }
-                            else
-                            {
-                                if (gauge.Kazematoi < 3)
-                                {
-                                    if (trueNorthArmor)
-                                        return All.TrueNorth;
-
-                                    return ArmorCrush;
-                                }
-
-                                return AeolianEdge;
-                            }
-                        }
-                        if (ComboAction == GustSlash && !ArmorCrush.LevelChecked() && AeolianEdge.LevelChecked())
-                        {
-                            if (trueNorthEdge)
-                                return OriginalHook(All.TrueNorth);
-                            else
-                                return OriginalHook(AeolianEdge);
+                            return AeolianEdge;
                         }
                     }
-                    return OriginalHook(SpinningEdge);
+                    if (ComboAction == GustSlash && !ArmorCrush.LevelChecked() && AeolianEdge.LevelChecked())
+                    {
+                        if (trueNorthEdge)
+                            return OriginalHook(All.TrueNorth);
+                        else
+                            return OriginalHook(AeolianEdge);
+                    }
                 }
-                return actionID;
+                return OriginalHook(SpinningEdge);
             }
         }
 
@@ -884,115 +878,113 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == DeathBlossom)
+                if (actionID is not DeathBlossom) return actionID;
+
+                var dotonBuff = FindEffect(Buffs.Doton);
+                var gauge = GetJobGauge<NINGauge>();
+                var canWeave = CanWeave();
+
+                if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat())
+                    mudraState.CurrentMudra = MudraCasting.MudraState.None;
+
+                if (OriginalHook(Ninjutsu) is Rabbit)
+                    return OriginalHook(Ninjutsu);
+
+                if (InMudra)
                 {
-                    var dotonBuff = FindEffect(Buffs.Doton);
-                    var gauge = GetJobGauge<NINGauge>();
-                    var canWeave = CanWeave();
-
-                    if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat())
-                        mudraState.CurrentMudra = MudraCasting.MudraState.None;
-
-                    if (OriginalHook(Ninjutsu) is Rabbit)
-                        return OriginalHook(Ninjutsu);
-
-                    if (InMudra)
-                    {
-                        if (mudraState.ContinueCurrentMudra(ref actionID))
-                            return actionID;
-                    }
-
-                    if (HasEffect(Buffs.TenChiJin))
-                    {
-                        if (WasLastAction(TCJFumaShurikenJin)) return OriginalHook(Ten);
-                        if (WasLastAction(TCJKaton) || WasLastAction(HollowNozuchi)) return OriginalHook(Chi);
-                        return OriginalHook(Jin);
-                    }
-
-                    if (HasEffect(Buffs.Kassatsu))
-                    {
-                        if (GokaMekkyaku.LevelChecked())
-                        {
-                            mudraState.CurrentMudra = MudraCasting.MudraState.CastingGokaMekkyaku;
-                            if (mudraState.CastGokaMekkyaku(ref actionID))
-                                return actionID;
-                        }
-                        else
-                        {
-                            mudraState.CurrentMudra = MudraCasting.MudraState.CastingKaton;
-                            if (mudraState.CastKaton(ref actionID))
-                                return actionID;
-                        }
-                    }
-
-                    if (IsEnabled(CustomComboPreset.NIN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.NIN_VariantCure))
-                        return Variant.VariantCure;
-
-
-                    if (!HasEffect(Buffs.ShadowWalker) && KunaisBane.LevelChecked() && GetCooldownRemainingTime(KunaisBane) < 5 && mudraState.CastHuton(ref actionID))
+                    if (mudraState.ContinueCurrentMudra(ref actionID))
                         return actionID;
+                }
 
-                    if (HasEffect(Buffs.ShadowWalker) && KunaisBane.LevelChecked() && IsOffCooldown(KunaisBane) && canWeave)
-                        return KunaisBane;
+                if (HasEffect(Buffs.TenChiJin))
+                {
+                    if (WasLastAction(TCJFumaShurikenJin)) return OriginalHook(Ten);
+                    if (WasLastAction(TCJKaton) || WasLastAction(HollowNozuchi)) return OriginalHook(Chi);
+                    return OriginalHook(Jin);
+                }
 
-                    if (GetTargetHPPercent() > 20 && (dotonBuff is null || dotonBuff?.RemainingTime <= GetCooldownChargeRemainingTime(Ten)) && !JustUsed(Doton) && IsOnCooldown(TenChiJin))
+                if (HasEffect(Buffs.Kassatsu))
+                {
+                    if (GokaMekkyaku.LevelChecked())
                     {
-                        if (mudraState.CastDoton(ref actionID))
+                        mudraState.CurrentMudra = MudraCasting.MudraState.CastingGokaMekkyaku;
+                        if (mudraState.CastGokaMekkyaku(ref actionID))
                             return actionID;
-                    }
-                    else if (mudraState.CurrentMudra == MudraCasting.MudraState.CastingDoton)
-                        mudraState.CurrentMudra = MudraCasting.MudraState.None;
-
-
-                    if (canWeave && !InMudra)
-                    {
-                        if (IsEnabled(CustomComboPreset.NIN_Variant_Rampart) &&
-                            IsEnabled(Variant.VariantRampart) &&
-                            IsOffCooldown(Variant.VariantRampart))
-                            return Variant.VariantRampart;
-
-                        if (IsOffCooldown(TenChiJin) && TenChiJin.LevelChecked())
-                            return OriginalHook(TenChiJin);
-
-                        if (HasEffect(Buffs.TenriJendo))
-                            return TenriJendo;
-
-                        if (IsOffCooldown(Bunshin) && gauge.Ninki >= 50 && Bunshin.LevelChecked())
-                            return OriginalHook(Bunshin);
-
-                        if (HasEffect(Buffs.ShadowWalker) && gauge.Ninki < 50 && IsOffCooldown(Meisui) && Meisui.LevelChecked())
-                            return OriginalHook(Meisui);
-
-                        if (HasEffect(Buffs.Meisui) && gauge.Ninki >= 50)
-                            return OriginalHook(Bhavacakra);
-
-                        if (gauge.Ninki >= 50 && Hellfrog.LevelChecked())
-                            return OriginalHook(Hellfrog);
-
-                        if (gauge.Ninki >= 50 && !Hellfrog.LevelChecked() && Bhavacakra.LevelChecked())
-                            return OriginalHook(Bhavacakra);
-
-                        if (IsOffCooldown(Kassatsu) && Kassatsu.LevelChecked())
-                            return OriginalHook(Kassatsu);
                     }
                     else
                     {
-                        if (HasEffect(Buffs.PhantomReady))
-                            return OriginalHook(PhantomKamaitachi);
+                        mudraState.CurrentMudra = MudraCasting.MudraState.CastingKaton;
+                        if (mudraState.CastKaton(ref actionID))
+                            return actionID;
                     }
-
-                    if (mudraState.CastKaton(ref actionID))
-                        return actionID;
-
-                    if (ComboTimer > 1f)
-                    {
-                        if (ComboAction is DeathBlossom && HakkeMujinsatsu.LevelChecked())
-                            return OriginalHook(HakkeMujinsatsu);
-                    }
-
-                    return OriginalHook(DeathBlossom);
                 }
-                return actionID;
+
+                if (IsEnabled(CustomComboPreset.NIN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.NIN_VariantCure))
+                    return Variant.VariantCure;
+
+
+                if (!HasEffect(Buffs.ShadowWalker) && KunaisBane.LevelChecked() && GetCooldownRemainingTime(KunaisBane) < 5 && mudraState.CastHuton(ref actionID))
+                    return actionID;
+
+                if (HasEffect(Buffs.ShadowWalker) && KunaisBane.LevelChecked() && IsOffCooldown(KunaisBane) && canWeave)
+                    return KunaisBane;
+
+                if (GetTargetHPPercent() > 20 && (dotonBuff is null || dotonBuff?.RemainingTime <= GetCooldownChargeRemainingTime(Ten)) && !JustUsed(Doton) && IsOnCooldown(TenChiJin))
+                {
+                    if (mudraState.CastDoton(ref actionID))
+                        return actionID;
+                }
+                else if (mudraState.CurrentMudra == MudraCasting.MudraState.CastingDoton)
+                    mudraState.CurrentMudra = MudraCasting.MudraState.None;
+
+
+                if (canWeave && !InMudra)
+                {
+                    if (IsEnabled(CustomComboPreset.NIN_Variant_Rampart) &&
+                        IsEnabled(Variant.VariantRampart) &&
+                        IsOffCooldown(Variant.VariantRampart))
+                        return Variant.VariantRampart;
+
+                    if (IsOffCooldown(TenChiJin) && TenChiJin.LevelChecked())
+                        return OriginalHook(TenChiJin);
+
+                    if (HasEffect(Buffs.TenriJendo))
+                        return TenriJendo;
+
+                    if (IsOffCooldown(Bunshin) && gauge.Ninki >= 50 && Bunshin.LevelChecked())
+                        return OriginalHook(Bunshin);
+
+                    if (HasEffect(Buffs.ShadowWalker) && gauge.Ninki < 50 && IsOffCooldown(Meisui) && Meisui.LevelChecked())
+                        return OriginalHook(Meisui);
+
+                    if (HasEffect(Buffs.Meisui) && gauge.Ninki >= 50)
+                        return OriginalHook(Bhavacakra);
+
+                    if (gauge.Ninki >= 50 && Hellfrog.LevelChecked())
+                        return OriginalHook(Hellfrog);
+
+                    if (gauge.Ninki >= 50 && !Hellfrog.LevelChecked() && Bhavacakra.LevelChecked())
+                        return OriginalHook(Bhavacakra);
+
+                    if (IsOffCooldown(Kassatsu) && Kassatsu.LevelChecked())
+                        return OriginalHook(Kassatsu);
+                }
+                else
+                {
+                    if (HasEffect(Buffs.PhantomReady))
+                        return OriginalHook(PhantomKamaitachi);
+                }
+
+                if (mudraState.CastKaton(ref actionID))
+                    return actionID;
+
+                if (ComboTimer > 1f)
+                {
+                    if (ComboAction is DeathBlossom && HakkeMujinsatsu.LevelChecked())
+                        return OriginalHook(HakkeMujinsatsu);
+                }
+
+                return OriginalHook(DeathBlossom);
             }
         }
 
@@ -1002,23 +994,20 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == ArmorCrush)
+                if (actionID is not ArmorCrush) return actionID;
+                if (ComboTimer > 0f)
                 {
-                    if (ComboTimer > 0f)
+                    if (ComboAction == SpinningEdge && GustSlash.LevelChecked())
                     {
-                        if (ComboAction == SpinningEdge && GustSlash.LevelChecked())
-                        {
-                            return GustSlash;
-                        }
-
-                        if (ComboAction == GustSlash && ArmorCrush.LevelChecked())
-                        {
-                            return ArmorCrush;
-                        }
+                        return GustSlash;
                     }
-                    return SpinningEdge;
+
+                    if (ComboAction == GustSlash && ArmorCrush.LevelChecked())
+                    {
+                        return ArmorCrush;
+                    }
                 }
-                return actionID;
+                return SpinningEdge;
             }
         }
 
@@ -1029,18 +1018,16 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == Hide)
+                if (actionID is not Hide) return actionID;
+
+                if (HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat))
                 {
-                    if (HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat))
-                    {
-                        return OriginalHook(Mug);
-                    }
+                    return OriginalHook(Mug);
+                }
 
-                    if (HasEffect(Buffs.Hidden))
-                    {
-                        return OriginalHook(TrickAttack);
-                    }
-
+                if (HasEffect(Buffs.Hidden))
+                {
+                    return OriginalHook(TrickAttack);
                 }
 
                 return actionID;
@@ -1067,15 +1054,12 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == Kassatsu)
+                if (actionID is not Kassatsu) return actionID;
+                if (HasEffect(Buffs.ShadowWalker) || HasEffect(Buffs.Hidden))
                 {
-                    if (HasEffect(Buffs.ShadowWalker) || HasEffect(Buffs.Hidden))
-                    {
-                        return OriginalHook(TrickAttack);
-                    }
-                    return OriginalHook(Kassatsu);
+                    return OriginalHook(TrickAttack);
                 }
-                return actionID;
+                return OriginalHook(Kassatsu);
             }
         }
 
@@ -1085,25 +1069,23 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == TenChiJin)
+                if (actionID is not TenChiJin) return actionID;
+
+                if (HasEffect(Buffs.ShadowWalker))
+                    return Meisui;
+
+                if (HasEffect(Buffs.TenChiJin) && IsEnabled(CustomComboPreset.NIN_TCJ))
                 {
+                    var tcjTimer = FindEffectAny(Buffs.TenChiJin).RemainingTime;
 
-                    if (HasEffect(Buffs.ShadowWalker))
-                        return Meisui;
+                    if (tcjTimer > 5)
+                        return OriginalHook(Ten);
 
-                    if (HasEffect(Buffs.TenChiJin) && IsEnabled(CustomComboPreset.NIN_TCJ))
-                    {
-                        var tcjTimer = FindEffectAny(Buffs.TenChiJin).RemainingTime;
+                    if (tcjTimer > 4)
+                        return OriginalHook(Chi);
 
-                        if (tcjTimer > 5)
-                            return OriginalHook(Ten);
-
-                        if (tcjTimer > 4)
-                            return OriginalHook(Chi);
-
-                        if (tcjTimer > 3)
-                            return OriginalHook(Jin);
-                    }
+                    if (tcjTimer > 3)
+                        return OriginalHook(Jin);
                 }
                 return actionID;
             }
@@ -1115,125 +1097,121 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is Ten or Chi or Jin)
+                if (actionID is not (Ten or Chi or Jin) || !HasEffect(Buffs.Mudra)) return actionID;
+
+                var mudrapath = GetOptionValue(Config.NIN_SimpleMudra_Choice);
+
+                if (mudrapath == 1)
                 {
-                    var mudrapath = GetOptionValue(Config.NIN_SimpleMudra_Choice);
-
-                    if (HasEffect(Buffs.Mudra))
+                    if (Ten.LevelChecked() && actionID == Ten)
                     {
-
-                        if (mudrapath == 1)
+                        if (Jin.LevelChecked() && (OriginalHook(Ninjutsu) is Raiton))
                         {
-                            if (Ten.LevelChecked() && actionID == Ten)
-                            {
-                                if (Jin.LevelChecked() && (OriginalHook(Ninjutsu) is Raiton))
-                                {
-                                    return OriginalHook(JinCombo);
-                                }
-
-                                if (Chi.LevelChecked() && (OriginalHook(Ninjutsu) is HyoshoRanryu))
-                                {
-                                    return OriginalHook(ChiCombo);
-                                }
-
-                                if (OriginalHook(Ninjutsu) == FumaShuriken)
-                                {
-                                    if (HasEffect(Buffs.Kassatsu) && Traits.EnhancedKasatsu.TraitLevelChecked())
-                                        return JinCombo;
-
-                                    if (Chi.LevelChecked())
-                                        return OriginalHook(ChiCombo);
-
-                                    if (Jin.LevelChecked())
-                                        return OriginalHook(JinCombo);
-                                }
-                            }
-
-                            if (Chi.LevelChecked() && actionID == Chi)
-                            {
-                                if (OriginalHook(Ninjutsu) is Hyoton)
-                                {
-                                    return OriginalHook(TenCombo);
-                                }
-
-                                if (Jin.LevelChecked() && OriginalHook(Ninjutsu) == FumaShuriken)
-                                {
-                                    return OriginalHook(JinCombo);
-                                }
-                            }
-
-                            if (Jin.LevelChecked() && actionID == Jin)
-                            {
-                                if (OriginalHook(Ninjutsu) is GokaMekkyaku or Katon)
-                                {
-                                    return OriginalHook(ChiCombo);
-                                }
-
-                                if (OriginalHook(Ninjutsu) == FumaShuriken)
-                                {
-                                    return OriginalHook(TenCombo);
-                                }
-                            }
-
-                            return OriginalHook(Ninjutsu);
+                            return OriginalHook(JinCombo);
                         }
 
-                        if (mudrapath == 2)
+                        if (Chi.LevelChecked() && (OriginalHook(Ninjutsu) is HyoshoRanryu))
                         {
-                            if (Ten.LevelChecked() && actionID == Ten)
-                            {
-                                if (Chi.LevelChecked() && (OriginalHook(Ninjutsu) is Hyoton or HyoshoRanryu))
-                                {
-                                    return OriginalHook(Chi);
-                                }
+                            return OriginalHook(ChiCombo);
+                        }
 
-                                if (OriginalHook(Ninjutsu) == FumaShuriken)
-                                {
-                                    if (Jin.LevelChecked())
-                                        return OriginalHook(JinCombo);
+                        if (OriginalHook(Ninjutsu) == FumaShuriken)
+                        {
+                            if (HasEffect(Buffs.Kassatsu) && Traits.EnhancedKasatsu.TraitLevelChecked())
+                                return JinCombo;
 
-                                    else if (Chi.LevelChecked())
-                                        return OriginalHook(ChiCombo);
-                                }
-                            }
+                            if (Chi.LevelChecked())
+                                return OriginalHook(ChiCombo);
 
-                            if (Chi.LevelChecked() && actionID == Chi)
-                            {
-                                if (Jin.LevelChecked() && (OriginalHook(Ninjutsu) is Katon or GokaMekkyaku))
-                                {
-                                    return OriginalHook(Jin);
-                                }
-
-                                if (OriginalHook(Ninjutsu) == FumaShuriken)
-                                {
-                                    return OriginalHook(Ten);
-                                }
-                            }
-
-                            if (Jin.LevelChecked() && actionID == Jin)
-                            {
-                                if (OriginalHook(Ninjutsu) is Raiton)
-                                {
-                                    return OriginalHook(Ten);
-                                }
-
-                                if (OriginalHook(Ninjutsu) == GokaMekkyaku)
-                                {
-                                    return OriginalHook(Chi);
-                                }
-
-                                if (OriginalHook(Ninjutsu) == FumaShuriken)
-                                {
-                                    if (HasEffect(Buffs.Kassatsu) && Traits.EnhancedKasatsu.TraitLevelChecked())
-                                        return OriginalHook(Ten);
-                                    return OriginalHook(Chi);
-                                }
-                            }
-
-                            return OriginalHook(Ninjutsu);
+                            if (Jin.LevelChecked())
+                                return OriginalHook(JinCombo);
                         }
                     }
+
+                    if (Chi.LevelChecked() && actionID == Chi)
+                    {
+                        if (OriginalHook(Ninjutsu) is Hyoton)
+                        {
+                            return OriginalHook(TenCombo);
+                        }
+
+                        if (Jin.LevelChecked() && OriginalHook(Ninjutsu) == FumaShuriken)
+                        {
+                            return OriginalHook(JinCombo);
+                        }
+                    }
+
+                    if (Jin.LevelChecked() && actionID == Jin)
+                    {
+                        if (OriginalHook(Ninjutsu) is GokaMekkyaku or Katon)
+                        {
+                            return OriginalHook(ChiCombo);
+                        }
+
+                        if (OriginalHook(Ninjutsu) == FumaShuriken)
+                        {
+                            return OriginalHook(TenCombo);
+                        }
+                    }
+
+                    return OriginalHook(Ninjutsu);
                 }
+
+                if (mudrapath == 2)
+                {
+                    if (Ten.LevelChecked() && actionID == Ten)
+                    {
+                        if (Chi.LevelChecked() && (OriginalHook(Ninjutsu) is Hyoton or HyoshoRanryu))
+                        {
+                            return OriginalHook(Chi);
+                        }
+
+                        if (OriginalHook(Ninjutsu) == FumaShuriken)
+                        {
+                            if (Jin.LevelChecked())
+                                return OriginalHook(JinCombo);
+
+                            else if (Chi.LevelChecked())
+                                return OriginalHook(ChiCombo);
+                        }
+                    }
+
+                    if (Chi.LevelChecked() && actionID == Chi)
+                    {
+                        if (Jin.LevelChecked() && (OriginalHook(Ninjutsu) is Katon or GokaMekkyaku))
+                        {
+                            return OriginalHook(Jin);
+                        }
+
+                        if (OriginalHook(Ninjutsu) == FumaShuriken)
+                        {
+                            return OriginalHook(Ten);
+                        }
+                    }
+
+                    if (Jin.LevelChecked() && actionID == Jin)
+                    {
+                        if (OriginalHook(Ninjutsu) is Raiton)
+                        {
+                            return OriginalHook(Ten);
+                        }
+
+                        if (OriginalHook(Ninjutsu) == GokaMekkyaku)
+                        {
+                            return OriginalHook(Chi);
+                        }
+
+                        if (OriginalHook(Ninjutsu) == FumaShuriken)
+                        {
+                            if (HasEffect(Buffs.Kassatsu) && Traits.EnhancedKasatsu.TraitLevelChecked())
+                                return OriginalHook(Ten);
+                            return OriginalHook(Chi);
+                        }
+                    }
+
+                    return OriginalHook(Ninjutsu);
+                }
+
                 return actionID;
             }
         }

--- a/WrathCombo/Combos/PvE/PCT/PCT.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT.cs
@@ -80,20 +80,20 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is FireInRed)
+                if (actionID is not FireInRed) return actionID;
+
+                PCTGauge gauge = GetJobGauge<PCTGauge>();
+                bool canWeave = CanSpellWeave() || CanSpellWeave();
+
+
+
+                // Lvl 100 Opener
+                if (StarPrism.LevelChecked())
                 {
-                    PCTGauge gauge = GetJobGauge<PCTGauge>();
-                    bool canWeave = CanSpellWeave() || CanSpellWeave();
-
-
-
-                    // Lvl 100 Opener
-                    if (StarPrism.LevelChecked())
-                    {
-                        if (Opener().FullOpener(ref actionID))
-                            return actionID;
-                    }
-                    /* Lvl 92 Opener
+                    if (Opener().FullOpener(ref actionID))
+                        return actionID;
+                }
+                /* Lvl 92 Opener
                     else if (!StarPrism.LevelChecked() && RainbowDrip.LevelChecked())
                     {
                         if (PCTOpenerLvl92.DoFullOpener(ref actionID))
@@ -119,190 +119,189 @@ namespace WrathCombo.Combos.PvE
                     }
                     */
 
-                    // General Weaves
-                    if (InCombat() && canWeave)
+                // General Weaves
+                if (InCombat() && canWeave)
+                {
+                    // ScenicMuse
+
+                    if (ScenicMuse.LevelChecked() &&
+                        gauge.LandscapeMotifDrawn &&
+                        gauge.WeaponMotifDrawn &&
+                        IsOffCooldown(ScenicMuse))
                     {
-                        // ScenicMuse
+                        return OriginalHook(ScenicMuse);
+                    }
 
-                        if (ScenicMuse.LevelChecked() &&
-                            gauge.LandscapeMotifDrawn &&
-                            gauge.WeaponMotifDrawn &&
-                            IsOffCooldown(ScenicMuse))
+                    // LivingMuse
+
+                    if (LivingMuse.LevelChecked() &&
+                        gauge.CreatureMotifDrawn &&
+                        (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
+                         GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)))
+                    {
+                        if (HasCharges(OriginalHook(LivingMuse)))
                         {
-                            return OriginalHook(ScenicMuse);
-                        }
-
-                        // LivingMuse
-
-                        if (LivingMuse.LevelChecked() &&
-                            gauge.CreatureMotifDrawn &&
-                            (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
-                            GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)))
-                        {
-                            if (HasCharges(OriginalHook(LivingMuse)))
+                            if (!ScenicMuse.LevelChecked() ||
+                                GetCooldown(ScenicMuse).CooldownRemaining > GetCooldownChargeRemainingTime(LivingMuse))
                             {
-                                if (!ScenicMuse.LevelChecked() ||
-                                    GetCooldown(ScenicMuse).CooldownRemaining > GetCooldownChargeRemainingTime(LivingMuse))
-                                {
-                                    return OriginalHook(LivingMuse);
-                                }
-                            }
-                        }
-
-                        // SteelMuse
-
-                        if (SteelMuse.LevelChecked() &&
-                            !HasEffect(Buffs.HammerTime) &&
-                            gauge.WeaponMotifDrawn &&
-                            HasCharges(OriginalHook(SteelMuse)) &&
-                            (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining ||
-                                GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
-                                !ScenicMuse.LevelChecked()))
-                        {
-                            return OriginalHook(SteelMuse);
-                        }
-
-                        // MogoftheAges
-
-                        if (MogoftheAges.LevelChecked() &&
-                            (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) &&
-                            IsOffCooldown(OriginalHook(MogoftheAges)) &&
-                            (GetCooldownRemainingTime(StarryMuse) >= 60 || !ScenicMuse.LevelChecked()))
-                        {
-                            return OriginalHook(MogoftheAges);
-                        }
-
-                        // Swiftcast
-
-                        if (IsMoving() &&
-                            IsOffCooldown(All.Swiftcast) &&
-                            All.Swiftcast.LevelChecked() &&
-                            !HasEffect(Buffs.HammerTime) &&
-                            gauge.Paint < 1 &&
-                            (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
-                        {
-                            return All.Swiftcast;
-                        }
-
-                        // SubtractivePalette
-
-                        if (SubtractivePalette.LevelChecked() &&
-                            !HasEffect(Buffs.SubtractivePalette) &&
-                            !HasEffect(Buffs.MonochromeTones))
-                        {
-                            if (HasEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
-                            {
-                                return SubtractivePalette;
+                                return OriginalHook(LivingMuse);
                             }
                         }
                     }
 
-                    // Swiftcast Motifs
-                    if (HasEffect(All.Buffs.Swiftcast))
+                    // SteelMuse
+
+                    if (SteelMuse.LevelChecked() &&
+                        !HasEffect(Buffs.HammerTime) &&
+                        gauge.WeaponMotifDrawn &&
+                        HasCharges(OriginalHook(SteelMuse)) &&
+                        (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining ||
+                         GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
+                         !ScenicMuse.LevelChecked()))
                     {
-                        if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
-                            return OriginalHook(CreatureMotif);
-                        if (!gauge.WeaponMotifDrawn && HammerMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse))
-                            return OriginalHook(HammerMotif);
-                        if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
-                            return OriginalHook(LandscapeMotif);
+                        return OriginalHook(SteelMuse);
                     }
 
-                    // IsMoving logic
-                    if (IsMoving() && InCombat())
+                    // MogoftheAges
+
+                    if (MogoftheAges.LevelChecked() &&
+                        (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) &&
+                        IsOffCooldown(OriginalHook(MogoftheAges)) &&
+                        (GetCooldownRemainingTime(StarryMuse) >= 60 || !ScenicMuse.LevelChecked()))
                     {
-                        if (HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
-                            return OriginalHook(HammerStamp);
-
-                        if (CometinBlack.LevelChecked() && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
-                            return OriginalHook(CometinBlack);
-
-                        if (HasEffect(Buffs.RainbowBright) || HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) <= 3f)
-                            return RainbowDrip;
-
-                        if (HolyInWhite.LevelChecked() && gauge.Paint >= 1)
-                            return OriginalHook(HolyInWhite);
+                        return OriginalHook(MogoftheAges);
                     }
 
-                    //Prepare for Burst
-                    if (GetCooldownRemainingTime(ScenicMuse) <= 20)
+                    // Swiftcast
+
+                    if (IsMoving() &&
+                        IsOffCooldown(All.Swiftcast) &&
+                        All.Swiftcast.LevelChecked() &&
+                        !HasEffect(Buffs.HammerTime) &&
+                        gauge.Paint < 1 &&
+                        (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
                     {
-                        if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn)
-                            return OriginalHook(LandscapeMotif);
-
-                        if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
-                            return OriginalHook(CreatureMotif);
-
-                        if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
-                            return OriginalHook(WeaponMotif);
+                        return All.Swiftcast;
                     }
 
-                    // Burst 
-                    if (HasEffect(Buffs.StarryMuse))
+                    // SubtractivePalette
+
+                    if (SubtractivePalette.LevelChecked() &&
+                        !HasEffect(Buffs.SubtractivePalette) &&
+                        !HasEffect(Buffs.MonochromeTones))
                     {
-
-                        if (CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
-                            return CometinBlack;
-
-                        if (HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.Starstruck))
-                            return OriginalHook(HammerStamp);
-
-                        if (HasEffect(Buffs.Starstruck) || HasEffect(Buffs.Starstruck) && GetBuffRemainingTime(Buffs.Starstruck) <= 3f)
-                            return StarPrism;
-
-                        if (HasEffect(Buffs.RainbowBright) || HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) <= 3f)
-                            return RainbowDrip;
-
-
+                        if (HasEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
+                        {
+                            return SubtractivePalette;
+                        }
                     }
+                }
 
-                    if (HasEffect(Buffs.RainbowBright) && !HasEffect(Buffs.StarryMuse))
-                        return RainbowDrip;
+                // Swiftcast Motifs
+                if (HasEffect(All.Buffs.Swiftcast))
+                {
+                    if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
+                        return OriginalHook(CreatureMotif);
+                    if (!gauge.WeaponMotifDrawn && HammerMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse))
+                        return OriginalHook(HammerMotif);
+                    if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
+                        return OriginalHook(LandscapeMotif);
+                }
 
-                    if (CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(StarryMuse) > 30f)
-                        return OriginalHook(CometinBlack);
-
+                // IsMoving logic
+                if (IsMoving() && InCombat())
+                {
                     if (HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
                         return OriginalHook(HammerStamp);
 
-                    if (!HasEffect(Buffs.StarryMuse))
+                    if (CometinBlack.LevelChecked() && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
+                        return OriginalHook(CometinBlack);
+
+                    if (HasEffect(Buffs.RainbowBright) || HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) <= 3f)
+                        return RainbowDrip;
+
+                    if (HolyInWhite.LevelChecked() && gauge.Paint >= 1)
+                        return OriginalHook(HolyInWhite);
+                }
+
+                //Prepare for Burst
+                if (GetCooldownRemainingTime(ScenicMuse) <= 20)
+                {
+                    if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn)
+                        return OriginalHook(LandscapeMotif);
+
+                    if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
+                        return OriginalHook(CreatureMotif);
+
+                    if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
+                        return OriginalHook(WeaponMotif);
+                }
+
+                // Burst
+                if (HasEffect(Buffs.StarryMuse))
+                {
+
+                    if (CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
+                        return CometinBlack;
+
+                    if (HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.Starstruck))
+                        return OriginalHook(HammerStamp);
+
+                    if (HasEffect(Buffs.Starstruck) || HasEffect(Buffs.Starstruck) && GetBuffRemainingTime(Buffs.Starstruck) <= 3f)
+                        return StarPrism;
+
+                    if (HasEffect(Buffs.RainbowBright) || HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) <= 3f)
+                        return RainbowDrip;
+
+
+                }
+
+                if (HasEffect(Buffs.RainbowBright) && !HasEffect(Buffs.StarryMuse))
+                    return RainbowDrip;
+
+                if (CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(StarryMuse) > 30f)
+                    return OriginalHook(CometinBlack);
+
+                if (HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
+                    return OriginalHook(HammerStamp);
+
+                if (!HasEffect(Buffs.StarryMuse))
+                {
+                    // LandscapeMotif
+
+                    if (LandscapeMotif.LevelChecked() &&
+                        !gauge.LandscapeMotifDrawn &&
+                        GetCooldownRemainingTime(ScenicMuse) <= 20)
                     {
-                        // LandscapeMotif
-
-                        if (LandscapeMotif.LevelChecked() &&
-                            !gauge.LandscapeMotifDrawn &&
-                            GetCooldownRemainingTime(ScenicMuse) <= 20)
-                        {
-                            return OriginalHook(LandscapeMotif);
-                        }
-
-                        // CreatureMotif
-
-                        if (CreatureMotif.LevelChecked() &&
-                            !gauge.CreatureMotifDrawn &&
-                            (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
-                        {
-                            return OriginalHook(CreatureMotif);
-                        }
-
-                        // WeaponMotif
-
-                        if (WeaponMotif.LevelChecked() &&
-                            !HasEffect(Buffs.HammerTime) &&
-                            !gauge.WeaponMotifDrawn &&
-                            (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
-                        {
-                            return OriginalHook(WeaponMotif);
-                        }
+                        return OriginalHook(LandscapeMotif);
                     }
 
+                    // CreatureMotif
 
-                    if (All.LucidDreaming.LevelChecked() && ActionReady(All.LucidDreaming) && CanSpellWeave() && LocalPlayer.CurrentMp <= 6500)
-                        return All.LucidDreaming;
+                    if (CreatureMotif.LevelChecked() &&
+                        !gauge.CreatureMotifDrawn &&
+                        (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
+                    {
+                        return OriginalHook(CreatureMotif);
+                    }
 
-                    if (BlizzardIIinCyan.LevelChecked() && HasEffect(Buffs.SubtractivePalette))
-                        return OriginalHook(BlizzardinCyan);
+                    // WeaponMotif
+
+                    if (WeaponMotif.LevelChecked() &&
+                        !HasEffect(Buffs.HammerTime) &&
+                        !gauge.WeaponMotifDrawn &&
+                        (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
+                    {
+                        return OriginalHook(WeaponMotif);
+                    }
                 }
+
+
+                if (All.LucidDreaming.LevelChecked() && ActionReady(All.LucidDreaming) && CanSpellWeave() && LocalPlayer.CurrentMp <= 6500)
+                    return All.LucidDreaming;
+
+                if (BlizzardIIinCyan.LevelChecked() && HasEffect(Buffs.SubtractivePalette))
+                    return OriginalHook(BlizzardinCyan);
 
                 return actionID;
             }
@@ -315,51 +314,51 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is FireInRed)
+                if (actionID is not FireInRed) return actionID;
+
+                PCTGauge gauge = GetJobGauge<PCTGauge>();
+                bool canWeave = CanSpellWeave() || CanSpellWeave();
+                int creatureStop = PluginConfiguration.GetCustomIntValue(Config.PCT_ST_CreatureStop);
+                int landscapeStop = PluginConfiguration.GetCustomIntValue(Config.PCT_ST_LandscapeStop);
+                int weaponStop = PluginConfiguration.GetCustomIntValue(Config.PCT_ST_WeaponStop);
+
+                // Variant Cure
+                if (IsEnabled(CustomComboPreset.PCT_Variant_Cure) &&
+                    IsEnabled(Variant.VariantCure) &&
+                    PlayerHealthPercentageHp() <= GetOptionValue(Config.PCT_VariantCure))
+                    return Variant.VariantCure;
+
+                // Variant Rampart
+                if (IsEnabled(CustomComboPreset.PCT_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart) &&
+                    canWeave)
+                    return Variant.VariantRampart;
+
+                // Prepull logic
+                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_PrePullMotifs))
                 {
-                    PCTGauge gauge = GetJobGauge<PCTGauge>();
-                    bool canWeave = CanSpellWeave() || CanSpellWeave();
-                    int creatureStop = PluginConfiguration.GetCustomIntValue(Config.PCT_ST_CreatureStop);
-                    int landscapeStop = PluginConfiguration.GetCustomIntValue(Config.PCT_ST_LandscapeStop);
-                    int weaponStop = PluginConfiguration.GetCustomIntValue(Config.PCT_ST_WeaponStop);
-
-                    // Variant Cure
-                    if (IsEnabled(CustomComboPreset.PCT_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= GetOptionValue(Config.PCT_VariantCure))
-                        return Variant.VariantCure;
-
-                    // Variant Rampart
-                    if (IsEnabled(CustomComboPreset.PCT_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        canWeave)
-                        return Variant.VariantRampart;
-
-                    // Prepull logic
-                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_PrePullMotifs))
+                    if (!InCombat() || (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_NoTargetMotifs) && InCombat() && CurrentTarget == null))
                     {
-                        if (!InCombat() || (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_NoTargetMotifs) && InCombat() && CurrentTarget == null))
-                        {
-                            if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
-                                return OriginalHook(CreatureMotif);
-                            if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
-                                return OriginalHook(WeaponMotif);
-                            if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && !HasEffect(Buffs.StarryMuse))
-                                return OriginalHook(LandscapeMotif);
-                        }
+                        if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
+                            return OriginalHook(CreatureMotif);
+                        if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
+                            return OriginalHook(WeaponMotif);
+                        if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && !HasEffect(Buffs.StarryMuse))
+                            return OriginalHook(LandscapeMotif);
                     }
+                }
 
-                    // Check if Openers are enabled and determine which opener to execute based on current level
-                    if (IsEnabled(CustomComboPreset.PCT_ST_Advanced_Openers))
+                // Check if Openers are enabled and determine which opener to execute based on current level
+                if (IsEnabled(CustomComboPreset.PCT_ST_Advanced_Openers))
+                {
+                    // Lvl 100 Opener
+                    if (StarPrism.LevelChecked())
                     {
-                        // Lvl 100 Opener
-                        if (StarPrism.LevelChecked())
-                        {
-                            if (Opener().FullOpener(ref actionID))
-                                return actionID;
-                        }
-                        /* Lvl 92 Opener
+                        if (Opener().FullOpener(ref actionID))
+                            return actionID;
+                    }
+                    /* Lvl 92 Opener
                         else if (!StarPrism.LevelChecked() && RainbowDrip.LevelChecked())
                         {
                             if (PCTOpenerLvl92.DoFullOpener(ref actionID))
@@ -384,212 +383,211 @@ namespace WrathCombo.Combos.PvE
                                 return actionID;
                         }
                         */
+                }
+
+                // General Weaves
+                if (InCombat() && canWeave)
+                {
+                    // ScenicMuse
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_ScenicMuse))
+                    {
+                        if (ScenicMuse.LevelChecked() &&
+                            gauge.LandscapeMotifDrawn &&
+                            gauge.WeaponMotifDrawn &&
+                            IsOffCooldown(ScenicMuse))
+                        {
+                            return OriginalHook(ScenicMuse);
+                        }
                     }
 
-                    // General Weaves
-                    if (InCombat() && canWeave)
+                    // LivingMuse
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LivingMuse))
                     {
-                        // ScenicMuse
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_ScenicMuse))
+                        if (LivingMuse.LevelChecked() &&
+                            gauge.CreatureMotifDrawn &&
+                            (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
+                             GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)))
                         {
-                            if (ScenicMuse.LevelChecked() &&
-                                gauge.LandscapeMotifDrawn &&
-                                gauge.WeaponMotifDrawn &&
-                                IsOffCooldown(ScenicMuse))
+                            if (HasCharges(OriginalHook(LivingMuse)))
                             {
-                                return OriginalHook(ScenicMuse);
-                            }
-                        }
-
-                        // LivingMuse
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LivingMuse))
-                        {
-                            if (LivingMuse.LevelChecked() &&
-                                gauge.CreatureMotifDrawn &&
-                                (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
-                                GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)))
-                            {
-                                if (HasCharges(OriginalHook(LivingMuse)))
+                                if (!ScenicMuse.LevelChecked() ||
+                                    GetCooldown(ScenicMuse).CooldownRemaining > GetCooldownChargeRemainingTime(LivingMuse))
                                 {
-                                    if (!ScenicMuse.LevelChecked() ||
-                                        GetCooldown(ScenicMuse).CooldownRemaining > GetCooldownChargeRemainingTime(LivingMuse))
-                                    {
-                                        return OriginalHook(LivingMuse);
-                                    }
-                                }
-                            }
-                        }
-
-                        // SteelMuse
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SteelMuse))
-                        {
-                            if (SteelMuse.LevelChecked() &&
-                                !HasEffect(Buffs.HammerTime) &&
-                                gauge.WeaponMotifDrawn &&
-                                HasCharges(OriginalHook(SteelMuse)) &&
-                                (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining ||
-                                 GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
-                                 !ScenicMuse.LevelChecked()))
-                            {
-                                return OriginalHook(SteelMuse);
-                            }
-                        }
-
-                        // MogoftheAges
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MogOfTheAges))
-                        {
-                            if (MogoftheAges.LevelChecked() &&
-                                (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) &&
-                                IsOffCooldown(OriginalHook(MogoftheAges)) &&
-                                (GetCooldownRemainingTime(StarryMuse) >= 60 || !ScenicMuse.LevelChecked()))
-                            {
-                                return OriginalHook(MogoftheAges);
-                            }
-                        }
-
-                        // SubtractivePalette
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SubtractivePalette))
-                        {
-                            if (SubtractivePalette.LevelChecked() &&
-                                !HasEffect(Buffs.SubtractivePalette) &&
-                                !HasEffect(Buffs.MonochromeTones))
-                            {
-                                if (HasEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
-                                {
-                                    return SubtractivePalette;
+                                    return OriginalHook(LivingMuse);
                                 }
                             }
                         }
                     }
 
-                    // Swiftcast Motifs
-                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SwiftMotifs) &&
-                        HasEffect(All.Buffs.Swiftcast))
+                    // SteelMuse
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SteelMuse))
                     {
-                        if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse) && GetTargetHPPercent() > creatureStop)
-                            return OriginalHook(CreatureMotif);
-                        if (!gauge.WeaponMotifDrawn && WeaponMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse) && GetTargetHPPercent() > weaponStop)
-                            return OriginalHook(WeaponMotif);
-                        if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse) && GetTargetHPPercent() > landscapeStop)
-                            return OriginalHook(LandscapeMotif);
-
-                    }
-
-                    // IsMoving logic
-                    if (IsMoving() && InCombat())
-                    {
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HammerStampCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
-                            return OriginalHook(HammerStamp);
-
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_CometinBlack) && CometinBlack.LevelChecked() && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
-                            return OriginalHook(CometinBlack);
-
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_RainbowDrip))
+                        if (SteelMuse.LevelChecked() &&
+                            !HasEffect(Buffs.HammerTime) &&
+                            gauge.WeaponMotifDrawn &&
+                            HasCharges(OriginalHook(SteelMuse)) &&
+                            (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining ||
+                             GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
+                             !ScenicMuse.LevelChecked()))
                         {
-                            if (HasEffect(Buffs.RainbowBright) || HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) <= 3f)
-                                return RainbowDrip;
+                            return OriginalHook(SteelMuse);
                         }
-
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HolyInWhite) && HolyInWhite.LevelChecked() && gauge.Paint >= 1)
-                            return OriginalHook(HolyInWhite);
-
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SwitfcastOption) && ActionReady(All.Swiftcast) &&
-                            ((LevelChecked(CreatureMotif) && !gauge.CreatureMotifDrawn) ||
-                             (LevelChecked(WeaponMotif) && !gauge.WeaponMotifDrawn) ||
-                             (LevelChecked(LandscapeMotif) && !gauge.LandscapeMotifDrawn)))
-                            return All.Swiftcast;
                     }
 
-                    //Prepare for Burst
-                    if (GetCooldownRemainingTime(ScenicMuse) <= 20)
+                    // MogoftheAges
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MogOfTheAges))
                     {
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif) && LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetTargetHPPercent() > landscapeStop)
-                            return OriginalHook(LandscapeMotif);
-
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif) && CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && GetTargetHPPercent() > creatureStop)
-                            return OriginalHook(CreatureMotif);
-
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif) && WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime) && GetTargetHPPercent() > weaponStop)
-                            return OriginalHook(WeaponMotif);
+                        if (MogoftheAges.LevelChecked() &&
+                            (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) &&
+                            IsOffCooldown(OriginalHook(MogoftheAges)) &&
+                            (GetCooldownRemainingTime(StarryMuse) >= 60 || !ScenicMuse.LevelChecked()))
+                        {
+                            return OriginalHook(MogoftheAges);
+                        }
                     }
 
-                    // Burst 
-                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_Phase) && HasEffect(Buffs.StarryMuse))
+                    // SubtractivePalette
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SubtractivePalette))
                     {
-
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_CometInBlack) && CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
-                            return CometinBlack;
-
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_HammerCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.Starstruck))
-                            return OriginalHook(HammerStamp);
-
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_StarPrism))
+                        if (SubtractivePalette.LevelChecked() &&
+                            !HasEffect(Buffs.SubtractivePalette) &&
+                            !HasEffect(Buffs.MonochromeTones))
                         {
-                            if (HasEffect(Buffs.Starstruck) || HasEffect(Buffs.Starstruck) && GetBuffRemainingTime(Buffs.Starstruck) <= 3f)
-                                return StarPrism;
+                            if (HasEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
+                            {
+                                return SubtractivePalette;
+                            }
                         }
-
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_RainbowDrip))
-                        {
-                            if (HasEffect(Buffs.RainbowBright) || HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) <= 3f)
-                                return RainbowDrip;
-                        }
-
                     }
+                }
 
-                    if (HasEffect(Buffs.RainbowBright) && !HasEffect(Buffs.StarryMuse))
-                        return RainbowDrip;
+                // Swiftcast Motifs
+                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SwiftMotifs) &&
+                    HasEffect(All.Buffs.Swiftcast))
+                {
+                    if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse) && GetTargetHPPercent() > creatureStop)
+                        return OriginalHook(CreatureMotif);
+                    if (!gauge.WeaponMotifDrawn && WeaponMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse) && GetTargetHPPercent() > weaponStop)
+                        return OriginalHook(WeaponMotif);
+                    if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse) && GetTargetHPPercent() > landscapeStop)
+                        return OriginalHook(LandscapeMotif);
 
-                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CometinBlack) && CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(StarryMuse) > 30f)
-                        return OriginalHook(CometinBlack);
+                }
 
-                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_HammerStampCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
+                // IsMoving logic
+                if (IsMoving() && InCombat())
+                {
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HammerStampCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
                         return OriginalHook(HammerStamp);
 
-                    if (!HasEffect(Buffs.StarryMuse))
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_CometinBlack) && CometinBlack.LevelChecked() && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
+                        return OriginalHook(CometinBlack);
+
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_RainbowDrip))
                     {
-                        // LandscapeMotif
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif) && GetTargetHPPercent() > landscapeStop)
-                        {
-                            if (LandscapeMotif.LevelChecked() &&
-                                !gauge.LandscapeMotifDrawn &&
-                                GetCooldownRemainingTime(ScenicMuse) <= 20)
-                            {
-                                return OriginalHook(LandscapeMotif);
-                            }
-                        }
+                        if (HasEffect(Buffs.RainbowBright) || HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) <= 3f)
+                            return RainbowDrip;
+                    }
 
-                        // CreatureMotif
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif) && GetTargetHPPercent() > creatureStop)
-                        {
-                            if (CreatureMotif.LevelChecked() &&
-                                !gauge.CreatureMotifDrawn &&
-                                (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
-                            {
-                                return OriginalHook(CreatureMotif);
-                            }
-                        }
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HolyInWhite) && HolyInWhite.LevelChecked() && gauge.Paint >= 1)
+                        return OriginalHook(HolyInWhite);
 
-                        // WeaponMotif
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif) && GetTargetHPPercent() > weaponStop)
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SwitfcastOption) && ActionReady(All.Swiftcast) &&
+                        ((LevelChecked(CreatureMotif) && !gauge.CreatureMotifDrawn) ||
+                         (LevelChecked(WeaponMotif) && !gauge.WeaponMotifDrawn) ||
+                         (LevelChecked(LandscapeMotif) && !gauge.LandscapeMotifDrawn)))
+                        return All.Swiftcast;
+                }
+
+                //Prepare for Burst
+                if (GetCooldownRemainingTime(ScenicMuse) <= 20)
+                {
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif) && LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetTargetHPPercent() > landscapeStop)
+                        return OriginalHook(LandscapeMotif);
+
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif) && CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && GetTargetHPPercent() > creatureStop)
+                        return OriginalHook(CreatureMotif);
+
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif) && WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime) && GetTargetHPPercent() > weaponStop)
+                        return OriginalHook(WeaponMotif);
+                }
+
+                // Burst
+                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_Phase) && HasEffect(Buffs.StarryMuse))
+                {
+
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_CometInBlack) && CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
+                        return CometinBlack;
+
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_HammerCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.Starstruck))
+                        return OriginalHook(HammerStamp);
+
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_StarPrism))
+                    {
+                        if (HasEffect(Buffs.Starstruck) || HasEffect(Buffs.Starstruck) && GetBuffRemainingTime(Buffs.Starstruck) <= 3f)
+                            return StarPrism;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_RainbowDrip))
+                    {
+                        if (HasEffect(Buffs.RainbowBright) || HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) <= 3f)
+                            return RainbowDrip;
+                    }
+
+                }
+
+                if (HasEffect(Buffs.RainbowBright) && !HasEffect(Buffs.StarryMuse))
+                    return RainbowDrip;
+
+                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CometinBlack) && CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(StarryMuse) > 30f)
+                    return OriginalHook(CometinBlack);
+
+                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_HammerStampCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
+                    return OriginalHook(HammerStamp);
+
+                if (!HasEffect(Buffs.StarryMuse))
+                {
+                    // LandscapeMotif
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif) && GetTargetHPPercent() > landscapeStop)
+                    {
+                        if (LandscapeMotif.LevelChecked() &&
+                            !gauge.LandscapeMotifDrawn &&
+                            GetCooldownRemainingTime(ScenicMuse) <= 20)
                         {
-                            if (WeaponMotif.LevelChecked() &&
-                                !HasEffect(Buffs.HammerTime) &&
-                                !gauge.WeaponMotifDrawn &&
-                                (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
-                            {
-                                return OriginalHook(WeaponMotif);
-                            }
+                            return OriginalHook(LandscapeMotif);
                         }
                     }
 
+                    // CreatureMotif
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif) && GetTargetHPPercent() > creatureStop)
+                    {
+                        if (CreatureMotif.LevelChecked() &&
+                            !gauge.CreatureMotifDrawn &&
+                            (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
+                        {
+                            return OriginalHook(CreatureMotif);
+                        }
+                    }
 
-                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LucidDreaming) && All.LucidDreaming.LevelChecked() && ActionReady(All.LucidDreaming) && CanSpellWeave() && LocalPlayer.CurrentMp <= Config.PCT_ST_AdvancedMode_LucidOption)
-                        return All.LucidDreaming;
-
-                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_BlizzardInCyan) && BlizzardIIinCyan.LevelChecked() && HasEffect(Buffs.SubtractivePalette))
-                        return OriginalHook(BlizzardinCyan);
+                    // WeaponMotif
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif) && GetTargetHPPercent() > weaponStop)
+                    {
+                        if (WeaponMotif.LevelChecked() &&
+                            !HasEffect(Buffs.HammerTime) &&
+                            !gauge.WeaponMotifDrawn &&
+                            (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
+                        {
+                            return OriginalHook(WeaponMotif);
+                        }
+                    }
                 }
+
+
+                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LucidDreaming) && All.LucidDreaming.LevelChecked() && ActionReady(All.LucidDreaming) && CanSpellWeave() && LocalPlayer.CurrentMp <= Config.PCT_ST_AdvancedMode_LucidOption)
+                    return All.LucidDreaming;
+
+                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_BlizzardInCyan) && BlizzardIIinCyan.LevelChecked() && HasEffect(Buffs.SubtractivePalette))
+                    return OriginalHook(BlizzardinCyan);
 
                 return actionID;
             }
@@ -601,199 +599,198 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is FireIIinRed)
+                if (actionID is not FireIIinRed) return actionID;
+
+                var gauge = GetJobGauge<PCTGauge>();
+                bool canWeave = CanSpellWeave();
+
+                // Variant Cure
+                if (IsEnabled(CustomComboPreset.PCT_Variant_Cure) &&
+                    IsEnabled(Variant.VariantCure) &&
+                    PlayerHealthPercentageHp() <= GetOptionValue(Config.PCT_VariantCure))
+                    return Variant.VariantCure;
+
+                // Variant Rampart
+                if (IsEnabled(CustomComboPreset.PCT_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart) &&
+                    canWeave)
+                    return Variant.VariantRampart;
+
+                // Prepull logic
+
+
+                if (!InCombat() || InCombat() && CurrentTarget == null)
                 {
-                    var gauge = GetJobGauge<PCTGauge>();
-                    bool canWeave = CanSpellWeave();
-
-                    // Variant Cure
-                    if (IsEnabled(CustomComboPreset.PCT_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= GetOptionValue(Config.PCT_VariantCure))
-                        return Variant.VariantCure;
-
-                    // Variant Rampart
-                    if (IsEnabled(CustomComboPreset.PCT_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        canWeave)
-                        return Variant.VariantRampart;
-
-                    // Prepull logic
+                    if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
+                        return OriginalHook(CreatureMotif);
+                    if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
+                        return OriginalHook(WeaponMotif);
+                    if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && !HasEffect(Buffs.StarryMuse))
+                        return OriginalHook(LandscapeMotif);
+                }
 
 
-                    if (!InCombat() || InCombat() && CurrentTarget == null)
+                // General Weaves
+                if (InCombat() && canWeave)
+                {
+                    // LivingMuse
+
+                    if (LivingMuse.LevelChecked() &&
+                        gauge.CreatureMotifDrawn &&
+                        (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
+                         GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)))
                     {
-                        if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
-                            return OriginalHook(CreatureMotif);
-                        if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
-                            return OriginalHook(WeaponMotif);
-                        if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && !HasEffect(Buffs.StarryMuse))
-                            return OriginalHook(LandscapeMotif);
-                    }
-
-
-                    // General Weaves
-                    if (InCombat() && canWeave)
-                    {
-                        // LivingMuse
-
-                        if (LivingMuse.LevelChecked() &&
-                            gauge.CreatureMotifDrawn &&
-                            (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
-                            GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)))
+                        if (HasCharges(OriginalHook(LivingMuse)))
                         {
-                            if (HasCharges(OriginalHook(LivingMuse)))
+                            if (!ScenicMuse.LevelChecked() ||
+                                GetCooldown(ScenicMuse).CooldownRemaining > GetCooldownChargeRemainingTime(LivingMuse))
                             {
-                                if (!ScenicMuse.LevelChecked() ||
-                                    GetCooldown(ScenicMuse).CooldownRemaining > GetCooldownChargeRemainingTime(LivingMuse))
-                                {
-                                    return OriginalHook(LivingMuse);
-                                }
+                                return OriginalHook(LivingMuse);
                             }
                         }
-
-                        // ScenicMuse
-
-                        if (ScenicMuse.LevelChecked() &&
-                            gauge.LandscapeMotifDrawn &&
-                            gauge.WeaponMotifDrawn &&
-                            IsOffCooldown(ScenicMuse))
-                        {
-                            return OriginalHook(ScenicMuse);
-                        }
-
-                        // SteelMuse
-
-                        if (SteelMuse.LevelChecked() &&
-                            !HasEffect(Buffs.HammerTime) &&
-                            gauge.WeaponMotifDrawn &&
-                            HasCharges(OriginalHook(SteelMuse)) &&
-                            (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining ||
-                                GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
-                                !ScenicMuse.LevelChecked()))
-                        {
-                            return OriginalHook(SteelMuse);
-                        }
-
-                        // MogoftheAges
-
-                        if (MogoftheAges.LevelChecked() &&
-                            (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) &&
-                            (IsOffCooldown(OriginalHook(MogoftheAges)) || !ScenicMuse.LevelChecked()))
-                        {
-                            return OriginalHook(MogoftheAges);
-                        }
-
-                        if (IsMoving() &&
-                            IsOffCooldown(All.Swiftcast) &&
-                            All.Swiftcast.LevelChecked() &&
-                            !HasEffect(Buffs.HammerTime) &&
-                            gauge.Paint < 1 &&
-                            (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
-                        {
-                            return All.Swiftcast;
-                        }
-
-                        // Subtractive Palette
-                        if (SubtractivePalette.LevelChecked() &&
-                            !HasEffect(Buffs.SubtractivePalette) &&
-                            !HasEffect(Buffs.MonochromeTones))
-                        {
-                            if (HasEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
-                                return SubtractivePalette;
-                        }
                     }
 
-                    if (HasEffect(All.Buffs.Swiftcast))
+                    // ScenicMuse
+
+                    if (ScenicMuse.LevelChecked() &&
+                        gauge.LandscapeMotifDrawn &&
+                        gauge.WeaponMotifDrawn &&
+                        IsOffCooldown(ScenicMuse))
                     {
-                        if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
-                            return OriginalHook(CreatureMotif);
-                        if (!gauge.WeaponMotifDrawn && HammerMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse))
-                            return OriginalHook(HammerMotif);
-                        if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
-                            return OriginalHook(LandscapeMotif);
+                        return OriginalHook(ScenicMuse);
                     }
 
-                    if (IsMoving() && InCombat())
+                    // SteelMuse
+
+                    if (SteelMuse.LevelChecked() &&
+                        !HasEffect(Buffs.HammerTime) &&
+                        gauge.WeaponMotifDrawn &&
+                        HasCharges(OriginalHook(SteelMuse)) &&
+                        (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining ||
+                         GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
+                         !ScenicMuse.LevelChecked()))
                     {
-                        if (HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
-                            return OriginalHook(HammerStamp);
-
-                        if (CometinBlack.LevelChecked() && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
-                            return OriginalHook(CometinBlack);
-
-                        if (HasEffect(Buffs.RainbowBright) || (HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) < 3))
-                            return RainbowDrip;
-
-                        if (HolyInWhite.LevelChecked() && gauge.Paint >= 1)
-                            return OriginalHook(HolyInWhite);
-
+                        return OriginalHook(SteelMuse);
                     }
 
-                    //Prepare for Burst
-                    if (GetCooldownRemainingTime(ScenicMuse) <= 20)
+                    // MogoftheAges
+
+                    if (MogoftheAges.LevelChecked() &&
+                        (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) &&
+                        (IsOffCooldown(OriginalHook(MogoftheAges)) || !ScenicMuse.LevelChecked()))
                     {
-                        if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn)
-                            return OriginalHook(LandscapeMotif);
-
-                        if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
-                            return OriginalHook(CreatureMotif);
-
-                        if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
-                            return OriginalHook(WeaponMotif);
+                        return OriginalHook(MogoftheAges);
                     }
 
-                    // Burst 
-                    if (HasEffect(Buffs.StarryMuse))
+                    if (IsMoving() &&
+                        IsOffCooldown(All.Swiftcast) &&
+                        All.Swiftcast.LevelChecked() &&
+                        !HasEffect(Buffs.HammerTime) &&
+                        gauge.Paint < 1 &&
+                        (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
                     {
-                        // Check for CometInBlack
-                        if (CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
-                            return CometinBlack;
-
-                        // Check for HammerTime 
-                        if (HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.Starstruck))
-                            return OriginalHook(HammerStamp);
-
-                        // Check for Starstruck
-                        if (HasEffect(Buffs.Starstruck) || (HasEffect(Buffs.Starstruck) && GetBuffRemainingTime(Buffs.Starstruck) < 3))
-                            return StarPrism;
-
-                        // Check for RainbowBright
-                        if (HasEffect(Buffs.RainbowBright) || (HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) < 3))
-                            return RainbowDrip;
+                        return All.Swiftcast;
                     }
 
-                    if (HasEffect(Buffs.RainbowBright) && !HasEffect(Buffs.StarryMuse))
-                        return RainbowDrip;
+                    // Subtractive Palette
+                    if (SubtractivePalette.LevelChecked() &&
+                        !HasEffect(Buffs.SubtractivePalette) &&
+                        !HasEffect(Buffs.MonochromeTones))
+                    {
+                        if (HasEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
+                            return SubtractivePalette;
+                    }
+                }
 
-                    if (CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(StarryMuse) > 60)
-                        return OriginalHook(CometinBlack);
+                if (HasEffect(All.Buffs.Swiftcast))
+                {
+                    if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
+                        return OriginalHook(CreatureMotif);
+                    if (!gauge.WeaponMotifDrawn && HammerMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse))
+                        return OriginalHook(HammerMotif);
+                    if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
+                        return OriginalHook(LandscapeMotif);
+                }
 
+                if (IsMoving() && InCombat())
+                {
                     if (HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
                         return OriginalHook(HammerStamp);
 
-                    if (!HasEffect(Buffs.StarryMuse))
-                    {
-                        if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetCooldownRemainingTime(ScenicMuse) <= 20)
-                            return OriginalHook(LandscapeMotif);
+                    if (CometinBlack.LevelChecked() && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
+                        return OriginalHook(CometinBlack);
 
-                        if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
-                            return OriginalHook(CreatureMotif);
+                    if (HasEffect(Buffs.RainbowBright) || (HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) < 3))
+                        return RainbowDrip;
 
-                        if (WeaponMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !gauge.WeaponMotifDrawn && (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
-                            return OriginalHook(WeaponMotif);
-                    }
-                    //Saves one Charge of White paint for movement/Black paint.
-                    if (HolyInWhite.LevelChecked() && gauge.Paint >= 2)
+                    if (HolyInWhite.LevelChecked() && gauge.Paint >= 1)
                         return OriginalHook(HolyInWhite);
 
-                    if (All.LucidDreaming.LevelChecked() && ActionReady(All.LucidDreaming) && CanSpellWeave() && LocalPlayer.CurrentMp <= 6500)
-                        return All.LucidDreaming;
-
-                    if (BlizzardIIinCyan.LevelChecked() && HasEffect(Buffs.SubtractivePalette))
-                        return OriginalHook(BlizzardIIinCyan);
                 }
+
+                //Prepare for Burst
+                if (GetCooldownRemainingTime(ScenicMuse) <= 20)
+                {
+                    if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn)
+                        return OriginalHook(LandscapeMotif);
+
+                    if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
+                        return OriginalHook(CreatureMotif);
+
+                    if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
+                        return OriginalHook(WeaponMotif);
+                }
+
+                // Burst
+                if (HasEffect(Buffs.StarryMuse))
+                {
+                    // Check for CometInBlack
+                    if (CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
+                        return CometinBlack;
+
+                    // Check for HammerTime
+                    if (HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.Starstruck))
+                        return OriginalHook(HammerStamp);
+
+                    // Check for Starstruck
+                    if (HasEffect(Buffs.Starstruck) || (HasEffect(Buffs.Starstruck) && GetBuffRemainingTime(Buffs.Starstruck) < 3))
+                        return StarPrism;
+
+                    // Check for RainbowBright
+                    if (HasEffect(Buffs.RainbowBright) || (HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) < 3))
+                        return RainbowDrip;
+                }
+
+                if (HasEffect(Buffs.RainbowBright) && !HasEffect(Buffs.StarryMuse))
+                    return RainbowDrip;
+
+                if (CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(StarryMuse) > 60)
+                    return OriginalHook(CometinBlack);
+
+                if (HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
+                    return OriginalHook(HammerStamp);
+
+                if (!HasEffect(Buffs.StarryMuse))
+                {
+                    if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetCooldownRemainingTime(ScenicMuse) <= 20)
+                        return OriginalHook(LandscapeMotif);
+
+                    if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
+                        return OriginalHook(CreatureMotif);
+
+                    if (WeaponMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !gauge.WeaponMotifDrawn && (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
+                        return OriginalHook(WeaponMotif);
+                }
+                //Saves one Charge of White paint for movement/Black paint.
+                if (HolyInWhite.LevelChecked() && gauge.Paint >= 2)
+                    return OriginalHook(HolyInWhite);
+
+                if (All.LucidDreaming.LevelChecked() && ActionReady(All.LucidDreaming) && CanSpellWeave() && LocalPlayer.CurrentMp <= 6500)
+                    return All.LucidDreaming;
+
+                if (BlizzardIIinCyan.LevelChecked() && HasEffect(Buffs.SubtractivePalette))
+                    return OriginalHook(BlizzardIIinCyan);
                 return actionID;
             }
         }
@@ -804,233 +801,231 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is FireIIinRed)
+                if (actionID is not FireIIinRed) return actionID;
+
+                var gauge = GetJobGauge<PCTGauge>();
+                bool canWeave = CanSpellWeave();
+                int creatureStop = PluginConfiguration.GetCustomIntValue(Config.PCT_AoE_CreatureStop);
+                int landscapeStop = PluginConfiguration.GetCustomIntValue(Config.PCT_AoE_LandscapeStop);
+                int weaponStop = PluginConfiguration.GetCustomIntValue(Config.PCT_AoE_WeaponStop);
+
+                // Variant Cure
+                if (IsEnabled(CustomComboPreset.PCT_Variant_Cure) &&
+                    IsEnabled(Variant.VariantCure) &&
+                    PlayerHealthPercentageHp() <= GetOptionValue(Config.PCT_VariantCure))
+                    return Variant.VariantCure;
+
+                // Variant Rampart
+                if (IsEnabled(CustomComboPreset.PCT_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart) &&
+                    canWeave)
+                    return Variant.VariantRampart;
+
+                // Prepull logic
+                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_PrePullMotifs))
                 {
-                    var gauge = GetJobGauge<PCTGauge>();
-                    bool canWeave = CanSpellWeave();
-                    int creatureStop = PluginConfiguration.GetCustomIntValue(Config.PCT_AoE_CreatureStop);
-                    int landscapeStop = PluginConfiguration.GetCustomIntValue(Config.PCT_AoE_LandscapeStop);
-                    int weaponStop = PluginConfiguration.GetCustomIntValue(Config.PCT_AoE_WeaponStop);
-
-                    // Variant Cure
-                    if (IsEnabled(CustomComboPreset.PCT_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= GetOptionValue(Config.PCT_VariantCure))
-                        return Variant.VariantCure;
-
-                    // Variant Rampart
-                    if (IsEnabled(CustomComboPreset.PCT_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        canWeave)
-                        return Variant.VariantRampart;
-
-                    // Prepull logic
-                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_PrePullMotifs))
+                    if (!InCombat() || (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_NoTargetMotifs) && InCombat() && CurrentTarget == null))
                     {
-                        if (!InCombat() || (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_NoTargetMotifs) && InCombat() && CurrentTarget == null))
-                        {
-                            if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
-                                return OriginalHook(CreatureMotif);
-                            if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
-                                return OriginalHook(WeaponMotif);
-                            if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && !HasEffect(Buffs.StarryMuse))
-                                return OriginalHook(LandscapeMotif);
-                        }
+                        if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
+                            return OriginalHook(CreatureMotif);
+                        if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
+                            return OriginalHook(WeaponMotif);
+                        if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && !HasEffect(Buffs.StarryMuse))
+                            return OriginalHook(LandscapeMotif);
                     }
+                }
 
-                    // General Weaves
-                    if (InCombat() && canWeave)
+                // General Weaves
+                if (InCombat() && canWeave)
+                {
+                    // LivingMuse
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LivingMuse))
                     {
-                        // LivingMuse
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LivingMuse))
+                        if (LivingMuse.LevelChecked() &&
+                            gauge.CreatureMotifDrawn &&
+                            (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
+                             GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)))
                         {
-                            if (LivingMuse.LevelChecked() &&
-                                gauge.CreatureMotifDrawn &&
-                                (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
-                                GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)))
+                            if (HasCharges(OriginalHook(LivingMuse)))
                             {
-                                if (HasCharges(OriginalHook(LivingMuse)))
+                                if (!ScenicMuse.LevelChecked() ||
+                                    GetCooldown(ScenicMuse).CooldownRemaining > GetCooldownChargeRemainingTime(LivingMuse))
                                 {
-                                    if (!ScenicMuse.LevelChecked() ||
-                                        GetCooldown(ScenicMuse).CooldownRemaining > GetCooldownChargeRemainingTime(LivingMuse))
-                                    {
-                                        return OriginalHook(LivingMuse);
-                                    }
+                                    return OriginalHook(LivingMuse);
                                 }
                             }
                         }
-
-                        // ScenicMuse
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_ScenicMuse))
-                        {
-                            if (ScenicMuse.LevelChecked() &&
-                                gauge.LandscapeMotifDrawn &&
-                                gauge.WeaponMotifDrawn &&
-                                IsOffCooldown(ScenicMuse))
-                            {
-                                return OriginalHook(ScenicMuse);
-                            }
-                        }
-
-                        // SteelMuse
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SteelMuse))
-                        {
-                            if (SteelMuse.LevelChecked() &&
-                                !HasEffect(Buffs.HammerTime) &&
-                                gauge.WeaponMotifDrawn &&
-                                HasCharges(OriginalHook(SteelMuse)) &&
-                                (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining ||
-                                 GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
-                                 !ScenicMuse.LevelChecked()))
-                            {
-                                return OriginalHook(SteelMuse);
-                            }
-                        }
-
-                        // MogoftheAges
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MogOfTheAges))
-                        {
-                            if (MogoftheAges.LevelChecked() &&
-                                (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) &&
-                                (IsOffCooldown(OriginalHook(MogoftheAges)) || !ScenicMuse.LevelChecked()))
-                            {
-                                return OriginalHook(MogoftheAges);
-                            }
-                        }
-
-
-                        // Subtractive Palette
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SubtractivePalette) &&
-                            SubtractivePalette.LevelChecked() &&
-                            !HasEffect(Buffs.SubtractivePalette) &&
-                            !HasEffect(Buffs.MonochromeTones))
-                        {
-                            if (HasEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
-                                return SubtractivePalette;
-                        }
                     }
 
-
-                    if (HasEffect(All.Buffs.Swiftcast))
+                    // ScenicMuse
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_ScenicMuse))
                     {
-                        if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse) && GetTargetHPPercent() > creatureStop)
-                            return OriginalHook(CreatureMotif);
-                        if (!gauge.WeaponMotifDrawn && HammerMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse) && GetTargetHPPercent() > weaponStop)
-                            return OriginalHook(HammerMotif);
-                        if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse) && GetTargetHPPercent() > landscapeStop)
-                            return OriginalHook(LandscapeMotif);
-                    }
-
-                    if (IsMoving() && InCombat())
-                    {
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HammerStampCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
-                            return OriginalHook(HammerStamp);
-
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_CometinBlack) && CometinBlack.LevelChecked() && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
-                            return OriginalHook(CometinBlack);
-
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_RainbowDrip))
+                        if (ScenicMuse.LevelChecked() &&
+                            gauge.LandscapeMotifDrawn &&
+                            gauge.WeaponMotifDrawn &&
+                            IsOffCooldown(ScenicMuse))
                         {
-                            if (HasEffect(Buffs.RainbowBright) || (HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) < 3))
-                                return RainbowDrip;
-                        }
-
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HolyInWhite) && HolyInWhite.LevelChecked() && gauge.Paint >= 1)
-                            return OriginalHook(HolyInWhite);
-
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SwitfcastOption) && ActionReady(All.Swiftcast) &&
-                            ((LevelChecked(CreatureMotif) && !gauge.CreatureMotifDrawn) ||
-                             (LevelChecked(WeaponMotif) && !gauge.WeaponMotifDrawn) ||
-                             (LevelChecked(LandscapeMotif) && !gauge.LandscapeMotifDrawn)))
-                            return All.Swiftcast;
-                    }
-
-                    //Prepare for Burst
-                    if (GetCooldownRemainingTime(ScenicMuse) <= 20)
-                    {
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LandscapeMotif) && LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetTargetHPPercent() > landscapeStop)
-                            return OriginalHook(LandscapeMotif);
-
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CreatureMotif) && CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && GetTargetHPPercent() > creatureStop)
-                            return OriginalHook(CreatureMotif);
-
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_WeaponMotif) && WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime) && GetTargetHPPercent() > weaponStop)
-                            return OriginalHook(WeaponMotif);
-                    }
-
-                    // Burst 
-                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_Phase) && HasEffect(Buffs.StarryMuse))
-                    {
-                        // Check for CometInBlack
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_CometInBlack) && CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
-                            return CometinBlack;
-
-                        // Check for HammerTime 
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_HammerCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.Starstruck))
-                            return OriginalHook(HammerStamp);
-
-                        // Check for Starstruck
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_StarPrism))
-                        {
-                            if (HasEffect(Buffs.Starstruck) || (HasEffect(Buffs.Starstruck) && GetBuffRemainingTime(Buffs.Starstruck) < 3))
-                                return StarPrism;
-                        }
-
-                        // Check for RainbowBright
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_RainbowDrip))
-                        {
-                            if (HasEffect(Buffs.RainbowBright) || (HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) < 3))
-                                return RainbowDrip;
+                            return OriginalHook(ScenicMuse);
                         }
                     }
 
-                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_HolyinWhite) && !HasEffect(Buffs.StarryMuse) && !HasEffect(Buffs.MonochromeTones))
+                    // SteelMuse
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SteelMuse))
                     {
-                        if (gauge.Paint > Config.PCT_AoE_AdvancedMode_HolyinWhiteOption ||
-                            (Config.PCT_AoE_AdvancedMode_HolyinWhiteOption == 5 && gauge.Paint == 5 && !HasEffect(Buffs.HammerTime) &&
-                            (HasEffect(Buffs.RainbowBright) || WasLastSpell(AeroIIinGreen) || WasLastSpell(StoneIIinYellow))))
-                            return OriginalHook(HolyInWhite);
+                        if (SteelMuse.LevelChecked() &&
+                            !HasEffect(Buffs.HammerTime) &&
+                            gauge.WeaponMotifDrawn &&
+                            HasCharges(OriginalHook(SteelMuse)) &&
+                            (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining ||
+                             GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
+                             !ScenicMuse.LevelChecked()))
+                        {
+                            return OriginalHook(SteelMuse);
+                        }
                     }
 
-                    if (HasEffect(Buffs.RainbowBright) && !HasEffect(Buffs.StarryMuse))
-                        return RainbowDrip;
+                    // MogoftheAges
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MogOfTheAges))
+                    {
+                        if (MogoftheAges.LevelChecked() &&
+                            (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) &&
+                            (IsOffCooldown(OriginalHook(MogoftheAges)) || !ScenicMuse.LevelChecked()))
+                        {
+                            return OriginalHook(MogoftheAges);
+                        }
+                    }
 
-                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CometinBlack) && CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(StarryMuse) > 60)
-                        return OriginalHook(CometinBlack);
 
-                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_HammerStampCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
+                    // Subtractive Palette
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SubtractivePalette) &&
+                        SubtractivePalette.LevelChecked() &&
+                        !HasEffect(Buffs.SubtractivePalette) &&
+                        !HasEffect(Buffs.MonochromeTones))
+                    {
+                        if (HasEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
+                            return SubtractivePalette;
+                    }
+                }
+
+
+                if (HasEffect(All.Buffs.Swiftcast))
+                {
+                    if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse) && GetTargetHPPercent() > creatureStop)
+                        return OriginalHook(CreatureMotif);
+                    if (!gauge.WeaponMotifDrawn && HammerMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse) && GetTargetHPPercent() > weaponStop)
+                        return OriginalHook(HammerMotif);
+                    if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse) && GetTargetHPPercent() > landscapeStop)
+                        return OriginalHook(LandscapeMotif);
+                }
+
+                if (IsMoving() && InCombat())
+                {
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HammerStampCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
                         return OriginalHook(HammerStamp);
 
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_CometinBlack) && CometinBlack.LevelChecked() && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
+                        return OriginalHook(CometinBlack);
 
-                    if (!HasEffect(Buffs.StarryMuse))
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_RainbowDrip))
                     {
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LandscapeMotif) && GetTargetHPPercent() > landscapeStop)
-                        {
-                            if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetCooldownRemainingTime(ScenicMuse) <= 20)
-                                return OriginalHook(LandscapeMotif);
-                        }
-
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CreatureMotif) && GetTargetHPPercent() > creatureStop)
-                        {
-                            if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
-                                return OriginalHook(CreatureMotif);
-                        }
-
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_WeaponMotif) && GetTargetHPPercent() > weaponStop)
-                        {
-                            if (WeaponMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !gauge.WeaponMotifDrawn && (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
-                                return OriginalHook(WeaponMotif);
-                        }
+                        if (HasEffect(Buffs.RainbowBright) || (HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) < 3))
+                            return RainbowDrip;
                     }
 
-                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LucidDreaming) && All.LucidDreaming.LevelChecked() && ActionReady(All.LucidDreaming) && CanSpellWeave() && LocalPlayer.CurrentMp <= Config.PCT_ST_AdvancedMode_LucidOption)
-                        return All.LucidDreaming;
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HolyInWhite) && HolyInWhite.LevelChecked() && gauge.Paint >= 1)
+                        return OriginalHook(HolyInWhite);
 
-                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_BlizzardInCyan) && BlizzardIIinCyan.LevelChecked() && HasEffect(Buffs.SubtractivePalette))
-                        return OriginalHook(BlizzardIIinCyan);
-
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SwitfcastOption) && ActionReady(All.Swiftcast) &&
+                        ((LevelChecked(CreatureMotif) && !gauge.CreatureMotifDrawn) ||
+                         (LevelChecked(WeaponMotif) && !gauge.WeaponMotifDrawn) ||
+                         (LevelChecked(LandscapeMotif) && !gauge.LandscapeMotifDrawn)))
+                        return All.Swiftcast;
                 }
+
+                //Prepare for Burst
+                if (GetCooldownRemainingTime(ScenicMuse) <= 20)
+                {
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LandscapeMotif) && LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetTargetHPPercent() > landscapeStop)
+                        return OriginalHook(LandscapeMotif);
+
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CreatureMotif) && CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && GetTargetHPPercent() > creatureStop)
+                        return OriginalHook(CreatureMotif);
+
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_WeaponMotif) && WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime) && GetTargetHPPercent() > weaponStop)
+                        return OriginalHook(WeaponMotif);
+                }
+
+                // Burst
+                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_Phase) && HasEffect(Buffs.StarryMuse))
+                {
+                    // Check for CometInBlack
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_CometInBlack) && CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
+                        return CometinBlack;
+
+                    // Check for HammerTime
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_HammerCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.Starstruck))
+                        return OriginalHook(HammerStamp);
+
+                    // Check for Starstruck
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_StarPrism))
+                    {
+                        if (HasEffect(Buffs.Starstruck) || (HasEffect(Buffs.Starstruck) && GetBuffRemainingTime(Buffs.Starstruck) < 3))
+                            return StarPrism;
+                    }
+
+                    // Check for RainbowBright
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_RainbowDrip))
+                    {
+                        if (HasEffect(Buffs.RainbowBright) || (HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) < 3))
+                            return RainbowDrip;
+                    }
+                }
+
+                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_HolyinWhite) && !HasEffect(Buffs.StarryMuse) && !HasEffect(Buffs.MonochromeTones))
+                {
+                    if (gauge.Paint > Config.PCT_AoE_AdvancedMode_HolyinWhiteOption ||
+                        (Config.PCT_AoE_AdvancedMode_HolyinWhiteOption == 5 && gauge.Paint == 5 && !HasEffect(Buffs.HammerTime) &&
+                         (HasEffect(Buffs.RainbowBright) || WasLastSpell(AeroIIinGreen) || WasLastSpell(StoneIIinYellow))))
+                        return OriginalHook(HolyInWhite);
+                }
+
+                if (HasEffect(Buffs.RainbowBright) && !HasEffect(Buffs.StarryMuse))
+                    return RainbowDrip;
+
+                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CometinBlack) && CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(StarryMuse) > 60)
+                    return OriginalHook(CometinBlack);
+
+                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_HammerStampCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
+                    return OriginalHook(HammerStamp);
+
+
+                if (!HasEffect(Buffs.StarryMuse))
+                {
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LandscapeMotif) && GetTargetHPPercent() > landscapeStop)
+                    {
+                        if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetCooldownRemainingTime(ScenicMuse) <= 20)
+                            return OriginalHook(LandscapeMotif);
+                    }
+
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CreatureMotif) && GetTargetHPPercent() > creatureStop)
+                    {
+                        if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
+                            return OriginalHook(CreatureMotif);
+                    }
+
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_WeaponMotif) && GetTargetHPPercent() > weaponStop)
+                    {
+                        if (WeaponMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !gauge.WeaponMotifDrawn && (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
+                            return OriginalHook(WeaponMotif);
+                    }
+                }
+
+                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LucidDreaming) && All.LucidDreaming.LevelChecked() && ActionReady(All.LucidDreaming) && CanSpellWeave() && LocalPlayer.CurrentMp <= Config.PCT_ST_AdvancedMode_LucidOption)
+                    return All.LucidDreaming;
+
+                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_BlizzardInCyan) && BlizzardIIinCyan.LevelChecked() && HasEffect(Buffs.SubtractivePalette))
+                    return OriginalHook(BlizzardIIinCyan);
                 return actionID;
             }
         }
@@ -1041,6 +1036,8 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
+                if (actionID is not (FireInRed or FireIIinRed)) return actionID;
+
                 int choice = Config.CombinedAetherhueChoices;
 
                 if (actionID == FireInRed && choice is 0 or 1)
@@ -1104,12 +1101,9 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == HolyInWhite)
-                {
-                    if (HasEffect(Buffs.MonochromeTones))
-                        return CometinBlack;
-                }
-
+                if (actionID != HolyInWhite) return actionID;
+                if (HasEffect(Buffs.MonochromeTones))
+                    return CometinBlack;
                 return actionID;
             }
         }

--- a/WrathCombo/Combos/PvE/RDM/RDM.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM.cs
@@ -103,43 +103,41 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is Jolt or Jolt2 or Jolt3)
-                {
-                    //VARIANTS
-                    if (IsEnabled(CustomComboPreset.RDM_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= GetOptionValue(Config.RDM_VariantCure))
-                        return Variant.VariantCure;
+                if (actionID is not (Jolt or Jolt2 or Jolt3)) return actionID;
 
-                    if (IsEnabled(CustomComboPreset.RDM_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanSpellWeave())
-                        return Variant.VariantRampart;
+                //VARIANTS
+                if (IsEnabled(CustomComboPreset.RDM_Variant_Cure) &&
+                    IsEnabled(Variant.VariantCure) &&
+                    PlayerHealthPercentageHp() <= GetOptionValue(Config.RDM_VariantCure))
+                    return Variant.VariantCure;
 
-                    // Opener for RDM
-                    if (Opener().FullOpener(ref actionID))
-                        return actionID;
+                if (IsEnabled(CustomComboPreset.RDM_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart) &&
+                    CanSpellWeave())
+                    return Variant.VariantRampart;
 
-                    //oGCDs
-                    if (TryOGCDs(actionID, true, out uint oGCDAction)) return oGCDAction;
+                // Opener for RDM
+                if (Opener().FullOpener(ref actionID))
+                    return actionID;
 
-                    //Lucid Dreaming
-                    if (TryLucidDreaming(actionID, 6500, ComboAction)) return All.LucidDreaming;
+                //oGCDs
+                if (TryOGCDs(actionID, true, out uint oGCDAction)) return oGCDAction;
 
-                    //Melee Finisher
-                    if (MeleeCombo.TryMeleeFinisher(out uint finisherAction)) return finisherAction;
+                //Lucid Dreaming
+                if (TryLucidDreaming(actionID, 6500, ComboAction)) return All.LucidDreaming;
 
-                    //Melee Combo
-                    //  Manafication/Embolden Code
-                    if (MeleeCombo.TrySTManaEmbolden(actionID, out uint ManaEmbolden)) return ManaEmbolden;
-                    if (MeleeCombo.TrySTMeleeCombo(actionID, out uint MeleeID)) return MeleeID;
+                //Melee Finisher
+                if (MeleeCombo.TryMeleeFinisher(out uint finisherAction)) return finisherAction;
 
-                    //Normal Spell Rotation
-                    if (SpellCombo.TryAcceleration(actionID, out uint Accel)) return Accel;
-                    if (SpellCombo.TrySTSpellRotation(actionID, out uint SpellID)) return SpellID;
-                                        
-                }
+                //Melee Combo
+                //  Manafication/Embolden Code
+                if (MeleeCombo.TrySTManaEmbolden(actionID, out uint ManaEmbolden)) return ManaEmbolden;
+                if (MeleeCombo.TrySTMeleeCombo(actionID, out uint MeleeID)) return MeleeID;
+
+                //Normal Spell Rotation
+                if (SpellCombo.TryAcceleration(actionID, out uint Accel)) return Accel;
+                if (SpellCombo.TrySTSpellRotation(actionID, out uint SpellID)) return SpellID;
 
                 //NO_CONDITIONS_MET
                 return actionID;
@@ -152,6 +150,9 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
+                if (actionID is not (Jolt or Jolt2 or Jolt3) &&
+                    actionID is not (Fleche or Riposte or Reprise)) return actionID;
+
                 if (actionID is Jolt or Jolt2 or Jolt3)
                 {
                     //VARIANTS
@@ -266,43 +267,42 @@ namespace WrathCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_AoE_SimpleMode;
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is Scatter or Impact)
-                { 
-                    //VARIANTS
-                    if (IsEnabled(CustomComboPreset.RDM_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= GetOptionValue(Config.RDM_VariantCure))
-                        return Variant.VariantCure;
+                if (actionID is not (Scatter or Impact)) return actionID;
 
-                    if (IsEnabled(CustomComboPreset.RDM_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanSpellWeave())
-                        return Variant.VariantRampart;
+                //VARIANTS
+                if (IsEnabled(CustomComboPreset.RDM_Variant_Cure) &&
+                    IsEnabled(Variant.VariantCure) &&
+                    PlayerHealthPercentageHp() <= GetOptionValue(Config.RDM_VariantCure))
+                    return Variant.VariantCure;
 
-                    //RDM_OGCD
-                    if (TryOGCDs(actionID, true, out uint oGCDAction, true)) return oGCDAction;
+                if (IsEnabled(CustomComboPreset.RDM_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart) &&
+                    CanSpellWeave())
+                    return Variant.VariantRampart;
 
-                    // LUCID
-                    if (TryLucidDreaming(actionID, 6500, ComboAction))
-                        return All.LucidDreaming;
+                //RDM_OGCD
+                if (TryOGCDs(actionID, true, out uint oGCDAction, true)) return oGCDAction;
 
-                    //RDM_MELEEFINISHER
-                    if (MeleeCombo.TryMeleeFinisher(out uint finisherAction))
-                        return finisherAction;
-                
-                    if (MeleeCombo.TryAoEManaEmbolden(actionID, out uint ManaEmbolden))
-                        return ManaEmbolden;
+                // LUCID
+                if (TryLucidDreaming(actionID, 6500, ComboAction))
+                    return All.LucidDreaming;
 
-                    if (MeleeCombo.TryAoEMeleeCombo(actionID, out uint AoEMeleeID))
-                        return AoEMeleeID;
-                    
-                    if (SpellCombo.TryAcceleration(actionID, out uint AccelID))
-                        return AccelID;
+                //RDM_MELEEFINISHER
+                if (MeleeCombo.TryMeleeFinisher(out uint finisherAction))
+                    return finisherAction;
 
-                    if (SpellCombo.TryAoESpellRotation(actionID, out uint SpellID))
-                        return SpellID;
-                }
+                if (MeleeCombo.TryAoEManaEmbolden(actionID, out uint ManaEmbolden))
+                    return ManaEmbolden;
+
+                if (MeleeCombo.TryAoEMeleeCombo(actionID, out uint AoEMeleeID))
+                    return AoEMeleeID;
+
+                if (SpellCombo.TryAcceleration(actionID, out uint AccelID))
+                    return AccelID;
+
+                if (SpellCombo.TryAoESpellRotation(actionID, out uint SpellID))
+                    return SpellID;
                 return actionID;
             }
         }
@@ -404,22 +404,20 @@ namespace WrathCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_Raise;
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is All.Swiftcast)
+                if (actionID is not All.Swiftcast) return actionID;
+
+                if (HasEffect(All.Buffs.Swiftcast) && IsEnabled(CustomComboPreset.SMN_Variant_Raise) && IsEnabled(Variant.VariantRaise))
+                    return Variant.VariantRaise;
+
+                if (LevelChecked(Verraise))
                 {
-                    if (HasEffect(All.Buffs.Swiftcast) && IsEnabled(CustomComboPreset.SMN_Variant_Raise) && IsEnabled(Variant.VariantRaise))
-                        return Variant.VariantRaise;
-
-                    if (LevelChecked(Verraise))
-                    {
-                        bool schwifty = HasEffect(All.Buffs.Swiftcast);
-                        if (schwifty || HasEffect(Buffs.Dualcast)) return Verraise;
-                        if (IsEnabled(CustomComboPreset.RDM_Raise_Vercure) &&
-                            !schwifty &&
-                            ActionReady(Vercure) &&
-                            IsOnCooldown(All.Swiftcast))
-                            return Vercure;
-                    }
-
+                    bool schwifty = HasEffect(All.Buffs.Swiftcast);
+                    if (schwifty || HasEffect(Buffs.Dualcast)) return Verraise;
+                    if (IsEnabled(CustomComboPreset.RDM_Raise_Vercure) &&
+                        !schwifty &&
+                        ActionReady(Vercure) &&
+                        IsOnCooldown(All.Swiftcast))
+                        return Vercure;
                 }
 
                 // Else we just exit normally and return Swiftcast

--- a/WrathCombo/Combos/PvE/RPR/RPR.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR.cs
@@ -188,207 +188,206 @@ internal partial class RPR
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Slice)
-            {
-                int PositionalChoice = Config.RPR_Positional;
+            if (actionID is not Slice) return actionID;
 
-                //Variant Cure
-                if (IsEnabled(CustomComboPreset.RPR_Variant_Cure) &&
+            int PositionalChoice = Config.RPR_Positional;
+
+            //Variant Cure
+            if (IsEnabled(CustomComboPreset.RPR_Variant_Cure) &&
                 IsEnabled(Variant.VariantCure) &&
                 PlayerHealthPercentageHp() <= GetOptionValue(Config.RPR_VariantCure))
-                    return Variant.VariantCure;
+                return Variant.VariantCure;
 
-                //Variant Rampart
-                if (IsEnabled(CustomComboPreset.RPR_Variant_Rampart) &&
-                    IsEnabled(Variant.VariantRampart) &&
-                    IsOffCooldown(Variant.VariantRampart) &&
-                    CanWeave())
-                    return Variant.VariantRampart;
+            //Variant Rampart
+            if (IsEnabled(CustomComboPreset.RPR_Variant_Rampart) &&
+                IsEnabled(Variant.VariantRampart) &&
+                IsOffCooldown(Variant.VariantRampart) &&
+                CanWeave())
+                return Variant.VariantRampart;
 
-                //RPR Opener
-                if (IsEnabled(CustomComboPreset.RPR_ST_Opener))
-                    if (Opener().FullOpener(ref actionID))
-                        return actionID;
+            //RPR Opener
+            if (IsEnabled(CustomComboPreset.RPR_ST_Opener))
+                if (Opener().FullOpener(ref actionID))
+                    return actionID;
 
-                //All Weaves
-                if (CanWeave())
+            //All Weaves
+            if (CanWeave())
+            {
+                //Arcane Cirlce
+                if (IsEnabled(CustomComboPreset.RPR_ST_ArcaneCircle) &&
+                    LevelChecked(ArcaneCircle) &&
+                    ((LevelChecked(Enshroud) && JustUsed(ShadowOfDeath) && IsOffCooldown(ArcaneCircle)) ||
+                     (!LevelChecked(Enshroud) && IsOffCooldown(ArcaneCircle))))
+                    return ArcaneCircle;
+
+                //Enshroud
+                if (IsEnabled(CustomComboPreset.RPR_ST_Enshroud) &&
+                    UseEnshroud(Gauge))
+                    return Enshroud;
+
+                //Gluttony/Bloodstalk
+                if (Gauge.Soul >= 50 &&
+                    !HasEffect(Buffs.Enshrouded) && !HasEffect(Buffs.SoulReaver) &&
+                    !HasEffect(Buffs.Executioner) && !HasEffect(Buffs.ImmortalSacrifice) &&
+                    !HasEffect(Buffs.IdealHost) && !HasEffect(Buffs.PerfectioParata) &&
+                    !IsComboExpiring(3))
                 {
-                    //Arcane Cirlce
-                    if (IsEnabled(CustomComboPreset.RPR_ST_ArcaneCircle) &&
-                        LevelChecked(ArcaneCircle) &&
-                        ((LevelChecked(Enshroud) && JustUsed(ShadowOfDeath) && IsOffCooldown(ArcaneCircle)) ||
-                         (!LevelChecked(Enshroud) && IsOffCooldown(ArcaneCircle))))
-                        return ArcaneCircle;
-
-                    //Enshroud
-                    if (IsEnabled(CustomComboPreset.RPR_ST_Enshroud) &&
-                        UseEnshroud(Gauge))
-                        return Enshroud;
-
-                    //Gluttony/Bloodstalk
-                    if (Gauge.Soul >= 50 &&
-                        !HasEffect(Buffs.Enshrouded) && !HasEffect(Buffs.SoulReaver) &&
-                        !HasEffect(Buffs.Executioner) && !HasEffect(Buffs.ImmortalSacrifice) &&
-                        !HasEffect(Buffs.IdealHost) && !HasEffect(Buffs.PerfectioParata) &&
-                        !IsComboExpiring(3))
+                    //Gluttony
+                    if (IsEnabled(CustomComboPreset.RPR_ST_Gluttony) &&
+                        ActionReady(Gluttony) &&
+                        (GetCooldownRemainingTime(ArcaneCircle) > GCD * 3 || !LevelChecked(ArcaneCircle)))
                     {
-                        //Gluttony
-                        if (IsEnabled(CustomComboPreset.RPR_ST_Gluttony) &&
-                            ActionReady(Gluttony) &&
-                            (GetCooldownRemainingTime(ArcaneCircle) > GCD * 3 || !LevelChecked(ArcaneCircle)))
-                        {
-                            if (IsEnabled(CustomComboPreset.RPR_ST_TrueNorthDynamic) &&
-                                TrueNorthReady)
-                                return All.TrueNorth;
+                        if (IsEnabled(CustomComboPreset.RPR_ST_TrueNorthDynamic) &&
+                            TrueNorthReady)
+                            return All.TrueNorth;
 
-                            return Gluttony;
-                        }
-
-                        //Bloodstalk
-                        if (IsEnabled(CustomComboPreset.RPR_ST_Bloodstalk) &&
-                            LevelChecked(BloodStalk) &&
-                            (!LevelChecked(Gluttony) ||
-                             (LevelChecked(Gluttony) && IsOnCooldown(Gluttony) &&
-                              (Gauge.Soul is 100 || GetCooldownRemainingTime(Gluttony) > GCD * 4))))
-                            return OriginalHook(BloodStalk);
+                        return Gluttony;
                     }
-                }
 
-                //Enshroud Weaves
-                if (HasEffect(Buffs.Enshrouded))
-                {
-                    //Sacrificium
-                    if (IsEnabled(CustomComboPreset.RPR_ST_Sacrificium) &&
-                        Gauge.LemureShroud is 2 && GetCooldownRemainingTime(ArcaneCircle) > GCD * 3 &&
-                        HasEffect(Buffs.Oblatio) && LevelChecked(Sacrificium))
-                        return OriginalHook(Gluttony);
-
-                    //Lemure's Slice
-                    if (IsEnabled(CustomComboPreset.RPR_ST_Lemure) &&
-                        Gauge.VoidShroud >= 2 && LevelChecked(LemuresSlice))
+                    //Bloodstalk
+                    if (IsEnabled(CustomComboPreset.RPR_ST_Bloodstalk) &&
+                        LevelChecked(BloodStalk) &&
+                        (!LevelChecked(Gluttony) ||
+                         (LevelChecked(Gluttony) && IsOnCooldown(Gluttony) &&
+                          (Gauge.Soul is 100 || GetCooldownRemainingTime(Gluttony) > GCD * 4))))
                         return OriginalHook(BloodStalk);
                 }
+            }
 
-                //Ranged Attacks
-                if (IsEnabled(CustomComboPreset.RPR_ST_RangedFiller) &&
-                    !InMeleeRange() && LevelChecked(Harpe) && HasBattleTarget() &&
-                    !HasEffect(Buffs.Executioner) && !HasEffect(Buffs.SoulReaver))
+            //Enshroud Weaves
+            if (HasEffect(Buffs.Enshrouded))
+            {
+                //Sacrificium
+                if (IsEnabled(CustomComboPreset.RPR_ST_Sacrificium) &&
+                    Gauge.LemureShroud is 2 && GetCooldownRemainingTime(ArcaneCircle) > GCD * 3 &&
+                    HasEffect(Buffs.Oblatio) && LevelChecked(Sacrificium))
+                    return OriginalHook(Gluttony);
+
+                //Lemure's Slice
+                if (IsEnabled(CustomComboPreset.RPR_ST_Lemure) &&
+                    Gauge.VoidShroud >= 2 && LevelChecked(LemuresSlice))
+                    return OriginalHook(BloodStalk);
+            }
+
+            //Ranged Attacks
+            if (IsEnabled(CustomComboPreset.RPR_ST_RangedFiller) &&
+                !InMeleeRange() && LevelChecked(Harpe) && HasBattleTarget() &&
+                !HasEffect(Buffs.Executioner) && !HasEffect(Buffs.SoulReaver))
+            {
+                //Communio
+                if (HasEffect(Buffs.Enshrouded) && Gauge.LemureShroud is 1 &&
+                    LevelChecked(Communio))
+                    return Communio;
+
+                return IsEnabled(CustomComboPreset.RPR_ST_RangedFillerHarvestMoon) &&
+                       HasEffect(Buffs.Soulsow) && LevelChecked(HarvestMoon)
+                    ? HarvestMoon
+                    : Harpe;
+            }
+
+            //Shadow Of Death
+            if (IsEnabled(CustomComboPreset.RPR_ST_SoD) &&
+                UseShadowOfDeath() && GetTargetHPPercent() > Config.RPR_SoDThreshold)
+                return ShadowOfDeath;
+
+            //Perfectio
+            if (IsEnabled(CustomComboPreset.RPR_ST_Perfectio) &&
+                HasEffect(Buffs.PerfectioParata) && LevelChecked(Perfectio) && !IsComboExpiring(1))
+                return OriginalHook(Communio);
+
+            //Gibbet/Gallows
+            if (IsEnabled(CustomComboPreset.RPR_ST_GibbetGallows) &&
+                LevelChecked(Gibbet) && !HasEffect(Buffs.Enshrouded) &&
+                (HasEffect(Buffs.SoulReaver) || HasEffect(Buffs.Executioner)))
+            {
+                //Gibbet
+                if (HasEffect(Buffs.EnhancedGibbet) ||
+                    (PositionalChoice is 1 && !HasEffect(Buffs.EnhancedGibbet) &&
+                     !HasEffect(Buffs.EnhancedGallows)))
                 {
-                    //Communio
-                    if (HasEffect(Buffs.Enshrouded) && Gauge.LemureShroud is 1 &&
-                        LevelChecked(Communio))
-                        return Communio;
+                    if (IsEnabled(CustomComboPreset.RPR_ST_TrueNorthDynamic) &&
+                        ((IsEnabled(CustomComboPreset.RPR_ST_TrueNorthDynamic_HoldCharge) &&
+                          GetRemainingCharges(All.TrueNorth) < 2) ||
+                         IsNotEnabled(CustomComboPreset.RPR_ST_TrueNorthDynamic_HoldCharge)) &&
+                        TrueNorthReady && !OnTargetsFlank() &&
+                        CanDelayedWeave())
+                        return All.TrueNorth;
 
-                    return IsEnabled(CustomComboPreset.RPR_ST_RangedFillerHarvestMoon) &&
-                           HasEffect(Buffs.Soulsow) && LevelChecked(HarvestMoon)
-                        ? HarvestMoon
-                        : Harpe;
+                    return OriginalHook(Gibbet);
                 }
 
-                //Shadow Of Death
-                if (IsEnabled(CustomComboPreset.RPR_ST_SoD) &&
-                    UseShadowOfDeath() && GetTargetHPPercent() > Config.RPR_SoDThreshold)
-                    return ShadowOfDeath;
-
-                //Perfectio
-                if (IsEnabled(CustomComboPreset.RPR_ST_Perfectio) &&
-                    HasEffect(Buffs.PerfectioParata) && LevelChecked(Perfectio) && !IsComboExpiring(1))
-                    return OriginalHook(Communio);
-
-                //Gibbet/Gallows
-                if (IsEnabled(CustomComboPreset.RPR_ST_GibbetGallows) &&
-                    LevelChecked(Gibbet) && !HasEffect(Buffs.Enshrouded) &&
-                    (HasEffect(Buffs.SoulReaver) || HasEffect(Buffs.Executioner)))
+                //Gallows
+                if (HasEffect(Buffs.EnhancedGallows) ||
+                    (PositionalChoice is 0 && !HasEffect(Buffs.EnhancedGibbet) &&
+                     !HasEffect(Buffs.EnhancedGallows)))
                 {
-                    //Gibbet
-                    if (HasEffect(Buffs.EnhancedGibbet) ||
-                        (PositionalChoice is 1 && !HasEffect(Buffs.EnhancedGibbet) &&
-                         !HasEffect(Buffs.EnhancedGallows)))
-                    {
-                        if (IsEnabled(CustomComboPreset.RPR_ST_TrueNorthDynamic) &&
-                            ((IsEnabled(CustomComboPreset.RPR_ST_TrueNorthDynamic_HoldCharge) &&
-                              GetRemainingCharges(All.TrueNorth) < 2) ||
-                             IsNotEnabled(CustomComboPreset.RPR_ST_TrueNorthDynamic_HoldCharge)) &&
-                            TrueNorthReady && !OnTargetsFlank() &&
-                            CanDelayedWeave())
-                            return All.TrueNorth;
+                    if (IsEnabled(CustomComboPreset.RPR_ST_TrueNorthDynamic) &&
+                        ((IsEnabled(CustomComboPreset.RPR_ST_TrueNorthDynamic_HoldCharge) &&
+                          GetRemainingCharges(All.TrueNorth) < 2) ||
+                         IsNotEnabled(CustomComboPreset.RPR_ST_TrueNorthDynamic_HoldCharge)) &&
+                        TrueNorthReady && !OnTargetsRear() &&
+                        CanDelayedWeave())
+                        return All.TrueNorth;
 
-                        return OriginalHook(Gibbet);
-                    }
-
-                    //Gallows
-                    if (HasEffect(Buffs.EnhancedGallows) ||
-                        (PositionalChoice is 0 && !HasEffect(Buffs.EnhancedGibbet) &&
-                         !HasEffect(Buffs.EnhancedGallows)))
-                    {
-                        if (IsEnabled(CustomComboPreset.RPR_ST_TrueNorthDynamic) &&
-                            ((IsEnabled(CustomComboPreset.RPR_ST_TrueNorthDynamic_HoldCharge) &&
-                              GetRemainingCharges(All.TrueNorth) < 2) ||
-                             IsNotEnabled(CustomComboPreset.RPR_ST_TrueNorthDynamic_HoldCharge)) &&
-                            TrueNorthReady && !OnTargetsRear() &&
-                            CanDelayedWeave())
-                            return All.TrueNorth;
-
-                        return OriginalHook(Gallows);
-                    }
+                    return OriginalHook(Gallows);
                 }
+            }
 
-                //Plentiful Harvest
-                if (IsEnabled(CustomComboPreset.RPR_ST_PlentifulHarvest) &&
-                    LevelChecked(PlentifulHarvest) &&
-                    !HasEffect(Buffs.Enshrouded) && !HasEffect(Buffs.SoulReaver) &&
-                    !HasEffect(Buffs.Executioner) && HasEffect(Buffs.ImmortalSacrifice) &&
-                    (GetBuffRemainingTime(Buffs.BloodsownCircle) <= 1 || JustUsed(Communio)))
-                    return PlentifulHarvest;
+            //Plentiful Harvest
+            if (IsEnabled(CustomComboPreset.RPR_ST_PlentifulHarvest) &&
+                LevelChecked(PlentifulHarvest) &&
+                !HasEffect(Buffs.Enshrouded) && !HasEffect(Buffs.SoulReaver) &&
+                !HasEffect(Buffs.Executioner) && HasEffect(Buffs.ImmortalSacrifice) &&
+                (GetBuffRemainingTime(Buffs.BloodsownCircle) <= 1 || JustUsed(Communio)))
+                return PlentifulHarvest;
 
-                //Enshroud Combo
-                if (HasEffect(Buffs.Enshrouded))
-                {
-                    //Communio
-                    if (IsEnabled(CustomComboPreset.RPR_ST_Communio) &&
-                        Gauge.LemureShroud is 1 && LevelChecked(Communio))
-                        return Communio;
+            //Enshroud Combo
+            if (HasEffect(Buffs.Enshrouded))
+            {
+                //Communio
+                if (IsEnabled(CustomComboPreset.RPR_ST_Communio) &&
+                    Gauge.LemureShroud is 1 && LevelChecked(Communio))
+                    return Communio;
 
-                    //Void Reaping
-                    if (IsEnabled(CustomComboPreset.RPR_ST_Reaping) &&
-                        HasEffect(Buffs.EnhancedVoidReaping))
-                        return OriginalHook(Gibbet);
+                //Void Reaping
+                if (IsEnabled(CustomComboPreset.RPR_ST_Reaping) &&
+                    HasEffect(Buffs.EnhancedVoidReaping))
+                    return OriginalHook(Gibbet);
 
-                    //Cross Reaping
-                    if (IsEnabled(CustomComboPreset.RPR_ST_Reaping) &&
-                        (HasEffect(Buffs.EnhancedCrossReaping) ||
-                         (!HasEffect(Buffs.EnhancedCrossReaping) && !HasEffect(Buffs.EnhancedVoidReaping))))
-                        return OriginalHook(Gallows);
-                }
+                //Cross Reaping
+                if (IsEnabled(CustomComboPreset.RPR_ST_Reaping) &&
+                    (HasEffect(Buffs.EnhancedCrossReaping) ||
+                     (!HasEffect(Buffs.EnhancedCrossReaping) && !HasEffect(Buffs.EnhancedVoidReaping))))
+                    return OriginalHook(Gallows);
+            }
 
-                //Soul Slice
-                if (IsEnabled(CustomComboPreset.RPR_ST_SoulSlice) &&
-                    Gauge.Soul <= 50 && ActionReady(SoulSlice) &&
-                    !IsComboExpiring(3) &&
-                    !HasEffect(Buffs.Enshrouded) && !HasEffect(Buffs.SoulReaver) &&
-                    !HasEffect(Buffs.IdealHost) && !HasEffect(Buffs.Executioner) &&
-                    !HasEffect(Buffs.PerfectioParata) && !HasEffect(Buffs.ImmortalSacrifice))
-                    return SoulSlice;
+            //Soul Slice
+            if (IsEnabled(CustomComboPreset.RPR_ST_SoulSlice) &&
+                Gauge.Soul <= 50 && ActionReady(SoulSlice) &&
+                !IsComboExpiring(3) &&
+                !HasEffect(Buffs.Enshrouded) && !HasEffect(Buffs.SoulReaver) &&
+                !HasEffect(Buffs.IdealHost) && !HasEffect(Buffs.Executioner) &&
+                !HasEffect(Buffs.PerfectioParata) && !HasEffect(Buffs.ImmortalSacrifice))
+                return SoulSlice;
 
-                //Healing
-                if (IsEnabled(CustomComboPreset.RPR_ST_ComboHeals))
-                {
-                    if (PlayerHealthPercentageHp() <= Config.RPR_STSecondWindThreshold && ActionReady(All.SecondWind))
-                        return All.SecondWind;
+            //Healing
+            if (IsEnabled(CustomComboPreset.RPR_ST_ComboHeals))
+            {
+                if (PlayerHealthPercentageHp() <= Config.RPR_STSecondWindThreshold && ActionReady(All.SecondWind))
+                    return All.SecondWind;
 
-                    if (PlayerHealthPercentageHp() <= Config.RPR_STBloodbathThreshold && ActionReady(All.Bloodbath))
-                        return All.Bloodbath;
-                }
+                if (PlayerHealthPercentageHp() <= Config.RPR_STBloodbathThreshold && ActionReady(All.Bloodbath))
+                    return All.Bloodbath;
+            }
 
-                //1-2-3 Combo
-                if (ComboTimer > 0)
-                {
-                    if (ComboAction == OriginalHook(Slice) && LevelChecked(WaxingSlice))
-                        return OriginalHook(WaxingSlice);
+            //1-2-3 Combo
+            if (ComboTimer > 0)
+            {
+                if (ComboAction == OriginalHook(Slice) && LevelChecked(WaxingSlice))
+                    return OriginalHook(WaxingSlice);
 
-                    if (ComboAction == OriginalHook(WaxingSlice) && LevelChecked(InfernalSlice))
-                        return OriginalHook(InfernalSlice);
-                }
+                if (ComboAction == OriginalHook(WaxingSlice) && LevelChecked(InfernalSlice))
+                    return OriginalHook(InfernalSlice);
             }
             return actionID;
         }
@@ -768,6 +767,10 @@ internal partial class RPR
 
         protected override uint Invoke(uint actionID)
         {
+            if (actionID is not (Harpe or Slice or SpinningScythe) &&
+                actionID is not (ShadowOfDeath or BloodStalk))
+                return actionID;
+
             bool [] soulSowOptions = Config.RPR_SoulsowOptions;
             bool soulsowReady = LevelChecked(Soulsow) && !HasEffect(Buffs.Soulsow);
 

--- a/WrathCombo/Combos/PvE/SAM/SAM.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM.cs
@@ -14,23 +14,21 @@ internal partial class SAM
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Yukikaze)
-            {
-                if (Config.SAM_Yukaze_KenkiOvercap && CanWeave() &&
-                    gauge.Kenki >= Config.SAM_Yukaze_KenkiOvercapAmount && LevelChecked(Shinten))
-                    return OriginalHook(Shinten);
+            if (actionID is not Yukikaze) return actionID;
 
-                if (HasEffect(Buffs.MeikyoShisui) && LevelChecked(Yukikaze))
+            if (Config.SAM_Yukaze_KenkiOvercap && CanWeave() &&
+                gauge.Kenki >= Config.SAM_Yukaze_KenkiOvercapAmount && LevelChecked(Shinten))
+                return OriginalHook(Shinten);
+
+            if (HasEffect(Buffs.MeikyoShisui) && LevelChecked(Yukikaze))
+                return OriginalHook(Yukikaze);
+
+            if (ComboTimer > 0)
+                if (ComboAction == OriginalHook(Hakaze) && LevelChecked(Yukikaze))
                     return OriginalHook(Yukikaze);
 
-                if (ComboTimer > 0)
-                    if (ComboAction == OriginalHook(Hakaze) && LevelChecked(Yukikaze))
-                        return OriginalHook(Yukikaze);
+            return OriginalHook(Hakaze);
 
-                return OriginalHook(Hakaze);
-            }
-
-            return actionID;
         }
     }
 
@@ -40,28 +38,26 @@ internal partial class SAM
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Kasha)
+            if (actionID is not Kasha) return actionID;
+
+            if (Config.SAM_Kasha_KenkiOvercap && CanWeave() &&
+                gauge.Kenki >= Config.SAM_Kasha_KenkiOvercapAmount && LevelChecked(Shinten))
+                return OriginalHook(Shinten);
+
+            if (HasEffect(Buffs.MeikyoShisui))
+                return OriginalHook(Kasha);
+
+            if (ComboTimer > 0)
             {
-                if (Config.SAM_Kasha_KenkiOvercap && CanWeave() &&
-                    gauge.Kenki >= Config.SAM_Kasha_KenkiOvercapAmount && LevelChecked(Shinten))
-                    return OriginalHook(Shinten);
+                if (ComboAction == OriginalHook(Hakaze) && LevelChecked(Shifu))
+                    return OriginalHook(Shifu);
 
-                if (HasEffect(Buffs.MeikyoShisui))
+                if (ComboAction is Shifu && LevelChecked(Kasha))
                     return OriginalHook(Kasha);
-
-                if (ComboTimer > 0)
-                {
-                    if (ComboAction == OriginalHook(Hakaze) && LevelChecked(Shifu))
-                        return OriginalHook(Shifu);
-
-                    if (ComboAction is Shifu && LevelChecked(Kasha))
-                        return OriginalHook(Kasha);
-                }
-
-                return OriginalHook(Hakaze);
             }
 
-            return actionID;
+            return OriginalHook(Hakaze);
+
         }
     }
 
@@ -71,28 +67,26 @@ internal partial class SAM
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Gekko)
+            if (actionID is not Gekko) return actionID;
+
+            if (Config.SAM_Gekko_KenkiOvercap && CanWeave() &&
+                gauge.Kenki >= Config.SAM_Gekko_KenkiOvercapAmount && LevelChecked(Shinten))
+                return OriginalHook(Shinten);
+
+            if (HasEffect(Buffs.MeikyoShisui))
+                return OriginalHook(Gekko);
+
+            if (ComboTimer > 0)
             {
-                if (Config.SAM_Gekko_KenkiOvercap && CanWeave() &&
-                    gauge.Kenki >= Config.SAM_Gekko_KenkiOvercapAmount && LevelChecked(Shinten))
-                    return OriginalHook(Shinten);
+                if (ComboAction == OriginalHook(Hakaze) && LevelChecked(Jinpu))
+                    return OriginalHook(Jinpu);
 
-                if (HasEffect(Buffs.MeikyoShisui))
+                if (ComboAction is Jinpu && LevelChecked(Gekko))
                     return OriginalHook(Gekko);
-
-                if (ComboTimer > 0)
-                {
-                    if (ComboAction == OriginalHook(Hakaze) && LevelChecked(Jinpu))
-                        return OriginalHook(Jinpu);
-
-                    if (ComboAction is Jinpu && LevelChecked(Gekko))
-                        return OriginalHook(Gekko);
-                }
-
-                return OriginalHook(Hakaze);
             }
 
-            return actionID;
+            return OriginalHook(Hakaze);
+
         }
     }
 
@@ -277,209 +271,208 @@ internal partial class SAM
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Hakaze or Gyofu)
-            {
-                int kenkiOvercap = Config.SAM_ST_KenkiOvercapAmount;
-                int shintenTreshhold = Config.SAM_ST_ExecuteThreshold;
-                int HiganbanaThreshold = Config.SAM_ST_Higanbana_Threshold;
+            if (actionID is not (Hakaze or Gyofu)) return actionID;
 
-                if (IsEnabled(CustomComboPreset.SAM_Variant_Cure) &&
+            int kenkiOvercap = Config.SAM_ST_KenkiOvercapAmount;
+            int shintenTreshhold = Config.SAM_ST_ExecuteThreshold;
+            int HiganbanaThreshold = Config.SAM_ST_Higanbana_Threshold;
+
+            if (IsEnabled(CustomComboPreset.SAM_Variant_Cure) &&
                 IsEnabled(Variant.VariantCure) &&
                 PlayerHealthPercentageHp() <= Config.SAM_VariantCure)
-                    return Variant.VariantCure;
+                return Variant.VariantCure;
 
-                if (IsEnabled(CustomComboPreset.SAM_Variant_Rampart) &&
-                    IsEnabled(Variant.VariantRampart) &&
-                    IsOffCooldown(Variant.VariantRampart) &&
-                    CanSpellWeave())
-                    return Variant.VariantRampart;
+            if (IsEnabled(CustomComboPreset.SAM_Variant_Rampart) &&
+                IsEnabled(Variant.VariantRampart) &&
+                IsOffCooldown(Variant.VariantRampart) &&
+                CanSpellWeave())
+                return Variant.VariantRampart;
 
-                // Opener for SAM
-                if (IsEnabled(CustomComboPreset.SAM_ST_Opener))
-                    if (Opener().FullOpener(ref actionID))
-                        return actionID;
+            // Opener for SAM
+            if (IsEnabled(CustomComboPreset.SAM_ST_Opener))
+                if (Opener().FullOpener(ref actionID))
+                    return actionID;
 
-                //Meikyo to start before combat
-                if (IsEnabled(CustomComboPreset.SAM_ST_CDs) &&
-                    IsEnabled(CustomComboPreset.SAM_ST_CDs_MeikyoShisui) &&
-                    !HasEffect(Buffs.MeikyoShisui) && ActionReady(MeikyoShisui) &&
-                    !InCombat() && TargetIsHostile())
-                    return MeikyoShisui;
+            //Meikyo to start before combat
+            if (IsEnabled(CustomComboPreset.SAM_ST_CDs) &&
+                IsEnabled(CustomComboPreset.SAM_ST_CDs_MeikyoShisui) &&
+                !HasEffect(Buffs.MeikyoShisui) && ActionReady(MeikyoShisui) &&
+                !InCombat() && TargetIsHostile())
+                return MeikyoShisui;
 
-                //oGCDs
-                if (CanWeave())
+            //oGCDs
+            if (CanWeave())
+            {
+                if (IsEnabled(CustomComboPreset.SAM_ST_CDs))
                 {
-                    if (IsEnabled(CustomComboPreset.SAM_ST_CDs))
+                    //Meikyo Features
+                    if (IsEnabled(CustomComboPreset.SAM_ST_CDs_MeikyoShisui))
                     {
-                        //Meikyo Features
-                        if (IsEnabled(CustomComboPreset.SAM_ST_CDs_MeikyoShisui))
-                        {
-                            if (UseMeikyo())
-                                return MeikyoShisui;
+                        if (UseMeikyo())
+                            return MeikyoShisui;
 
-                            if (GetCooldownRemainingTime(MeikyoShisui) <= GCD * 3 && !ComboStarted &&
-                                !HasEffect(Buffs.MeikyoShisui)) //Overcap protection for scuffed runs
-                                return MeikyoShisui;
-                        }
-
-                        //Ikishoten Features
-                        if (IsEnabled(CustomComboPreset.SAM_ST_CDs_Ikishoten) && LevelChecked(Ikishoten))
-                        {
-                            //Dumps Kenki in preparation for Ikishoten
-                            if (gauge.Kenki > 50 && GetCooldownRemainingTime(Ikishoten) < 10)
-                                return Shinten;
-
-                            if (gauge.Kenki <= 50 && IsOffCooldown(Ikishoten))
-                                return Ikishoten;
-                        }
-
-                        //Senei Features
-                        if (IsEnabled(CustomComboPreset.SAM_ST_CDs_Senei))
-                        {
-                            if (gauge.Kenki >= 25 && ActionReady(Senei) &&
-                                HasEffect(Buffs.Fugetsu) && HasEffect(Buffs.Fuka))
-                                return Senei;
-
-                            //Guren if no Senei
-                            if (IsEnabled(CustomComboPreset.SAM_ST_CDs_Guren) &&
-                                !LevelChecked(Senei) &&
-                                gauge.Kenki >= 25 && ActionReady(Guren) &&
-                                HasEffect(Buffs.Fugetsu) && HasEffect(Buffs.Fuka))
-                                return Guren;
-                        }
-
-                        //Zanshin Usage
-                        if (IsEnabled(CustomComboPreset.SAM_ST_CDs_Zanshin) &&
-                            LevelChecked(Zanshin) && gauge.Kenki >= 50 &&
-                            CanWeave() && HasEffect(Buffs.ZanshinReady) &&
-                            (JustUsed(Higanbana, 7f) || (SenCount is 1 && HasEffect(Buffs.OgiNamikiriReady)) ||
-                             GetBuffRemainingTime(Buffs.ZanshinReady) <= 6))
-                            return Zanshin;
-
-                        if (IsEnabled(CustomComboPreset.SAM_ST_CDs_Shoha) &&
-                            LevelChecked(Shoha) && gauge.MeditationStacks is 3)
-                            return Shoha;
+                        if (GetCooldownRemainingTime(MeikyoShisui) <= GCD * 3 && !ComboStarted &&
+                            !HasEffect(Buffs.MeikyoShisui)) //Overcap protection for scuffed runs
+                            return MeikyoShisui;
                     }
 
-                    if (IsEnabled(CustomComboPreset.SAM_ST_Shinten) &&
-                        LevelChecked(Shinten) && gauge.Kenki > 50 &&
-                        !HasEffect(Buffs.ZanshinReady) &&
-                        (gauge.Kenki >= kenkiOvercap ||
-                         GetTargetHPPercent() <= shintenTreshhold))
-                        return Shinten;
+                    //Ikishoten Features
+                    if (IsEnabled(CustomComboPreset.SAM_ST_CDs_Ikishoten) && LevelChecked(Ikishoten))
+                    {
+                        //Dumps Kenki in preparation for Ikishoten
+                        if (gauge.Kenki > 50 && GetCooldownRemainingTime(Ikishoten) < 10)
+                            return Shinten;
+
+                        if (gauge.Kenki <= 50 && IsOffCooldown(Ikishoten))
+                            return Ikishoten;
+                    }
+
+                    //Senei Features
+                    if (IsEnabled(CustomComboPreset.SAM_ST_CDs_Senei))
+                    {
+                        if (gauge.Kenki >= 25 && ActionReady(Senei) &&
+                            HasEffect(Buffs.Fugetsu) && HasEffect(Buffs.Fuka))
+                            return Senei;
+
+                        //Guren if no Senei
+                        if (IsEnabled(CustomComboPreset.SAM_ST_CDs_Guren) &&
+                            !LevelChecked(Senei) &&
+                            gauge.Kenki >= 25 && ActionReady(Guren) &&
+                            HasEffect(Buffs.Fugetsu) && HasEffect(Buffs.Fuka))
+                            return Guren;
+                    }
+
+                    //Zanshin Usage
+                    if (IsEnabled(CustomComboPreset.SAM_ST_CDs_Zanshin) &&
+                        LevelChecked(Zanshin) && gauge.Kenki >= 50 &&
+                        CanWeave() && HasEffect(Buffs.ZanshinReady) &&
+                        (JustUsed(Higanbana, 7f) || (SenCount is 1 && HasEffect(Buffs.OgiNamikiriReady)) ||
+                         GetBuffRemainingTime(Buffs.ZanshinReady) <= 6))
+                        return Zanshin;
+
+                    if (IsEnabled(CustomComboPreset.SAM_ST_CDs_Shoha) &&
+                        LevelChecked(Shoha) && gauge.MeditationStacks is 3)
+                        return Shoha;
                 }
 
-                if (IsEnabled(CustomComboPreset.SAM_ST_RangedUptime) &&
-                    LevelChecked(Enpi) && !InMeleeRange() && HasBattleTarget())
-                    return Enpi;
+                if (IsEnabled(CustomComboPreset.SAM_ST_Shinten) &&
+                    LevelChecked(Shinten) && gauge.Kenki > 50 &&
+                    !HasEffect(Buffs.ZanshinReady) &&
+                    (gauge.Kenki >= kenkiOvercap ||
+                     GetTargetHPPercent() <= shintenTreshhold))
+                    return Shinten;
+            }
 
-                if (IsEnabled(CustomComboPreset.SAM_ST_CDs) &&
-                    HasEffect(Buffs.Fugetsu) && HasEffect(Buffs.Fuka))
+            if (IsEnabled(CustomComboPreset.SAM_ST_RangedUptime) &&
+                LevelChecked(Enpi) && !InMeleeRange() && HasBattleTarget())
+                return Enpi;
+
+            if (IsEnabled(CustomComboPreset.SAM_ST_CDs) &&
+                HasEffect(Buffs.Fugetsu) && HasEffect(Buffs.Fuka))
+            {
+                //Ogi Namikiri Features
+                if (IsEnabled(CustomComboPreset.SAM_ST_CDs_OgiNamikiri) &&
+                    (!IsEnabled(CustomComboPreset.SAM_ST_CDs_OgiNamikiri_Movement) ||
+                     (IsEnabled(CustomComboPreset.SAM_ST_CDs_OgiNamikiri_Movement) && !IsMoving())) &&
+                    ActionReady(OgiNamikiri) &&
+                    (((JustUsed(Higanbana, 5f) || GetDebuffRemainingTime(Debuffs.Higanbana) > 30) &&
+                      HasEffect(Buffs.OgiNamikiriReady)) ||
+                     GetBuffRemainingTime(Buffs.OgiNamikiriReady) <= GCD) &&
+                    (gauge.Kaeshi == Kaeshi.NAMIKIRI || HasEffect(Buffs.OgiNamikiriReady)))
+                    return OriginalHook(OgiNamikiri);
+
+                // Iaijutsu Features
+                if (IsEnabled(CustomComboPreset.SAM_ST_CDs_Iaijutsu) && LevelChecked(Iaijutsu))
                 {
-                    //Ogi Namikiri Features
-                    if (IsEnabled(CustomComboPreset.SAM_ST_CDs_OgiNamikiri) &&
-                        (!IsEnabled(CustomComboPreset.SAM_ST_CDs_OgiNamikiri_Movement) ||
-                         (IsEnabled(CustomComboPreset.SAM_ST_CDs_OgiNamikiri_Movement) && !IsMoving())) &&
-                        ActionReady(OgiNamikiri) &&
-                        (((JustUsed(Higanbana, 5f) || GetDebuffRemainingTime(Debuffs.Higanbana) > 30) &&
-                          HasEffect(Buffs.OgiNamikiriReady)) ||
-                         GetBuffRemainingTime(Buffs.OgiNamikiriReady) <= GCD) &&
-                        (gauge.Kaeshi == Kaeshi.NAMIKIRI || HasEffect(Buffs.OgiNamikiriReady)))
-                        return OriginalHook(OgiNamikiri);
+                    if (HasEffect(Buffs.TendoKaeshiSetsugekkaReady))
+                        return OriginalHook(TsubameGaeshi);
 
-                    // Iaijutsu Features
-                    if (IsEnabled(CustomComboPreset.SAM_ST_CDs_Iaijutsu) && LevelChecked(Iaijutsu))
-                    {
-                        if (HasEffect(Buffs.TendoKaeshiSetsugekkaReady))
+                    if (LevelChecked(TsubameGaeshi) && HasEffect(Buffs.TsubameReady))
+                        if (GetCooldownRemainingTime(Senei) > 33 ||
+                            SenCount is 3)
                             return OriginalHook(TsubameGaeshi);
 
-                        if (LevelChecked(TsubameGaeshi) && HasEffect(Buffs.TsubameReady))
-                            if (GetCooldownRemainingTime(Senei) > 33 ||
-                                SenCount is 3)
-                                return OriginalHook(TsubameGaeshi);
-
-                        if ((!IsEnabled(CustomComboPreset.SAM_ST_CDs_Iaijutsu_Movement) ||
-                             (IsEnabled(CustomComboPreset.SAM_ST_CDs_Iaijutsu_Movement) && !IsMoving())) &&
-                            ((SenCount is 1 && GetTargetHPPercent() > HiganbanaThreshold &&
-                              (Config.SAM_ST_Higanbana_Suboption == 0 ||
-                               (Config.SAM_ST_Higanbana_Suboption == 1 && TargetIsBoss())) &&
-                              ((GetDebuffRemainingTime(Debuffs.Higanbana) <= 19 && JustUsed(Gekko) &&
-                                JustUsed(MeikyoShisui, 15f)) || !TargetHasEffect(Debuffs.Higanbana))) ||
-                             (SenCount is 2 && !LevelChecked(MidareSetsugekka)) ||
-                             (SenCount is 3 && LevelChecked(MidareSetsugekka) && !HasEffect(Buffs.TsubameReady))))
-                            return OriginalHook(Iaijutsu);
-                    }
+                    if ((!IsEnabled(CustomComboPreset.SAM_ST_CDs_Iaijutsu_Movement) ||
+                         (IsEnabled(CustomComboPreset.SAM_ST_CDs_Iaijutsu_Movement) && !IsMoving())) &&
+                        ((SenCount is 1 && GetTargetHPPercent() > HiganbanaThreshold &&
+                          (Config.SAM_ST_Higanbana_Suboption == 0 ||
+                           (Config.SAM_ST_Higanbana_Suboption == 1 && TargetIsBoss())) &&
+                          ((GetDebuffRemainingTime(Debuffs.Higanbana) <= 19 && JustUsed(Gekko) &&
+                            JustUsed(MeikyoShisui, 15f)) || !TargetHasEffect(Debuffs.Higanbana))) ||
+                         (SenCount is 2 && !LevelChecked(MidareSetsugekka)) ||
+                         (SenCount is 3 && LevelChecked(MidareSetsugekka) && !HasEffect(Buffs.TsubameReady))))
+                        return OriginalHook(Iaijutsu);
                 }
+            }
 
-                if (HasEffect(Buffs.MeikyoShisui))
+            if (HasEffect(Buffs.MeikyoShisui))
+            {
+                if (IsEnabled(CustomComboPreset.SAM_ST_TrueNorth) &&
+                    TrueNorthReady && CanDelayedWeave())
+                    return All.TrueNorth;
+
+                if (LevelChecked(Gekko) && (!HasEffect(Buffs.Fugetsu) ||
+                                            (!gauge.Sen.HasFlag(Sen.GETSU) && HasEffect(Buffs.Fuka))))
+                    return Gekko;
+
+                if (IsEnabled(CustomComboPreset.SAM_ST_Kasha) &&
+                    LevelChecked(Kasha) && (!HasEffect(Buffs.Fuka) ||
+                                            (!gauge.Sen.HasFlag(Sen.KA) && HasEffect(Buffs.Fugetsu))))
+                    return Kasha;
+
+                if (IsEnabled(CustomComboPreset.SAM_ST_Yukikaze) &&
+                    LevelChecked(Yukikaze) && !gauge.Sen.HasFlag(Sen.SETSU))
+                    return Yukikaze;
+            }
+
+            // healing
+            if (IsEnabled(CustomComboPreset.SAM_ST_ComboHeals))
+            {
+                if (PlayerHealthPercentageHp() <= Config.SAM_STSecondWindThreshold && ActionReady(All.SecondWind))
+                    return All.SecondWind;
+
+                if (PlayerHealthPercentageHp() <= Config.SAM_STBloodbathThreshold && ActionReady(All.Bloodbath))
+                    return All.Bloodbath;
+            }
+
+            if (ComboTimer > 0)
+            {
+                if (ComboAction is Hakaze or Gyofu && LevelChecked(Jinpu))
                 {
-                    if (IsEnabled(CustomComboPreset.SAM_ST_TrueNorth) &&
-                        TrueNorthReady && CanDelayedWeave())
-                        return All.TrueNorth;
-
-                    if (LevelChecked(Gekko) && (!HasEffect(Buffs.Fugetsu) ||
-                                                (!gauge.Sen.HasFlag(Sen.GETSU) && HasEffect(Buffs.Fuka))))
-                        return Gekko;
-
-                    if (IsEnabled(CustomComboPreset.SAM_ST_Kasha) &&
-                        LevelChecked(Kasha) && (!HasEffect(Buffs.Fuka) ||
-                                                (!gauge.Sen.HasFlag(Sen.KA) && HasEffect(Buffs.Fugetsu))))
-                        return Kasha;
-
                     if (IsEnabled(CustomComboPreset.SAM_ST_Yukikaze) &&
-                        LevelChecked(Yukikaze) && !gauge.Sen.HasFlag(Sen.SETSU))
+                        !gauge.Sen.HasFlag(Sen.SETSU) && LevelChecked(Yukikaze) && HasEffect(Buffs.Fugetsu) &&
+                        HasEffect(Buffs.Fuka))
                         return Yukikaze;
-                }
 
-                // healing
-                if (IsEnabled(CustomComboPreset.SAM_ST_ComboHeals))
-                {
-                    if (PlayerHealthPercentageHp() <= Config.SAM_STSecondWindThreshold && ActionReady(All.SecondWind))
-                        return All.SecondWind;
-
-                    if (PlayerHealthPercentageHp() <= Config.SAM_STBloodbathThreshold && ActionReady(All.Bloodbath))
-                        return All.Bloodbath;
-                }
-
-                if (ComboTimer > 0)
-                {
-                    if (ComboAction is Hakaze or Gyofu && LevelChecked(Jinpu))
-                    {
-                        if (IsEnabled(CustomComboPreset.SAM_ST_Yukikaze) &&
-                            !gauge.Sen.HasFlag(Sen.SETSU) && LevelChecked(Yukikaze) && HasEffect(Buffs.Fugetsu) &&
-                            HasEffect(Buffs.Fuka))
-                            return Yukikaze;
-
-                        if ((!LevelChecked(Kasha) &&
-                             (GetBuffRemainingTime(Buffs.Fugetsu) < GetBuffRemainingTime(Buffs.Fuka) ||
-                              !HasEffect(Buffs.Fugetsu))) ||
-                            (LevelChecked(Kasha) && (!HasEffect(Buffs.Fugetsu) ||
-                                                     (HasEffect(Buffs.Fuka) && !gauge.Sen.HasFlag(Sen.GETSU)) ||
-                                                     (SenCount is 3 && GetBuffRemainingTime(Buffs.Fugetsu) <
-                                                         GetBuffRemainingTime(Buffs.Fuka)))))
-                            return Jinpu;
-
-                        if (IsEnabled(CustomComboPreset.SAM_ST_Kasha) &&
-                            LevelChecked(Shifu) && ((!LevelChecked(Kasha) &&
-                                                     (GetBuffRemainingTime(Buffs.Fuka) <
-                                                      GetBuffRemainingTime(Buffs.Fugetsu) ||
-                                                      !HasEffect(Buffs.Fuka))) ||
-                                                    (LevelChecked(Kasha) && (!HasEffect(Buffs.Fuka) ||
-                                                                             (HasEffect(Buffs.Fugetsu) &&
-                                                                              !gauge.Sen.HasFlag(Sen.KA)) ||
-                                                                             (SenCount is 3 &&
-                                                                              GetBuffRemainingTime(Buffs.Fuka) <
-                                                                              GetBuffRemainingTime(Buffs.Fugetsu))))))
-                            return Shifu;
-                    }
-
-                    if (ComboAction is Jinpu && LevelChecked(Gekko))
-                        return Gekko;
+                    if ((!LevelChecked(Kasha) &&
+                         (GetBuffRemainingTime(Buffs.Fugetsu) < GetBuffRemainingTime(Buffs.Fuka) ||
+                          !HasEffect(Buffs.Fugetsu))) ||
+                        (LevelChecked(Kasha) && (!HasEffect(Buffs.Fugetsu) ||
+                                                 (HasEffect(Buffs.Fuka) && !gauge.Sen.HasFlag(Sen.GETSU)) ||
+                                                 (SenCount is 3 && GetBuffRemainingTime(Buffs.Fugetsu) <
+                                                     GetBuffRemainingTime(Buffs.Fuka)))))
+                        return Jinpu;
 
                     if (IsEnabled(CustomComboPreset.SAM_ST_Kasha) &&
-                        ComboAction is Shifu && LevelChecked(Kasha))
-                        return Kasha;
+                        LevelChecked(Shifu) && ((!LevelChecked(Kasha) &&
+                                                 (GetBuffRemainingTime(Buffs.Fuka) <
+                                                  GetBuffRemainingTime(Buffs.Fugetsu) ||
+                                                  !HasEffect(Buffs.Fuka))) ||
+                                                (LevelChecked(Kasha) && (!HasEffect(Buffs.Fuka) ||
+                                                    (HasEffect(Buffs.Fugetsu) &&
+                                                     !gauge.Sen.HasFlag(Sen.KA)) ||
+                                                    (SenCount is 3 &&
+                                                     GetBuffRemainingTime(Buffs.Fuka) <
+                                                     GetBuffRemainingTime(Buffs.Fugetsu))))))
+                        return Shifu;
                 }
+
+                if (ComboAction is Jinpu && LevelChecked(Gekko))
+                    return Gekko;
+
+                if (IsEnabled(CustomComboPreset.SAM_ST_Kasha) &&
+                    ComboAction is Shifu && LevelChecked(Kasha))
+                    return Kasha;
             }
             return actionID;
         }
@@ -491,23 +484,21 @@ internal partial class SAM
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Oka)
-            {
-                if (Config.SAM_Oka_KenkiOvercap && gauge.Kenki >= Config.SAM_Oka_KenkiOvercapAmount &&
-                    LevelChecked(Kyuten) && CanWeave())
-                    return Kyuten;
+            if (actionID is not Oka) return actionID;
 
-                if (HasEffect(Buffs.MeikyoShisui))
+            if (Config.SAM_Oka_KenkiOvercap && gauge.Kenki >= Config.SAM_Oka_KenkiOvercapAmount &&
+                LevelChecked(Kyuten) && CanWeave())
+                return Kyuten;
+
+            if (HasEffect(Buffs.MeikyoShisui))
+                return Oka;
+
+            if (ComboTimer > 0 && LevelChecked(Oka))
+                if (ComboAction == OriginalHook(Fuko))
                     return Oka;
 
-                if (ComboTimer > 0 && LevelChecked(Oka))
-                    if (ComboAction == OriginalHook(Fuko))
-                        return Oka;
+            return OriginalHook(Fuko);
 
-                return OriginalHook(Fuko);
-            }
-
-            return actionID;
         }
     }
 
@@ -517,23 +508,21 @@ internal partial class SAM
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Mangetsu)
-            {
-                if (Config.SAM_Mangetsu_KenkiOvercap && gauge.Kenki >= Config.SAM_Mangetsu_KenkiOvercapAmount &&
-                    LevelChecked(Kyuten) && CanWeave())
-                    return Kyuten;
+            if (actionID is not Mangetsu) return actionID;
 
-                if (HasEffect(Buffs.MeikyoShisui))
+            if (Config.SAM_Mangetsu_KenkiOvercap && gauge.Kenki >= Config.SAM_Mangetsu_KenkiOvercapAmount &&
+                LevelChecked(Kyuten) && CanWeave())
+                return Kyuten;
+
+            if (HasEffect(Buffs.MeikyoShisui))
+                return Mangetsu;
+
+            if (ComboTimer > 0 && LevelChecked(Mangetsu))
+                if (ComboAction == OriginalHook(Fuko))
                     return Mangetsu;
 
-                if (ComboTimer > 0 && LevelChecked(Mangetsu))
-                    if (ComboAction == OriginalHook(Fuko))
-                        return Mangetsu;
+            return OriginalHook(Fuko);
 
-                return OriginalHook(Fuko);
-            }
-
-            return actionID;
         }
     }
 
@@ -649,115 +638,114 @@ internal partial class SAM
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Fuga or Fuko)
-            {
-                float kenkiOvercap = Config.SAM_AoE_KenkiOvercapAmount;
+            if (actionID is not (Fuga or Fuko)) return actionID;
 
-                if (IsEnabled(CustomComboPreset.SAM_Variant_Cure) &&
+            float kenkiOvercap = Config.SAM_AoE_KenkiOvercapAmount;
+
+            if (IsEnabled(CustomComboPreset.SAM_Variant_Cure) &&
                 IsEnabled(Variant.VariantCure) &&
                 PlayerHealthPercentageHp() <= Config.SAM_VariantCure)
-                    return Variant.VariantCure;
+                return Variant.VariantCure;
 
-                if (IsEnabled(CustomComboPreset.SAM_Variant_Rampart) &&
-                    IsEnabled(Variant.VariantRampart) &&
-                    IsOffCooldown(Variant.VariantRampart) &&
-                    CanWeave())
-                    return Variant.VariantRampart;
+            if (IsEnabled(CustomComboPreset.SAM_Variant_Rampart) &&
+                IsEnabled(Variant.VariantRampart) &&
+                IsOffCooldown(Variant.VariantRampart) &&
+                CanWeave())
+                return Variant.VariantRampart;
 
-                //oGCD Features
-                if (CanWeave())
+            //oGCD Features
+            if (CanWeave())
+            {
+                if (IsEnabled(CustomComboPreset.SAM_AoE_Hagakure) &&
+                    OriginalHook(Iaijutsu) is MidareSetsugekka && LevelChecked(Hagakure))
+                    return Hagakure;
+
+                if (IsEnabled(CustomComboPreset.SAM_AoE_Guren) &&
+                    ActionReady(Guren) && gauge.Kenki >= 25)
+                    return Guren;
+
+                if (IsEnabled(CustomComboPreset.SAM_AOE_CDs_Ikishoten) &&
+                    LevelChecked(Ikishoten))
                 {
-                    if (IsEnabled(CustomComboPreset.SAM_AoE_Hagakure) &&
-                        OriginalHook(Iaijutsu) is MidareSetsugekka && LevelChecked(Hagakure))
-                        return Hagakure;
-
-                    if (IsEnabled(CustomComboPreset.SAM_AoE_Guren) &&
-                        ActionReady(Guren) && gauge.Kenki >= 25)
-                        return Guren;
-
-                    if (IsEnabled(CustomComboPreset.SAM_AOE_CDs_Ikishoten) &&
-                        LevelChecked(Ikishoten))
-                    {
-                        //Dumps Kenki in preparation for Ikishoten
-                        if (gauge.Kenki > 50 && GetCooldownRemainingTime(Ikishoten) < 10)
-                            return Kyuten;
-
-                        if (gauge.Kenki <= 50 && IsOffCooldown(Ikishoten))
-                            return Ikishoten;
-                    }
-
-                    if (IsEnabled(CustomComboPreset.SAM_AoE_Kyuten) &&
-                        Kyuten.LevelChecked() && gauge.Kenki >= 50 &&
-                        ((IsOnCooldown(Guren) && LevelChecked(Guren)) ||
-                         gauge.Kenki >= kenkiOvercap))
+                    //Dumps Kenki in preparation for Ikishoten
+                    if (gauge.Kenki > 50 && GetCooldownRemainingTime(Ikishoten) < 10)
                         return Kyuten;
 
-                    if (IsEnabled(CustomComboPreset.SAM_AoE_Shoha) &&
-                        ActionReady(Shoha) && gauge.MeditationStacks is 3)
-                        return Shoha;
-
-                    if (IsEnabled(CustomComboPreset.SAM_AoE_MeikyoShisui) &&
-                        ActionReady(MeikyoShisui) && !HasEffect(Buffs.MeikyoShisui))
-                        return MeikyoShisui;
+                    if (gauge.Kenki <= 50 && IsOffCooldown(Ikishoten))
+                        return Ikishoten;
                 }
 
-                if (IsEnabled(CustomComboPreset.SAM_AoE_Zanshin) &&
-                    LevelChecked(Zanshin) && HasEffect(Buffs.ZanshinReady) && gauge.Kenki >= 50)
-                    return OriginalHook(Ikishoten);
+                if (IsEnabled(CustomComboPreset.SAM_AoE_Kyuten) &&
+                    Kyuten.LevelChecked() && gauge.Kenki >= 50 &&
+                    ((IsOnCooldown(Guren) && LevelChecked(Guren)) ||
+                     gauge.Kenki >= kenkiOvercap))
+                    return Kyuten;
 
-                if (IsEnabled(CustomComboPreset.SAM_AoE_OgiNamikiri) &&
-                    LevelChecked(OgiNamikiri) && ((!IsMoving() && HasEffect(Buffs.OgiNamikiriReady)) ||
-                                                  gauge.Kaeshi is Kaeshi.NAMIKIRI))
-                    return OriginalHook(OgiNamikiri);
+                if (IsEnabled(CustomComboPreset.SAM_AoE_Shoha) &&
+                    ActionReady(Shoha) && gauge.MeditationStacks is 3)
+                    return Shoha;
 
-                if (IsEnabled(CustomComboPreset.SAM_AoE_TenkaGoken) && LevelChecked(TenkaGoken))
-                {
-                    if (!IsMoving() && OriginalHook(Iaijutsu) is TenkaGoken)
-                        return OriginalHook(Iaijutsu);
+                if (IsEnabled(CustomComboPreset.SAM_AoE_MeikyoShisui) &&
+                    ActionReady(MeikyoShisui) && !HasEffect(Buffs.MeikyoShisui))
+                    return MeikyoShisui;
+            }
 
-                    if (!IsMoving() && LevelChecked(TendoGoken) && OriginalHook(Iaijutsu) is TendoGoken)
-                        return OriginalHook(Iaijutsu);
+            if (IsEnabled(CustomComboPreset.SAM_AoE_Zanshin) &&
+                LevelChecked(Zanshin) && HasEffect(Buffs.ZanshinReady) && gauge.Kenki >= 50)
+                return OriginalHook(Ikishoten);
 
-                    if (LevelChecked(TsubameGaeshi) &&
-                        (HasEffect(Buffs.KaeshiGokenReady) || HasEffect(Buffs.TendoKaeshiGokenReady)))
-                        return OriginalHook(TsubameGaeshi);
-                }
+            if (IsEnabled(CustomComboPreset.SAM_AoE_OgiNamikiri) &&
+                LevelChecked(OgiNamikiri) && ((!IsMoving() && HasEffect(Buffs.OgiNamikiriReady)) ||
+                                              gauge.Kaeshi is Kaeshi.NAMIKIRI))
+                return OriginalHook(OgiNamikiri);
 
-                if (HasEffect(Buffs.MeikyoShisui))
-                {
-                    if ((!gauge.Sen.HasFlag(Sen.GETSU) && HasEffect(Buffs.Fuka)) || !HasEffect(Buffs.Fugetsu))
-                        return Mangetsu;
+            if (IsEnabled(CustomComboPreset.SAM_AoE_TenkaGoken) && LevelChecked(TenkaGoken))
+            {
+                if (!IsMoving() && OriginalHook(Iaijutsu) is TenkaGoken)
+                    return OriginalHook(Iaijutsu);
 
-                    if (IsEnabled(CustomComboPreset.SAM_AoE_Oka) &&
-                        ((!gauge.Sen.HasFlag(Sen.KA) && HasEffect(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka)))
-                        return Oka;
-                }
+                if (!IsMoving() && LevelChecked(TendoGoken) && OriginalHook(Iaijutsu) is TendoGoken)
+                    return OriginalHook(Iaijutsu);
 
-                if (IsEnabled(CustomComboPreset.SAM_AoE_ComboHeals))
-                {
-                    if (PlayerHealthPercentageHp() <= Config.SAM_AoESecondWindThreshold && ActionReady(All.SecondWind))
-                        return All.SecondWind;
+                if (LevelChecked(TsubameGaeshi) &&
+                    (HasEffect(Buffs.KaeshiGokenReady) || HasEffect(Buffs.TendoKaeshiGokenReady)))
+                    return OriginalHook(TsubameGaeshi);
+            }
 
-                    if (PlayerHealthPercentageHp() <= Config.SAM_AoEBloodbathThreshold && ActionReady(All.Bloodbath))
-                        return All.Bloodbath;
-                }
+            if (HasEffect(Buffs.MeikyoShisui))
+            {
+                if ((!gauge.Sen.HasFlag(Sen.GETSU) && HasEffect(Buffs.Fuka)) || !HasEffect(Buffs.Fugetsu))
+                    return Mangetsu;
 
-                if (ComboTimer > 0 &&
-                    ComboAction is Fuko or Fuga && LevelChecked(Mangetsu))
-                {
-                    if (IsNotEnabled(CustomComboPreset.SAM_AoE_Oka) ||
-                        !gauge.Sen.HasFlag(Sen.GETSU) ||
-                        GetBuffRemainingTime(Buffs.Fugetsu) < GetBuffRemainingTime(Buffs.Fuka) ||
-                        !HasEffect(Buffs.Fugetsu) || !LevelChecked(Oka))
-                        return Mangetsu;
+                if (IsEnabled(CustomComboPreset.SAM_AoE_Oka) &&
+                    ((!gauge.Sen.HasFlag(Sen.KA) && HasEffect(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka)))
+                    return Oka;
+            }
 
-                    if (IsEnabled(CustomComboPreset.SAM_AoE_Oka) &&
-                        LevelChecked(Oka) &&
-                        (!gauge.Sen.HasFlag(Sen.KA) ||
-                         GetBuffRemainingTime(Buffs.Fuka) < GetBuffRemainingTime(Buffs.Fugetsu) ||
-                         !HasEffect(Buffs.Fuka)))
-                        return Oka;
-                }
+            if (IsEnabled(CustomComboPreset.SAM_AoE_ComboHeals))
+            {
+                if (PlayerHealthPercentageHp() <= Config.SAM_AoESecondWindThreshold && ActionReady(All.SecondWind))
+                    return All.SecondWind;
+
+                if (PlayerHealthPercentageHp() <= Config.SAM_AoEBloodbathThreshold && ActionReady(All.Bloodbath))
+                    return All.Bloodbath;
+            }
+
+            if (ComboTimer > 0 &&
+                ComboAction is Fuko or Fuga && LevelChecked(Mangetsu))
+            {
+                if (IsNotEnabled(CustomComboPreset.SAM_AoE_Oka) ||
+                    !gauge.Sen.HasFlag(Sen.GETSU) ||
+                    GetBuffRemainingTime(Buffs.Fugetsu) < GetBuffRemainingTime(Buffs.Fuka) ||
+                    !HasEffect(Buffs.Fugetsu) || !LevelChecked(Oka))
+                    return Mangetsu;
+
+                if (IsEnabled(CustomComboPreset.SAM_AoE_Oka) &&
+                    LevelChecked(Oka) &&
+                    (!gauge.Sen.HasFlag(Sen.KA) ||
+                     GetBuffRemainingTime(Buffs.Fuka) < GetBuffRemainingTime(Buffs.Fugetsu) ||
+                     !HasEffect(Buffs.Fuka)))
+                    return Oka;
             }
             return actionID;
         }
@@ -769,19 +757,19 @@ internal partial class SAM
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is MeikyoShisui && HasEffect(Buffs.MeikyoShisui))
-            {
-                if (!HasEffect(Buffs.Fugetsu) ||
-                    !gauge.Sen.HasFlag(Sen.GETSU))
-                    return Gekko;
+            if (actionID is not MeikyoShisui || !HasEffect(Buffs.MeikyoShisui))
+                return actionID;
 
-                if (!HasEffect(Buffs.Fuka) ||
-                    !gauge.Sen.HasFlag(Sen.KA))
-                    return Kasha;
+            if (!HasEffect(Buffs.Fugetsu) ||
+                !gauge.Sen.HasFlag(Sen.GETSU))
+                return Gekko;
 
-                if (!gauge.Sen.HasFlag(Sen.SETSU))
-                    return Yukikaze;
-            }
+            if (!HasEffect(Buffs.Fuka) ||
+                !gauge.Sen.HasFlag(Sen.KA))
+                return Kasha;
+
+            if (!gauge.Sen.HasFlag(Sen.SETSU))
+                return Yukikaze;
 
             return actionID;
         }
@@ -793,31 +781,29 @@ internal partial class SAM
 
         protected override uint Invoke(uint actionID)
         {
+            if (actionID is not Iaijutsu) return actionID;
 
-            if (actionID is Iaijutsu)
-            {
-                bool canAddShoha = IsEnabled(CustomComboPreset.SAM_Iaijutsu_Shoha) &&
+            bool canAddShoha = IsEnabled(CustomComboPreset.SAM_Iaijutsu_Shoha) &&
                                ActionReady(Shoha) &&
                                gauge.MeditationStacks is 3;
 
-                if (canAddShoha && CanWeave())
-                    return Shoha;
+            if (canAddShoha && CanWeave())
+                return Shoha;
 
-                if (IsEnabled(CustomComboPreset.SAM_Iaijutsu_OgiNamikiri) && (
-                        (LevelChecked(OgiNamikiri) && HasEffect(Buffs.OgiNamikiriReady)) ||
-                        gauge.Kaeshi == Kaeshi.NAMIKIRI))
-                    return OriginalHook(OgiNamikiri);
+            if (IsEnabled(CustomComboPreset.SAM_Iaijutsu_OgiNamikiri) && (
+                    (LevelChecked(OgiNamikiri) && HasEffect(Buffs.OgiNamikiriReady)) ||
+                    gauge.Kaeshi == Kaeshi.NAMIKIRI))
+                return OriginalHook(OgiNamikiri);
 
-                if (IsEnabled(CustomComboPreset.SAM_Iaijutsu_TsubameGaeshi) && (
-                        (LevelChecked(TsubameGaeshi) &&
-                         (HasEffect(Buffs.TsubameReady) || HasEffect(Buffs.KaeshiGokenReady))) ||
-                        (LevelChecked(TendoKaeshiSetsugekka) && (HasEffect(Buffs.TendoKaeshiSetsugekkaReady) ||
-                                                                 HasEffect(Buffs.TendoKaeshiGokenReady)))))
-                    return OriginalHook(TsubameGaeshi);
+            if (IsEnabled(CustomComboPreset.SAM_Iaijutsu_TsubameGaeshi) && (
+                    (LevelChecked(TsubameGaeshi) &&
+                     (HasEffect(Buffs.TsubameReady) || HasEffect(Buffs.KaeshiGokenReady))) ||
+                    (LevelChecked(TendoKaeshiSetsugekka) && (HasEffect(Buffs.TendoKaeshiSetsugekkaReady) ||
+                        HasEffect(Buffs.TendoKaeshiGokenReady)))))
+                return OriginalHook(TsubameGaeshi);
 
-                if (canAddShoha)
-                    return Shoha;
-            }
+            if (canAddShoha)
+                return Shoha;
 
             return actionID;
         }
@@ -888,21 +874,19 @@ internal partial class SAM
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Ikishoten)
+            if (actionID is not Ikishoten) return actionID;
+            if (!IsEnabled(CustomComboPreset.SAM_Ikishoten)) return actionID;
 
-                if (IsEnabled(CustomComboPreset.SAM_Ikishoten))
-                {
-                    if (IsEnabled(CustomComboPreset.SAM_Ikishoten_Shoha) &&
-                        ActionReady(Shoha) &&
-                        HasEffect(Buffs.OgiNamikiriReady) &&
-                        gauge.MeditationStacks is 3)
-                        return Shoha;
+            if (IsEnabled(CustomComboPreset.SAM_Ikishoten_Shoha) &&
+                ActionReady(Shoha) &&
+                HasEffect(Buffs.OgiNamikiriReady) &&
+                gauge.MeditationStacks is 3)
+                return Shoha;
 
-                    if ((IsEnabled(CustomComboPreset.SAM_Ikishoten_Namikiri) &&
-                         LevelChecked(OgiNamikiri) && HasEffect(Buffs.OgiNamikiriReady)) ||
-                        gauge.Kaeshi == Kaeshi.NAMIKIRI)
-                        return OriginalHook(OgiNamikiri);
-                }
+            if ((IsEnabled(CustomComboPreset.SAM_Ikishoten_Namikiri) &&
+                 LevelChecked(OgiNamikiri) && HasEffect(Buffs.OgiNamikiriReady)) ||
+                gauge.Kaeshi == Kaeshi.NAMIKIRI)
+                return OriginalHook(OgiNamikiri);
 
             return actionID;
         }

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -125,16 +125,16 @@ namespace WrathCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Recitation;
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is Recitation && HasEffect(Buffs.Recitation))
+                if (actionID is not Recitation || !HasEffect(Buffs.Recitation))
+                    return actionID;
+
+                switch ((int)Config.SCH_Recitation_Mode)
                 {
-                    switch ((int)Config.SCH_Recitation_Mode)
-                    {
-                        case 0: return OriginalHook(Adloquium);
-                        case 1: return OriginalHook(Succor);
-                        case 2: return OriginalHook(Indomitability);
-                        case 3: return OriginalHook(Excogitation);
-                        default: break;
-                    }
+                    case 0: return OriginalHook(Adloquium);
+                    case 1: return OriginalHook(Succor);
+                    case 2: return OriginalHook(Indomitability);
+                    case 3: return OriginalHook(Excogitation);
+                    default: break;
                 }
 
                 return actionID;
@@ -153,44 +153,44 @@ namespace WrathCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Aetherflow;
             protected override uint Invoke(uint actionID)
             {
-                if (AetherflowList.Contains(actionID) && LevelChecked(Aetherflow))
+                if (!AetherflowList.Contains(actionID) || !LevelChecked(Aetherflow))
+                    return actionID;
+
+                bool HasAetherFlows = Gauge.HasAetherflow(); //False if Zero stacks
+                if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Recite) &&
+                    LevelChecked(Recitation) &&
+                    (IsOffCooldown(Recitation) || HasEffect(Buffs.Recitation)))
                 {
-                    bool HasAetherFlows = Gauge.HasAetherflow(); //False if Zero stacks
-                    if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Recite) &&
-                        LevelChecked(Recitation) &&
-                        (IsOffCooldown(Recitation) || HasEffect(Buffs.Recitation)))
-                    {
-                        //Recitation Indominability and Excogitation, with optional check against AF zero stack count
-                        bool AlwaysShowReciteExcog = (Config.SCH_Aetherflow_Recite_ExcogMode == 1);
-                        if (Config.SCH_Aetherflow_Recite_Excog &&
-                            (AlwaysShowReciteExcog || (!AlwaysShowReciteExcog && !HasAetherFlows)) &&
-                            actionID is Excogitation)
-                        {   //Do not merge this nested if with above. Won't procede with next set
-                            return HasEffect(Buffs.Recitation) && IsOffCooldown(Excogitation) ? Excogitation : Recitation;
-                        }
-
-                        bool AlwaysShowReciteIndom = (Config.SCH_Aetherflow_Recite_IndomMode == 1);
-                        if (Config.SCH_Aetherflow_Recite_Indom &&
-                            (AlwaysShowReciteIndom || (!AlwaysShowReciteIndom && !HasAetherFlows)) &&
-                            actionID is Indomitability)
-                        {   //Same as above, do not nest with above. It won't procede with the next set
-                            return HasEffect(Buffs.Recitation) && IsOffCooldown(Excogitation) ? Indomitability : Recitation;
-                        }
+                    //Recitation Indominability and Excogitation, with optional check against AF zero stack count
+                    bool AlwaysShowReciteExcog = (Config.SCH_Aetherflow_Recite_ExcogMode == 1);
+                    if (Config.SCH_Aetherflow_Recite_Excog &&
+                        (AlwaysShowReciteExcog || (!AlwaysShowReciteExcog && !HasAetherFlows)) &&
+                        actionID is Excogitation)
+                    {   //Do not merge this nested if with above. Won't procede with next set
+                        return HasEffect(Buffs.Recitation) && IsOffCooldown(Excogitation) ? Excogitation : Recitation;
                     }
-                    if (!HasAetherFlows)
-                    {
-                        bool ShowAetherflowOnAll = (Config.SCH_Aetherflow_Display == 1);
-                        if (((actionID is EnergyDrain && !ShowAetherflowOnAll) || ShowAetherflowOnAll) &&
-                            IsOffCooldown(actionID))
-                        {
-                            if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Dissipation) &&
-                                ActionReady(Dissipation) &&
-                                IsOnCooldown(Aetherflow) &&
-                                //Dissipation requires fairy, can't seem to make it replace dissipation with fairy summon feature *shrug*
-                                HasPetPresent()) return Dissipation;
 
-                            else return Aetherflow;
-                        }
+                    bool AlwaysShowReciteIndom = (Config.SCH_Aetherflow_Recite_IndomMode == 1);
+                    if (Config.SCH_Aetherflow_Recite_Indom &&
+                        (AlwaysShowReciteIndom || (!AlwaysShowReciteIndom && !HasAetherFlows)) &&
+                        actionID is Indomitability)
+                    {   //Same as above, do not nest with above. It won't procede with the next set
+                        return HasEffect(Buffs.Recitation) && IsOffCooldown(Excogitation) ? Indomitability : Recitation;
+                    }
+                }
+                if (!HasAetherFlows)
+                {
+                    bool ShowAetherflowOnAll = (Config.SCH_Aetherflow_Display == 1);
+                    if (((actionID is EnergyDrain && !ShowAetherflowOnAll) || ShowAetherflowOnAll) &&
+                        IsOffCooldown(actionID))
+                    {
+                        if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Dissipation) &&
+                            ActionReady(Dissipation) &&
+                            IsOnCooldown(Aetherflow) &&
+                            //Dissipation requires fairy, can't seem to make it replace dissipation with fairy summon feature *shrug*
+                            HasPetPresent()) return Dissipation;
+
+                        else return Aetherflow;
                     }
                 }
                 return actionID;
@@ -227,19 +227,19 @@ namespace WrathCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_DeploymentTactics;
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is DeploymentTactics && ActionReady(DeploymentTactics))
+                if (actionID is not DeploymentTactics ||
+                    !ActionReady(DeploymentTactics)) return actionID;
+
+                //Grab our target (Soft->Hard->Self)
+                IGameObject? healTarget = GetHealTarget(Config.SCH_DeploymentTactics_Adv && Config.SCH_DeploymentTactics_UIMouseOver);
+
+                //Check for the Galvanize shield buff. Start applying if it doesn't exist
+                if (FindEffect(Buffs.Galvanize, healTarget, LocalPlayer.GameObjectId) is null)
                 {
-                    //Grab our target (Soft->Hard->Self)
-                    IGameObject? healTarget = GetHealTarget(Config.SCH_DeploymentTactics_Adv && Config.SCH_DeploymentTactics_UIMouseOver);
+                    if (IsEnabled(CustomComboPreset.SCH_DeploymentTactics_Recitation) && ActionReady(Recitation))
+                        return Recitation;
 
-                    //Check for the Galvanize shield buff. Start applying if it doesn't exist
-                    if (FindEffect(Buffs.Galvanize, healTarget, LocalPlayer.GameObjectId) is null)
-                    {
-                        if (IsEnabled(CustomComboPreset.SCH_DeploymentTactics_Recitation) && ActionReady(Recitation))
-                            return Recitation;
-
-                        return OriginalHook(Adloquium);
-                    }
+                    return OriginalHook(Adloquium);
                 }
                 return actionID;
             }
@@ -270,88 +270,88 @@ namespace WrathCombo.Combos.PvE
                 }
                 else ActionFound = BroilList.Contains(actionID); //default handling
 
-                if (ActionFound)
+                // Return if action not found
+                if (!ActionFound) return actionID;
+
+                if (IsEnabled(CustomComboPreset.SCH_DPS_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart) &&
+                    CanSpellWeave())
+                    return Variant.VariantRampart;
+
+                //Opener
+                if (IsEnabled(CustomComboPreset.SCH_DPS_Balance_Opener) &&
+                    Opener().FullOpener(ref actionID))
+                    return actionID;
+
+                // Aetherflow
+                if (IsEnabled(CustomComboPreset.SCH_DPS_Aetherflow) && !WasLastAction(Dissipation) &&
+                    ActionReady(Aetherflow) && !Gauge.HasAetherflow() &&
+                    InCombat() && CanSpellWeave())
+                    return Aetherflow;
+
+                // Lucid Dreaming
+                if (IsEnabled(CustomComboPreset.SCH_DPS_Lucid) &&
+                    ActionReady(All.LucidDreaming) &&
+                    LocalPlayer.CurrentMp <= Config.SCH_ST_DPS_LucidOption &&
+                    CanSpellWeave())
+                    return All.LucidDreaming;
+
+                //Target based options
+                if (HasBattleTarget())
                 {
-                    if (IsEnabled(CustomComboPreset.SCH_DPS_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanSpellWeave())
-                        return Variant.VariantRampart;
-
-                    //Opener
-                    if (IsEnabled(CustomComboPreset.SCH_DPS_Balance_Opener) &&
-                        Opener().FullOpener(ref actionID))
-                        return actionID;
-
-                    // Aetherflow
-                    if (IsEnabled(CustomComboPreset.SCH_DPS_Aetherflow) && !WasLastAction(Dissipation) &&
-                        ActionReady(Aetherflow) && !Gauge.HasAetherflow() &&
-                        InCombat() && CanSpellWeave())
-                        return Aetherflow;
-
-                    // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SCH_DPS_Lucid) &&
-                        ActionReady(All.LucidDreaming) &&
-                        LocalPlayer.CurrentMp <= Config.SCH_ST_DPS_LucidOption &&
-                        CanSpellWeave())
-                        return All.LucidDreaming;
-
-                    //Target based options
-                    if (HasBattleTarget())
+                    // Energy Drain
+                    if (IsEnabled(CustomComboPreset.SCH_DPS_EnergyDrain))
                     {
-                        // Energy Drain
-                        if (IsEnabled(CustomComboPreset.SCH_DPS_EnergyDrain))
-                        {
-                            float edTime = Config.SCH_ST_DPS_EnergyDrain_Adv ? Config.SCH_ST_DPS_EnergyDrain : 10f;
-                            if (LevelChecked(EnergyDrain) && InCombat() &&
-                                Gauge.HasAetherflow() &&
-                                GetCooldownRemainingTime(Aetherflow) <= edTime &&
-                                (!IsEnabled(CustomComboPreset.SCH_DPS_EnergyDrain_BurstSaver) || (LevelChecked(ChainStratagem) && GetCooldownRemainingTime(ChainStratagem) > 10) || (!ChainStratagem.LevelChecked())) &&
-                                CanSpellWeave())
-                                return EnergyDrain;
-                        }
-
-                        // Chain Stratagem
-                        if (IsEnabled(CustomComboPreset.SCH_DPS_ChainStrat))
-                        {
-                            // If CS is available and usable, or if the Impact Buff is on Player
-                            if (ActionReady(ChainStratagem) &&
-                                !TargetHasEffectAny(Debuffs.ChainStratagem) &&
-                                GetTargetHPPercent() > Config.SCH_ST_DPS_ChainStratagemOption &&
-                                InCombat() &&
-                                CanSpellWeave())
-                                return ChainStratagem;
-
-                            if (LevelChecked(BanefulImpaction) &&
-                                HasEffect(Buffs.ImpactImminent) &&
-                                InCombat() &&
-                                CanSpellWeave())
-                                return BanefulImpaction;
-                            // Don't use OriginalHook(ChainStratagem), because player can disable ingame action replacement
-                        }
-
-
-                        //Bio/Biolysis
-                        if (IsEnabled(CustomComboPreset.SCH_DPS_Bio) && LevelChecked(Bio) && InCombat() &&
-                            BioList.TryGetValue(OriginalHook(Bio), out ushort dotDebuffID))
-                        {
-                            if (IsEnabled(CustomComboPreset.SCH_DPS_Variant_SpiritDart) &&
-                                IsEnabled(Variant.VariantSpiritDart) &&
-                                GetDebuffRemainingTime(Variant.Debuffs.SustainedDamage) <= 3 &&
-                                CanSpellWeave())
-                                return Variant.VariantSpiritDart;
-
-                            float refreshtimer = Config.SCH_ST_DPS_Bio_Adv ? Config.SCH_ST_DPS_Bio_Threshold : 3;
-                            if (GetDebuffRemainingTime(dotDebuffID) <= refreshtimer &&
-                                GetTargetHPPercent() > Config.SCH_ST_DPS_BioOption)
-                                return OriginalHook(Bio); //Use appropriate DoT Action
-                        }
-
-                        //Ruin 2 Movement 
-                        if (IsEnabled(CustomComboPreset.SCH_DPS_Ruin2Movement) &&
-                            LevelChecked(Ruin2) &&
-                            IsMoving()) return OriginalHook(Ruin2);
+                        float edTime = Config.SCH_ST_DPS_EnergyDrain_Adv ? Config.SCH_ST_DPS_EnergyDrain : 10f;
+                        if (LevelChecked(EnergyDrain) && InCombat() &&
+                            Gauge.HasAetherflow() &&
+                            GetCooldownRemainingTime(Aetherflow) <= edTime &&
+                            (!IsEnabled(CustomComboPreset.SCH_DPS_EnergyDrain_BurstSaver) || (LevelChecked(ChainStratagem) && GetCooldownRemainingTime(ChainStratagem) > 10) || (!ChainStratagem.LevelChecked())) &&
+                            CanSpellWeave())
+                            return EnergyDrain;
                     }
+
+                    // Chain Stratagem
+                    if (IsEnabled(CustomComboPreset.SCH_DPS_ChainStrat))
+                    {
+                        // If CS is available and usable, or if the Impact Buff is on Player
+                        if (ActionReady(ChainStratagem) &&
+                            !TargetHasEffectAny(Debuffs.ChainStratagem) &&
+                            GetTargetHPPercent() > Config.SCH_ST_DPS_ChainStratagemOption &&
+                            InCombat() &&
+                            CanSpellWeave())
+                            return ChainStratagem;
+
+                        if (LevelChecked(BanefulImpaction) &&
+                            HasEffect(Buffs.ImpactImminent) &&
+                            InCombat() &&
+                            CanSpellWeave())
+                            return BanefulImpaction;
+                        // Don't use OriginalHook(ChainStratagem), because player can disable ingame action replacement
+                    }
+
+
+                    //Bio/Biolysis
+                    if (IsEnabled(CustomComboPreset.SCH_DPS_Bio) && LevelChecked(Bio) && InCombat() &&
+                        BioList.TryGetValue(OriginalHook(Bio), out ushort dotDebuffID))
+                    {
+                        if (IsEnabled(CustomComboPreset.SCH_DPS_Variant_SpiritDart) &&
+                            IsEnabled(Variant.VariantSpiritDart) &&
+                            GetDebuffRemainingTime(Variant.Debuffs.SustainedDamage) <= 3 &&
+                            CanSpellWeave())
+                            return Variant.VariantSpiritDart;
+
+                        float refreshtimer = Config.SCH_ST_DPS_Bio_Adv ? Config.SCH_ST_DPS_Bio_Threshold : 3;
+                        if (GetDebuffRemainingTime(dotDebuffID) <= refreshtimer &&
+                            GetTargetHPPercent() > Config.SCH_ST_DPS_BioOption)
+                            return OriginalHook(Bio); //Use appropriate DoT Action
+                    }
+
+                    //Ruin 2 Movement
+                    if (IsEnabled(CustomComboPreset.SCH_DPS_Ruin2Movement) &&
+                        LevelChecked(Ruin2) &&
+                        IsMoving()) return OriginalHook(Ruin2);
                 }
                 return actionID;
             }
@@ -367,35 +367,34 @@ namespace WrathCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AoE;
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is ArtOfWar or ArtOfWarII)
-                {
-                    if (IsEnabled(CustomComboPreset.SCH_DPS_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanSpellWeave())
-                        return Variant.VariantRampart;
+                if (actionID is not (ArtOfWar or ArtOfWarII)) return actionID;
 
-                    Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
-                    if (IsEnabled(CustomComboPreset.SCH_DPS_Variant_SpiritDart) &&
-                        IsEnabled(Variant.VariantSpiritDart) &&
-                        (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3) &&
-                        HasBattleTarget() &&
-                        CanSpellWeave())
-                        return Variant.VariantSpiritDart;
+                if (IsEnabled(CustomComboPreset.SCH_DPS_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart) &&
+                    CanSpellWeave())
+                    return Variant.VariantRampart;
 
-                    // Aetherflow
-                    if (IsEnabled(CustomComboPreset.SCH_AoE_Aetherflow) &&
-                        ActionReady(Aetherflow) && !Gauge.HasAetherflow() &&
-                        InCombat() && CanSpellWeave())
-                        return Aetherflow;
+                Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+                if (IsEnabled(CustomComboPreset.SCH_DPS_Variant_SpiritDart) &&
+                    IsEnabled(Variant.VariantSpiritDart) &&
+                    (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3) &&
+                    HasBattleTarget() &&
+                    CanSpellWeave())
+                    return Variant.VariantSpiritDart;
 
-                    // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SCH_AoE_Lucid) &&
-                        ActionReady(All.LucidDreaming) &&
-                        LocalPlayer.CurrentMp <= Config.SCH_AoE_LucidOption &&
-                        CanSpellWeave())
-                        return All.LucidDreaming;
-                }
+                // Aetherflow
+                if (IsEnabled(CustomComboPreset.SCH_AoE_Aetherflow) &&
+                    ActionReady(Aetherflow) && !Gauge.HasAetherflow() &&
+                    InCombat() && CanSpellWeave())
+                    return Aetherflow;
+
+                // Lucid Dreaming
+                if (IsEnabled(CustomComboPreset.SCH_AoE_Lucid) &&
+                    ActionReady(All.LucidDreaming) &&
+                    LocalPlayer.CurrentMp <= Config.SCH_AoE_LucidOption &&
+                    CanSpellWeave())
+                    return All.LucidDreaming;
                 return actionID;
             }
         }
@@ -410,37 +409,36 @@ namespace WrathCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AoE_Heal;
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is Succor)
+                if (actionID is not Succor) return actionID;
+
+                // Aetherflow
+                if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Aetherflow) &&
+                    ActionReady(Aetherflow) && !Gauge.HasAetherflow() &&
+                    !(IsEnabled(CustomComboPreset.SCH_AoE_Heal_Aetherflow_Indomitability) && GetCooldownRemainingTime(Indomitability) <= 0.6f) &&
+                    InCombat())
+                    return Aetherflow;
+
+                if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Dissipation)
+                    && ActionReady(Dissipation)
+                    && !Gauge.HasAetherflow()
+                    && InCombat())
+                    return Dissipation;
+
+                // Lucid Dreaming
+                if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Lucid)
+                    && All.CanUseLucid(actionID, Config.SCH_AoE_Heal_LucidOption, true))
+                    return All.LucidDreaming;
+
+                foreach (var prio in Config.SCH_AoE_Heals_Priority.Items.OrderBy(x => x))
                 {
-                    // Aetherflow
-                    if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Aetherflow) &&
-                        ActionReady(Aetherflow) && !Gauge.HasAetherflow() &&
-                        !(IsEnabled(CustomComboPreset.SCH_AoE_Heal_Aetherflow_Indomitability) && GetCooldownRemainingTime(Indomitability) <= 0.6f) &&
-                            InCombat())
-                        return Aetherflow;
+                    var index = Config.SCH_AoE_Heals_Priority.IndexOf(prio);
+                    var config = GetMatchingConfigAoE(index, out var spell, out bool enabled);
 
-                    if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Dissipation)
-                        && ActionReady(Dissipation)
-                        && !Gauge.HasAetherflow()
-                        && InCombat())
-                        return Dissipation;
-
-                    // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Lucid)
-                        && All.CanUseLucid(actionID, Config.SCH_AoE_Heal_LucidOption, true))
-                        return All.LucidDreaming;
-
-                    foreach (var prio in Config.SCH_AoE_Heals_Priority.Items.OrderBy(x => x))
+                    if (enabled)
                     {
-                        var index = Config.SCH_AoE_Heals_Priority.IndexOf(prio);
-                        var config = GetMatchingConfigAoE(index, out var spell, out bool enabled);
-
-                        if (enabled)
-                        {
-                            if (GetPartyAvgHPPercent() <= config &&
-                                ActionReady(spell))
-                                return spell;
-                        }
+                        if (GetPartyAvgHPPercent() <= config &&
+                            ActionReady(spell))
+                            return spell;
                     }
                 }
                 return actionID;
@@ -456,23 +454,21 @@ namespace WrathCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Fairy_Combo;
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is WhisperingDawn)
-                {
+                if (actionID is not WhisperingDawn) return actionID;
 
-                    // FeyIllumination
-                    if (ActionReady(FeyIllumination))
-                        return OriginalHook(FeyIllumination);
+                // FeyIllumination
+                if (ActionReady(FeyIllumination))
+                    return OriginalHook(FeyIllumination);
 
-                    // FeyBlessing
-                    if (ActionReady(FeyBlessing) && !(Gauge.SeraphTimer > 0))
-                        return OriginalHook(FeyBlessing);
+                // FeyBlessing
+                if (ActionReady(FeyBlessing) && !(Gauge.SeraphTimer > 0))
+                    return OriginalHook(FeyBlessing);
 
-                    if (IsEnabled(CustomComboPreset.SCH_Fairy_Combo_Consolation) && ActionReady(WhisperingDawn))
-                        return OriginalHook(actionID);
+                if (IsEnabled(CustomComboPreset.SCH_Fairy_Combo_Consolation) && ActionReady(WhisperingDawn))
+                    return OriginalHook(actionID);
 
-                    if (IsEnabled(CustomComboPreset.SCH_Fairy_Combo_Consolation) && Gauge.SeraphTimer > 0 && GetRemainingCharges(Consolation) > 0)
-                        return OriginalHook(Consolation);
-                }
+                if (IsEnabled(CustomComboPreset.SCH_Fairy_Combo_Consolation) && Gauge.SeraphTimer > 0 && GetRemainingCharges(Consolation) > 0)
+                    return OriginalHook(Consolation);
                 return actionID;
             }
         }
@@ -487,61 +483,60 @@ namespace WrathCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_ST_Heal;
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is Physick)
+                if (actionID is not Physick) return actionID;
+
+                // Aetherflow
+                if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Aetherflow) &&
+                    ActionReady(Aetherflow) && !Gauge.HasAetherflow() &&
+                    InCombat() && CanSpellWeave())
+                    return Aetherflow;
+
+                if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Dissipation)
+                    && ActionReady(Dissipation)
+                    && !Gauge.HasAetherflow()
+                    && InCombat())
+                    return Dissipation;
+
+                // Lucid Dreaming
+                if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Lucid) &&
+                    ActionReady(All.LucidDreaming) &&
+                    LocalPlayer.CurrentMp <= Config.SCH_ST_Heal_LucidOption &&
+                    CanSpellWeave())
+                    return All.LucidDreaming;
+
+                //Grab our target (Soft->Hard->Self)
+                IGameObject? healTarget = this.OptionalTarget ?? GetHealTarget(Config.SCH_ST_Heal_Adv && Config.SCH_ST_Heal_UIMouseOver);
+
+                if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Esuna) && ActionReady(All.Esuna) &&
+                    GetTargetHPPercent(healTarget, Config.SCH_ST_Heal_IncludeShields) >= Config.SCH_ST_Heal_EsunaOption &&
+                    HasCleansableDebuff(healTarget))
+                    return All.Esuna;
+
+                foreach (var prio in Config.SCH_ST_Heals_Priority.Items.OrderBy(x => x))
                 {
-                    // Aetherflow
-                    if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Aetherflow) &&
-                        ActionReady(Aetherflow) && !Gauge.HasAetherflow() &&
-                        InCombat() && CanSpellWeave())
-                        return Aetherflow;
+                    var index = Config.SCH_ST_Heals_Priority.IndexOf(prio);
+                    var config = GetMatchingConfigST(index, out var spell, out bool enabled);
 
-                    if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Dissipation) 
-                        && ActionReady(Dissipation) 
-                        && !Gauge.HasAetherflow() 
-                        && InCombat())
-                        return Dissipation;
-
-                    // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Lucid) &&
-                        ActionReady(All.LucidDreaming) &&
-                        LocalPlayer.CurrentMp <= Config.SCH_ST_Heal_LucidOption &&
-                        CanSpellWeave())
-                        return All.LucidDreaming;
-
-                    //Grab our target (Soft->Hard->Self)
-                    IGameObject? healTarget = this.OptionalTarget ?? GetHealTarget(Config.SCH_ST_Heal_Adv && Config.SCH_ST_Heal_UIMouseOver);
-
-                    if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Esuna) && ActionReady(All.Esuna) &&
-                        GetTargetHPPercent(healTarget, Config.SCH_ST_Heal_IncludeShields) >= Config.SCH_ST_Heal_EsunaOption &&
-                        HasCleansableDebuff(healTarget))
-                        return All.Esuna;
-
-                    foreach (var prio in Config.SCH_ST_Heals_Priority.Items.OrderBy(x => x))
+                    if (enabled)
                     {
-                        var index = Config.SCH_ST_Heals_Priority.IndexOf(prio);
-                        var config = GetMatchingConfigST(index, out var spell, out bool enabled);
-
-                        if (enabled)
-                        {
-                            if (GetTargetHPPercent(healTarget, Config.SCH_ST_Heal_IncludeShields) <= config &&
-                                ActionReady(spell))
-                                return spell;
-                        }
+                        if (GetTargetHPPercent(healTarget, Config.SCH_ST_Heal_IncludeShields) <= config &&
+                            ActionReady(spell))
+                            return spell;
                     }
+                }
 
-                    //Check for the Galvanize shield buff. Start applying if it doesn't exist or Target HP is below %
-                    if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Adloquium) &&
-                        ActionReady(Adloquium) &&
-                        GetTargetHPPercent(healTarget, Config.SCH_ST_Heal_IncludeShields) <= Config.SCH_ST_Heal_AdloquiumOption)
-                    {
-                        if (Config.SCH_ST_Heal_AldoquimOpts[2] && ActionReady(EmergencyTactics)) return EmergencyTactics;
+                //Check for the Galvanize shield buff. Start applying if it doesn't exist or Target HP is below %
+                if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Adloquium) &&
+                    ActionReady(Adloquium) &&
+                    GetTargetHPPercent(healTarget, Config.SCH_ST_Heal_IncludeShields) <= Config.SCH_ST_Heal_AdloquiumOption)
+                {
+                    if (Config.SCH_ST_Heal_AldoquimOpts[2] && ActionReady(EmergencyTactics)) return EmergencyTactics;
 
-                        if ((Config.SCH_ST_Heal_AldoquimOpts[0] || FindEffectOnMember(Buffs.Galvanize, healTarget) is null) && //Ignore existing shield check
-                            (!Config.SCH_ST_Heal_AldoquimOpts[1] || 
-                            (FindEffectOnMember(SGE.Buffs.EukrasianDiagnosis, healTarget) is null && FindEffectOnMember(SGE.Buffs.EukrasianPrognosis, healTarget) is null)
+                    if ((Config.SCH_ST_Heal_AldoquimOpts[0] || FindEffectOnMember(Buffs.Galvanize, healTarget) is null) && //Ignore existing shield check
+                        (!Config.SCH_ST_Heal_AldoquimOpts[1] ||
+                         (FindEffectOnMember(SGE.Buffs.EukrasianDiagnosis, healTarget) is null && FindEffectOnMember(SGE.Buffs.EukrasianPrognosis, healTarget) is null)
                         )) //Eukrasia Shield Check
                         return OriginalHook(Adloquium);
-                    }
                 }
                 return actionID;
             }

--- a/WrathCombo/Combos/PvE/SGE/SGE.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE.cs
@@ -178,101 +178,100 @@ internal partial class SGE
 
         protected override uint Invoke(uint actionID)
         {
-            if (DyskrasiaList.Contains(actionID))
-                if (!HasEffect(Buffs.Eukrasia))
+            if (!DyskrasiaList.Contains(actionID)) return actionID;
+            if (HasEffect(Buffs.Eukrasia)) return actionID;
+
+            // Variant Rampart
+            if (IsEnabled(CustomComboPreset.SGE_DPS_Variant_Rampart) &&
+                IsEnabled(Variant.VariantRampart) &&
+                IsOffCooldown(Variant.VariantRampart) &&
+                CanSpellWeave())
+                return Variant.VariantRampart;
+
+            // Variant Spirit Dart
+            Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+
+            if (IsEnabled(CustomComboPreset.SGE_DPS_Variant_SpiritDart) &&
+                IsEnabled(Variant.VariantSpiritDart) &&
+                (sustainedDamage is null || sustainedDamage.RemainingTime <= 3) &&
+                CanSpellWeave())
+                return Variant.VariantSpiritDart;
+
+            // Lucid Dreaming
+            if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Lucid) &&
+                ActionReady(All.LucidDreaming) && CanSpellWeave() &&
+                LocalPlayer.CurrentMp <= Config.SGE_AoE_DPS_Lucid)
+                return All.LucidDreaming;
+
+            // Rhizomata
+            if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Rhizo) && CanSpellWeave() &&
+                ActionReady(Rhizomata) && Gauge.Addersgall <= Config.SGE_AoE_DPS_Rhizo)
+                return Rhizomata;
+
+            //Soteria
+            if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Soteria) && CanSpellWeave() &&
+                ActionReady(Soteria) && HasEffect(Buffs.Kardia))
+                return Soteria;
+
+            // Addersgall Protection
+            if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_AddersgallProtect) &&
+                CanSpellWeave() &&
+                ActionReady(Druochole) && Gauge.Addersgall >= Config.SGE_AoE_DPS_AddersgallProtect)
+                return Druochole;
+
+            //Eukrasia for DoT
+            if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_EDyskrasia))
+                if (IsOffCooldown(Eukrasia) &&
+                    !WasLastSpell(
+                        EukrasianDyskrasia) && //AoE DoT can be slow to take affect, doesn't apply to target first before others
+                    TraitLevelChecked(Traits.OffensiveMagicMasteryII) &&
+                    HasBattleTarget() &&
+                    InActionRange(Dyskrasia) && //Same range
+                    DosisList.TryGetValue(OriginalHook(Dosis), out ushort dotDebuffID))
                 {
-                    // Variant Rampart
-                    if (IsEnabled(CustomComboPreset.SGE_DPS_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanSpellWeave())
-                        return Variant.VariantRampart;
+                    float dotDebuff = Math.Max(GetDebuffRemainingTime(dotDebuffID),
+                        GetDebuffRemainingTime(Debuffs.EukrasianDyskrasia));
 
-                    // Variant Spirit Dart
-                    Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+                    float
+                        refreshtimer =
+                            3; //Will revisit if it's really needed....SGE_ST_DPS_EDosis_Adv ? Config.SGE_ST_DPS_EDosisThreshold : 3;
 
-                    if (IsEnabled(CustomComboPreset.SGE_DPS_Variant_SpiritDart) &&
-                        IsEnabled(Variant.VariantSpiritDart) &&
-                        (sustainedDamage is null || sustainedDamage.RemainingTime <= 3) &&
-                        CanSpellWeave())
-                        return Variant.VariantSpiritDart;
-
-                    // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Lucid) &&
-                        ActionReady(All.LucidDreaming) && CanSpellWeave() &&
-                        LocalPlayer.CurrentMp <= Config.SGE_AoE_DPS_Lucid)
-                        return All.LucidDreaming;
-
-                    // Rhizomata
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Rhizo) && CanSpellWeave() &&
-                        ActionReady(Rhizomata) && Gauge.Addersgall <= Config.SGE_AoE_DPS_Rhizo)
-                        return Rhizomata;
-
-                    //Soteria
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Soteria) && CanSpellWeave() &&
-                        ActionReady(Soteria) && HasEffect(Buffs.Kardia))
-                        return Soteria;
-
-                    // Addersgall Protection
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_AddersgallProtect) &&
-                        CanSpellWeave() &&
-                        ActionReady(Druochole) && Gauge.Addersgall >= Config.SGE_AoE_DPS_AddersgallProtect)
-                        return Druochole;
-
-                    //Eukrasia for DoT
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_EDyskrasia))
-                        if (IsOffCooldown(Eukrasia) &&
-                            !WasLastSpell(
-                                EukrasianDyskrasia) && //AoE DoT can be slow to take affect, doesn't apply to target first before others
-                            TraitLevelChecked(Traits.OffensiveMagicMasteryII) &&
-                            HasBattleTarget() &&
-                            InActionRange(Dyskrasia) && //Same range
-                            DosisList.TryGetValue(OriginalHook(Dosis), out ushort dotDebuffID))
-                        {
-                            float dotDebuff = Math.Max(GetDebuffRemainingTime(dotDebuffID),
-                                GetDebuffRemainingTime(Debuffs.EukrasianDyskrasia));
-
-                            float
-                                refreshtimer =
-                                    3; //Will revisit if it's really needed....SGE_ST_DPS_EDosis_Adv ? Config.SGE_ST_DPS_EDosisThreshold : 3;
-
-                            if (dotDebuff <= refreshtimer &&
-                                GetTargetHPPercent() >
-                                10) //Will Revisit if Config is needed Config.SGE_ST_DPS_EDosisHPPer)
-                                return Eukrasia;
-                        }
-
-                    // Psyche
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Psyche))
-                        if (ActionReady(Psyche) &&
-                            HasBattleTarget() &&
-                            InActionRange(Psyche) &&
-                            CanSpellWeave())
-                            return Psyche;
-
-                    //Phlegma
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Phlegma))
-                    {
-                        uint PhlegmaID = OriginalHook(Phlegma);
-
-                        if (ActionReady(PhlegmaID) &&
-                            HasBattleTarget() &&
-                            InActionRange(PhlegmaID))
-                            return PhlegmaID;
-                    }
-
-                    //Toxikon
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Toxikon))
-                    {
-                        uint ToxikonID = OriginalHook(Toxikon);
-
-                        if (ActionReady(ToxikonID) &&
-                            HasBattleTarget() &&
-                            InActionRange(ToxikonID) &&
-                            Gauge.HasAddersting())
-                            return ToxikonID;
-                    }
+                    if (dotDebuff <= refreshtimer &&
+                        GetTargetHPPercent() >
+                        10) //Will Revisit if Config is needed Config.SGE_ST_DPS_EDosisHPPer)
+                        return Eukrasia;
                 }
+
+            // Psyche
+            if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Psyche))
+                if (ActionReady(Psyche) &&
+                    HasBattleTarget() &&
+                    InActionRange(Psyche) &&
+                    CanSpellWeave())
+                    return Psyche;
+
+            //Phlegma
+            if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Phlegma))
+            {
+                uint PhlegmaID = OriginalHook(Phlegma);
+
+                if (ActionReady(PhlegmaID) &&
+                    HasBattleTarget() &&
+                    InActionRange(PhlegmaID))
+                    return PhlegmaID;
+            }
+
+            //Toxikon
+            if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Toxikon))
+            {
+                uint ToxikonID = OriginalHook(Toxikon);
+
+                if (ActionReady(ToxikonID) &&
+                    HasBattleTarget() &&
+                    InActionRange(ToxikonID) &&
+                    Gauge.HasAddersting())
+                    return ToxikonID;
+            }
 
             return actionID;
         }
@@ -291,110 +290,109 @@ internal partial class SGE
         {
             bool ActionFound = actionID is Dosis2 || (!Config.SGE_ST_DPS_Adv && DosisList.ContainsKey(actionID));
 
-            if (ActionFound)
+            if (!ActionFound) return actionID;
+
+            // Kardia Reminder
+            if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Kardia) && LevelChecked(Kardia) &&
+                FindEffect(Buffs.Kardia) is null)
+                return Kardia;
+
+            // Opener for SGE
+            if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Opener))
+                if (Opener().FullOpener(ref actionID))
+                    return actionID;
+
+            // Lucid Dreaming
+            if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Lucid) &&
+                All.CanUseLucid(actionID, Config.SGE_ST_DPS_Lucid))
+                return All.LucidDreaming;
+
+            // Variant
+            if (IsEnabled(CustomComboPreset.SGE_DPS_Variant_Rampart) &&
+                IsEnabled(Variant.VariantRampart) &&
+                IsOffCooldown(Variant.VariantRampart) &&
+                CanSpellWeave())
+                return Variant.VariantRampart;
+
+            // Rhizomata
+            if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Rhizo) && CanSpellWeave() &&
+                ActionReady(Rhizomata) && Gauge.Addersgall <= Config.SGE_ST_DPS_Rhizo)
+                return Rhizomata;
+
+            //Soteria
+            if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Soteria) && CanSpellWeave() &&
+                ActionReady(Soteria) && HasEffect(Buffs.Kardia))
+                return Soteria;
+
+            // Addersgall Protection
+            if (IsEnabled(CustomComboPreset.SGE_ST_DPS_AddersgallProtect) && CanSpellWeave() &&
+                ActionReady(Druochole) && Gauge.Addersgall >= Config.SGE_ST_DPS_AddersgallProtect)
+                return Druochole;
+
+            if (HasBattleTarget() && !HasEffect(Buffs.Eukrasia))
+
+                // Buff check Above. Without it, Toxikon and any future option will interfere in the Eukrasia->Eukrasia Dosis combo
             {
-                // Kardia Reminder
-                if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Kardia) && LevelChecked(Kardia) &&
-                    FindEffect(Buffs.Kardia) is null)
-                    return Kardia;
+                // Eukrasian Dosis.
+                // If we're too low level to use Eukrasia, we can stop here.
+                if (IsEnabled(CustomComboPreset.SGE_ST_DPS_EDosis) && LevelChecked(Eukrasia) && InCombat())
 
-                // Opener for SGE
-                if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Opener))
-                    if (Opener().FullOpener(ref actionID))
-                        return actionID;
+                    // Grab current Dosis via OriginalHook, grab it's fellow debuff ID from Dictionary, then check for the debuff
+                    // Using TryGetValue due to edge case where the actionID would be read as Eukrasian Dosis instead of Dosis
+                    // EDosis will show for half a second if the buff is removed manually or some other act of God
+                    if (DosisList.TryGetValue(OriginalHook(actionID), out ushort dotDebuffID))
+                    {
+                        if (IsEnabled(CustomComboPreset.SGE_DPS_Variant_SpiritDart) &&
+                            IsEnabled(Variant.VariantSpiritDart) &&
+                            GetDebuffRemainingTime(Variant.Debuffs.SustainedDamage) <= 3 &&
+                            CanSpellWeave())
+                            return Variant.VariantSpiritDart;
 
-                // Lucid Dreaming
-                if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Lucid) &&
-                    All.CanUseLucid(actionID, Config.SGE_ST_DPS_Lucid))
-                    return All.LucidDreaming;
+                        // Dosis DoT Debuff
+                        float dotDebuff = GetDebuffRemainingTime(dotDebuffID);
 
-                // Variant
-                if (IsEnabled(CustomComboPreset.SGE_DPS_Variant_Rampart) &&
-                    IsEnabled(Variant.VariantRampart) &&
-                    IsOffCooldown(Variant.VariantRampart) &&
-                    CanSpellWeave())
-                    return Variant.VariantRampart;
+                        // Check for the AoE DoT.  These DoTs overlap, so get time remaining of any of them
+                        if (TraitLevelChecked(Traits.OffensiveMagicMasteryII))
+                            dotDebuff = Math.Max(dotDebuff, GetDebuffRemainingTime(Debuffs.EukrasianDyskrasia));
 
-                // Rhizomata
-                if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Rhizo) && CanSpellWeave() &&
-                    ActionReady(Rhizomata) && Gauge.Addersgall <= Config.SGE_ST_DPS_Rhizo)
-                    return Rhizomata;
+                        float refreshtimer = Config.SGE_ST_DPS_EDosis_Adv ? Config.SGE_ST_DPS_EDosisThreshold : 3;
 
-                //Soteria
-                if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Soteria) && CanSpellWeave() &&
-                    ActionReady(Soteria) && HasEffect(Buffs.Kardia))
-                    return Soteria;
+                        if (dotDebuff <= refreshtimer &&
+                            GetTargetHPPercent() > Config.SGE_ST_DPS_EDosisHPPer)
+                            return Eukrasia;
+                    }
 
-                // Addersgall Protection
-                if (IsEnabled(CustomComboPreset.SGE_ST_DPS_AddersgallProtect) && CanSpellWeave() &&
-                    ActionReady(Druochole) && Gauge.Addersgall >= Config.SGE_ST_DPS_AddersgallProtect)
-                    return Druochole;
-
-                if (HasBattleTarget() && !HasEffect(Buffs.Eukrasia))
-
-                    // Buff check Above. Without it, Toxikon and any future option will interfere in the Eukrasia->Eukrasia Dosis combo
+                // Phlegma
+                if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Phlegma) && InCombat())
                 {
-                    // Eukrasian Dosis.
-                    // If we're too low level to use Eukrasia, we can stop here.
-                    if (IsEnabled(CustomComboPreset.SGE_ST_DPS_EDosis) && LevelChecked(Eukrasia) && InCombat())
+                    uint phlegma = OriginalHook(Phlegma);
 
-                        // Grab current Dosis via OriginalHook, grab it's fellow debuff ID from Dictionary, then check for the debuff
-                        // Using TryGetValue due to edge case where the actionID would be read as Eukrasian Dosis instead of Dosis
-                        // EDosis will show for half a second if the buff is removed manually or some other act of God
-                        if (DosisList.TryGetValue(OriginalHook(actionID), out ushort dotDebuffID))
-                        {
-                            if (IsEnabled(CustomComboPreset.SGE_DPS_Variant_SpiritDart) &&
-                                IsEnabled(Variant.VariantSpiritDart) &&
-                                GetDebuffRemainingTime(Variant.Debuffs.SustainedDamage) <= 3 &&
-                                CanSpellWeave())
-                                return Variant.VariantSpiritDart;
+                    if (InActionRange(phlegma) && ActionReady(phlegma)) return phlegma;
+                }
 
-                            // Dosis DoT Debuff
-                            float dotDebuff = GetDebuffRemainingTime(dotDebuffID);
+                // Psyche
+                if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Psyche) &&
+                    ActionReady(Psyche) &&
+                    InCombat() &&
+                    CanSpellWeave())
+                    return Psyche;
 
-                            // Check for the AoE DoT.  These DoTs overlap, so get time remaining of any of them
-                            if (TraitLevelChecked(Traits.OffensiveMagicMasteryII))
-                                dotDebuff = Math.Max(dotDebuff, GetDebuffRemainingTime(Debuffs.EukrasianDyskrasia));
-
-                            float refreshtimer = Config.SGE_ST_DPS_EDosis_Adv ? Config.SGE_ST_DPS_EDosisThreshold : 3;
-
-                            if (dotDebuff <= refreshtimer &&
-                                GetTargetHPPercent() > Config.SGE_ST_DPS_EDosisHPPer)
-                                return Eukrasia;
-                        }
-
-                    // Phlegma
-                    if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Phlegma) && InCombat())
-                    {
-                        uint phlegma = OriginalHook(Phlegma);
-
-                        if (InActionRange(phlegma) && ActionReady(phlegma)) return phlegma;
-                    }
-
+                // Movement Options
+                if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Movement) && InCombat() && IsMoving())
+                {
                     // Psyche
-                    if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Psyche) &&
-                        ActionReady(Psyche) &&
-                        InCombat() &&
-                        CanSpellWeave())
-                        return Psyche;
+                    if (Config.SGE_ST_DPS_Movement[3] && ActionReady(Psyche)) return Psyche;
 
-                    // Movement Options
-                    if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Movement) && InCombat() && IsMoving())
-                    {
-                        // Psyche
-                        if (Config.SGE_ST_DPS_Movement[3] && ActionReady(Psyche)) return Psyche;
+                    // Toxikon
+                    if (Config.SGE_ST_DPS_Movement[0] && LevelChecked(Toxikon) && Gauge.HasAddersting())
+                        return OriginalHook(Toxikon);
 
-                        // Toxikon
-                        if (Config.SGE_ST_DPS_Movement[0] && LevelChecked(Toxikon) && Gauge.HasAddersting())
-                            return OriginalHook(Toxikon);
+                    // Dyskrasia
+                    if (Config.SGE_ST_DPS_Movement[1] && LevelChecked(Dyskrasia) && InActionRange(Dyskrasia))
+                        return OriginalHook(Dyskrasia);
 
-                        // Dyskrasia
-                        if (Config.SGE_ST_DPS_Movement[1] && LevelChecked(Dyskrasia) && InActionRange(Dyskrasia))
-                            return OriginalHook(Dyskrasia);
-
-                        // Eukrasia
-                        if (Config.SGE_ST_DPS_Movement[2] && LevelChecked(Eukrasia)) return Eukrasia;
-                    }
+                    // Eukrasia
+                    if (Config.SGE_ST_DPS_Movement[2] && LevelChecked(Eukrasia)) return Eukrasia;
                 }
             }
 
@@ -427,17 +425,19 @@ internal partial class SGE
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Eukrasia && HasEffect(Buffs.Eukrasia))
-                switch ((int)Config.SGE_Eukrasia_Mode)
-                {
-                    case 0: return OriginalHook(Dosis);
+            if (actionID is not Eukrasia || !HasEffect(Buffs.Eukrasia))
+                return actionID;
 
-                    case 1: return OriginalHook(Diagnosis);
+            switch ((int)Config.SGE_Eukrasia_Mode)
+            {
+                case 0: return OriginalHook(Dosis);
 
-                    case 2: return OriginalHook(Prognosis);
+                case 1: return OriginalHook(Diagnosis);
 
-                    case 3: return OriginalHook(Dyskrasia);
-                }
+                case 2: return OriginalHook(Prognosis);
+
+                case 3: return OriginalHook(Dyskrasia);
+            }
 
             return actionID;
         }
@@ -454,48 +454,47 @@ internal partial class SGE
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Diagnosis)
+            if (actionID is not Diagnosis) return actionID;
+
+            if (HasEffect(Buffs.Eukrasia))
+                return EukrasianDiagnosis;
+
+            IGameObject? healTarget = OptionalTarget ??
+                                      GetHealTarget(Config.SGE_ST_Heal_Adv && Config.SGE_ST_Heal_UIMouseOver);
+
+            if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Esuna) && ActionReady(All.Esuna) &&
+                GetTargetHPPercent(healTarget, Config.SGE_ST_Heal_IncludeShields) >= Config.SGE_ST_Heal_Esuna &&
+                HasCleansableDebuff(healTarget))
+                return All.Esuna;
+
+            if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Rhizomata) && ActionReady(Rhizomata) &&
+                !Gauge.HasAddersgall())
+                return Rhizomata;
+
+            if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Kardia) && LevelChecked(Kardia) &&
+                FindEffect(Buffs.Kardia) is null &&
+                FindEffect(Buffs.Kardion, healTarget, LocalPlayer?.GameObjectId) is null)
+                return Kardia;
+
+            foreach (int prio in Config.SGE_ST_Heals_Priority.Items.OrderBy(x => x))
             {
-                if (HasEffect(Buffs.Eukrasia))
-                    return EukrasianDiagnosis;
+                int index = Config.SGE_ST_Heals_Priority.IndexOf(prio);
+                int config = SGEHelper.GetMatchingConfigST(index, OptionalTarget, out uint spell, out bool enabled);
 
-                IGameObject? healTarget = OptionalTarget ??
-                                          GetHealTarget(Config.SGE_ST_Heal_Adv && Config.SGE_ST_Heal_UIMouseOver);
-
-                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Esuna) && ActionReady(All.Esuna) &&
-                    GetTargetHPPercent(healTarget, Config.SGE_ST_Heal_IncludeShields) >= Config.SGE_ST_Heal_Esuna &&
-                    HasCleansableDebuff(healTarget))
-                    return All.Esuna;
-
-                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Rhizomata) && ActionReady(Rhizomata) &&
-                    !Gauge.HasAddersgall())
-                    return Rhizomata;
-
-                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Kardia) && LevelChecked(Kardia) &&
-                    FindEffect(Buffs.Kardia) is null &&
-                    FindEffect(Buffs.Kardion, healTarget, LocalPlayer?.GameObjectId) is null)
-                    return Kardia;
-
-                foreach (int prio in Config.SGE_ST_Heals_Priority.Items.OrderBy(x => x))
-                {
-                    int index = Config.SGE_ST_Heals_Priority.IndexOf(prio);
-                    int config = SGEHelper.GetMatchingConfigST(index, OptionalTarget, out uint spell, out bool enabled);
-
-                    if (enabled)
-                        if (GetTargetHPPercent(healTarget, Config.SGE_ST_Heal_IncludeShields) <= config &&
-                            ActionReady(spell))
-                            return spell;
-                }
-
-                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_EDiagnosis) && LevelChecked(Eukrasia) &&
-                    GetTargetHPPercent(healTarget, Config.SGE_ST_Heal_IncludeShields) <=
-                    Config.SGE_ST_Heal_EDiagnosisHP &&
-                    (Config.SGE_ST_Heal_EDiagnosisOpts[0] ||
-                     FindEffectOnMember(Buffs.EukrasianDiagnosis, healTarget) is null) && //Ignore existing shield check
-                    (!Config.SGE_ST_Heal_EDiagnosisOpts[1] ||
-                     FindEffectOnMember(SCH.Buffs.Galvanize, healTarget) is null)) //Galvenize Check
-                    return Eukrasia;
+                if (enabled)
+                    if (GetTargetHPPercent(healTarget, Config.SGE_ST_Heal_IncludeShields) <= config &&
+                        ActionReady(spell))
+                        return spell;
             }
+
+            if (IsEnabled(CustomComboPreset.SGE_ST_Heal_EDiagnosis) && LevelChecked(Eukrasia) &&
+                GetTargetHPPercent(healTarget, Config.SGE_ST_Heal_IncludeShields) <=
+                Config.SGE_ST_Heal_EDiagnosisHP &&
+                (Config.SGE_ST_Heal_EDiagnosisOpts[0] ||
+                 FindEffectOnMember(Buffs.EukrasianDiagnosis, healTarget) is null) && //Ignore existing shield check
+                (!Config.SGE_ST_Heal_EDiagnosisOpts[1] ||
+                 FindEffectOnMember(SCH.Buffs.Galvanize, healTarget) is null)) //Galvenize Check
+                return Eukrasia;
 
             return actionID;
         }
@@ -512,30 +511,29 @@ internal partial class SGE
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Prognosis)
+            if (actionID is not Prognosis) return actionID;
+
+            if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EPrognosis) && HasEffect(Buffs.Eukrasia))
+                return OriginalHook(Prognosis);
+
+            if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Rhizomata) && ActionReady(Rhizomata) &&
+                !Gauge.HasAddersgall())
+                return Rhizomata;
+
+            foreach (int prio in Config.SGE_AoE_Heals_Priority.Items.OrderBy(x => x))
             {
-                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EPrognosis) && HasEffect(Buffs.Eukrasia))
-                    return OriginalHook(Prognosis);
+                int index = Config.SGE_AoE_Heals_Priority.IndexOf(prio);
+                int config = SGEHelper.GetMatchingConfigAoE(index, out uint spell, out bool enabled);
 
-                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Rhizomata) && ActionReady(Rhizomata) &&
-                    !Gauge.HasAddersgall())
-                    return Rhizomata;
-
-                foreach (int prio in Config.SGE_AoE_Heals_Priority.Items.OrderBy(x => x))
-                {
-                    int index = Config.SGE_AoE_Heals_Priority.IndexOf(prio);
-                    int config = SGEHelper.GetMatchingConfigAoE(index, out uint spell, out bool enabled);
-
-                    if (enabled)
-                        if (ActionReady(spell))
-                            return spell;
-                }
-
-                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EPrognosis) && LevelChecked(Eukrasia) &&
-                    (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EPrognosis_IgnoreShield) ||
-                     FindEffect(Buffs.EukrasianPrognosis) is null))
-                    return Eukrasia;
+                if (enabled)
+                    if (ActionReady(spell))
+                        return spell;
             }
+
+            if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EPrognosis) && LevelChecked(Eukrasia) &&
+                (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EPrognosis_IgnoreShield) ||
+                 FindEffect(Buffs.EukrasianPrognosis) is null))
+                return Eukrasia;
 
             return actionID;
         }
@@ -547,6 +545,8 @@ internal partial class SGE
 
         protected override uint Invoke(uint actionID)
         {
+            if (actionID is not (Kerachole or Panhaima or Philosophia)) return actionID;
+
             if (actionID is Kerachole && IsEnabled(CustomComboPreset.SGE_OverProtect_Kerachole) &&
                 ActionReady(Kerachole))
                 if (HasEffectAny(Buffs.Kerachole) ||

--- a/WrathCombo/Combos/PvE/SMN/SMN.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN.cs
@@ -147,14 +147,13 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == All.Swiftcast)
-                {
-                    if (HasEffect(All.Buffs.Swiftcast) && IsEnabled(CustomComboPreset.SMN_Variant_Raise) && IsEnabled(Variant.VariantRaise))
-                        return Variant.VariantRaise;
+                if (actionID != All.Swiftcast) return actionID;
 
-                    if (IsOnCooldown(All.Swiftcast))
-                        return Resurrection;
-                }
+                if (HasEffect(All.Buffs.Swiftcast) && IsEnabled(CustomComboPreset.SMN_Variant_Raise) && IsEnabled(Variant.VariantRaise))
+                    return Variant.VariantRaise;
+
+                if (IsOnCooldown(All.Swiftcast))
+                    return Resurrection;
                 return actionID;
             }
         }
@@ -165,13 +164,11 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == Ruin4)
-                {
-                    var furtherRuin = HasEffect(Buffs.FurtherRuin);
+                if (actionID != Ruin4) return actionID;
+                var furtherRuin = HasEffect(Buffs.FurtherRuin);
 
-                    if (!furtherRuin)
-                        return Ruin3;
-                }
+                if (!furtherRuin)
+                    return Ruin3;
                 return actionID;
             }
         }
@@ -182,15 +179,14 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is Fester or Necrotize)
-                {
-                    var gauge = GetJobGauge<SMNGauge>();
-                    if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergyDrain) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SMN_EDFester_Ruin4))
-                        return Ruin4;
+                if (actionID is not (Fester or Necrotize)) return actionID;
 
-                    if (LevelChecked(EnergyDrain) && !gauge.HasAetherflowStacks)
-                        return EnergyDrain;
-                }
+                var gauge = GetJobGauge<SMNGauge>();
+                if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergyDrain) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SMN_EDFester_Ruin4))
+                    return Ruin4;
+
+                if (LevelChecked(EnergyDrain) && !gauge.HasAetherflowStacks)
+                    return EnergyDrain;
 
                 return actionID;
             }
@@ -202,19 +198,20 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
+                if (actionID is not Painflare) return actionID;
+
                 var gauge = GetJobGauge<SMNGauge>();
 
-                if (actionID == Painflare && LevelChecked(Painflare) && !gauge.HasAetherflowStacks)
-                {
-                    if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergySiphon) && IsEnabled(CustomComboPreset.SMN_ESPainflare_Ruin4))
-                        return Ruin4;
+                if (!LevelChecked(Painflare) || gauge.HasAetherflowStacks) return actionID;
 
-                    if (LevelChecked(EnergySiphon))
-                        return EnergySiphon;
+                if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergySiphon) && IsEnabled(CustomComboPreset.SMN_ESPainflare_Ruin4))
+                    return Ruin4;
 
-                    if (LevelChecked(EnergyDrain))
-                        return EnergyDrain;
-                }
+                if (LevelChecked(EnergySiphon))
+                    return EnergySiphon;
+
+                if (LevelChecked(EnergyDrain))
+                    return EnergyDrain;
 
                 return actionID;
             }
@@ -226,6 +223,8 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
+                if (actionID is not (Ruin or Ruin2)) return actionID;
+
                 var gauge = GetJobGauge<SMNGauge>();
                 var IsGarudaAttuned = OriginalHook(Gemshine) is EmeralRuin1 or EmeralRuin2 or EmeralRuin3 or EmeraldRite;
                 var IsTitanAttuned = OriginalHook(Gemshine) is TopazRuin1 or TopazRuin2 or TopazRuin3 or TopazRite;
@@ -234,109 +233,106 @@ namespace WrathCombo.Combos.PvE
                 var IsPhoenixReady = OriginalHook(Aethercharge) is SummonPhoenix;
                 var IsSolarBahamutReady = OriginalHook(Aethercharge) is SummonSolarBahamut;
 
-                if (actionID is Ruin or Ruin2)
+                if (IsEnabled(CustomComboPreset.SMN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.SMN_VariantCure))
+                    return Variant.VariantCure;
+
+                if (IsEnabled(CustomComboPreset.SMN_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart) &&
+                    CanSpellWeave())
+                    return Variant.VariantRampart;
+
+                if (!HasPetPresent())
+                    return SummonCarbuncle;
+
+                if (CanSpellWeave())
                 {
-                    if (IsEnabled(CustomComboPreset.SMN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.SMN_VariantCure))
-                        return Variant.VariantCure;
+                    if (IsOffCooldown(SearingLight) && LevelChecked(SearingLight) && ((!LevelChecked(SummonSolarBahamut) && OriginalHook(Ruin) is AstralImpulse) || OriginalHook(Ruin) is UmbralImpulse))
+                        return SearingLight;
 
-                    if (IsEnabled(CustomComboPreset.SMN_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanSpellWeave())
-                        return Variant.VariantRampart;
+                    if (!gauge.HasAetherflowStacks && LevelChecked(EnergyDrain) && IsOffCooldown(EnergyDrain))
+                        return EnergyDrain;
 
-                    if (!HasPetPresent())
-                        return SummonCarbuncle;
+                    if (HasEffect(Buffs.RubysGlimmer) && LevelChecked(SearingFlash))
+                        return SearingFlash;
 
-                    if (CanSpellWeave())
+                    if (OriginalHook(Ruin) is AstralImpulse or UmbralImpulse or FountainOfFire)
                     {
-                        if (IsOffCooldown(SearingLight) && LevelChecked(SearingLight) && ((!LevelChecked(SummonSolarBahamut) && OriginalHook(Ruin) is AstralImpulse) || OriginalHook(Ruin) is UmbralImpulse))
-                            return SearingLight;
+                        if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && LevelChecked(SummonBahamut))
+                            return OriginalHook(EnkindleBahamut);
 
-                        if (!gauge.HasAetherflowStacks && LevelChecked(EnergyDrain) && IsOffCooldown(EnergyDrain))
-                            return EnergyDrain;
+                        if (IsOffCooldown(Deathflare) && LevelChecked(Deathflare) && OriginalHook(Ruin) is AstralImpulse or UmbralImpulse)
+                            return OriginalHook(AstralFlow);
 
-                        if (HasEffect(Buffs.RubysGlimmer) && LevelChecked(SearingFlash))
-                            return SearingFlash;
+                        if (IsOffCooldown(Rekindle) && OriginalHook(Ruin) is FountainOfFire)
+                            return OriginalHook(AstralFlow);
 
-                        if (OriginalHook(Ruin) is AstralImpulse or UmbralImpulse or FountainOfFire)
-                        {
-                            if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && LevelChecked(SummonBahamut))
-                                return OriginalHook(EnkindleBahamut);
-
-                            if (IsOffCooldown(Deathflare) && LevelChecked(Deathflare) && OriginalHook(Ruin) is AstralImpulse or UmbralImpulse)
-                                return OriginalHook(AstralFlow);
-
-                            if (IsOffCooldown(Rekindle) && OriginalHook(Ruin) is FountainOfFire)
-                                return OriginalHook(AstralFlow);
-
-                            if (IsOffCooldown(LuxSolaris) && HasEffect(Buffs.RefulgentLux))
-                                return OriginalHook(LuxSolaris);
-                        }
-
-                        if (gauge.HasAetherflowStacks && CanSpellWeave())
-                        {
-                            if (!LevelChecked(SearingLight))
-                                return OriginalHook(Fester);
-
-                            if (HasEffect(Buffs.SearingLight))
-                                return OriginalHook(Fester);
-                        }
-
-                        if (ActionReady(All.LucidDreaming) && LocalPlayer.CurrentMp <= 4000)
-                            return All.LucidDreaming;
+                        if (IsOffCooldown(LuxSolaris) && HasEffect(Buffs.RefulgentLux))
+                            return OriginalHook(LuxSolaris);
                     }
 
-                    if (InCombat() && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
-                        ((LevelChecked(Aethercharge) && !LevelChecked(SummonBahamut)) ||
-                         (gauge.IsBahamutReady && LevelChecked(SummonBahamut)) ||
-                         (gauge.IsPhoenixReady && LevelChecked(SummonPhoenix))))
-                        return OriginalHook(Aethercharge);
-
-                    if (LevelChecked(All.Swiftcast))
+                    if (gauge.HasAetherflowStacks && CanSpellWeave())
                     {
-                        if (LevelChecked(Slipstream) && HasEffect(Buffs.GarudasFavor))
-                        {
-                            if (CanSpellWeave() && IsGarudaAttuned && IsOffCooldown(All.Swiftcast))
-                                return All.Swiftcast;
+                        if (!LevelChecked(SearingLight))
+                            return OriginalHook(Fester);
 
-                            if (HasEffect(Buffs.GarudasFavor) && HasEffect(All.Buffs.Swiftcast))
-                                return OriginalHook(AstralFlow);
-                        }
-
-                        if (IsIfritAttuned && gauge.Attunement >= 1 && IsOffCooldown(All.Swiftcast))
-                            return All.Swiftcast;
+                        if (HasEffect(Buffs.SearingLight))
+                            return OriginalHook(Fester);
                     }
 
-                    if (IsIfritAttuned && gauge.Attunement >= 1 && HasEffect(All.Buffs.Swiftcast) && ComboAction is not CrimsonCyclone)
-                        return OriginalHook(Gemshine);
-
-                    if ((HasEffect(Buffs.GarudasFavor) && gauge.Attunement is 0) ||
-                        (HasEffect(Buffs.TitansFavor) && ComboAction is TopazRite or TopazCata && CanSpellWeave()) ||
-                        (HasEffect(Buffs.IfritsFavor) && (IsMoving() || gauge.Attunement is 0)) || (ComboAction == CrimsonCyclone && InMeleeRange()))
-                        return OriginalHook(AstralFlow);
-
-                    if (HasEffect(Buffs.FurtherRuin) && ((!HasEffect(All.Buffs.Swiftcast) && IsIfritAttuned && IsMoving()) || (GetCooldownRemainingTime(OriginalHook(Aethercharge)) is < 2.5f and > 0)))
-                        return Ruin4;
-
-                    if (IsGarudaAttuned || IsTitanAttuned || IsIfritAttuned)
-                        return OriginalHook(Gemshine);
-
-                    if (gauge.SummonTimerRemaining == 0 && IsOnCooldown(SummonPhoenix) && IsOnCooldown(SummonBahamut))
-                    {
-                        if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && LevelChecked(SummonRuby))
-                            return OriginalHook(SummonRuby);
-
-                        if (gauge.IsTitanReady && LevelChecked(SummonTopaz))
-                            return OriginalHook(SummonTopaz);
-
-                        if (gauge.IsGarudaReady && LevelChecked(SummonEmerald))
-                            return OriginalHook(SummonEmerald);
-                    }
-
-                    if (LevelChecked(Ruin4) && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
-                        return Ruin4;
+                    if (ActionReady(All.LucidDreaming) && LocalPlayer.CurrentMp <= 4000)
+                        return All.LucidDreaming;
                 }
+
+                if (InCombat() && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
+                    ((LevelChecked(Aethercharge) && !LevelChecked(SummonBahamut)) ||
+                     (gauge.IsBahamutReady && LevelChecked(SummonBahamut)) ||
+                     (gauge.IsPhoenixReady && LevelChecked(SummonPhoenix))))
+                    return OriginalHook(Aethercharge);
+
+                if (LevelChecked(All.Swiftcast))
+                {
+                    if (LevelChecked(Slipstream) && HasEffect(Buffs.GarudasFavor))
+                    {
+                        if (CanSpellWeave() && IsGarudaAttuned && IsOffCooldown(All.Swiftcast))
+                            return All.Swiftcast;
+
+                        if (HasEffect(Buffs.GarudasFavor) && HasEffect(All.Buffs.Swiftcast))
+                            return OriginalHook(AstralFlow);
+                    }
+
+                    if (IsIfritAttuned && gauge.Attunement >= 1 && IsOffCooldown(All.Swiftcast))
+                        return All.Swiftcast;
+                }
+
+                if (IsIfritAttuned && gauge.Attunement >= 1 && HasEffect(All.Buffs.Swiftcast) && ComboAction is not CrimsonCyclone)
+                    return OriginalHook(Gemshine);
+
+                if ((HasEffect(Buffs.GarudasFavor) && gauge.Attunement is 0) ||
+                    (HasEffect(Buffs.TitansFavor) && ComboAction is TopazRite or TopazCata && CanSpellWeave()) ||
+                    (HasEffect(Buffs.IfritsFavor) && (IsMoving() || gauge.Attunement is 0)) || (ComboAction == CrimsonCyclone && InMeleeRange()))
+                    return OriginalHook(AstralFlow);
+
+                if (HasEffect(Buffs.FurtherRuin) && ((!HasEffect(All.Buffs.Swiftcast) && IsIfritAttuned && IsMoving()) || (GetCooldownRemainingTime(OriginalHook(Aethercharge)) is < 2.5f and > 0)))
+                    return Ruin4;
+
+                if (IsGarudaAttuned || IsTitanAttuned || IsIfritAttuned)
+                    return OriginalHook(Gemshine);
+
+                if (gauge.SummonTimerRemaining == 0 && IsOnCooldown(SummonPhoenix) && IsOnCooldown(SummonBahamut))
+                {
+                    if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && LevelChecked(SummonRuby))
+                        return OriginalHook(SummonRuby);
+
+                    if (gauge.IsTitanReady && LevelChecked(SummonTopaz))
+                        return OriginalHook(SummonTopaz);
+
+                    if (gauge.IsGarudaReady && LevelChecked(SummonEmerald))
+                        return OriginalHook(SummonEmerald);
+                }
+
+                if (LevelChecked(Ruin4) && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
+                    return Ruin4;
 
                 return actionID;
             }
@@ -348,6 +344,8 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
+                if (actionID is not Outburst) return actionID;
+
                 var gauge = GetJobGauge<SMNGauge>();
                 var IsGarudaAttuned = OriginalHook(Gemshine) is EmeralRuin1 or EmeralRuin2 or EmeralRuin3 or EmeraldRite;
                 var IsTitanAttuned = OriginalHook(Gemshine) is TopazRuin1 or TopazRuin2 or TopazRuin3 or TopazRite;
@@ -356,117 +354,114 @@ namespace WrathCombo.Combos.PvE
                 var IsPhoenixReady = OriginalHook(Aethercharge) is SummonPhoenix;
                 var IsSolarBahamutReady = OriginalHook(Aethercharge) is SummonSolarBahamut;
 
-                if (actionID is Outburst)
+                if (IsEnabled(CustomComboPreset.SMN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.SMN_VariantCure))
+                    return Variant.VariantCure;
+
+                if (IsEnabled(CustomComboPreset.SMN_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart) &&
+                    CanSpellWeave())
+                    return Variant.VariantRampart;
+
+                if (!HasPetPresent())
+                    return SummonCarbuncle;
+
+                if (CanSpellWeave())
                 {
-                    if (IsEnabled(CustomComboPreset.SMN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.SMN_VariantCure))
-                        return Variant.VariantCure;
+                    if (IsOffCooldown(SearingLight) && LevelChecked(SearingLight) && ((!LevelChecked(SummonSolarBahamut) && OriginalHook(Ruin) is AstralImpulse) || OriginalHook(Ruin) is UmbralImpulse))
+                        return SearingLight;
 
-                    if (IsEnabled(CustomComboPreset.SMN_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanSpellWeave())
-                        return Variant.VariantRampart;
-
-                    if (!HasPetPresent())
-                        return SummonCarbuncle;
-
-                    if (CanSpellWeave())
+                    if (!gauge.HasAetherflowStacks && IsOffCooldown(EnergyDrain))
                     {
-                        if (IsOffCooldown(SearingLight) && LevelChecked(SearingLight) && ((!LevelChecked(SummonSolarBahamut) && OriginalHook(Ruin) is AstralImpulse) || OriginalHook(Ruin) is UmbralImpulse))
-                            return SearingLight;
+                        if (!LevelChecked(EnergySiphon) && LevelChecked(EnergyDrain))
+                            return EnergyDrain;
 
-                        if (!gauge.HasAetherflowStacks && IsOffCooldown(EnergyDrain))
-                        {
-                            if (!LevelChecked(EnergySiphon) && LevelChecked(EnergyDrain))
-                                return EnergyDrain;
-
-                            if (LevelChecked(EnergySiphon))
-                                return EnergySiphon;
-                        }
-
-                        if (HasEffect(Buffs.RubysGlimmer) && LevelChecked(SearingFlash))
-                            return SearingFlash;
-
-                        if (OriginalHook(Ruin) is AstralImpulse or UmbralImpulse or FountainOfFire)
-                        {
-                            if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && LevelChecked(SummonBahamut))
-                                return OriginalHook(EnkindleBahamut);
-
-                            if (IsOffCooldown(Deathflare) && LevelChecked(Deathflare) && OriginalHook(Ruin) is AstralImpulse or UmbralImpulse)
-                                return OriginalHook(AstralFlow);
-
-                            if (IsOffCooldown(Rekindle) && OriginalHook(Ruin) is FountainOfFire)
-                                return OriginalHook(AstralFlow);
-
-                            if (IsOffCooldown(LuxSolaris) && HasEffect(Buffs.RefulgentLux))
-                                return OriginalHook(LuxSolaris);
-                        }
-
-                        if (gauge.HasAetherflowStacks && CanSpellWeave())
-                        {
-                            if (!LevelChecked(SearingLight) && LevelChecked(Painflare))
-                                return Painflare;
-
-                            if (HasEffect(Buffs.SearingLight) && LevelChecked(Painflare))
-                                return Painflare;
-
-                        }
-
-                        if (ActionReady(All.LucidDreaming) && LocalPlayer.CurrentMp <= 4000)
-                            return All.LucidDreaming;
+                        if (LevelChecked(EnergySiphon))
+                            return EnergySiphon;
                     }
 
-                    if (InCombat() && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
-                        ((LevelChecked(Aethercharge) && !LevelChecked(SummonBahamut)) ||
-                         (gauge.IsBahamutReady && LevelChecked(SummonBahamut)) ||
-                         (gauge.IsPhoenixReady && LevelChecked(SummonPhoenix))))
-                        return OriginalHook(Aethercharge);
+                    if (HasEffect(Buffs.RubysGlimmer) && LevelChecked(SearingFlash))
+                        return SearingFlash;
 
-                    if (LevelChecked(All.Swiftcast))
+                    if (OriginalHook(Ruin) is AstralImpulse or UmbralImpulse or FountainOfFire)
                     {
-                        if (LevelChecked(Slipstream) && HasEffect(Buffs.GarudasFavor))
-                        {
-                            if (CanSpellWeave() && IsGarudaAttuned && IsOffCooldown(All.Swiftcast))
-                                return All.Swiftcast;
+                        if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && LevelChecked(SummonBahamut))
+                            return OriginalHook(EnkindleBahamut);
 
-                            if (HasEffect(Buffs.GarudasFavor) && HasEffect(All.Buffs.Swiftcast))
-                                return OriginalHook(AstralFlow);
-                        }
+                        if (IsOffCooldown(Deathflare) && LevelChecked(Deathflare) && OriginalHook(Ruin) is AstralImpulse or UmbralImpulse)
+                            return OriginalHook(AstralFlow);
 
-                        if (IsIfritAttuned && gauge.Attunement >= 1 && IsOffCooldown(All.Swiftcast))
-                            return All.Swiftcast;
+                        if (IsOffCooldown(Rekindle) && OriginalHook(Ruin) is FountainOfFire)
+                            return OriginalHook(AstralFlow);
+
+                        if (IsOffCooldown(LuxSolaris) && HasEffect(Buffs.RefulgentLux))
+                            return OriginalHook(LuxSolaris);
                     }
 
-                    if (IsIfritAttuned && gauge.Attunement >= 1 && HasEffect(All.Buffs.Swiftcast) && LevelChecked(PreciousBrilliance) && ComboAction is not CrimsonCyclone)
-                        return OriginalHook(PreciousBrilliance);
-
-
-                    if ((HasEffect(Buffs.GarudasFavor) && gauge.Attunement is 0) ||
-                        (HasEffect(Buffs.TitansFavor) && ComboAction is TopazRite or TopazCata && CanSpellWeave()) ||
-                        (HasEffect(Buffs.IfritsFavor) && (IsMoving() || gauge.Attunement is 0)) || (ComboAction == CrimsonCyclone && InMeleeRange()))
-                        return OriginalHook(AstralFlow);
-
-                    if (HasEffect(Buffs.FurtherRuin) && ((!HasEffect(All.Buffs.Swiftcast) && IsIfritAttuned && IsMoving()) || (GetCooldownRemainingTime(OriginalHook(Aethercharge)) is < 2.5f and > 0)))
-                        return Ruin4;
-
-                    if ((IsGarudaAttuned || IsTitanAttuned || IsIfritAttuned) && LevelChecked(PreciousBrilliance))
-                        return OriginalHook(PreciousBrilliance);
-
-                    if (gauge.SummonTimerRemaining == 0 && IsOnCooldown(SummonPhoenix) && IsOnCooldown(SummonBahamut))
+                    if (gauge.HasAetherflowStacks && CanSpellWeave())
                     {
-                        if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && LevelChecked(SummonRuby))
-                            return OriginalHook(SummonRuby);
+                        if (!LevelChecked(SearingLight) && LevelChecked(Painflare))
+                            return Painflare;
 
-                        if (gauge.IsTitanReady && LevelChecked(SummonTopaz))
-                            return OriginalHook(SummonTopaz);
+                        if (HasEffect(Buffs.SearingLight) && LevelChecked(Painflare))
+                            return Painflare;
 
-                        if (gauge.IsGarudaReady && LevelChecked(SummonEmerald))
-                            return OriginalHook(SummonEmerald);
                     }
 
-                    if (LevelChecked(Ruin4) && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
-                        return Ruin4;
+                    if (ActionReady(All.LucidDreaming) && LocalPlayer.CurrentMp <= 4000)
+                        return All.LucidDreaming;
                 }
+
+                if (InCombat() && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
+                    ((LevelChecked(Aethercharge) && !LevelChecked(SummonBahamut)) ||
+                     (gauge.IsBahamutReady && LevelChecked(SummonBahamut)) ||
+                     (gauge.IsPhoenixReady && LevelChecked(SummonPhoenix))))
+                    return OriginalHook(Aethercharge);
+
+                if (LevelChecked(All.Swiftcast))
+                {
+                    if (LevelChecked(Slipstream) && HasEffect(Buffs.GarudasFavor))
+                    {
+                        if (CanSpellWeave() && IsGarudaAttuned && IsOffCooldown(All.Swiftcast))
+                            return All.Swiftcast;
+
+                        if (HasEffect(Buffs.GarudasFavor) && HasEffect(All.Buffs.Swiftcast))
+                            return OriginalHook(AstralFlow);
+                    }
+
+                    if (IsIfritAttuned && gauge.Attunement >= 1 && IsOffCooldown(All.Swiftcast))
+                        return All.Swiftcast;
+                }
+
+                if (IsIfritAttuned && gauge.Attunement >= 1 && HasEffect(All.Buffs.Swiftcast) && LevelChecked(PreciousBrilliance) && ComboAction is not CrimsonCyclone)
+                    return OriginalHook(PreciousBrilliance);
+
+
+                if ((HasEffect(Buffs.GarudasFavor) && gauge.Attunement is 0) ||
+                    (HasEffect(Buffs.TitansFavor) && ComboAction is TopazRite or TopazCata && CanSpellWeave()) ||
+                    (HasEffect(Buffs.IfritsFavor) && (IsMoving() || gauge.Attunement is 0)) || (ComboAction == CrimsonCyclone && InMeleeRange()))
+                    return OriginalHook(AstralFlow);
+
+                if (HasEffect(Buffs.FurtherRuin) && ((!HasEffect(All.Buffs.Swiftcast) && IsIfritAttuned && IsMoving()) || (GetCooldownRemainingTime(OriginalHook(Aethercharge)) is < 2.5f and > 0)))
+                    return Ruin4;
+
+                if ((IsGarudaAttuned || IsTitanAttuned || IsIfritAttuned) && LevelChecked(PreciousBrilliance))
+                    return OriginalHook(PreciousBrilliance);
+
+                if (gauge.SummonTimerRemaining == 0 && IsOnCooldown(SummonPhoenix) && IsOnCooldown(SummonBahamut))
+                {
+                    if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && LevelChecked(SummonRuby))
+                        return OriginalHook(SummonRuby);
+
+                    if (gauge.IsTitanReady && LevelChecked(SummonTopaz))
+                        return OriginalHook(SummonTopaz);
+
+                    if (gauge.IsGarudaReady && LevelChecked(SummonEmerald))
+                        return OriginalHook(SummonEmerald);
+                }
+
+                if (LevelChecked(Ruin4) && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
+                    return Ruin4;
 
                 return actionID;
             }
@@ -479,210 +474,233 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is Ruin or Ruin2)
+                if (actionID is not (Ruin or Ruin2)) return actionID;
+
+                SMNGauge gauge = GetJobGauge<SMNGauge>();
+                int summonerPrimalChoice = PluginConfiguration.GetCustomIntValue(Config.SMN_PrimalChoice);
+                int SummonerBurstPhase = PluginConfiguration.GetCustomIntValue(Config.SMN_BurstPhase);
+                int lucidThreshold = PluginConfiguration.GetCustomIntValue(Config.SMN_Lucid);
+                int swiftcastPhase = PluginConfiguration.GetCustomIntValue(Config.SMN_SwiftcastPhase);
+                int burstDelay = PluginConfiguration.GetCustomIntValue(Config.SMN_Burst_Delay);
+                bool inOpener = CombatEngageDuration().TotalSeconds < 40;
+
+                bool IsGarudaAttuned =
+                    OriginalHook(Gemshine) is EmeralRuin1 or EmeralRuin2 or EmeralRuin3 or EmeraldRite;
+                bool IsTitanAttuned = OriginalHook(Gemshine) is TopazRuin1 or TopazRuin2 or TopazRuin3 or TopazRite;
+                bool IsIfritAttuned = OriginalHook(Gemshine) is RubyRuin1 or RubyRuin2 or RubyRuin3 or RubyRite;
+                bool IsBahamutReady = OriginalHook(Aethercharge) is SummonBahamut;
+                bool IsPhoenixReady = OriginalHook(Aethercharge) is SummonPhoenix;
+                bool IsSolarBahamutReady = OriginalHook(Aethercharge) is SummonSolarBahamut;
+
+                if (WasLastAction(OriginalHook(Aethercharge))) DemiAttackCount = 0;    // Resets counter
+
+                if (IsEnabled(CustomComboPreset.SMN_Advanced_Burst_Delay_Option) && !inOpener) DemiAttackCount = 6; // If SMN_Advanced_Burst_Delay_Option is active and outside opener window, set DemiAttackCount to 6 to ignore delayed oGCDs
+
+                if (GetCooldown(OriginalHook(Aethercharge)).CooldownElapsed >= 12.5) DemiAttackCount = 6; // Sets DemiAttackCount to 6 if for whatever reason you're in a position that you can't demi attack to prevent ogcd waste.
+
+                if (gauge.SummonTimerRemaining == 0 && !InCombat()) DemiAttackCount = 0;
+
+                //CHECK_DEMIATTACK_USE
+                if (UsedDemiAttack == false && ComboAction is AstralImpulse or UmbralImpulse or FountainOfFire or AstralFlare or UmbralFlare or BrandOfPurgatory && DemiAttackCount is not 6 && GetCooldownRemainingTime(AstralImpulse) > 1)
                 {
-                    SMNGauge gauge = GetJobGauge<SMNGauge>();
-                    int summonerPrimalChoice = PluginConfiguration.GetCustomIntValue(Config.SMN_PrimalChoice);
-                    int SummonerBurstPhase = PluginConfiguration.GetCustomIntValue(Config.SMN_BurstPhase);
-                    int lucidThreshold = PluginConfiguration.GetCustomIntValue(Config.SMN_Lucid);
-                    int swiftcastPhase = PluginConfiguration.GetCustomIntValue(Config.SMN_SwiftcastPhase);
-                    int burstDelay = PluginConfiguration.GetCustomIntValue(Config.SMN_Burst_Delay);
-                    bool inOpener = CombatEngageDuration().TotalSeconds < 40;
+                    UsedDemiAttack = true;      // Registers that a Demi Attack was used and blocks further incrementation of DemiAttackCountCount
+                    DemiAttackCount++;          // Increments DemiAttack counter
+                }
 
-                    bool IsGarudaAttuned =
-                        OriginalHook(Gemshine) is EmeralRuin1 or EmeralRuin2 or EmeralRuin3 or EmeraldRite;
-                    bool IsTitanAttuned = OriginalHook(Gemshine) is TopazRuin1 or TopazRuin2 or TopazRuin3 or TopazRite;
-                    bool IsIfritAttuned = OriginalHook(Gemshine) is RubyRuin1 or RubyRuin2 or RubyRuin3 or RubyRite;
-                    bool IsBahamutReady = OriginalHook(Aethercharge) is SummonBahamut;
-                    bool IsPhoenixReady = OriginalHook(Aethercharge) is SummonPhoenix;
-                    bool IsSolarBahamutReady = OriginalHook(Aethercharge) is SummonSolarBahamut;
+                //CHECK_DEMIATTACK_USE_RESET
+                if (UsedDemiAttack && GetCooldownRemainingTime(AstralImpulse) < 1) UsedDemiAttack = false;  // Resets block to allow CHECK_DEMIATTACK_USE
 
-                    if (WasLastAction(OriginalHook(Aethercharge))) DemiAttackCount = 0;    // Resets counter
 
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Burst_Delay_Option) && !inOpener) DemiAttackCount = 6; // If SMN_Advanced_Burst_Delay_Option is active and outside opener window, set DemiAttackCount to 6 to ignore delayed oGCDs 
+                if (IsEnabled(CustomComboPreset.SMN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.SMN_VariantCure))
+                    return Variant.VariantCure;
 
-                    if (GetCooldown(OriginalHook(Aethercharge)).CooldownElapsed >= 12.5) DemiAttackCount = 6; // Sets DemiAttackCount to 6 if for whatever reason you're in a position that you can't demi attack to prevent ogcd waste.
+                if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Balance_Opener) && Opener().FullOpener(ref actionID))
+                    return actionID;
 
-                    if (gauge.SummonTimerRemaining == 0 && !InCombat()) DemiAttackCount = 0;
+                if (IsEnabled(CustomComboPreset.SMN_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart) &&
+                    CanSpellWeave())
+                    return Variant.VariantRampart;
 
-                    //CHECK_DEMIATTACK_USE
-                    if (UsedDemiAttack == false && ComboAction is AstralImpulse or UmbralImpulse or FountainOfFire or AstralFlare or UmbralFlare or BrandOfPurgatory && DemiAttackCount is not 6 && GetCooldownRemainingTime(AstralImpulse) > 1)
+                if (CanSpellWeave())
+                {
+                    // Searing Light
+                    if (IsEnabled(CustomComboPreset.SMN_SearingLight) && IsOffCooldown(SearingLight) && LevelChecked(SearingLight))
                     {
-                        UsedDemiAttack = true;      // Registers that a Demi Attack was used and blocks further incrementation of DemiAttackCountCount
-                        DemiAttackCount++;          // Increments DemiAttack counter
+                        if (IsEnabled(CustomComboPreset.SMN_SearingLight_Burst))
+                        {
+                            if (SummonerBurstPhase is 0 or 1 && ((!LevelChecked(SummonSolarBahamut) && OriginalHook(Ruin) is AstralImpulse) || OriginalHook(Ruin) is UmbralImpulse) && DemiAttackCount >= 1 ||
+                                (SummonerBurstPhase == 2 && OriginalHook(Ruin) == FountainOfFire) ||
+                                (SummonerBurstPhase == 3 && OriginalHook(Ruin) is AstralImpulse or UmbralImpulse or FountainOfFire) ||
+                                (SummonerBurstPhase == 4))
+                                return SearingLight;
+                        }
+                        else return SearingLight;
                     }
 
-                    //CHECK_DEMIATTACK_USE_RESET
-                    if (UsedDemiAttack && GetCooldownRemainingTime(AstralImpulse) < 1) UsedDemiAttack = false;  // Resets block to allow CHECK_DEMIATTACK_USE
-
-
-                    if (IsEnabled(CustomComboPreset.SMN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.SMN_VariantCure))
-                        return Variant.VariantCure;
-
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Balance_Opener) && Opener().FullOpener(ref actionID))
-                        return actionID;
-
-                    if (IsEnabled(CustomComboPreset.SMN_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanSpellWeave())
-                        return Variant.VariantRampart;
-
-                    if (CanSpellWeave())
+                    // Emergency priority Demi Nuke to prevent waste if you can't get demi attacks out to satisfy the slider check.
+                    if (OriginalHook(Ruin) is AstralImpulse or UmbralImpulse or FountainOfFire &&
+                        IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks) && GetCooldown(OriginalHook(Aethercharge)).CooldownElapsed >= 12.5)
                     {
-                        // Searing Light
-                        if (IsEnabled(CustomComboPreset.SMN_SearingLight) && IsOffCooldown(SearingLight) && LevelChecked(SearingLight))
+                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks))
                         {
-                            if (IsEnabled(CustomComboPreset.SMN_SearingLight_Burst))
-                            {
-                                if (SummonerBurstPhase is 0 or 1 && ((!LevelChecked(SummonSolarBahamut) && OriginalHook(Ruin) is AstralImpulse) || OriginalHook(Ruin) is UmbralImpulse) && DemiAttackCount >= 1 ||
-                                    (SummonerBurstPhase == 2 && OriginalHook(Ruin) == FountainOfFire) ||
-                                    (SummonerBurstPhase == 3 && OriginalHook(Ruin) is AstralImpulse or UmbralImpulse or FountainOfFire) ||
-                                    (SummonerBurstPhase == 4))
-                                    return SearingLight;
-                            }
-                            else return SearingLight;
+                            if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && LevelChecked(SummonBahamut))
+                                return OriginalHook(EnkindleBahamut);
+
+                            if (IsOffCooldown(Deathflare) && LevelChecked(Deathflare) && OriginalHook(Ruin) is AstralImpulse)
+                                return OriginalHook(AstralFlow);
+
+                            if (IsOffCooldown(OriginalHook(EnkindlePhoenix)) && LevelChecked(SummonPhoenix))
+                                return OriginalHook(EnkindlePhoenix);
+
+                            if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Rekindle))
+                                if (IsOffCooldown(Rekindle) && OriginalHook(Ruin) is FountainOfFire)
+                                    return OriginalHook(AstralFlow);
+
+                            if (IsOffCooldown(OriginalHook(EnkindleSolarBahamut)) && LevelChecked(SummonSolarBahamut))
+                                return OriginalHook(EnkindleSolarBahamut);
+
+                            if (IsOffCooldown(Sunflare) && LevelChecked(Sunflare) && OriginalHook(Ruin) is UmbralImpulse)
+                                return OriginalHook(AstralFlow);
                         }
-
-                        // Emergency priority Demi Nuke to prevent waste if you can't get demi attacks out to satisfy the slider check.
-                        if (OriginalHook(Ruin) is AstralImpulse or UmbralImpulse or FountainOfFire &&
-                            IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks) && GetCooldown(OriginalHook(Aethercharge)).CooldownElapsed >= 12.5)
-                        {
-                            if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks))
-                            {
-                                if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && LevelChecked(SummonBahamut))
-                                    return OriginalHook(EnkindleBahamut);
-
-                                if (IsOffCooldown(Deathflare) && LevelChecked(Deathflare) && OriginalHook(Ruin) is AstralImpulse)
-                                    return OriginalHook(AstralFlow);
-
-                                if (IsOffCooldown(OriginalHook(EnkindlePhoenix)) && LevelChecked(SummonPhoenix))
-                                    return OriginalHook(EnkindlePhoenix);
-
-                                if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Rekindle))
-                                    if (IsOffCooldown(Rekindle) && OriginalHook(Ruin) is FountainOfFire)
-                                        return OriginalHook(AstralFlow);
-
-                                if (IsOffCooldown(OriginalHook(EnkindleSolarBahamut)) && LevelChecked(SummonSolarBahamut))
-                                    return OriginalHook(EnkindleSolarBahamut);
-
-                                if (IsOffCooldown(Sunflare) && LevelChecked(Sunflare) && OriginalHook(Ruin) is UmbralImpulse)
-                                    return OriginalHook(AstralFlow);
-                            }
-                        }
-
-                        // Energy Drain
-                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && !gauge.HasAetherflowStacks && IsOffCooldown(EnergyDrain) && LevelChecked(EnergyDrain) &&
-                            (!LevelChecked(DreadwyrmTrance) || !inOpener || DemiAttackCount >= burstDelay))
-                            return EnergyDrain;
-
-                        // First set of Festers if Energy Drain is close to being off CD, or off CD while you have aetherflow stacks.
-                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling) && gauge.HasAetherflowStacks)
-                        {
-                            if (GetCooldown(EnergyDrain).CooldownRemaining <= 3.2)
-                            {
-                                if ((((HasEffect(Buffs.SearingLight) && IsNotEnabled(CustomComboPreset.SMN_Advanced_Burst_Any_Option)) || HasEffectAny(Buffs.SearingLight)) &&
-                                    (SummonerBurstPhase is not 4)) ||
-                                    (SummonerBurstPhase == 4 && !HasEffect(Buffs.TitansFavor)))
-                                    return OriginalHook(Fester);
-
-                            }
-                        }
-
-                        if (IsEnabled(CustomComboPreset.SMN_SearingFlash) && HasEffect(Buffs.RubysGlimmer) && LevelChecked(SearingFlash))
-                            return SearingFlash;
-
-                        // Demi Nuke
-                        if (OriginalHook(Ruin) is AstralImpulse or UmbralImpulse or FountainOfFire)
-                        {
-                            if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks) && IsBahamutReady && (LevelChecked(SummonSolarBahamut) || DemiAttackCount >= burstDelay)
-                                && (IsNotEnabled(CustomComboPreset.SMN_SearingLight_Burst) || (LevelChecked(SummonSolarBahamut) || HasEffect(Buffs.SearingLight))))
-                            {
-                                if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && LevelChecked(SummonBahamut))
-                                    return OriginalHook(EnkindleBahamut);
-
-                                if (IsOffCooldown(Deathflare) && LevelChecked(Deathflare) && OriginalHook(Ruin) is AstralImpulse)
-                                    return OriginalHook(AstralFlow);
-                            }
-
-                            // Demi Nuke 2: Electric Boogaloo
-                            if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks) && IsPhoenixReady)
-                            {
-                                if (IsOffCooldown(OriginalHook(EnkindlePhoenix)) && LevelChecked(SummonPhoenix) && OriginalHook(Ruin) is FountainOfFire)
-                                    return OriginalHook(EnkindlePhoenix);
-
-                                if (IsOffCooldown(Rekindle) && IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Rekindle) && OriginalHook(Ruin) is FountainOfFire)
-                                    return OriginalHook(AstralFlow);
-                            }
-
-                            // Demi Nuke 3: More Boogaloo
-                            if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks) && IsSolarBahamutReady && DemiAttackCount >= burstDelay &&
-                                (IsNotEnabled(CustomComboPreset.SMN_SearingLight_Burst) || HasEffect(Buffs.SearingLight)))
-                            {
-                                if (IsOffCooldown(OriginalHook(EnkindleSolarBahamut)) && LevelChecked(SummonSolarBahamut))
-                                    return OriginalHook(EnkindleSolarBahamut);
-
-                                if (IsOffCooldown(Sunflare) && LevelChecked(Sunflare) && OriginalHook(Ruin) is UmbralImpulse)
-                                    return OriginalHook(AstralFlow);
-                            }
-                        }
-
-                        // Lux Solaris 
-                        if (IsOffCooldown(LuxSolaris) && IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_LuxSolaris) && HasEffect(Buffs.RefulgentLux) &&
-                            (PlayerHealthPercentageHp() < 100 || GetBuffRemainingTime(Buffs.RefulgentLux) is < 3 and > 0))
-                            return OriginalHook(LuxSolaris);
-
-
                     }
 
-                    // Fester
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester))
+                    // Energy Drain
+                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && !gauge.HasAetherflowStacks && IsOffCooldown(EnergyDrain) && LevelChecked(EnergyDrain) &&
+                        (!LevelChecked(DreadwyrmTrance) || !inOpener || DemiAttackCount >= burstDelay))
+                        return EnergyDrain;
+
+                    // First set of Festers if Energy Drain is close to being off CD, or off CD while you have aetherflow stacks.
+                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling) && gauge.HasAetherflowStacks)
                     {
-                        if (gauge.HasAetherflowStacks && CanSpellWeave())
+                        if (GetCooldown(EnergyDrain).CooldownRemaining <= 3.2)
                         {
-                            if (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling))
+                            if ((((HasEffect(Buffs.SearingLight) && IsNotEnabled(CustomComboPreset.SMN_Advanced_Burst_Any_Option)) || HasEffectAny(Buffs.SearingLight)) &&
+                                 (SummonerBurstPhase is not 4)) ||
+                                (SummonerBurstPhase == 4 && !HasEffect(Buffs.TitansFavor)))
                                 return OriginalHook(Fester);
 
-                            if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling))
-                            {
-                                if (!LevelChecked(SearingLight))
-                                    return OriginalHook(Fester);
-
-                                if ((((HasEffect(Buffs.SearingLight) && IsNotEnabled(CustomComboPreset.SMN_Advanced_Burst_Any_Option)) || HasEffectAny(Buffs.SearingLight)) &&
-                                     SummonerBurstPhase is 0 or 1 or 2 or 3 && DemiAttackCount >= burstDelay) ||
-                                    (SummonerBurstPhase == 4 && !HasEffect(Buffs.TitansFavor)))
-                                    return OriginalHook(Fester);
-                            }
                         }
                     }
 
-                    // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SMN_Lucid) && CanSpellWeave() && ActionReady(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold)
-                        return All.LucidDreaming;
+                    if (IsEnabled(CustomComboPreset.SMN_SearingFlash) && HasEffect(Buffs.RubysGlimmer) && LevelChecked(SearingFlash))
+                        return SearingFlash;
 
-
-                    // Demi
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons))
+                    // Demi Nuke
+                    if (OriginalHook(Ruin) is AstralImpulse or UmbralImpulse or FountainOfFire)
                     {
-                        if (InCombat() && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
-                            ((LevelChecked(Aethercharge) && !LevelChecked(SummonBahamut)) ||   // Pre-Bahamut Phase
-                             (IsBahamutReady && LevelChecked(SummonBahamut)) ||            // Bahamut Phase
-                             (IsPhoenixReady && LevelChecked(SummonPhoenix)) ||            // Phoenix Phase
-                             (IsSolarBahamutReady && LevelChecked(SummonSolarBahamut))))   // Solar Bahamut Phase
-                            return OriginalHook(Aethercharge);
+                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks) && IsBahamutReady && (LevelChecked(SummonSolarBahamut) || DemiAttackCount >= burstDelay)
+                            && (IsNotEnabled(CustomComboPreset.SMN_SearingLight_Burst) || (LevelChecked(SummonSolarBahamut) || HasEffect(Buffs.SearingLight))))
+                        {
+                            if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && LevelChecked(SummonBahamut))
+                                return OriginalHook(EnkindleBahamut);
+
+                            if (IsOffCooldown(Deathflare) && LevelChecked(Deathflare) && OriginalHook(Ruin) is AstralImpulse)
+                                return OriginalHook(AstralFlow);
+                        }
+
+                        // Demi Nuke 2: Electric Boogaloo
+                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks) && IsPhoenixReady)
+                        {
+                            if (IsOffCooldown(OriginalHook(EnkindlePhoenix)) && LevelChecked(SummonPhoenix) && OriginalHook(Ruin) is FountainOfFire)
+                                return OriginalHook(EnkindlePhoenix);
+
+                            if (IsOffCooldown(Rekindle) && IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Rekindle) && OriginalHook(Ruin) is FountainOfFire)
+                                return OriginalHook(AstralFlow);
+                        }
+
+                        // Demi Nuke 3: More Boogaloo
+                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks) && IsSolarBahamutReady && DemiAttackCount >= burstDelay &&
+                            (IsNotEnabled(CustomComboPreset.SMN_SearingLight_Burst) || HasEffect(Buffs.SearingLight)))
+                        {
+                            if (IsOffCooldown(OriginalHook(EnkindleSolarBahamut)) && LevelChecked(SummonSolarBahamut))
+                                return OriginalHook(EnkindleSolarBahamut);
+
+                            if (IsOffCooldown(Sunflare) && LevelChecked(Sunflare) && OriginalHook(Ruin) is UmbralImpulse)
+                                return OriginalHook(AstralFlow);
+                        }
                     }
 
-                    //Ruin4 in Egi Phases
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && HasEffect(Buffs.FurtherRuin) &&
-                        ((!HasEffect(All.Buffs.Swiftcast) && IsMoving() && ((HasEffect(Buffs.GarudasFavor) && !IsGarudaAttuned) || (IsIfritAttuned && ComboAction is not CrimsonCyclone))) ||
-                         GetCooldownRemainingTime(OriginalHook(Aethercharge)) is < 2.5f and > 0))
-                        return Ruin4;
+                    // Lux Solaris
+                    if (IsOffCooldown(LuxSolaris) && IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_LuxSolaris) && HasEffect(Buffs.RefulgentLux) &&
+                        (PlayerHealthPercentageHp() < 100 || GetBuffRemainingTime(Buffs.RefulgentLux) is < 3 and > 0))
+                        return OriginalHook(LuxSolaris);
 
-                    // Egi Features
-                    if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) && LevelChecked(All.Swiftcast))
+
+                }
+
+                // Fester
+                if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester))
+                {
+                    if (gauge.HasAetherflowStacks && CanSpellWeave())
+                    {
+                        if (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling))
+                            return OriginalHook(Fester);
+
+                        if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling))
+                        {
+                            if (!LevelChecked(SearingLight))
+                                return OriginalHook(Fester);
+
+                            if ((((HasEffect(Buffs.SearingLight) && IsNotEnabled(CustomComboPreset.SMN_Advanced_Burst_Any_Option)) || HasEffectAny(Buffs.SearingLight)) &&
+                                 SummonerBurstPhase is 0 or 1 or 2 or 3 && DemiAttackCount >= burstDelay) ||
+                                (SummonerBurstPhase == 4 && !HasEffect(Buffs.TitansFavor)))
+                                return OriginalHook(Fester);
+                        }
+                    }
+                }
+
+                // Lucid Dreaming
+                if (IsEnabled(CustomComboPreset.SMN_Lucid) && CanSpellWeave() && ActionReady(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold)
+                    return All.LucidDreaming;
+
+
+                // Demi
+                if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons))
+                {
+                    if (InCombat() && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
+                        ((LevelChecked(Aethercharge) && !LevelChecked(SummonBahamut)) ||   // Pre-Bahamut Phase
+                         (IsBahamutReady && LevelChecked(SummonBahamut)) ||            // Bahamut Phase
+                         (IsPhoenixReady && LevelChecked(SummonPhoenix)) ||            // Phoenix Phase
+                         (IsSolarBahamutReady && LevelChecked(SummonSolarBahamut))))   // Solar Bahamut Phase
+                        return OriginalHook(Aethercharge);
+                }
+
+                //Ruin4 in Egi Phases
+                if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && HasEffect(Buffs.FurtherRuin) &&
+                    ((!HasEffect(All.Buffs.Swiftcast) && IsMoving() && ((HasEffect(Buffs.GarudasFavor) && !IsGarudaAttuned) || (IsIfritAttuned && ComboAction is not CrimsonCyclone))) ||
+                     GetCooldownRemainingTime(OriginalHook(Aethercharge)) is < 2.5f and > 0))
+                    return Ruin4;
+
+                // Egi Features
+                if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) && LevelChecked(All.Swiftcast))
+                {
+                    // Swiftcast Garuda Feature
+                    if (swiftcastPhase is 0 or 1 && LevelChecked(Slipstream) && HasEffect(Buffs.GarudasFavor))
+                    {
+                        if (CanSpellWeave() && IsGarudaAttuned && IsOffCooldown(All.Swiftcast))
+                            return All.Swiftcast;
+
+                        if (Config.SMN_ST_Egi_AstralFlow[2] &&
+                            ((HasEffect(Buffs.GarudasFavor) && HasEffect(All.Buffs.Swiftcast)) || (gauge.Attunement == 0)))     // Astral Flow if Swiftcast is not ready throughout Garuda
+                            return OriginalHook(AstralFlow);
+                    }
+
+                    // Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
+                    if (swiftcastPhase == 2)
+                    {
+                        if (IsOffCooldown(All.Swiftcast) && IsIfritAttuned && ComboAction is not CrimsonCyclone)
+                        {
+                            if (!Config.SMN_ST_Egi_AstralFlow[1] || (Config.SMN_ST_Egi_AstralFlow[1] && gauge.Attunement >= 1))
+                                return All.Swiftcast;
+                        }
+                    }
+                    // SpS Swiftcast
+                    if (swiftcastPhase == 3)
                     {
                         // Swiftcast Garuda Feature
-                        if (swiftcastPhase is 0 or 1 && LevelChecked(Slipstream) && HasEffect(Buffs.GarudasFavor))
+                        if (LevelChecked(Slipstream) && HasEffect(Buffs.GarudasFavor))
                         {
                             if (CanSpellWeave() && IsGarudaAttuned && IsOffCooldown(All.Swiftcast))
                                 return All.Swiftcast;
@@ -693,93 +711,69 @@ namespace WrathCombo.Combos.PvE
                         }
 
                         // Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
-                        if (swiftcastPhase == 2)
+                        if (IsOffCooldown(All.Swiftcast) && IsIfritAttuned && ComboAction is not CrimsonCyclone)
                         {
-                            if (IsOffCooldown(All.Swiftcast) && IsIfritAttuned && ComboAction is not CrimsonCyclone)
-                            {
-                                if (!Config.SMN_ST_Egi_AstralFlow[1] || (Config.SMN_ST_Egi_AstralFlow[1] && gauge.Attunement >= 1))
-                                    return All.Swiftcast;
-                            }
-                        }
-                        // SpS Swiftcast
-                        if (swiftcastPhase == 3)
-                        {
-                            // Swiftcast Garuda Feature
-                            if (LevelChecked(Slipstream) && HasEffect(Buffs.GarudasFavor))
-                            {
-                                if (CanSpellWeave() && IsGarudaAttuned && IsOffCooldown(All.Swiftcast))
-                                    return All.Swiftcast;
-
-                                if (Config.SMN_ST_Egi_AstralFlow[2] &&
-                                    ((HasEffect(Buffs.GarudasFavor) && HasEffect(All.Buffs.Swiftcast)) || (gauge.Attunement == 0)))     // Astral Flow if Swiftcast is not ready throughout Garuda
-                                    return OriginalHook(AstralFlow);
-                            }
-
-                            // Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
-                            if (IsOffCooldown(All.Swiftcast) && IsIfritAttuned && ComboAction is not CrimsonCyclone)
-                            {
-                                if (!Config.SMN_ST_Egi_AstralFlow[1] || (Config.SMN_ST_Egi_AstralFlow[1] && gauge.Attunement >= 1))
-                                    return All.Swiftcast;
-                            }
-                        }
-
-                    }
-
-                    // Gemshine priority casting
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EgiSummons_Attacks) &&
-                        ((IsIfritAttuned && gauge.Attunement >= 1 && HasEffect(All.Buffs.Swiftcast) && ComboAction is not CrimsonCyclone) ||
-                         (HasEffect(Buffs.GarudasFavor) && gauge.Attunement >= 1 && !HasEffect(All.Buffs.Swiftcast) && IsMoving())))
-                        return OriginalHook(Gemshine);
-
-                    if ((Config.SMN_ST_Egi_AstralFlow[2] && HasEffect(Buffs.GarudasFavor) && (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) || swiftcastPhase == 2)) ||                 // Garuda
-                        (Config.SMN_ST_Egi_AstralFlow[0] && HasEffect(Buffs.TitansFavor) && ComboAction is TopazRite or TopazCata && CanSpellWeave()) ||                                  // Titan
-                        (Config.SMN_ST_Egi_AstralFlow[1] && (HasEffect(Buffs.IfritsFavor) && !Config.SMN_ST_CrimsonCycloneMelee && (IsMoving() || gauge.Attunement == 0) || (ComboAction is CrimsonCyclone && InMeleeRange()))) ||
-                        (Config.SMN_ST_Egi_AstralFlow[1] && HasEffect(Buffs.IfritsFavor) && Config.SMN_ST_CrimsonCycloneMelee && InMeleeRange()))  // Ifrit
-                        return OriginalHook(AstralFlow);
-
-                    if (IsGarudaAttuned)
-                    {
-                        // Use Ruin III instead of Emerald Ruin III if enabled and Ruin Mastery III is not active
-                        if (IsEnabled(CustomComboPreset.SMN_ST_Ruin3_Emerald_Ruin3) && !TraitLevelChecked(Traits.RuinMastery3) && LevelChecked(Ruin3)) 
-                        {
-                            if (!IsMoving())
-                                return Ruin3;
+                            if (!Config.SMN_ST_Egi_AstralFlow[1] || (Config.SMN_ST_Egi_AstralFlow[1] && gauge.Attunement >= 1))
+                                return All.Swiftcast;
                         }
                     }
 
-                    // Gemshine
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EgiSummons_Attacks) && (IsGarudaAttuned || IsTitanAttuned || IsIfritAttuned))
-                        return OriginalHook(Gemshine);
-
-                    // Egi Order
-                    if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_EgiOrder) && gauge.SummonTimerRemaining == 0)
-                    {
-                        if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && LevelChecked(SummonRuby))
-                            return OriginalHook(SummonRuby);
-
-                        if (summonerPrimalChoice is 0 or 1)
-                        {
-                            if (gauge.IsTitanReady && LevelChecked(SummonTopaz))
-                                return OriginalHook(SummonTopaz);
-
-                            if (gauge.IsGarudaReady && LevelChecked(SummonEmerald))
-                                return OriginalHook(SummonEmerald);
-                        }
-
-                        if (summonerPrimalChoice == 2)
-                        {
-                            if (gauge.IsGarudaReady && LevelChecked(SummonEmerald))
-                                return OriginalHook(SummonEmerald);
-
-                            if (gauge.IsTitanReady && LevelChecked(SummonTopaz))
-                                return OriginalHook(SummonTopaz);
-                        }
-                    }
-
-                    // Ruin 4
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && LevelChecked(Ruin4) && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
-                        return Ruin4;
                 }
+
+                // Gemshine priority casting
+                if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EgiSummons_Attacks) &&
+                    ((IsIfritAttuned && gauge.Attunement >= 1 && HasEffect(All.Buffs.Swiftcast) && ComboAction is not CrimsonCyclone) ||
+                     (HasEffect(Buffs.GarudasFavor) && gauge.Attunement >= 1 && !HasEffect(All.Buffs.Swiftcast) && IsMoving())))
+                    return OriginalHook(Gemshine);
+
+                if ((Config.SMN_ST_Egi_AstralFlow[2] && HasEffect(Buffs.GarudasFavor) && (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) || swiftcastPhase == 2)) ||                 // Garuda
+                    (Config.SMN_ST_Egi_AstralFlow[0] && HasEffect(Buffs.TitansFavor) && ComboAction is TopazRite or TopazCata && CanSpellWeave()) ||                                  // Titan
+                    (Config.SMN_ST_Egi_AstralFlow[1] && (HasEffect(Buffs.IfritsFavor) && !Config.SMN_ST_CrimsonCycloneMelee && (IsMoving() || gauge.Attunement == 0) || (ComboAction is CrimsonCyclone && InMeleeRange()))) ||
+                    (Config.SMN_ST_Egi_AstralFlow[1] && HasEffect(Buffs.IfritsFavor) && Config.SMN_ST_CrimsonCycloneMelee && InMeleeRange()))  // Ifrit
+                    return OriginalHook(AstralFlow);
+
+                if (IsGarudaAttuned)
+                {
+                    // Use Ruin III instead of Emerald Ruin III if enabled and Ruin Mastery III is not active
+                    if (IsEnabled(CustomComboPreset.SMN_ST_Ruin3_Emerald_Ruin3) && !TraitLevelChecked(Traits.RuinMastery3) && LevelChecked(Ruin3))
+                    {
+                        if (!IsMoving())
+                            return Ruin3;
+                    }
+                }
+
+                // Gemshine
+                if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EgiSummons_Attacks) && (IsGarudaAttuned || IsTitanAttuned || IsIfritAttuned))
+                    return OriginalHook(Gemshine);
+
+                // Egi Order
+                if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_EgiOrder) && gauge.SummonTimerRemaining == 0)
+                {
+                    if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && LevelChecked(SummonRuby))
+                        return OriginalHook(SummonRuby);
+
+                    if (summonerPrimalChoice is 0 or 1)
+                    {
+                        if (gauge.IsTitanReady && LevelChecked(SummonTopaz))
+                            return OriginalHook(SummonTopaz);
+
+                        if (gauge.IsGarudaReady && LevelChecked(SummonEmerald))
+                            return OriginalHook(SummonEmerald);
+                    }
+
+                    if (summonerPrimalChoice == 2)
+                    {
+                        if (gauge.IsGarudaReady && LevelChecked(SummonEmerald))
+                            return OriginalHook(SummonEmerald);
+
+                        if (gauge.IsTitanReady && LevelChecked(SummonTopaz))
+                            return OriginalHook(SummonTopaz);
+                    }
+                }
+
+                // Ruin 4
+                if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && LevelChecked(Ruin4) && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
+                    return Ruin4;
 
                 return actionID;
             }
@@ -793,6 +787,8 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
+                if (actionID is not Outburst) return actionID;
+
                 var gauge = GetJobGauge<SMNGauge>();
                 var summonerPrimalChoice = PluginConfiguration.GetCustomIntValue(Config.SMN_PrimalChoice);
                 var SummonerBurstPhase = PluginConfiguration.GetCustomIntValue(Config.SMN_BurstPhase);
@@ -825,171 +821,193 @@ namespace WrathCombo.Combos.PvE
                 //CHECK_DEMIATTACK_USE_RESET
                 if (UsedDemiAttack && GetCooldownRemainingTime(AstralImpulse) < 1) UsedDemiAttack = false;  // Resets block to allow CHECK_DEMIATTACK_USE
 
-                if (actionID is Outburst)
+                if (IsEnabled(CustomComboPreset.SMN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.SMN_VariantCure))
+                    return Variant.VariantCure;
+
+                if (IsEnabled(CustomComboPreset.SMN_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart) &&
+                    CanSpellWeave())
+                    return Variant.VariantRampart;
+
+                if (CanSpellWeave())
                 {
-                    if (IsEnabled(CustomComboPreset.SMN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.SMN_VariantCure))
-                        return Variant.VariantCure;
-
-                    if (IsEnabled(CustomComboPreset.SMN_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanSpellWeave())
-                        return Variant.VariantRampart;
-
-                    if (CanSpellWeave())
+                    // Searing Light
+                    if (IsEnabled(CustomComboPreset.SMN_SearingLight_AoE) && IsOffCooldown(SearingLight) && LevelChecked(SearingLight))
                     {
-                        // Searing Light
-                        if (IsEnabled(CustomComboPreset.SMN_SearingLight_AoE) && IsOffCooldown(SearingLight) && LevelChecked(SearingLight))
+                        if (IsEnabled(CustomComboPreset.SMN_SearingLight_Burst_AoE))
                         {
-                            if (IsEnabled(CustomComboPreset.SMN_SearingLight_Burst_AoE))
-                            {
-                                if (SummonerBurstPhase is 0 or 1 && ((!LevelChecked(SummonSolarBahamut) && OriginalHook(Ruin) is AstralImpulse) || OriginalHook(Ruin) is UmbralImpulse) && DemiAttackCount >= 1 ||
-                                    (SummonerBurstPhase == 2 && OriginalHook(Ruin) == FountainOfFire) ||
-                                    (SummonerBurstPhase == 3 && OriginalHook(Ruin) is AstralImpulse or UmbralImpulse or FountainOfFire) ||
-                                    (SummonerBurstPhase == 4))
-                                    return SearingLight;
-                            }
-                            else return SearingLight;
+                            if (SummonerBurstPhase is 0 or 1 && ((!LevelChecked(SummonSolarBahamut) && OriginalHook(Ruin) is AstralImpulse) || OriginalHook(Ruin) is UmbralImpulse) && DemiAttackCount >= 1 ||
+                                (SummonerBurstPhase == 2 && OriginalHook(Ruin) == FountainOfFire) ||
+                                (SummonerBurstPhase == 3 && OriginalHook(Ruin) is AstralImpulse or UmbralImpulse or FountainOfFire) ||
+                                (SummonerBurstPhase == 4))
+                                return SearingLight;
                         }
-
-                        // Emergency priority Demi Nuke to prevent waste if you can't get demi attacks out to satisfy the slider check.
-                        if (OriginalHook(Ruin) is AstralImpulse or UmbralImpulse or FountainOfFire &&
-                            IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks_AoE) && GetCooldown(OriginalHook(Aethercharge)).CooldownElapsed >= 12.5)
-                        {
-                            if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks_AoE))
-                            {
-                                if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && LevelChecked(SummonBahamut))
-                                    return OriginalHook(EnkindleBahamut);
-
-                                if (IsOffCooldown(Deathflare) && LevelChecked(Deathflare) && OriginalHook(Ruin) is AstralImpulse)
-                                    return OriginalHook(AstralFlow);
-
-                                if (IsOffCooldown(OriginalHook(EnkindlePhoenix)) && LevelChecked(SummonPhoenix))
-                                    return OriginalHook(EnkindlePhoenix);
-
-                                if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Rekindle_AoE))
-                                    if (IsOffCooldown(Rekindle) && OriginalHook(Ruin) is FountainOfFire)
-                                        return OriginalHook(AstralFlow);
-
-                                if (IsOffCooldown(OriginalHook(EnkindleSolarBahamut)) && LevelChecked(SummonSolarBahamut))
-                                    return OriginalHook(EnkindleSolarBahamut);
-
-                                if (IsOffCooldown(Sunflare) && LevelChecked(Sunflare) && OriginalHook(Ruin) is UmbralImpulse)
-                                    return OriginalHook(AstralFlow);
-                            }
-                        }
-
-                        // Energy Siphon
-                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_ESPainflare) && !gauge.HasAetherflowStacks && IsOffCooldown(EnergySiphon) && LevelChecked(EnergySiphon) &&
-                            (!LevelChecked(DreadwyrmTrance) || !inOpener || DemiAttackCount >= burstDelay))
-                            return EnergySiphon;
-
-                        // First set of Painflares if Energy Siphon is close to being off CD, or off CD while you have aetherflow stacks.
-                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_ESPainflare) && IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling_AoE) && gauge.HasAetherflowStacks && LevelChecked(Painflare))
-                        {
-                            if (GetCooldown(EnergySiphon).CooldownRemaining <= 3.2)
-                            {
-                                if ((((HasEffect(Buffs.SearingLight) && IsNotEnabled(CustomComboPreset.SMN_Advanced_Burst_Any_Option_AoE)) || HasEffectAny(Buffs.SearingLight)) &&
-                                    (SummonerBurstPhase is not 4)) ||
-                                    (SummonerBurstPhase == 4 && !HasEffect(Buffs.TitansFavor)))
-                                    return OriginalHook(Painflare);
-
-                            }
-                        }
-
-                        if (IsEnabled(CustomComboPreset.SMN_SearingFlash_AoE) && HasEffect(Buffs.RubysGlimmer) && LevelChecked(SearingFlash))
-                            return SearingFlash;
-
-                        // Demi Nuke
-                        if (OriginalHook(Ruin) is AstralImpulse or UmbralImpulse or FountainOfFire)
-                        {
-                            if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks_AoE) && IsBahamutReady && (LevelChecked(SummonSolarBahamut) || DemiAttackCount >= burstDelay)
-                                && (IsNotEnabled(CustomComboPreset.SMN_SearingLight_Burst_AoE) || (LevelChecked(SummonSolarBahamut) || HasEffect(Buffs.SearingLight))))
-                            {
-                                if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && LevelChecked(SummonBahamut))
-                                    return OriginalHook(EnkindleBahamut);
-
-                                if (IsOffCooldown(Deathflare) && LevelChecked(Deathflare) && OriginalHook(Ruin) is AstralImpulse)
-                                    return OriginalHook(AstralFlow);
-                            }
-
-                            // Demi Nuke 2: Electric Boogaloo
-                            if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks_AoE) && IsPhoenixReady)
-                            {
-                                if (IsOffCooldown(OriginalHook(EnkindlePhoenix)) && LevelChecked(SummonPhoenix) && OriginalHook(Ruin) is FountainOfFire)
-                                    return OriginalHook(EnkindlePhoenix);
-
-                                if (IsOffCooldown(Rekindle) && IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Rekindle_AoE) && OriginalHook(Ruin) is FountainOfFire)
-                                    return OriginalHook(AstralFlow);
-                            }
-
-                            // Demi Nuke 3: More Boogaloo
-                            if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks_AoE) && IsSolarBahamutReady && DemiAttackCount >= burstDelay &&
-                                (IsNotEnabled(CustomComboPreset.SMN_SearingLight_Burst_AoE) || HasEffect(Buffs.SearingLight)))
-                            {
-                                if (IsOffCooldown(OriginalHook(EnkindleSolarBahamut)) && LevelChecked(SummonSolarBahamut))
-                                    return OriginalHook(EnkindleSolarBahamut);
-
-                                if (IsOffCooldown(Sunflare) && LevelChecked(Sunflare) && OriginalHook(Ruin) is UmbralImpulse)
-                                    return OriginalHook(AstralFlow);
-                            }
-                        }
-
-                        // Lux Solaris 
-                        if (IsOffCooldown(LuxSolaris) && IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_LuxSolaris_AoE) && HasEffect(Buffs.RefulgentLux) &&
-                            (PlayerHealthPercentageHp() < 100 || GetBuffRemainingTime(Buffs.RefulgentLux) is < 3 and > 0))
-                            return OriginalHook(LuxSolaris);
-
+                        else return SearingLight;
                     }
 
-                    // Painflare
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_ESPainflare) && LevelChecked(Painflare))
+                    // Emergency priority Demi Nuke to prevent waste if you can't get demi attacks out to satisfy the slider check.
+                    if (OriginalHook(Ruin) is AstralImpulse or UmbralImpulse or FountainOfFire &&
+                        IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks_AoE) && GetCooldown(OriginalHook(Aethercharge)).CooldownElapsed >= 12.5)
                     {
-                        if (gauge.HasAetherflowStacks && CanSpellWeave())
+                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks_AoE))
                         {
-                            if (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling_AoE))
+                            if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && LevelChecked(SummonBahamut))
+                                return OriginalHook(EnkindleBahamut);
+
+                            if (IsOffCooldown(Deathflare) && LevelChecked(Deathflare) && OriginalHook(Ruin) is AstralImpulse)
+                                return OriginalHook(AstralFlow);
+
+                            if (IsOffCooldown(OriginalHook(EnkindlePhoenix)) && LevelChecked(SummonPhoenix))
+                                return OriginalHook(EnkindlePhoenix);
+
+                            if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Rekindle_AoE))
+                                if (IsOffCooldown(Rekindle) && OriginalHook(Ruin) is FountainOfFire)
+                                    return OriginalHook(AstralFlow);
+
+                            if (IsOffCooldown(OriginalHook(EnkindleSolarBahamut)) && LevelChecked(SummonSolarBahamut))
+                                return OriginalHook(EnkindleSolarBahamut);
+
+                            if (IsOffCooldown(Sunflare) && LevelChecked(Sunflare) && OriginalHook(Ruin) is UmbralImpulse)
+                                return OriginalHook(AstralFlow);
+                        }
+                    }
+
+                    // Energy Siphon
+                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_ESPainflare) && !gauge.HasAetherflowStacks && IsOffCooldown(EnergySiphon) && LevelChecked(EnergySiphon) &&
+                        (!LevelChecked(DreadwyrmTrance) || !inOpener || DemiAttackCount >= burstDelay))
+                        return EnergySiphon;
+
+                    // First set of Painflares if Energy Siphon is close to being off CD, or off CD while you have aetherflow stacks.
+                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_ESPainflare) && IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling_AoE) && gauge.HasAetherflowStacks && LevelChecked(Painflare))
+                    {
+                        if (GetCooldown(EnergySiphon).CooldownRemaining <= 3.2)
+                        {
+                            if ((((HasEffect(Buffs.SearingLight) && IsNotEnabled(CustomComboPreset.SMN_Advanced_Burst_Any_Option_AoE)) || HasEffectAny(Buffs.SearingLight)) &&
+                                 (SummonerBurstPhase is not 4)) ||
+                                (SummonerBurstPhase == 4 && !HasEffect(Buffs.TitansFavor)))
                                 return OriginalHook(Painflare);
 
-                            if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling_AoE))
-                            {
-                                if (!LevelChecked(SearingLight))
-                                    return OriginalHook(Painflare);
-
-                                if ((((HasEffect(Buffs.SearingLight) && IsNotEnabled(CustomComboPreset.SMN_Advanced_Burst_Any_Option_AoE)) || HasEffectAny(Buffs.SearingLight)) &&
-                                     SummonerBurstPhase is 0 or 1 or 2 or 3 && DemiAttackCount >= burstDelay) ||
-                                    (SummonerBurstPhase == 4 && !HasEffect(Buffs.TitansFavor)))
-                                    return OriginalHook(Painflare);
-                            }
                         }
                     }
 
-                    // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SMN_Lucid_AoE) && CanSpellWeave() && ActionReady(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold)
-                        return All.LucidDreaming;
+                    if (IsEnabled(CustomComboPreset.SMN_SearingFlash_AoE) && HasEffect(Buffs.RubysGlimmer) && LevelChecked(SearingFlash))
+                        return SearingFlash;
 
-
-                    // Demi
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_AoE))
+                    // Demi Nuke
+                    if (OriginalHook(Ruin) is AstralImpulse or UmbralImpulse or FountainOfFire)
                     {
-                        if (InCombat() && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
-                            ((LevelChecked(Aethercharge) && !LevelChecked(SummonBahamut)) ||   // Pre-Bahamut Phase
-                             (IsBahamutReady && LevelChecked(SummonBahamut)) ||            // Bahamut Phase
-                             (IsPhoenixReady && LevelChecked(SummonPhoenix)) ||            // Phoenix Phase
-                             (IsSolarBahamutReady && LevelChecked(SummonSolarBahamut))))   // Solar Bahamut Phase
-                            return OriginalHook(Aethercharge);
+                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks_AoE) && IsBahamutReady && (LevelChecked(SummonSolarBahamut) || DemiAttackCount >= burstDelay)
+                            && (IsNotEnabled(CustomComboPreset.SMN_SearingLight_Burst_AoE) || (LevelChecked(SummonSolarBahamut) || HasEffect(Buffs.SearingLight))))
+                        {
+                            if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && LevelChecked(SummonBahamut))
+                                return OriginalHook(EnkindleBahamut);
+
+                            if (IsOffCooldown(Deathflare) && LevelChecked(Deathflare) && OriginalHook(Ruin) is AstralImpulse)
+                                return OriginalHook(AstralFlow);
+                        }
+
+                        // Demi Nuke 2: Electric Boogaloo
+                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks_AoE) && IsPhoenixReady)
+                        {
+                            if (IsOffCooldown(OriginalHook(EnkindlePhoenix)) && LevelChecked(SummonPhoenix) && OriginalHook(Ruin) is FountainOfFire)
+                                return OriginalHook(EnkindlePhoenix);
+
+                            if (IsOffCooldown(Rekindle) && IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Rekindle_AoE) && OriginalHook(Ruin) is FountainOfFire)
+                                return OriginalHook(AstralFlow);
+                        }
+
+                        // Demi Nuke 3: More Boogaloo
+                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks_AoE) && IsSolarBahamutReady && DemiAttackCount >= burstDelay &&
+                            (IsNotEnabled(CustomComboPreset.SMN_SearingLight_Burst_AoE) || HasEffect(Buffs.SearingLight)))
+                        {
+                            if (IsOffCooldown(OriginalHook(EnkindleSolarBahamut)) && LevelChecked(SummonSolarBahamut))
+                                return OriginalHook(EnkindleSolarBahamut);
+
+                            if (IsOffCooldown(Sunflare) && LevelChecked(Sunflare) && OriginalHook(Ruin) is UmbralImpulse)
+                                return OriginalHook(AstralFlow);
+                        }
                     }
 
-                    //Ruin4 in Egi Phases
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4_AoE) && HasEffect(Buffs.FurtherRuin) &&
-                        ((!HasEffect(All.Buffs.Swiftcast) && IsMoving() && ((HasEffect(Buffs.GarudasFavor) && !IsGarudaAttuned) || (IsIfritAttuned && ComboAction is not CrimsonCyclone))) ||
-                         GetCooldownRemainingTime(OriginalHook(Aethercharge)) is < 2.5f and > 0))
-                        return Ruin4;
+                    // Lux Solaris
+                    if (IsOffCooldown(LuxSolaris) && IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_LuxSolaris_AoE) && HasEffect(Buffs.RefulgentLux) &&
+                        (PlayerHealthPercentageHp() < 100 || GetBuffRemainingTime(Buffs.RefulgentLux) is < 3 and > 0))
+                        return OriginalHook(LuxSolaris);
 
-                    // Egi Features
-                    if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi_AoE) && LevelChecked(All.Swiftcast))
+                }
+
+                // Painflare
+                if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_ESPainflare) && LevelChecked(Painflare))
+                {
+                    if (gauge.HasAetherflowStacks && CanSpellWeave())
+                    {
+                        if (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling_AoE))
+                            return OriginalHook(Painflare);
+
+                        if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling_AoE))
+                        {
+                            if (!LevelChecked(SearingLight))
+                                return OriginalHook(Painflare);
+
+                            if ((((HasEffect(Buffs.SearingLight) && IsNotEnabled(CustomComboPreset.SMN_Advanced_Burst_Any_Option_AoE)) || HasEffectAny(Buffs.SearingLight)) &&
+                                 SummonerBurstPhase is 0 or 1 or 2 or 3 && DemiAttackCount >= burstDelay) ||
+                                (SummonerBurstPhase == 4 && !HasEffect(Buffs.TitansFavor)))
+                                return OriginalHook(Painflare);
+                        }
+                    }
+                }
+
+                // Lucid Dreaming
+                if (IsEnabled(CustomComboPreset.SMN_Lucid_AoE) && CanSpellWeave() && ActionReady(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold)
+                    return All.LucidDreaming;
+
+
+                // Demi
+                if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_AoE))
+                {
+                    if (InCombat() && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
+                        ((LevelChecked(Aethercharge) && !LevelChecked(SummonBahamut)) ||   // Pre-Bahamut Phase
+                         (IsBahamutReady && LevelChecked(SummonBahamut)) ||            // Bahamut Phase
+                         (IsPhoenixReady && LevelChecked(SummonPhoenix)) ||            // Phoenix Phase
+                         (IsSolarBahamutReady && LevelChecked(SummonSolarBahamut))))   // Solar Bahamut Phase
+                        return OriginalHook(Aethercharge);
+                }
+
+                //Ruin4 in Egi Phases
+                if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4_AoE) && HasEffect(Buffs.FurtherRuin) &&
+                    ((!HasEffect(All.Buffs.Swiftcast) && IsMoving() && ((HasEffect(Buffs.GarudasFavor) && !IsGarudaAttuned) || (IsIfritAttuned && ComboAction is not CrimsonCyclone))) ||
+                     GetCooldownRemainingTime(OriginalHook(Aethercharge)) is < 2.5f and > 0))
+                    return Ruin4;
+
+                // Egi Features
+                if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi_AoE) && LevelChecked(All.Swiftcast))
+                {
+                    // Swiftcast Garuda Feature
+                    if (swiftcastPhase is 0 or 1 && LevelChecked(Slipstream) && HasEffect(Buffs.GarudasFavor))
+                    {
+                        if (CanSpellWeave() && IsGarudaAttuned && IsOffCooldown(All.Swiftcast))
+                            return All.Swiftcast;
+
+                        if (Config.SMN_ST_Egi_AstralFlow[2] &&
+                            ((HasEffect(Buffs.GarudasFavor) && HasEffect(All.Buffs.Swiftcast)) || (gauge.Attunement == 0)))     // Astral Flow if Swiftcast is not ready throughout Garuda
+                            return OriginalHook(AstralFlow);
+                    }
+
+                    // Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
+                    if (swiftcastPhase == 2)
+                    {
+                        if (IsOffCooldown(All.Swiftcast) && IsIfritAttuned && ComboAction is not CrimsonCyclone)
+                        {
+                            if (!Config.SMN_ST_Egi_AstralFlow[1] || (Config.SMN_ST_Egi_AstralFlow[1] && gauge.Attunement >= 1))
+                                return All.Swiftcast;
+                        }
+                    }
+
+                    // SpS Swiftcast
+                    if (swiftcastPhase == 3)
                     {
                         // Swiftcast Garuda Feature
-                        if (swiftcastPhase is 0 or 1 && LevelChecked(Slipstream) && HasEffect(Buffs.GarudasFavor))
+                        if (LevelChecked(Slipstream) && HasEffect(Buffs.GarudasFavor))
                         {
                             if (CanSpellWeave() && IsGarudaAttuned && IsOffCooldown(All.Swiftcast))
                                 return All.Swiftcast;
@@ -1000,83 +1018,58 @@ namespace WrathCombo.Combos.PvE
                         }
 
                         // Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
-                        if (swiftcastPhase == 2)
+                        if (IsOffCooldown(All.Swiftcast) && IsIfritAttuned && ComboAction is not CrimsonCyclone)
                         {
-                            if (IsOffCooldown(All.Swiftcast) && IsIfritAttuned && ComboAction is not CrimsonCyclone)
-                            {
-                                if (!Config.SMN_ST_Egi_AstralFlow[1] || (Config.SMN_ST_Egi_AstralFlow[1] && gauge.Attunement >= 1))
-                                    return All.Swiftcast;
-                            }
-                        }
-
-                        // SpS Swiftcast
-                        if (swiftcastPhase == 3)
-                        {
-                            // Swiftcast Garuda Feature
-                            if (LevelChecked(Slipstream) && HasEffect(Buffs.GarudasFavor))
-                            {
-                                if (CanSpellWeave() && IsGarudaAttuned && IsOffCooldown(All.Swiftcast))
-                                    return All.Swiftcast;
-
-                                if (Config.SMN_ST_Egi_AstralFlow[2] &&
-                                    ((HasEffect(Buffs.GarudasFavor) && HasEffect(All.Buffs.Swiftcast)) || (gauge.Attunement == 0)))     // Astral Flow if Swiftcast is not ready throughout Garuda
-                                    return OriginalHook(AstralFlow);
-                            }
-
-                            // Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
-                            if (IsOffCooldown(All.Swiftcast) && IsIfritAttuned && ComboAction is not CrimsonCyclone)
-                            {
-                                if (!Config.SMN_ST_Egi_AstralFlow[1] || (Config.SMN_ST_Egi_AstralFlow[1] && gauge.Attunement >= 1))
-                                    return All.Swiftcast;
-                            }
+                            if (!Config.SMN_ST_Egi_AstralFlow[1] || (Config.SMN_ST_Egi_AstralFlow[1] && gauge.Attunement >= 1))
+                                return All.Swiftcast;
                         }
                     }
-
-                    // Precious Brilliance priority casting
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EgiSummons_Attacks_AoE) && LevelChecked(PreciousBrilliance) &&
-                        ((IsIfritAttuned && gauge.Attunement >= 1 && HasEffect(All.Buffs.Swiftcast) && ComboAction is not CrimsonCyclone) ||
-                         (HasEffect(Buffs.GarudasFavor) && gauge.Attunement >= 1 && !HasEffect(All.Buffs.Swiftcast) && IsMoving())))
-                        return OriginalHook(PreciousBrilliance);
-
-                    if ((Config.SMN_ST_Egi_AstralFlow[2] && HasEffect(Buffs.GarudasFavor) && (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi_AoE) || swiftcastPhase == 2)) ||                 // Garuda
-                        (Config.SMN_ST_Egi_AstralFlow[0] && HasEffect(Buffs.TitansFavor) && ComboAction is TopazRite or TopazCata && CanSpellWeave()) ||                                  // Titan
-                        (Config.SMN_ST_Egi_AstralFlow[1] && (HasEffect(Buffs.IfritsFavor) && !Config.SMN_ST_CrimsonCycloneMelee && (IsMoving() || gauge.Attunement == 0) || (ComboAction is CrimsonCyclone && InMeleeRange()))) ||
-                        (Config.SMN_ST_Egi_AstralFlow[1] && HasEffect(Buffs.IfritsFavor) && Config.SMN_ST_CrimsonCycloneMelee && InMeleeRange()))  // Ifrit
-                        return OriginalHook(AstralFlow);
-
-                    // Precious Brilliance
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EgiSummons_Attacks_AoE) && LevelChecked(PreciousBrilliance) && (IsGarudaAttuned || IsTitanAttuned || IsIfritAttuned))
-                        return OriginalHook(PreciousBrilliance);
-
-                    // Egi Order
-                    if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_EgiOrder_AoE) && gauge.SummonTimerRemaining == 0)
-                    {
-                        if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && LevelChecked(SummonRuby))
-                            return OriginalHook(SummonRuby);
-
-                        if (summonerPrimalChoice is 0 or 1)
-                        {
-                            if (gauge.IsTitanReady && LevelChecked(SummonTopaz))
-                                return OriginalHook(SummonTopaz);
-
-                            if (gauge.IsGarudaReady && LevelChecked(SummonEmerald))
-                                return OriginalHook(SummonEmerald);
-                        }
-
-                        if (summonerPrimalChoice == 2)
-                        {
-                            if (gauge.IsGarudaReady && LevelChecked(SummonEmerald))
-                                return OriginalHook(SummonEmerald);
-
-                            if (gauge.IsTitanReady && LevelChecked(SummonTopaz))
-                                return OriginalHook(SummonTopaz);
-                        }
-                    }
-
-                    // Ruin 4
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4_AoE) && LevelChecked(Ruin4) && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
-                        return Ruin4;
                 }
+
+                // Precious Brilliance priority casting
+                if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EgiSummons_Attacks_AoE) && LevelChecked(PreciousBrilliance) &&
+                    ((IsIfritAttuned && gauge.Attunement >= 1 && HasEffect(All.Buffs.Swiftcast) && ComboAction is not CrimsonCyclone) ||
+                     (HasEffect(Buffs.GarudasFavor) && gauge.Attunement >= 1 && !HasEffect(All.Buffs.Swiftcast) && IsMoving())))
+                    return OriginalHook(PreciousBrilliance);
+
+                if ((Config.SMN_ST_Egi_AstralFlow[2] && HasEffect(Buffs.GarudasFavor) && (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi_AoE) || swiftcastPhase == 2)) ||                 // Garuda
+                    (Config.SMN_ST_Egi_AstralFlow[0] && HasEffect(Buffs.TitansFavor) && ComboAction is TopazRite or TopazCata && CanSpellWeave()) ||                                  // Titan
+                    (Config.SMN_ST_Egi_AstralFlow[1] && (HasEffect(Buffs.IfritsFavor) && !Config.SMN_ST_CrimsonCycloneMelee && (IsMoving() || gauge.Attunement == 0) || (ComboAction is CrimsonCyclone && InMeleeRange()))) ||
+                    (Config.SMN_ST_Egi_AstralFlow[1] && HasEffect(Buffs.IfritsFavor) && Config.SMN_ST_CrimsonCycloneMelee && InMeleeRange()))  // Ifrit
+                    return OriginalHook(AstralFlow);
+
+                // Precious Brilliance
+                if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EgiSummons_Attacks_AoE) && LevelChecked(PreciousBrilliance) && (IsGarudaAttuned || IsTitanAttuned || IsIfritAttuned))
+                    return OriginalHook(PreciousBrilliance);
+
+                // Egi Order
+                if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_EgiOrder_AoE) && gauge.SummonTimerRemaining == 0)
+                {
+                    if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && LevelChecked(SummonRuby))
+                        return OriginalHook(SummonRuby);
+
+                    if (summonerPrimalChoice is 0 or 1)
+                    {
+                        if (gauge.IsTitanReady && LevelChecked(SummonTopaz))
+                            return OriginalHook(SummonTopaz);
+
+                        if (gauge.IsGarudaReady && LevelChecked(SummonEmerald))
+                            return OriginalHook(SummonEmerald);
+                    }
+
+                    if (summonerPrimalChoice == 2)
+                    {
+                        if (gauge.IsGarudaReady && LevelChecked(SummonEmerald))
+                            return OriginalHook(SummonEmerald);
+
+                        if (gauge.IsTitanReady && LevelChecked(SummonTopaz))
+                            return OriginalHook(SummonTopaz);
+                    }
+                }
+
+                // Ruin 4
+                if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4_AoE) && LevelChecked(Ruin4) && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
+                    return Ruin4;
                 return actionID;
             }
         }
@@ -1090,25 +1083,28 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is Ruin or Ruin2 or Ruin3 or DreadwyrmTrance or AstralFlow or EnkindleBahamut or SearingLight or RadiantAegis or Outburst or Tridisaster or PreciousBrilliance or Gemshine)
+                if (actionID is not (Ruin or Ruin2 or Ruin3 or DreadwyrmTrance) &&
+                    actionID is not (AstralFlow or EnkindleBahamut or SearingLight) &&
+                    actionID is not (RadiantAegis or Outburst or Tridisaster) &&
+                    actionID is not (PreciousBrilliance or Gemshine))
+                    return actionID;
+
+                presentTime = DateTime.Now;
+                int deltaTime = (presentTime - noPetTime).Milliseconds;
+                var gauge = GetJobGauge<SMNGauge>();
+
+                if (HasPetPresent())
                 {
-                    presentTime = DateTime.Now;
-                    int deltaTime = (presentTime - noPetTime).Milliseconds;
-                    var gauge = GetJobGauge<SMNGauge>();
-
-                    if (HasPetPresent())
-                    {
-                        carbyPresent = true;
-                        noPetTime = DateTime.Now;
-                    }
-
-                    //Deals with the game's half second pet refresh
-                    if (deltaTime > 500 && !HasPetPresent() && gauge.SummonTimerRemaining == 0 && gauge.Attunement == 0 && GetCooldownRemainingTime(Ruin) == 0)
-                        carbyPresent = false;
-
-                    if (carbyPresent == false)
-                        return SummonCarbuncle;
+                    carbyPresent = true;
+                    noPetTime = DateTime.Now;
                 }
+
+                //Deals with the game's half second pet refresh
+                if (deltaTime > 500 && !HasPetPresent() && gauge.SummonTimerRemaining == 0 && gauge.Attunement == 0 && GetCooldownRemainingTime(Ruin) == 0)
+                    carbyPresent = false;
+
+                if (carbyPresent == false)
+                    return SummonCarbuncle;
 
                 return actionID;
             }
@@ -1135,23 +1131,24 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is Aethercharge or DreadwyrmTrance or SummonBahamut or SummonPhoenix or SummonSolarBahamut)
-                {
-                    if (IsOffCooldown(EnkindleBahamut) && OriginalHook(Ruin) is AstralImpulse)
-                        return OriginalHook(EnkindleBahamut);
+                if (actionID is not (Aethercharge or DreadwyrmTrance or SummonBahamut) &&
+                    actionID is not (SummonPhoenix or SummonSolarBahamut))
+                    return actionID;
 
-                    if (IsOffCooldown(EnkindlePhoenix) && OriginalHook(Ruin) is FountainOfFire)
-                        return OriginalHook(EnkindlePhoenix);
+                if (IsOffCooldown(EnkindleBahamut) && OriginalHook(Ruin) is AstralImpulse)
+                    return OriginalHook(EnkindleBahamut);
 
-                    if (IsOffCooldown(EnkindleSolarBahamut) && OriginalHook(Ruin) is UmbralImpulse)
-                        return OriginalHook(EnkindleBahamut);
+                if (IsOffCooldown(EnkindlePhoenix) && OriginalHook(Ruin) is FountainOfFire)
+                    return OriginalHook(EnkindlePhoenix);
 
-                    if ((OriginalHook(AstralFlow) is Deathflare && IsOffCooldown(Deathflare)) || (OriginalHook(AstralFlow) is Rekindle && IsOffCooldown(Rekindle)))
-                        return OriginalHook(AstralFlow);
+                if (IsOffCooldown(EnkindleSolarBahamut) && OriginalHook(Ruin) is UmbralImpulse)
+                    return OriginalHook(EnkindleBahamut);
 
-                    if (OriginalHook(AstralFlow) is Sunflare && IsOffCooldown(Sunflare))
-                        return OriginalHook(Sunflare);
-                }
+                if ((OriginalHook(AstralFlow) is Deathflare && IsOffCooldown(Deathflare)) || (OriginalHook(AstralFlow) is Rekindle && IsOffCooldown(Rekindle)))
+                    return OriginalHook(AstralFlow);
+
+                if (OriginalHook(AstralFlow) is Sunflare && IsOffCooldown(Sunflare))
+                    return OriginalHook(Sunflare);
 
                 return actionID;
             }

--- a/WrathCombo/Combos/PvE/VPR/VPR.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR.cs
@@ -11,7 +11,468 @@ internal static partial class VPR
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is SteelFangs)
+            if (actionID is not SteelFangs) return actionID;
+
+            // Variant Cure
+            if (IsEnabled(CustomComboPreset.VPR_Variant_Cure) &&
+                IsEnabled(Variant.VariantCure) &&
+                PlayerHealthPercentageHp() <= GetOptionValue(Config.VPR_VariantCure))
+                return Variant.VariantCure;
+
+            // Variant Rampart
+            if (IsEnabled(CustomComboPreset.VPR_Variant_Rampart) &&
+                IsEnabled(Variant.VariantRampart) &&
+                IsOffCooldown(Variant.VariantRampart) &&
+                CanWeave())
+                return Variant.VariantRampart;
+
+            // Opener for VPR
+            if (Opener().FullOpener(ref actionID))
+                return actionID;
+
+            //oGCDs
+            if (CanWeave())
+            {
+                //Serpents Ire - ForceWeave
+                if (InCombat() && !CappedOnCoils && ActionReady(SerpentsIre))
+                    return SerpentsIre;
+
+                // Legacy Weaves
+                if (In5y && TraitLevelChecked(Traits.SerpentsLegacy) && HasEffect(Buffs.Reawakened)
+                    && OriginalHook(SerpentsTail) is not SerpentsTail)
+                    return OriginalHook(SerpentsTail);
+
+                // Fury Twin Weaves
+                if (HasEffect(Buffs.PoisedForTwinfang))
+                    return OriginalHook(Twinfang);
+
+                if (HasEffect(Buffs.PoisedForTwinblood))
+                    return OriginalHook(Twinblood);
+
+                //Vice Twin Weaves
+                if (!HasEffect(Buffs.Reawakened) && In5y)
+                {
+                    if (HasEffect(Buffs.HuntersVenom))
+                        return OriginalHook(Twinfang);
+
+                    if (HasEffect(Buffs.SwiftskinsVenom))
+                        return OriginalHook(Twinblood);
+                }
+            }
+
+            // Death Rattle - Force to avoid loss
+            if (In5y && LevelChecked(SerpentsTail) && OriginalHook(SerpentsTail) is DeathRattle)
+                return OriginalHook(SerpentsTail);
+
+            //GCDs
+            if (LevelChecked(WrithingSnap) && !InMeleeRange() && HasBattleTarget())
+                return HasRattlingCoilStack(gauge)
+                    ? UncoiledFury
+                    : WrithingSnap;
+
+            //Vicewinder Combo
+            if (!HasEffect(Buffs.Reawakened) && LevelChecked(Vicewinder) && InMeleeRange())
+            {
+                // Swiftskin's Coil
+                if ((VicewinderReady && (!OnTargetsFlank() || !TargetNeedsPositionals())) || HuntersCoilReady)
+                    return SwiftskinsCoil;
+
+                // Hunter's Coil
+                if ((VicewinderReady && (!OnTargetsRear() || !TargetNeedsPositionals())) || SwiftskinsCoilReady)
+                    return HuntersCoil;
+            }
+
+            //Reawakend Usage
+            if (UseReawaken(gauge))
+                return Reawaken;
+
+            //Overcap protection
+            if (CappedOnCoils &&
+                ((HasCharges(Vicewinder) && !HasEffect(Buffs.SwiftskinsVenom) && !HasEffect(Buffs.HuntersVenom) &&
+                  !HasEffect(Buffs.Reawakened)) || //spend if Vicewinder is up, after Reawaken
+                 IreCD <= GCD * 5)) //spend in case under Reawaken right as Ire comes up
+                return UncoiledFury;
+
+            //Vicewinder Usage
+            if (HasEffect(Buffs.Swiftscaled) && !IsComboExpiring(3) &&
+                ActionReady(Vicewinder) && !HasEffect(Buffs.Reawakened) && InMeleeRange() &&
+                (IreCD >= GCD * 5 || !LevelChecked(SerpentsIre)) &&
+                !IsVenomExpiring(3) && !IsHoningExpiring(3))
+                return Vicewinder;
+
+            // Uncoiled Fury usage
+            if (LevelChecked(UncoiledFury) && HasEffect(Buffs.Swiftscaled) && HasEffect(Buffs.HuntersInstinct) &&
+                !IsComboExpiring(2) &&
+                gauge.RattlingCoilStacks > 1 &&
+                !VicewinderReady && !HuntersCoilReady && !SwiftskinsCoilReady &&
+                !HasEffect(Buffs.Reawakened) && !HasEffect(Buffs.ReadyToReawaken) &&
+                !WasLastWeaponskill(Ouroboros) &&
+                !IsEmpowermentExpiring(6) && !IsVenomExpiring(3) &&
+                !IsHoningExpiring(3))
+                return UncoiledFury;
+
+            //Reawaken combo
+            if (HasEffect(Buffs.Reawakened))
+            {
+                #region Pre Ouroboros
+
+                if (!TraitLevelChecked(Traits.EnhancedSerpentsLineage))
+                    switch (gauge.AnguineTribute)
+                    {
+                        case 4:
+                            return OriginalHook(SteelFangs);
+
+                        case 3:
+                            return OriginalHook(ReavingFangs);
+
+                        case 2:
+                            return OriginalHook(HuntersCoil);
+
+                        case 1:
+                            return OriginalHook(SwiftskinsCoil);
+                    }
+
+                #endregion
+
+                #region With Ouroboros
+
+                if (TraitLevelChecked(Traits.EnhancedSerpentsLineage))
+                    switch (gauge.AnguineTribute)
+                    {
+                        case 5:
+                            return OriginalHook(SteelFangs);
+
+                        case 4:
+                            return OriginalHook(ReavingFangs);
+
+                        case 3:
+                            return OriginalHook(HuntersCoil);
+
+                        case 2:
+                            return OriginalHook(SwiftskinsCoil);
+
+                        case 1:
+                            return OriginalHook(Reawaken);
+                    }
+
+                #endregion
+            }
+
+            //1-2-3 (4-5-6) Combo
+            if (ComboTimer > 0 && !HasEffect(Buffs.Reawakened))
+            {
+                if (ComboAction is ReavingFangs or SteelFangs)
+                {
+                    if (LevelChecked(HuntersSting) &&
+                        (HasEffect(Buffs.FlankstungVenom) || HasEffect(Buffs.FlanksbaneVenom)))
+                        return OriginalHook(SteelFangs);
+
+                    if (LevelChecked(SwiftskinsSting) &&
+                        (HasEffect(Buffs.HindstungVenom) || HasEffect(Buffs.HindsbaneVenom) ||
+                         (!HasEffect(Buffs.Swiftscaled) && !HasEffect(Buffs.HuntersInstinct))))
+                        return OriginalHook(ReavingFangs);
+                }
+
+                if (ComboAction is HuntersSting or SwiftskinsSting)
+                {
+                    if ((HasEffect(Buffs.FlankstungVenom) || HasEffect(Buffs.HindstungVenom)) &&
+                        LevelChecked(FlanksbaneFang))
+                    {
+                        if (TrueNorthReady && !OnTargetsRear() && HasEffect(Buffs.HindstungVenom) &&
+                            CanDelayedWeave())
+                            return All.TrueNorth;
+
+                        if (TrueNorthReady && !OnTargetsFlank() && HasEffect(Buffs.FlankstungVenom) &&
+                            CanDelayedWeave())
+                            return All.TrueNorth;
+
+                        return OriginalHook(SteelFangs);
+                    }
+
+                    if ((HasEffect(Buffs.FlanksbaneVenom) || HasEffect(Buffs.HindsbaneVenom)) &&
+                        LevelChecked(HindstingStrike))
+                    {
+                        if (TrueNorthReady && !OnTargetsRear() && HasEffect(Buffs.HindsbaneVenom) &&
+                            CanDelayedWeave())
+                            return All.TrueNorth;
+
+                        if (TrueNorthReady && !OnTargetsFlank() && HasEffect(Buffs.FlanksbaneVenom) &&
+                            CanDelayedWeave())
+                            return All.TrueNorth;
+
+                        return OriginalHook(ReavingFangs);
+                    }
+                }
+
+                if (ComboAction is HindstingStrike or HindsbaneFang or FlankstingStrike or FlanksbaneFang)
+                    return LevelChecked(ReavingFangs) && HasEffect(Buffs.HonedReavers)
+                        ? OriginalHook(ReavingFangs)
+                        : OriginalHook(SteelFangs);
+            }
+
+            //LowLevels
+            if (LevelChecked(ReavingFangs) && (HasEffect(Buffs.HonedReavers) ||
+                                               (!HasEffect(Buffs.HonedReavers) && !HasEffect(Buffs.HonedSteel))))
+                return OriginalHook(ReavingFangs);
+            return actionID;
+        }
+    }
+
+    internal class VPR_ST_AdvancedMode : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.VPR_ST_AdvancedMode;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not SteelFangs) return actionID;
+
+            // Variant Cure
+            if (IsEnabled(CustomComboPreset.VPR_Variant_Cure) &&
+                IsEnabled(Variant.VariantCure) &&
+                PlayerHealthPercentageHp() <= GetOptionValue(Config.VPR_VariantCure))
+                return Variant.VariantCure;
+
+            // Variant Rampart
+            if (IsEnabled(CustomComboPreset.VPR_Variant_Rampart) &&
+                IsEnabled(Variant.VariantRampart) &&
+                IsOffCooldown(Variant.VariantRampart) &&
+                CanWeave())
+                return Variant.VariantRampart;
+
+            // Opener for VPR
+            if (IsEnabled(CustomComboPreset.VPR_ST_Opener))
+                if (Opener().FullOpener(ref actionID))
+                    return actionID;
+
+            //oGCDs
+            if (CanWeave())
+            {
+                //Serpents Ire
+                if (IsEnabled(CustomComboPreset.VPR_ST_SerpentsIre) && InCombat() &&
+                    !CappedOnCoils && ActionReady(SerpentsIre))
+                    return SerpentsIre;
+
+                // Death Rattle
+                if (IsEnabled(CustomComboPreset.VPR_ST_SerpentsTail) && In5y &&
+                    LevelChecked(SerpentsTail) && OriginalHook(SerpentsTail) is DeathRattle)
+                    return OriginalHook(SerpentsTail);
+
+                // Legacy Weaves
+                if (IsEnabled(CustomComboPreset.VPR_ST_ReawakenCombo) && In5y &&
+                    TraitLevelChecked(Traits.SerpentsLegacy) && HasEffect(Buffs.Reawakened)
+                    && OriginalHook(SerpentsTail) is not SerpentsTail)
+                    return OriginalHook(SerpentsTail);
+
+                // Fury Twin Weaves
+                if (IsEnabled(CustomComboPreset.VPR_ST_UncoiledFuryCombo))
+                {
+                    if (HasEffect(Buffs.PoisedForTwinfang))
+                        return OriginalHook(Twinfang);
+
+                    if (HasEffect(Buffs.PoisedForTwinblood))
+                        return OriginalHook(Twinblood);
+                }
+
+                //Vice Twin Weaves
+                if (IsEnabled(CustomComboPreset.VPR_ST_VicewinderWeaves) &&
+                    !HasEffect(Buffs.Reawakened) && In5y)
+                {
+                    if (HasEffect(Buffs.HuntersVenom))
+                        return OriginalHook(Twinfang);
+
+                    if (HasEffect(Buffs.SwiftskinsVenom))
+                        return OriginalHook(Twinblood);
+                }
+            }
+
+            // Death Rattle - Force to avoid loss
+            if (IsEnabled(CustomComboPreset.VPR_ST_SerpentsTail) && In5y &&
+                LevelChecked(SerpentsTail) && OriginalHook(SerpentsTail) is DeathRattle)
+                return OriginalHook(SerpentsTail);
+
+            //GCDs
+            if (IsEnabled(CustomComboPreset.VPR_ST_RangedUptime) &&
+                LevelChecked(WrithingSnap) && !InMeleeRange() && HasBattleTarget())
+                return IsEnabled(CustomComboPreset.VPR_ST_RangedUptimeUncoiledFury) &&
+                       HasRattlingCoilStack(gauge)
+                    ? UncoiledFury
+                    : WrithingSnap;
+
+            //Vicewinder Combo
+            if (IsEnabled(CustomComboPreset.VPR_ST_VicewinderCombo) &&
+                !HasEffect(Buffs.Reawakened) && LevelChecked(Vicewinder) && InMeleeRange())
+            {
+                // Swiftskin's Coil
+                if ((VicewinderReady && (!OnTargetsFlank() || !TargetNeedsPositionals())) || HuntersCoilReady)
+                    return SwiftskinsCoil;
+
+                // Hunter's Coil
+                if ((VicewinderReady && (!OnTargetsRear() || !TargetNeedsPositionals())) || SwiftskinsCoilReady)
+                    return HuntersCoil;
+            }
+
+            //Reawakend Usage
+            if (IsEnabled(CustomComboPreset.VPR_ST_Reawaken) && UseReawaken(gauge))
+                return Reawaken;
+
+            //Overcap protection
+            if (IsEnabled(CustomComboPreset.VPR_ST_UncoiledFury) && CappedOnCoils &&
+                ((HasCharges(Vicewinder) && !HasEffect(Buffs.SwiftskinsVenom) && !HasEffect(Buffs.HuntersVenom) &&
+                  !HasEffect(Buffs.Reawakened)) || //spend if Vicewinder is up, after Reawaken
+                 IreCD <= GCD * 5)) //spend in case under Reawaken right as Ire comes up
+                return UncoiledFury;
+
+            //Vicewinder Usage
+            if (IsEnabled(CustomComboPreset.VPR_ST_Vicewinder) && HasEffect(Buffs.Swiftscaled) &&
+                !IsComboExpiring(3) &&
+                ActionReady(Vicewinder) && !HasEffect(Buffs.Reawakened) && InMeleeRange() &&
+                (IreCD >= GCD * 5 || !LevelChecked(SerpentsIre)) &&
+                !IsVenomExpiring(3) && !IsHoningExpiring(3))
+                return Vicewinder;
+
+            // Uncoiled Fury usage
+            if (IsEnabled(CustomComboPreset.VPR_ST_UncoiledFury) && !IsComboExpiring(2) &&
+                LevelChecked(UncoiledFury) && HasEffect(Buffs.Swiftscaled) && HasEffect(Buffs.HuntersInstinct) &&
+                (gauge.RattlingCoilStacks > Config.VPR_ST_UncoiledFury_HoldCharges ||
+                 (GetTargetHPPercent() < Config.VPR_ST_UncoiledFury_Threshold && HasRattlingCoilStack(gauge))) &&
+                !VicewinderReady && !HuntersCoilReady && !SwiftskinsCoilReady &&
+                !HasEffect(Buffs.Reawakened) && !HasEffect(Buffs.ReadyToReawaken) &&
+                !WasLastWeaponskill(Ouroboros) &&
+                !IsEmpowermentExpiring(3))
+                return UncoiledFury;
+
+            //Reawaken combo
+            if (IsEnabled(CustomComboPreset.VPR_ST_ReawakenCombo) &&
+                HasEffect(Buffs.Reawakened))
+            {
+                #region Pre Ouroboros
+
+                if (!TraitLevelChecked(Traits.EnhancedSerpentsLineage))
+                    switch (gauge.AnguineTribute)
+                    {
+                        case 4:
+                            return OriginalHook(SteelFangs);
+
+                        case 3:
+                            return OriginalHook(ReavingFangs);
+
+                        case 2:
+                            return OriginalHook(HuntersCoil);
+
+                        case 1:
+                            return OriginalHook(SwiftskinsCoil);
+                    }
+
+                #endregion
+
+                #region With Ouroboros
+
+                if (TraitLevelChecked(Traits.EnhancedSerpentsLineage))
+                    switch (gauge.AnguineTribute)
+                    {
+                        case 5:
+                            return OriginalHook(SteelFangs);
+
+                        case 4:
+                            return OriginalHook(ReavingFangs);
+
+                        case 3:
+                            return OriginalHook(HuntersCoil);
+
+                        case 2:
+                            return OriginalHook(SwiftskinsCoil);
+
+                        case 1:
+                            return OriginalHook(Reawaken);
+                    }
+
+                #endregion
+            }
+
+            // healing
+            if (IsEnabled(CustomComboPreset.VPR_ST_ComboHeals))
+            {
+                if (PlayerHealthPercentageHp() <= Config.VPR_ST_SecondWind_Threshold && ActionReady(All.SecondWind))
+                    return All.SecondWind;
+
+                if (PlayerHealthPercentageHp() <= Config.VPR_ST_Bloodbath_Threshold && ActionReady(All.Bloodbath))
+                    return All.Bloodbath;
+            }
+
+            //1-2-3 (4-5-6) Combo
+            if (ComboTimer > 0 && !HasEffect(Buffs.Reawakened))
+            {
+                if (ComboAction is ReavingFangs or SteelFangs)
+                {
+                    if (LevelChecked(HuntersSting) &&
+                        (HasEffect(Buffs.FlankstungVenom) || HasEffect(Buffs.FlanksbaneVenom)))
+                        return OriginalHook(SteelFangs);
+
+                    if (LevelChecked(SwiftskinsSting) &&
+                        (HasEffect(Buffs.HindstungVenom) || HasEffect(Buffs.HindsbaneVenom) ||
+                         (!HasEffect(Buffs.Swiftscaled) && !HasEffect(Buffs.HuntersInstinct))))
+                        return OriginalHook(ReavingFangs);
+                }
+
+                if (ComboAction is HuntersSting or SwiftskinsSting)
+                {
+                    if ((HasEffect(Buffs.FlankstungVenom) || HasEffect(Buffs.HindstungVenom)) &&
+                        LevelChecked(FlanksbaneFang))
+                    {
+                        if (IsEnabled(CustomComboPreset.VPR_TrueNorthDynamic) &&
+                            TrueNorthReady && !OnTargetsRear() && HasEffect(Buffs.HindstungVenom) &&
+                            CanDelayedWeave())
+                            return All.TrueNorth;
+
+                        if (IsEnabled(CustomComboPreset.VPR_TrueNorthDynamic) &&
+                            TrueNorthReady && !OnTargetsFlank() && HasEffect(Buffs.FlankstungVenom) &&
+                            CanDelayedWeave())
+                            return All.TrueNorth;
+
+                        return OriginalHook(SteelFangs);
+                    }
+
+                    if ((HasEffect(Buffs.FlanksbaneVenom) || HasEffect(Buffs.HindsbaneVenom)) &&
+                        LevelChecked(HindstingStrike))
+                    {
+                        if (IsEnabled(CustomComboPreset.VPR_TrueNorthDynamic) &&
+                            TrueNorthReady && !OnTargetsRear() && HasEffect(Buffs.HindsbaneVenom) &&
+                            CanDelayedWeave())
+                            return All.TrueNorth;
+
+                        if (IsEnabled(CustomComboPreset.VPR_TrueNorthDynamic) &&
+                            TrueNorthReady && !OnTargetsFlank() && HasEffect(Buffs.FlanksbaneVenom) &&
+                            CanDelayedWeave())
+                            return All.TrueNorth;
+
+                        return OriginalHook(ReavingFangs);
+                    }
+                }
+
+                if (ComboAction is HindstingStrike or HindsbaneFang or FlankstingStrike or FlanksbaneFang)
+                    return LevelChecked(ReavingFangs) && HasEffect(Buffs.HonedReavers)
+                        ? OriginalHook(ReavingFangs)
+                        : OriginalHook(SteelFangs);
+            }
+
+            //LowLevels
+            if (LevelChecked(ReavingFangs) && (HasEffect(Buffs.HonedReavers) ||
+                                               (!HasEffect(Buffs.HonedReavers) && !HasEffect(Buffs.HonedSteel))))
+                return OriginalHook(ReavingFangs);
+            return actionID;
+
+        }
+    }
+
+    internal class VPR_AoE_Simplemode : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.VPR_AoE_SimpleMode;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not SteelMaw) return actionID;
+
+            if (CanWeave())
             {
                 // Variant Cure
                 if (IsEnabled(CustomComboPreset.VPR_Variant_Cure) &&
@@ -26,630 +487,164 @@ internal static partial class VPR
                     CanWeave())
                     return Variant.VariantRampart;
 
-                // Opener for VPR
-                if (Opener().FullOpener(ref actionID))
-                    return actionID;
-
-                //oGCDs
-                if (CanWeave())
-                {
-                    //Serpents Ire - ForceWeave
-                    if (InCombat() && !CappedOnCoils && ActionReady(SerpentsIre))
-                        return SerpentsIre;
-
-                    // Legacy Weaves
-                    if (In5y && TraitLevelChecked(Traits.SerpentsLegacy) && HasEffect(Buffs.Reawakened)
-                        && OriginalHook(SerpentsTail) is not SerpentsTail)
-                        return OriginalHook(SerpentsTail);
-
-                    // Fury Twin Weaves
-                    if (HasEffect(Buffs.PoisedForTwinfang))
-                        return OriginalHook(Twinfang);
-
-                    if (HasEffect(Buffs.PoisedForTwinblood))
-                        return OriginalHook(Twinblood);
-
-                    //Vice Twin Weaves
-                    if (!HasEffect(Buffs.Reawakened) && In5y)
-                    {
-                        if (HasEffect(Buffs.HuntersVenom))
-                            return OriginalHook(Twinfang);
-
-                        if (HasEffect(Buffs.SwiftskinsVenom))
-                            return OriginalHook(Twinblood);
-                    }
-                }
-
-                // Death Rattle - Force to avoid loss
-                if (In5y && LevelChecked(SerpentsTail) && OriginalHook(SerpentsTail) is DeathRattle)
+                // Death Rattle
+                if (LevelChecked(SerpentsTail) && OriginalHook(SerpentsTail) is LastLash)
                     return OriginalHook(SerpentsTail);
 
-                //GCDs
-                if (LevelChecked(WrithingSnap) && !InMeleeRange() && HasBattleTarget())
-                    return HasRattlingCoilStack(gauge)
-                        ? UncoiledFury
-                        : WrithingSnap;
-
-                //Vicewinder Combo
-                if (!HasEffect(Buffs.Reawakened) && LevelChecked(Vicewinder) && InMeleeRange())
-                {
-                    // Swiftskin's Coil
-                    if ((VicewinderReady && (!OnTargetsFlank() || !TargetNeedsPositionals())) || HuntersCoilReady)
-                        return SwiftskinsCoil;
-
-                    // Hunter's Coil
-                    if ((VicewinderReady && (!OnTargetsRear() || !TargetNeedsPositionals())) || SwiftskinsCoilReady)
-                        return HuntersCoil;
-                }
-
-                //Reawakend Usage
-                if (UseReawaken(gauge))
-                    return Reawaken;
-
-                //Overcap protection
-                if (CappedOnCoils &&
-                    ((HasCharges(Vicewinder) && !HasEffect(Buffs.SwiftskinsVenom) && !HasEffect(Buffs.HuntersVenom) &&
-                      !HasEffect(Buffs.Reawakened)) || //spend if Vicewinder is up, after Reawaken
-                     IreCD <= GCD * 5)) //spend in case under Reawaken right as Ire comes up
-                    return UncoiledFury;
-
-                //Vicewinder Usage
-                if (HasEffect(Buffs.Swiftscaled) && !IsComboExpiring(3) &&
-                    ActionReady(Vicewinder) && !HasEffect(Buffs.Reawakened) && InMeleeRange() &&
-                    (IreCD >= GCD * 5 || !LevelChecked(SerpentsIre)) &&
-                    !IsVenomExpiring(3) && !IsHoningExpiring(3))
-                    return Vicewinder;
-
-                // Uncoiled Fury usage
-                if (LevelChecked(UncoiledFury) && HasEffect(Buffs.Swiftscaled) && HasEffect(Buffs.HuntersInstinct) &&
-                    !IsComboExpiring(2) &&
-                    gauge.RattlingCoilStacks > 1 &&
-                    !VicewinderReady && !HuntersCoilReady && !SwiftskinsCoilReady &&
-                    !HasEffect(Buffs.Reawakened) && !HasEffect(Buffs.ReadyToReawaken) &&
-                    !WasLastWeaponskill(Ouroboros) &&
-                    !IsEmpowermentExpiring(6) && !IsVenomExpiring(3) &&
-                    !IsHoningExpiring(3))
-                    return UncoiledFury;
-
-                //Reawaken combo
-                if (HasEffect(Buffs.Reawakened))
-                {
-                    #region Pre Ouroboros
-
-                    if (!TraitLevelChecked(Traits.EnhancedSerpentsLineage))
-                        switch (gauge.AnguineTribute)
-                        {
-                            case 4:
-                                return OriginalHook(SteelFangs);
-
-                            case 3:
-                                return OriginalHook(ReavingFangs);
-
-                            case 2:
-                                return OriginalHook(HuntersCoil);
-
-                            case 1:
-                                return OriginalHook(SwiftskinsCoil);
-                        }
-
-                    #endregion
-
-                    #region With Ouroboros
-
-                    if (TraitLevelChecked(Traits.EnhancedSerpentsLineage))
-                        switch (gauge.AnguineTribute)
-                        {
-                            case 5:
-                                return OriginalHook(SteelFangs);
-
-                            case 4:
-                                return OriginalHook(ReavingFangs);
-
-                            case 3:
-                                return OriginalHook(HuntersCoil);
-
-                            case 2:
-                                return OriginalHook(SwiftskinsCoil);
-
-                            case 1:
-                                return OriginalHook(Reawaken);
-                        }
-
-                    #endregion
-                }
-
-                //1-2-3 (4-5-6) Combo
-                if (ComboTimer > 0 && !HasEffect(Buffs.Reawakened))
-                {
-                    if (ComboAction is ReavingFangs or SteelFangs)
-                    {
-                        if (LevelChecked(HuntersSting) &&
-                            (HasEffect(Buffs.FlankstungVenom) || HasEffect(Buffs.FlanksbaneVenom)))
-                            return OriginalHook(SteelFangs);
-
-                        if (LevelChecked(SwiftskinsSting) &&
-                            (HasEffect(Buffs.HindstungVenom) || HasEffect(Buffs.HindsbaneVenom) ||
-                             (!HasEffect(Buffs.Swiftscaled) && !HasEffect(Buffs.HuntersInstinct))))
-                            return OriginalHook(ReavingFangs);
-                    }
-
-                    if (ComboAction is HuntersSting or SwiftskinsSting)
-                    {
-                        if ((HasEffect(Buffs.FlankstungVenom) || HasEffect(Buffs.HindstungVenom)) &&
-                            LevelChecked(FlanksbaneFang))
-                        {
-                            if (TrueNorthReady && !OnTargetsRear() && HasEffect(Buffs.HindstungVenom) &&
-                                CanDelayedWeave())
-                                return All.TrueNorth;
-
-                            if (TrueNorthReady && !OnTargetsFlank() && HasEffect(Buffs.FlankstungVenom) &&
-                                CanDelayedWeave())
-                                return All.TrueNorth;
-
-                            return OriginalHook(SteelFangs);
-                        }
-
-                        if ((HasEffect(Buffs.FlanksbaneVenom) || HasEffect(Buffs.HindsbaneVenom)) &&
-                            LevelChecked(HindstingStrike))
-                        {
-                            if (TrueNorthReady && !OnTargetsRear() && HasEffect(Buffs.HindsbaneVenom) &&
-                                CanDelayedWeave())
-                                return All.TrueNorth;
-
-                            if (TrueNorthReady && !OnTargetsFlank() && HasEffect(Buffs.FlanksbaneVenom) &&
-                                CanDelayedWeave())
-                                return All.TrueNorth;
-
-                            return OriginalHook(ReavingFangs);
-                        }
-                    }
-
-                    if (ComboAction is HindstingStrike or HindsbaneFang or FlankstingStrike or FlanksbaneFang)
-                        return LevelChecked(ReavingFangs) && HasEffect(Buffs.HonedReavers)
-                            ? OriginalHook(ReavingFangs)
-                            : OriginalHook(SteelFangs);
-                }
-
-                //LowLevels
-                if (LevelChecked(ReavingFangs) && (HasEffect(Buffs.HonedReavers) ||
-                    (!HasEffect(Buffs.HonedReavers) && !HasEffect(Buffs.HonedSteel))))
-                    return OriginalHook(ReavingFangs);
-
-            }
-            return actionID;
-        }
-    }
-
-    internal class VPR_ST_AdvancedMode : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.VPR_ST_AdvancedMode;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is SteelFangs)
-            {
-                // Variant Cure
-                if (IsEnabled(CustomComboPreset.VPR_Variant_Cure) &&
-                IsEnabled(Variant.VariantCure) &&
-                PlayerHealthPercentageHp() <= GetOptionValue(Config.VPR_VariantCure))
-                    return Variant.VariantCure;
-
-                // Variant Rampart
-                if (IsEnabled(CustomComboPreset.VPR_Variant_Rampart) &&
-                    IsEnabled(Variant.VariantRampart) &&
-                    IsOffCooldown(Variant.VariantRampart) &&
-                    CanWeave())
-                    return Variant.VariantRampart;
-
-                // Opener for VPR
-                if (IsEnabled(CustomComboPreset.VPR_ST_Opener))
-                    if (Opener().FullOpener(ref actionID))
-                        return actionID;
-
-                //oGCDs
-                if (CanWeave())
-                {
-                    //Serpents Ire
-                    if (IsEnabled(CustomComboPreset.VPR_ST_SerpentsIre) && InCombat() &&
-                       !CappedOnCoils && ActionReady(SerpentsIre))
-                        return SerpentsIre;
-
-                    // Death Rattle
-                    if (IsEnabled(CustomComboPreset.VPR_ST_SerpentsTail) && In5y &&
-                        LevelChecked(SerpentsTail) && OriginalHook(SerpentsTail) is DeathRattle)
-                        return OriginalHook(SerpentsTail);
-
-                    // Legacy Weaves
-                    if (IsEnabled(CustomComboPreset.VPR_ST_ReawakenCombo) && In5y &&
-                        TraitLevelChecked(Traits.SerpentsLegacy) && HasEffect(Buffs.Reawakened)
-                        && OriginalHook(SerpentsTail) is not SerpentsTail)
-                        return OriginalHook(SerpentsTail);
-
-                    // Fury Twin Weaves
-                    if (IsEnabled(CustomComboPreset.VPR_ST_UncoiledFuryCombo))
-                    {
-                        if (HasEffect(Buffs.PoisedForTwinfang))
-                            return OriginalHook(Twinfang);
-
-                        if (HasEffect(Buffs.PoisedForTwinblood))
-                            return OriginalHook(Twinblood);
-                    }
-
-                    //Vice Twin Weaves
-                    if (IsEnabled(CustomComboPreset.VPR_ST_VicewinderWeaves) &&
-                        !HasEffect(Buffs.Reawakened) && In5y)
-                    {
-                        if (HasEffect(Buffs.HuntersVenom))
-                            return OriginalHook(Twinfang);
-
-                        if (HasEffect(Buffs.SwiftskinsVenom))
-                            return OriginalHook(Twinblood);
-                    }
-                }
-
-                // Death Rattle - Force to avoid loss
-                if (IsEnabled(CustomComboPreset.VPR_ST_SerpentsTail) && In5y &&
-                    LevelChecked(SerpentsTail) && OriginalHook(SerpentsTail) is DeathRattle)
+                // Legacy Weaves
+                if (TraitLevelChecked(Traits.SerpentsLegacy) &&
+                    HasEffect(Buffs.Reawakened) &&
+                    OriginalHook(SerpentsTail) is not SerpentsTail)
                     return OriginalHook(SerpentsTail);
 
-                //GCDs
-                if (IsEnabled(CustomComboPreset.VPR_ST_RangedUptime) &&
-                    LevelChecked(WrithingSnap) && !InMeleeRange() && HasBattleTarget())
-                    return IsEnabled(CustomComboPreset.VPR_ST_RangedUptimeUncoiledFury) &&
-                           HasRattlingCoilStack(gauge)
-                        ? UncoiledFury
-                        : WrithingSnap;
+                // Uncoiled combo
+                if (HasEffect(Buffs.PoisedForTwinfang))
+                    return OriginalHook(Twinfang);
 
-                //Vicewinder Combo
-                if (IsEnabled(CustomComboPreset.VPR_ST_VicewinderCombo) &&
-                    !HasEffect(Buffs.Reawakened) && LevelChecked(Vicewinder) && InMeleeRange())
+                if (HasEffect(Buffs.PoisedForTwinblood))
+                    return OriginalHook(Twinblood);
+
+                if (!HasEffect(Buffs.Reawakened))
                 {
-                    // Swiftskin's Coil
-                    if ((VicewinderReady && (!OnTargetsFlank() || !TargetNeedsPositionals())) || HuntersCoilReady)
-                        return SwiftskinsCoil;
-
-                    // Hunter's Coil
-                    if ((VicewinderReady && (!OnTargetsRear() || !TargetNeedsPositionals())) || SwiftskinsCoilReady)
-                        return HuntersCoil;
-                }
-
-                //Reawakend Usage
-                if (IsEnabled(CustomComboPreset.VPR_ST_Reawaken) && UseReawaken(gauge))
-                    return Reawaken;
-
-                //Overcap protection
-                if (IsEnabled(CustomComboPreset.VPR_ST_UncoiledFury) && CappedOnCoils &&
-                    ((HasCharges(Vicewinder) && !HasEffect(Buffs.SwiftskinsVenom) && !HasEffect(Buffs.HuntersVenom) &&
-                      !HasEffect(Buffs.Reawakened)) || //spend if Vicewinder is up, after Reawaken
-                     IreCD <= GCD * 5)) //spend in case under Reawaken right as Ire comes up
-                    return UncoiledFury;
-
-                //Vicewinder Usage
-                if (IsEnabled(CustomComboPreset.VPR_ST_Vicewinder) && HasEffect(Buffs.Swiftscaled) &&
-                    !IsComboExpiring(3) &&
-                    ActionReady(Vicewinder) && !HasEffect(Buffs.Reawakened) && InMeleeRange() &&
-                    (IreCD >= GCD * 5 || !LevelChecked(SerpentsIre)) &&
-                    !IsVenomExpiring(3) && !IsHoningExpiring(3))
-                    return Vicewinder;
-
-                // Uncoiled Fury usage
-                if (IsEnabled(CustomComboPreset.VPR_ST_UncoiledFury) && !IsComboExpiring(2) &&
-                    LevelChecked(UncoiledFury) && HasEffect(Buffs.Swiftscaled) && HasEffect(Buffs.HuntersInstinct) &&
-                    (gauge.RattlingCoilStacks > Config.VPR_ST_UncoiledFury_HoldCharges ||
-                     (GetTargetHPPercent() < Config.VPR_ST_UncoiledFury_Threshold && HasRattlingCoilStack(gauge))) &&
-                    !VicewinderReady && !HuntersCoilReady && !SwiftskinsCoilReady &&
-                    !HasEffect(Buffs.Reawakened) && !HasEffect(Buffs.ReadyToReawaken) &&
-                    !WasLastWeaponskill(Ouroboros) &&
-                    !IsEmpowermentExpiring(3))
-                    return UncoiledFury;
-
-                //Reawaken combo
-                if (IsEnabled(CustomComboPreset.VPR_ST_ReawakenCombo) &&
-                    HasEffect(Buffs.Reawakened))
-                {
-                    #region Pre Ouroboros
-
-                    if (!TraitLevelChecked(Traits.EnhancedSerpentsLineage))
-                        switch (gauge.AnguineTribute)
-                        {
-                            case 4:
-                                return OriginalHook(SteelFangs);
-
-                            case 3:
-                                return OriginalHook(ReavingFangs);
-
-                            case 2:
-                                return OriginalHook(HuntersCoil);
-
-                            case 1:
-                                return OriginalHook(SwiftskinsCoil);
-                        }
-
-                    #endregion
-
-                    #region With Ouroboros
-
-                    if (TraitLevelChecked(Traits.EnhancedSerpentsLineage))
-                        switch (gauge.AnguineTribute)
-                        {
-                            case 5:
-                                return OriginalHook(SteelFangs);
-
-                            case 4:
-                                return OriginalHook(ReavingFangs);
-
-                            case 3:
-                                return OriginalHook(HuntersCoil);
-
-                            case 2:
-                                return OriginalHook(SwiftskinsCoil);
-
-                            case 1:
-                                return OriginalHook(Reawaken);
-                        }
-
-                    #endregion
-                }
-
-                // healing
-                if (IsEnabled(CustomComboPreset.VPR_ST_ComboHeals))
-                {
-                    if (PlayerHealthPercentageHp() <= Config.VPR_ST_SecondWind_Threshold && ActionReady(All.SecondWind))
-                        return All.SecondWind;
-
-                    if (PlayerHealthPercentageHp() <= Config.VPR_ST_Bloodbath_Threshold && ActionReady(All.Bloodbath))
-                        return All.Bloodbath;
-                }
-
-                //1-2-3 (4-5-6) Combo
-                if (ComboTimer > 0 && !HasEffect(Buffs.Reawakened))
-                {
-                    if (ComboAction is ReavingFangs or SteelFangs)
-                    {
-                        if (LevelChecked(HuntersSting) &&
-                            (HasEffect(Buffs.FlankstungVenom) || HasEffect(Buffs.FlanksbaneVenom)))
-                            return OriginalHook(SteelFangs);
-
-                        if (LevelChecked(SwiftskinsSting) &&
-                            (HasEffect(Buffs.HindstungVenom) || HasEffect(Buffs.HindsbaneVenom) ||
-                             (!HasEffect(Buffs.Swiftscaled) && !HasEffect(Buffs.HuntersInstinct))))
-                            return OriginalHook(ReavingFangs);
-                    }
-
-                    if (ComboAction is HuntersSting or SwiftskinsSting)
-                    {
-                        if ((HasEffect(Buffs.FlankstungVenom) || HasEffect(Buffs.HindstungVenom)) &&
-                            LevelChecked(FlanksbaneFang))
-                        {
-                            if (IsEnabled(CustomComboPreset.VPR_TrueNorthDynamic) &&
-                                TrueNorthReady && !OnTargetsRear() && HasEffect(Buffs.HindstungVenom) &&
-                                CanDelayedWeave())
-                                return All.TrueNorth;
-
-                            if (IsEnabled(CustomComboPreset.VPR_TrueNorthDynamic) &&
-                                TrueNorthReady && !OnTargetsFlank() && HasEffect(Buffs.FlankstungVenom) &&
-                                CanDelayedWeave())
-                                return All.TrueNorth;
-
-                            return OriginalHook(SteelFangs);
-                        }
-
-                        if ((HasEffect(Buffs.FlanksbaneVenom) || HasEffect(Buffs.HindsbaneVenom)) &&
-                            LevelChecked(HindstingStrike))
-                        {
-                            if (IsEnabled(CustomComboPreset.VPR_TrueNorthDynamic) &&
-                                TrueNorthReady && !OnTargetsRear() && HasEffect(Buffs.HindsbaneVenom) &&
-                                CanDelayedWeave())
-                                return All.TrueNorth;
-
-                            if (IsEnabled(CustomComboPreset.VPR_TrueNorthDynamic) &&
-                                TrueNorthReady && !OnTargetsFlank() && HasEffect(Buffs.FlanksbaneVenom) &&
-                                CanDelayedWeave())
-                                return All.TrueNorth;
-
-                            return OriginalHook(ReavingFangs);
-                        }
-                    }
-
-                    if (ComboAction is HindstingStrike or HindsbaneFang or FlankstingStrike or FlanksbaneFang)
-                        return LevelChecked(ReavingFangs) && HasEffect(Buffs.HonedReavers)
-                            ? OriginalHook(ReavingFangs)
-                            : OriginalHook(SteelFangs);
-                }
-
-                //LowLevels
-                if (LevelChecked(ReavingFangs) && (HasEffect(Buffs.HonedReavers) ||
-                    (!HasEffect(Buffs.HonedReavers) && !HasEffect(Buffs.HonedSteel))))
-                    return OriginalHook(ReavingFangs);
-            }
-            return actionID;
-
-        }
-    }
-
-    internal class VPR_AoE_Simplemode : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.VPR_AoE_SimpleMode;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is SteelMaw)
-            {
-                if (CanWeave())
-                {
-                    // Variant Cure
-                    if (IsEnabled(CustomComboPreset.VPR_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= GetOptionValue(Config.VPR_VariantCure))
-                        return Variant.VariantCure;
-
-                    // Variant Rampart
-                    if (IsEnabled(CustomComboPreset.VPR_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanWeave())
-                        return Variant.VariantRampart;
-
-                    // Death Rattle
-                    if (LevelChecked(SerpentsTail) && OriginalHook(SerpentsTail) is LastLash)
-                        return OriginalHook(SerpentsTail);
-
-                    // Legacy Weaves
-                    if (TraitLevelChecked(Traits.SerpentsLegacy) &&
-                        HasEffect(Buffs.Reawakened) &&
-                        OriginalHook(SerpentsTail) is not SerpentsTail)
-                        return OriginalHook(SerpentsTail);
-
-                    // Uncoiled combo
-                    if (HasEffect(Buffs.PoisedForTwinfang))
+                    //Vicepit weaves
+                    if (HasEffect(Buffs.FellhuntersVenom) && In5y)
                         return OriginalHook(Twinfang);
 
-                    if (HasEffect(Buffs.PoisedForTwinblood))
+                    if (HasEffect(Buffs.FellskinsVenom) && In5y)
                         return OriginalHook(Twinblood);
 
-                    if (!HasEffect(Buffs.Reawakened))
-                    {
-                        //Vicepit weaves
-                        if (HasEffect(Buffs.FellhuntersVenom) && In5y)
-                            return OriginalHook(Twinfang);
-
-                        if (HasEffect(Buffs.FellskinsVenom) && In5y)
-                            return OriginalHook(Twinblood);
-
-                        //Serpents Ire usage
-                        if (!CappedOnCoils && ActionReady(SerpentsIre))
-                            return SerpentsIre;
-                    }
+                    //Serpents Ire usage
+                    if (!CappedOnCoils && ActionReady(SerpentsIre))
+                        return SerpentsIre;
                 }
-
-                //Vicepit combo
-                if (!HasEffect(Buffs.Reawakened) && In5y)
-                {
-                    if (SwiftskinsDenReady)
-                        return HuntersDen;
-
-                    if (VicepitReady)
-                        return SwiftskinsDen;
-                }
-
-                //Reawakend Usage
-                if ((HasEffect(Buffs.ReadyToReawaken) || gauge.SerpentOffering >= 50) && LevelChecked(Reawaken) &&
-                    HasEffect(Buffs.Swiftscaled) && HasEffect(Buffs.HuntersInstinct) &&
-                    !HasEffect(Buffs.Reawakened) && In5y &&
-                    !HasEffect(Buffs.FellhuntersVenom) && !HasEffect(Buffs.FellskinsVenom) &&
-                    !HasEffect(Buffs.PoisedForTwinblood) && !HasEffect(Buffs.PoisedForTwinfang))
-                    return Reawaken;
-
-                //Overcap protection
-                if (((HasCharges(Vicepit) && !HasEffect(Buffs.FellskinsVenom) && !HasEffect(Buffs.FellhuntersVenom)) ||
-                     IreCD <= GCD * 2) && !HasEffect(Buffs.Reawakened) && CappedOnCoils)
-                    return UncoiledFury;
-
-                //Vicepit Usage
-                if (ActionReady(Vicepit) && !HasEffect(Buffs.Reawakened) &&
-                    (IreCD >= GCD * 5 || !LevelChecked(SerpentsIre)) && In5y)
-                    return Vicepit;
-
-                // Uncoiled Fury usage
-                if (LevelChecked(UncoiledFury) &&
-                    HasRattlingCoilStack(gauge) &&
-                    HasEffect(Buffs.Swiftscaled) && HasEffect(Buffs.HuntersInstinct) &&
-                    !VicepitReady && !HuntersDenReady && !SwiftskinsDenReady &&
-                    !HasEffect(Buffs.Reawakened) && !HasEffect(Buffs.FellskinsVenom) &&
-                    !HasEffect(Buffs.FellhuntersVenom) &&
-                    !WasLastWeaponskill(JaggedMaw) && !WasLastWeaponskill(BloodiedMaw) && !WasLastAbility(SerpentsIre))
-                    return UncoiledFury;
-
-                //Reawaken combo
-                if (HasEffect(Buffs.Reawakened))
-                {
-                    #region Pre Ouroboros
-
-                    if (!TraitLevelChecked(Traits.EnhancedSerpentsLineage))
-                        switch (gauge.AnguineTribute)
-                        {
-                            case 4:
-                                return OriginalHook(SteelMaw);
-
-                            case 3:
-                                return OriginalHook(ReavingMaw);
-
-                            case 2:
-                                return OriginalHook(HuntersDen);
-
-                            case 1:
-                                return OriginalHook(SwiftskinsDen);
-                        }
-
-                    #endregion
-
-                    #region With Ouroboros
-
-                    if (TraitLevelChecked(Traits.EnhancedSerpentsLineage))
-                        switch (gauge.AnguineTribute)
-                        {
-                            case 5:
-                                return OriginalHook(SteelMaw);
-
-                            case 4:
-                                return OriginalHook(ReavingMaw);
-
-                            case 3:
-                                return OriginalHook(HuntersDen);
-
-                            case 2:
-                                return OriginalHook(SwiftskinsDen);
-
-                            case 1:
-                                return OriginalHook(Reawaken);
-                        }
-
-                    #endregion
-                }
-
-                // healing
-                if (PlayerHealthPercentageHp() <= 25 && ActionReady(All.SecondWind))
-                    return All.SecondWind;
-
-                if (PlayerHealthPercentageHp() <= 40 && ActionReady(All.Bloodbath))
-                    return All.Bloodbath;
-
-                //1-2-3 (4-5-6) Combo
-                if (ComboTimer > 0 && !HasEffect(Buffs.Reawakened))
-                {
-                    if (ComboAction is ReavingMaw or SteelMaw)
-                    {
-                        if (LevelChecked(HuntersBite) &&
-                            HasEffect(Buffs.GrimhuntersVenom))
-                            return OriginalHook(SteelMaw);
-
-                        if (LevelChecked(SwiftskinsBite) &&
-                            (HasEffect(Buffs.GrimskinsVenom) ||
-                             (!HasEffect(Buffs.Swiftscaled) && !HasEffect(Buffs.HuntersInstinct))))
-                            return OriginalHook(ReavingMaw);
-                    }
-
-                    if (ComboAction is HuntersBite or SwiftskinsBite)
-                    {
-                        if (HasEffect(Buffs.GrimhuntersVenom) && LevelChecked(JaggedMaw))
-                            return OriginalHook(SteelMaw);
-
-                        if (HasEffect(Buffs.GrimskinsVenom) && LevelChecked(BloodiedMaw))
-                            return OriginalHook(ReavingMaw);
-                    }
-
-                    if (ComboAction is BloodiedMaw or JaggedMaw)
-                        return LevelChecked(ReavingMaw) && HasEffect(Buffs.HonedReavers)
-                            ? OriginalHook(ReavingMaw)
-                            : OriginalHook(SteelMaw);
-                }
-
-                //for lower lvls
-                if (LevelChecked(ReavingMaw) && (HasEffect(Buffs.HonedReavers)
-                    || (!HasEffect(Buffs.HonedReavers) && !HasEffect(Buffs.HonedSteel))))
-                    return OriginalHook(ReavingMaw);
-
             }
+
+            //Vicepit combo
+            if (!HasEffect(Buffs.Reawakened) && In5y)
+            {
+                if (SwiftskinsDenReady)
+                    return HuntersDen;
+
+                if (VicepitReady)
+                    return SwiftskinsDen;
+            }
+
+            //Reawakend Usage
+            if ((HasEffect(Buffs.ReadyToReawaken) || gauge.SerpentOffering >= 50) && LevelChecked(Reawaken) &&
+                HasEffect(Buffs.Swiftscaled) && HasEffect(Buffs.HuntersInstinct) &&
+                !HasEffect(Buffs.Reawakened) && In5y &&
+                !HasEffect(Buffs.FellhuntersVenom) && !HasEffect(Buffs.FellskinsVenom) &&
+                !HasEffect(Buffs.PoisedForTwinblood) && !HasEffect(Buffs.PoisedForTwinfang))
+                return Reawaken;
+
+            //Overcap protection
+            if (((HasCharges(Vicepit) && !HasEffect(Buffs.FellskinsVenom) && !HasEffect(Buffs.FellhuntersVenom)) ||
+                 IreCD <= GCD * 2) && !HasEffect(Buffs.Reawakened) && CappedOnCoils)
+                return UncoiledFury;
+
+            //Vicepit Usage
+            if (ActionReady(Vicepit) && !HasEffect(Buffs.Reawakened) &&
+                (IreCD >= GCD * 5 || !LevelChecked(SerpentsIre)) && In5y)
+                return Vicepit;
+
+            // Uncoiled Fury usage
+            if (LevelChecked(UncoiledFury) &&
+                HasRattlingCoilStack(gauge) &&
+                HasEffect(Buffs.Swiftscaled) && HasEffect(Buffs.HuntersInstinct) &&
+                !VicepitReady && !HuntersDenReady && !SwiftskinsDenReady &&
+                !HasEffect(Buffs.Reawakened) && !HasEffect(Buffs.FellskinsVenom) &&
+                !HasEffect(Buffs.FellhuntersVenom) &&
+                !WasLastWeaponskill(JaggedMaw) && !WasLastWeaponskill(BloodiedMaw) && !WasLastAbility(SerpentsIre))
+                return UncoiledFury;
+
+            //Reawaken combo
+            if (HasEffect(Buffs.Reawakened))
+            {
+                #region Pre Ouroboros
+
+                if (!TraitLevelChecked(Traits.EnhancedSerpentsLineage))
+                    switch (gauge.AnguineTribute)
+                    {
+                        case 4:
+                            return OriginalHook(SteelMaw);
+
+                        case 3:
+                            return OriginalHook(ReavingMaw);
+
+                        case 2:
+                            return OriginalHook(HuntersDen);
+
+                        case 1:
+                            return OriginalHook(SwiftskinsDen);
+                    }
+
+                #endregion
+
+                #region With Ouroboros
+
+                if (TraitLevelChecked(Traits.EnhancedSerpentsLineage))
+                    switch (gauge.AnguineTribute)
+                    {
+                        case 5:
+                            return OriginalHook(SteelMaw);
+
+                        case 4:
+                            return OriginalHook(ReavingMaw);
+
+                        case 3:
+                            return OriginalHook(HuntersDen);
+
+                        case 2:
+                            return OriginalHook(SwiftskinsDen);
+
+                        case 1:
+                            return OriginalHook(Reawaken);
+                    }
+
+                #endregion
+            }
+
+            // healing
+            if (PlayerHealthPercentageHp() <= 25 && ActionReady(All.SecondWind))
+                return All.SecondWind;
+
+            if (PlayerHealthPercentageHp() <= 40 && ActionReady(All.Bloodbath))
+                return All.Bloodbath;
+
+            //1-2-3 (4-5-6) Combo
+            if (ComboTimer > 0 && !HasEffect(Buffs.Reawakened))
+            {
+                if (ComboAction is ReavingMaw or SteelMaw)
+                {
+                    if (LevelChecked(HuntersBite) &&
+                        HasEffect(Buffs.GrimhuntersVenom))
+                        return OriginalHook(SteelMaw);
+
+                    if (LevelChecked(SwiftskinsBite) &&
+                        (HasEffect(Buffs.GrimskinsVenom) ||
+                         (!HasEffect(Buffs.Swiftscaled) && !HasEffect(Buffs.HuntersInstinct))))
+                        return OriginalHook(ReavingMaw);
+                }
+
+                if (ComboAction is HuntersBite or SwiftskinsBite)
+                {
+                    if (HasEffect(Buffs.GrimhuntersVenom) && LevelChecked(JaggedMaw))
+                        return OriginalHook(SteelMaw);
+
+                    if (HasEffect(Buffs.GrimskinsVenom) && LevelChecked(BloodiedMaw))
+                        return OriginalHook(ReavingMaw);
+                }
+
+                if (ComboAction is BloodiedMaw or JaggedMaw)
+                    return LevelChecked(ReavingMaw) && HasEffect(Buffs.HonedReavers)
+                        ? OriginalHook(ReavingMaw)
+                        : OriginalHook(SteelMaw);
+            }
+
+            //for lower lvls
+            if (LevelChecked(ReavingMaw) && (HasEffect(Buffs.HonedReavers)
+                                             || (!HasEffect(Buffs.HonedReavers) && !HasEffect(Buffs.HonedSteel))))
+                return OriginalHook(ReavingMaw);
             return actionID;
 
         }
@@ -661,207 +656,205 @@ internal static partial class VPR
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is SteelMaw)
-            {
-                // Variant Cure
-                if (IsEnabled(CustomComboPreset.VPR_Variant_Cure) &&
+            if (actionID is not SteelMaw) return actionID;
+
+            // Variant Cure
+            if (IsEnabled(CustomComboPreset.VPR_Variant_Cure) &&
                 IsEnabled(Variant.VariantCure) &&
                 PlayerHealthPercentageHp() <= GetOptionValue(Config.VPR_VariantCure))
-                    return Variant.VariantCure;
+                return Variant.VariantCure;
 
-                // Variant Rampart
-                if (IsEnabled(CustomComboPreset.VPR_Variant_Rampart) &&
-                    IsEnabled(Variant.VariantRampart) &&
-                    IsOffCooldown(Variant.VariantRampart) &&
-                    CanWeave())
-                    return Variant.VariantRampart;
+            // Variant Rampart
+            if (IsEnabled(CustomComboPreset.VPR_Variant_Rampart) &&
+                IsEnabled(Variant.VariantRampart) &&
+                IsOffCooldown(Variant.VariantRampart) &&
+                CanWeave())
+                return Variant.VariantRampart;
 
-                if (CanWeave())
+            if (CanWeave())
+            {
+                // Death Rattle
+                if (IsEnabled(CustomComboPreset.VPR_AoE_SerpentsTail) &&
+                    LevelChecked(SerpentsTail) && OriginalHook(SerpentsTail) is LastLash)
+                    return OriginalHook(SerpentsTail);
+
+                // Legacy Weaves
+                if (IsEnabled(CustomComboPreset.VPR_AoE_ReawakenCombo) &&
+                    TraitLevelChecked(Traits.SerpentsLegacy) && HasEffect(Buffs.Reawakened)
+                    && OriginalHook(SerpentsTail) is not SerpentsTail)
+                    return OriginalHook(SerpentsTail);
+
+                // Uncoiled combo
+                if (IsEnabled(CustomComboPreset.VPR_AoE_UncoiledFuryCombo))
                 {
-                    // Death Rattle
-                    if (IsEnabled(CustomComboPreset.VPR_AoE_SerpentsTail) &&
-                        LevelChecked(SerpentsTail) && OriginalHook(SerpentsTail) is LastLash)
-                        return OriginalHook(SerpentsTail);
+                    if (HasEffect(Buffs.PoisedForTwinfang))
+                        return OriginalHook(Twinfang);
 
-                    // Legacy Weaves
-                    if (IsEnabled(CustomComboPreset.VPR_AoE_ReawakenCombo) &&
-                        TraitLevelChecked(Traits.SerpentsLegacy) && HasEffect(Buffs.Reawakened)
-                        && OriginalHook(SerpentsTail) is not SerpentsTail)
-                        return OriginalHook(SerpentsTail);
+                    if (HasEffect(Buffs.PoisedForTwinblood))
+                        return OriginalHook(Twinblood);
+                }
 
-                    // Uncoiled combo
-                    if (IsEnabled(CustomComboPreset.VPR_AoE_UncoiledFuryCombo))
+                if (!HasEffect(Buffs.Reawakened))
+                {
+                    //Vicepit weaves
+                    if (IsEnabled(CustomComboPreset.VPR_AoE_VicepitWeaves) &&
+                        (In5y || IsEnabled(CustomComboPreset.VPR_AoE_VicepitCombo_DisableRange)))
                     {
-                        if (HasEffect(Buffs.PoisedForTwinfang))
+                        if (HasEffect(Buffs.FellhuntersVenom))
                             return OriginalHook(Twinfang);
 
-                        if (HasEffect(Buffs.PoisedForTwinblood))
+                        if (HasEffect(Buffs.FellskinsVenom))
                             return OriginalHook(Twinblood);
                     }
 
-                    if (!HasEffect(Buffs.Reawakened))
-                    {
-                        //Vicepit weaves
-                        if (IsEnabled(CustomComboPreset.VPR_AoE_VicepitWeaves) &&
-                            (In5y || IsEnabled(CustomComboPreset.VPR_AoE_VicepitCombo_DisableRange)))
-                        {
-                            if (HasEffect(Buffs.FellhuntersVenom))
-                                return OriginalHook(Twinfang);
-
-                            if (HasEffect(Buffs.FellskinsVenom))
-                                return OriginalHook(Twinblood);
-                        }
-
-                        //Serpents Ire usage
-                        if (IsEnabled(CustomComboPreset.VPR_AoE_SerpentsIre) &&
-                            !CappedOnCoils && ActionReady(SerpentsIre))
-                            return SerpentsIre;
-                    }
+                    //Serpents Ire usage
+                    if (IsEnabled(CustomComboPreset.VPR_AoE_SerpentsIre) &&
+                        !CappedOnCoils && ActionReady(SerpentsIre))
+                        return SerpentsIre;
                 }
-
-                //Vicepit combo
-                if (IsEnabled(CustomComboPreset.VPR_AoE_VicepitCombo) &&
-                    !HasEffect(Buffs.Reawakened) &&
-                    (In5y || IsEnabled(CustomComboPreset.VPR_AoE_VicepitCombo_DisableRange)))
-                {
-                    if (SwiftskinsDenReady)
-                        return HuntersDen;
-
-                    if (VicepitReady)
-                        return SwiftskinsDen;
-                }
-
-                //Reawakend Usage
-                if (IsEnabled(CustomComboPreset.VPR_AoE_Reawaken) &&
-                    (HasEffect(Buffs.ReadyToReawaken) || gauge.SerpentOffering >= 50) && LevelChecked(Reawaken) &&
-                    HasEffect(Buffs.Swiftscaled) && HasEffect(Buffs.HuntersInstinct) &&
-                    !HasEffect(Buffs.Reawakened) &&
-                    (In5y || IsEnabled(CustomComboPreset.VPR_AoE_Reawaken_DisableRange)) &&
-                    !HasEffect(Buffs.FellhuntersVenom) && !HasEffect(Buffs.FellskinsVenom) &&
-                    !HasEffect(Buffs.PoisedForTwinblood) && !HasEffect(Buffs.PoisedForTwinfang))
-                    return Reawaken;
-
-                //Overcap protection
-                if (IsEnabled(CustomComboPreset.VPR_AoE_UncoiledFury) &&
-                    ((HasCharges(Vicepit) && !HasEffect(Buffs.FellskinsVenom) && !HasEffect(Buffs.FellhuntersVenom)) ||
-                     IreCD <= GCD * 2) && !HasEffect(Buffs.Reawakened) && CappedOnCoils)
-                    return UncoiledFury;
-
-                //Vicepit Usage
-                if (IsEnabled(CustomComboPreset.VPR_AoE_Vicepit) &&
-                    ActionReady(Vicepit) && !HasEffect(Buffs.Reawakened) &&
-                    (In5y || IsEnabled(CustomComboPreset.VPR_AoE_Vicepit_DisableRange)) &&
-                    (IreCD >= GCD * 5 || !LevelChecked(SerpentsIre)))
-                    return Vicepit;
-
-                // Uncoiled Fury usage
-                if (IsEnabled(CustomComboPreset.VPR_AoE_UncoiledFury) &&
-                    LevelChecked(UncoiledFury) &&
-                    (gauge.RattlingCoilStacks > Config.VPR_AoE_UncoiledFury_HoldCharges ||
-                     (GetTargetHPPercent() < Config.VPR_AoE_UncoiledFury_Threshold &&
-                      HasRattlingCoilStack(gauge))) &&
-                    HasEffect(Buffs.Swiftscaled) && HasEffect(Buffs.HuntersInstinct) &&
-                    !VicepitReady && !HuntersDenReady && !SwiftskinsDenReady &&
-                    !HasEffect(Buffs.Reawakened) && !HasEffect(Buffs.FellskinsVenom) &&
-                    !HasEffect(Buffs.FellhuntersVenom) &&
-                    !WasLastWeaponskill(JaggedMaw) && !WasLastWeaponskill(BloodiedMaw) && !WasLastAbility(SerpentsIre))
-                    return UncoiledFury;
-
-                //Reawaken combo
-                if (IsEnabled(CustomComboPreset.VPR_AoE_ReawakenCombo) &&
-                    HasEffect(Buffs.Reawakened))
-                {
-                    #region Pre Ouroboros
-
-                    if (!TraitLevelChecked(Traits.EnhancedSerpentsLineage))
-                        switch (gauge.AnguineTribute)
-                        {
-                            case 4:
-                                return OriginalHook(SteelMaw);
-
-                            case 3:
-                                return OriginalHook(ReavingMaw);
-
-                            case 2:
-                                return OriginalHook(HuntersDen);
-
-                            case 1:
-                                return OriginalHook(SwiftskinsDen);
-                        }
-
-                    #endregion
-
-                    #region With Ouroboros
-
-                    if (TraitLevelChecked(Traits.EnhancedSerpentsLineage))
-                        switch (gauge.AnguineTribute)
-                        {
-                            case 5:
-                                return OriginalHook(SteelMaw);
-
-                            case 4:
-                                return OriginalHook(ReavingMaw);
-
-                            case 3:
-                                return OriginalHook(HuntersDen);
-
-                            case 2:
-                                return OriginalHook(SwiftskinsDen);
-
-                            case 1:
-                                return OriginalHook(Reawaken);
-                        }
-
-                    #endregion
-                }
-
-                // healing
-                if (IsEnabled(CustomComboPreset.VPR_AoE_ComboHeals))
-                {
-                    if (PlayerHealthPercentageHp() <= Config.VPR_AoE_SecondWind_Threshold &&
-                        ActionReady(All.SecondWind))
-                        return All.SecondWind;
-
-                    if (PlayerHealthPercentageHp() <= Config.VPR_AoE_Bloodbath_Threshold && ActionReady(All.Bloodbath))
-                        return All.Bloodbath;
-                }
-
-                //1-2-3 (4-5-6) Combo
-                if (ComboTimer > 0 && !HasEffect(Buffs.Reawakened))
-                {
-                    if (ComboAction is ReavingMaw or SteelMaw)
-                    {
-                        if (LevelChecked(HuntersBite) &&
-                            HasEffect(Buffs.GrimhuntersVenom))
-                            return OriginalHook(SteelMaw);
-
-                        if (LevelChecked(SwiftskinsBite) &&
-                            (HasEffect(Buffs.GrimskinsVenom) ||
-                             (!HasEffect(Buffs.Swiftscaled) && !HasEffect(Buffs.HuntersInstinct))))
-                            return OriginalHook(ReavingMaw);
-                    }
-
-                    if (ComboAction is HuntersBite or SwiftskinsBite)
-                    {
-                        if (HasEffect(Buffs.GrimhuntersVenom) && LevelChecked(JaggedMaw))
-                            return OriginalHook(SteelMaw);
-
-                        if (HasEffect(Buffs.GrimskinsVenom) && LevelChecked(BloodiedMaw))
-                            return OriginalHook(ReavingMaw);
-                    }
-
-                    if (ComboAction is BloodiedMaw or JaggedMaw)
-                        return LevelChecked(ReavingMaw) && HasEffect(Buffs.HonedReavers)
-                            ? OriginalHook(ReavingMaw)
-                            : OriginalHook(SteelMaw);
-                }
-
-                //for lower lvls
-                if (LevelChecked(ReavingMaw) && (HasEffect(Buffs.HonedReavers)
-                    || (!HasEffect(Buffs.HonedReavers) && !HasEffect(Buffs.HonedSteel))))
-                    return OriginalHook(ReavingMaw);
-
             }
+
+            //Vicepit combo
+            if (IsEnabled(CustomComboPreset.VPR_AoE_VicepitCombo) &&
+                !HasEffect(Buffs.Reawakened) &&
+                (In5y || IsEnabled(CustomComboPreset.VPR_AoE_VicepitCombo_DisableRange)))
+            {
+                if (SwiftskinsDenReady)
+                    return HuntersDen;
+
+                if (VicepitReady)
+                    return SwiftskinsDen;
+            }
+
+            //Reawakend Usage
+            if (IsEnabled(CustomComboPreset.VPR_AoE_Reawaken) &&
+                (HasEffect(Buffs.ReadyToReawaken) || gauge.SerpentOffering >= 50) && LevelChecked(Reawaken) &&
+                HasEffect(Buffs.Swiftscaled) && HasEffect(Buffs.HuntersInstinct) &&
+                !HasEffect(Buffs.Reawakened) &&
+                (In5y || IsEnabled(CustomComboPreset.VPR_AoE_Reawaken_DisableRange)) &&
+                !HasEffect(Buffs.FellhuntersVenom) && !HasEffect(Buffs.FellskinsVenom) &&
+                !HasEffect(Buffs.PoisedForTwinblood) && !HasEffect(Buffs.PoisedForTwinfang))
+                return Reawaken;
+
+            //Overcap protection
+            if (IsEnabled(CustomComboPreset.VPR_AoE_UncoiledFury) &&
+                ((HasCharges(Vicepit) && !HasEffect(Buffs.FellskinsVenom) && !HasEffect(Buffs.FellhuntersVenom)) ||
+                 IreCD <= GCD * 2) && !HasEffect(Buffs.Reawakened) && CappedOnCoils)
+                return UncoiledFury;
+
+            //Vicepit Usage
+            if (IsEnabled(CustomComboPreset.VPR_AoE_Vicepit) &&
+                ActionReady(Vicepit) && !HasEffect(Buffs.Reawakened) &&
+                (In5y || IsEnabled(CustomComboPreset.VPR_AoE_Vicepit_DisableRange)) &&
+                (IreCD >= GCD * 5 || !LevelChecked(SerpentsIre)))
+                return Vicepit;
+
+            // Uncoiled Fury usage
+            if (IsEnabled(CustomComboPreset.VPR_AoE_UncoiledFury) &&
+                LevelChecked(UncoiledFury) &&
+                (gauge.RattlingCoilStacks > Config.VPR_AoE_UncoiledFury_HoldCharges ||
+                 (GetTargetHPPercent() < Config.VPR_AoE_UncoiledFury_Threshold &&
+                  HasRattlingCoilStack(gauge))) &&
+                HasEffect(Buffs.Swiftscaled) && HasEffect(Buffs.HuntersInstinct) &&
+                !VicepitReady && !HuntersDenReady && !SwiftskinsDenReady &&
+                !HasEffect(Buffs.Reawakened) && !HasEffect(Buffs.FellskinsVenom) &&
+                !HasEffect(Buffs.FellhuntersVenom) &&
+                !WasLastWeaponskill(JaggedMaw) && !WasLastWeaponskill(BloodiedMaw) && !WasLastAbility(SerpentsIre))
+                return UncoiledFury;
+
+            //Reawaken combo
+            if (IsEnabled(CustomComboPreset.VPR_AoE_ReawakenCombo) &&
+                HasEffect(Buffs.Reawakened))
+            {
+                #region Pre Ouroboros
+
+                if (!TraitLevelChecked(Traits.EnhancedSerpentsLineage))
+                    switch (gauge.AnguineTribute)
+                    {
+                        case 4:
+                            return OriginalHook(SteelMaw);
+
+                        case 3:
+                            return OriginalHook(ReavingMaw);
+
+                        case 2:
+                            return OriginalHook(HuntersDen);
+
+                        case 1:
+                            return OriginalHook(SwiftskinsDen);
+                    }
+
+                #endregion
+
+                #region With Ouroboros
+
+                if (TraitLevelChecked(Traits.EnhancedSerpentsLineage))
+                    switch (gauge.AnguineTribute)
+                    {
+                        case 5:
+                            return OriginalHook(SteelMaw);
+
+                        case 4:
+                            return OriginalHook(ReavingMaw);
+
+                        case 3:
+                            return OriginalHook(HuntersDen);
+
+                        case 2:
+                            return OriginalHook(SwiftskinsDen);
+
+                        case 1:
+                            return OriginalHook(Reawaken);
+                    }
+
+                #endregion
+            }
+
+            // healing
+            if (IsEnabled(CustomComboPreset.VPR_AoE_ComboHeals))
+            {
+                if (PlayerHealthPercentageHp() <= Config.VPR_AoE_SecondWind_Threshold &&
+                    ActionReady(All.SecondWind))
+                    return All.SecondWind;
+
+                if (PlayerHealthPercentageHp() <= Config.VPR_AoE_Bloodbath_Threshold && ActionReady(All.Bloodbath))
+                    return All.Bloodbath;
+            }
+
+            //1-2-3 (4-5-6) Combo
+            if (ComboTimer > 0 && !HasEffect(Buffs.Reawakened))
+            {
+                if (ComboAction is ReavingMaw or SteelMaw)
+                {
+                    if (LevelChecked(HuntersBite) &&
+                        HasEffect(Buffs.GrimhuntersVenom))
+                        return OriginalHook(SteelMaw);
+
+                    if (LevelChecked(SwiftskinsBite) &&
+                        (HasEffect(Buffs.GrimskinsVenom) ||
+                         (!HasEffect(Buffs.Swiftscaled) && !HasEffect(Buffs.HuntersInstinct))))
+                        return OriginalHook(ReavingMaw);
+                }
+
+                if (ComboAction is HuntersBite or SwiftskinsBite)
+                {
+                    if (HasEffect(Buffs.GrimhuntersVenom) && LevelChecked(JaggedMaw))
+                        return OriginalHook(SteelMaw);
+
+                    if (HasEffect(Buffs.GrimskinsVenom) && LevelChecked(BloodiedMaw))
+                        return OriginalHook(ReavingMaw);
+                }
+
+                if (ComboAction is BloodiedMaw or JaggedMaw)
+                    return LevelChecked(ReavingMaw) && HasEffect(Buffs.HonedReavers)
+                        ? OriginalHook(ReavingMaw)
+                        : OriginalHook(SteelMaw);
+            }
+
+            //for lower lvls
+            if (LevelChecked(ReavingMaw) && (HasEffect(Buffs.HonedReavers)
+                                             || (!HasEffect(Buffs.HonedReavers) && !HasEffect(Buffs.HonedSteel))))
+                return OriginalHook(ReavingMaw);
             return actionID;
 
         }
@@ -1074,16 +1067,17 @@ internal static partial class VPR
 
         protected override uint Invoke(uint actionID)
         {
+            if (!HasEffect(Buffs.Reawakened)) return actionID;
+
             //Reawaken combo
-            if (HasEffect(Buffs.Reawakened))
-                switch (actionID)
-                {
-                    case SteelFangs when WasLastAction(OriginalHook(SteelFangs)) && gauge.AnguineTribute is 4:
-                    case ReavingFangs when WasLastAction(OriginalHook(ReavingFangs)) && gauge.AnguineTribute is 3:
-                    case HuntersCoil when WasLastAction(OriginalHook(HuntersCoil)) && gauge.AnguineTribute is 2:
-                    case SwiftskinsCoil when WasLastAction(OriginalHook(SwiftskinsCoil)) && gauge.AnguineTribute is 1:
-                        return OriginalHook(SerpentsTail);
-                }
+            switch (actionID)
+            {
+                case SteelFangs when WasLastAction(OriginalHook(SteelFangs)) && gauge.AnguineTribute is 4:
+                case ReavingFangs when WasLastAction(OriginalHook(ReavingFangs)) && gauge.AnguineTribute is 3:
+                case HuntersCoil when WasLastAction(OriginalHook(HuntersCoil)) && gauge.AnguineTribute is 2:
+                case SwiftskinsCoil when WasLastAction(OriginalHook(SwiftskinsCoil)) && gauge.AnguineTribute is 1:
+                    return OriginalHook(SerpentsTail);
+            }
 
             return actionID;
         }

--- a/WrathCombo/Combos/PvE/WAR/WAR.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR.cs
@@ -108,177 +108,175 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == StormsPath) //Our button
+                if (actionID is not StormsPath) return actionID; //Our button
+
+                var gauge = GetJobGauge<WARGauge>().BeastGauge; //WAR gauge
+                bool justMitted = JustUsed(OriginalHook(RawIntuition), 4f) ||
+                                  JustUsed(OriginalHook(Vengeance), 5f) ||
+                                  JustUsed(ThrillOfBattle, 5f) ||
+                                  JustUsed(All.Rampart, 5f) ||
+                                  JustUsed(Holmgang, 9f);
+
+                #region Variant
+                Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+                if (IsEnabled(CustomComboPreset.WAR_Variant_SpiritDart) &&
+                    IsEnabled(Variant.VariantSpiritDart) &&
+                    (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
+                    return Variant.VariantSpiritDart;
+
+                if (IsEnabled(CustomComboPreset.WAR_Variant_Ultimatum) &&
+                    IsEnabled(Variant.VariantUltimatum) &&
+                    CanWeave() &&
+                    ActionReady(Variant.VariantUltimatum))
+                    return Variant.VariantUltimatum;
+
+                if (IsEnabled(CustomComboPreset.WAR_Variant_Cure) &&
+                    IsEnabled(Variant.VariantCure) &&
+                    CanWeave() &&
+                    PlayerHealthPercentageHp() <= GetOptionValue(Config.WAR_VariantCure))
+                    return Variant.VariantCure;
+                #endregion
+
+                #region Mitigations
+                if (Config.WAR_ST_MitsOptions != 1)
                 {
-                    var gauge = GetJobGauge<WARGauge>().BeastGauge; //WAR gauge
-                    bool justMitted = JustUsed(OriginalHook(RawIntuition), 4f) ||
-                                      JustUsed(OriginalHook(Vengeance), 5f) ||
-                                      JustUsed(ThrillOfBattle, 5f) ||
-                                      JustUsed(All.Rampart, 5f) ||
-                                      JustUsed(Holmgang, 9f);
-
-                    #region Variant
-                    Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
-                    if (IsEnabled(CustomComboPreset.WAR_Variant_SpiritDart) &&
-                        IsEnabled(Variant.VariantSpiritDart) &&
-                        (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
-                        return Variant.VariantSpiritDart;
-
-                    if (IsEnabled(CustomComboPreset.WAR_Variant_Ultimatum) &&
-                        IsEnabled(Variant.VariantUltimatum) &&
-                        CanWeave() &&
-                        ActionReady(Variant.VariantUltimatum))
-                        return Variant.VariantUltimatum;
-
-                    if (IsEnabled(CustomComboPreset.WAR_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        CanWeave() &&
-                        PlayerHealthPercentageHp() <= GetOptionValue(Config.WAR_VariantCure))
-                        return Variant.VariantCure;
-                    #endregion
-
-                    #region Mitigations
-                    if (Config.WAR_ST_MitsOptions != 1)
-                    {
-                        if (InCombat() && //Player is in combat
+                    if (InCombat() && //Player is in combat
                         !justMitted) //Player has not used a mitigation ability in the last 4-9 seconds
-                        {
-                            //Holmgang
-                            if (ActionReady(Holmgang) && //Holmgang is ready
-                                PlayerHealthPercentageHp() < 30) //Player's health is below 30%
-                                return Holmgang;
-
-                            if (IsPlayerTargeted())
-                            {
-                                //Vengeance / Damnation
-                                if (ActionReady(OriginalHook(Vengeance)) && //Vengeance is ready
-                                    PlayerHealthPercentageHp() < 60) //Player's health is below 60%
-                                    return OriginalHook(Vengeance);
-
-                                //Rampart
-                                if (ActionReady(All.Rampart) && //Rampart is ready
-                                    PlayerHealthPercentageHp() < 80) //Player's health is below 80%
-                                    return All.Rampart;
-
-                                //Reprisal
-                                if (ActionReady(All.Reprisal) && //Reprisal is ready
-                                    InActionRange(All.Reprisal) && //Player is in range of Reprisal
-                                    PlayerHealthPercentageHp() < 90) //Player's health is below 90%
-                                    return All.Reprisal;
-                            }
-
-                            //Thrill
-                            if (ActionReady(ThrillOfBattle) && //Thrill is ready
-                                PlayerHealthPercentageHp() < 70) //Player's health is below 80%
-                                return ThrillOfBattle;
-
-                            //Equilibrium
-                            if (ActionReady(Equilibrium) && //Equilibrium is ready
-                                PlayerHealthPercentageHp() < 50) //Player's health is below 30%
-                                return Equilibrium;
-
-                            //Bloodwhetting
-                            if (ActionReady(OriginalHook(RawIntuition)) && //Bloodwhetting
-                                PlayerHealthPercentageHp() < 90) //Player's health is below 95%
-                                return OriginalHook(Bloodwhetting);
-                        }
-
-                    }
-                    #endregion
-
-                    if (LevelChecked(Tomahawk) && //Tomahawk is available
-                        !InMeleeRange() && //not in melee range
-                        HasBattleTarget()) //has a target
-                        return Tomahawk;
-
-                    if (CanWeave()) //in weave window
                     {
-                        if (InCombat() && //in combat
-                            ActionReady(Infuriate) && //Infuriate is ready
-                            !HasEffect(Buffs.NascentChaos) && //does not have Nascent Chaos
-                            !HasEffect(Buffs.InnerReleaseStacks) && //does not have Inner Release stacks
-                            gauge <= 40) //gauge is less than or equal to 40
-                            return Infuriate;
+                        //Holmgang
+                        if (ActionReady(Holmgang) && //Holmgang is ready
+                            PlayerHealthPercentageHp() < 30) //Player's health is below 30%
+                            return Holmgang;
 
-                        //pre-Surging Tempest IR
-                        if (InCombat() && //in combat
-                            ActionReady(OriginalHook(Berserk)) && //Berserk is ready
-                            !LevelChecked(StormsEye)) //does not have Storm's Eye
-                            return OriginalHook(Berserk);
-                    }
-
-                    if (HasEffect(Buffs.SurgingTempest) && //has Surging Tempest
-                        InCombat()) //in combat
-                    {
-                        if (CanWeave()) //in weave window
+                        if (IsPlayerTargeted())
                         {
-                            if (ActionReady(OriginalHook(Berserk))) //Berserk is ready
-                                return OriginalHook(Berserk);
+                            //Vengeance / Damnation
+                            if (ActionReady(OriginalHook(Vengeance)) && //Vengeance is ready
+                                PlayerHealthPercentageHp() < 60) //Player's health is below 60%
+                                return OriginalHook(Vengeance);
 
-                            if (ActionReady(Upheaval)) //Upheaval is ready
-                                return Upheaval;
+                            //Rampart
+                            if (ActionReady(All.Rampart) && //Rampart is ready
+                                PlayerHealthPercentageHp() < 80) //Player's health is below 80%
+                                return All.Rampart;
 
-                            if (LevelChecked(PrimalWrath) && //Primal Wrath is available
-                                HasEffect(Buffs.Wrathful)) //has Wrathful
-                                return PrimalWrath;
-
-                            if (LevelChecked(Onslaught) && //Onslaught is available
-                                GetRemainingCharges(Onslaught) > 1) //has more than 1 charge
-                            {
-                                if (!IsMoving() && //not moving
-                                    GetTargetDistance() <= 1 && //within 1y of target
-                                    (GetCooldownRemainingTime(InnerRelease) > 40 || !LevelChecked(InnerRelease))) //IR is not ready or available
-                                    return Onslaught;
-                            }
+                            //Reprisal
+                            if (ActionReady(All.Reprisal) && //Reprisal is ready
+                                InActionRange(All.Reprisal) && //Player is in range of Reprisal
+                                PlayerHealthPercentageHp() < 90) //Player's health is below 90%
+                                return All.Reprisal;
                         }
 
-                        if (HasEffect(Buffs.PrimalRendReady) && //has Primal Rend ready
-                            !JustUsed(InnerRelease) && //has not just used IR
-                            !IsMoving() && //not moving
-                            GetTargetDistance() <= 1) //within 1y of target
-                            return PrimalRend;
+                        //Thrill
+                        if (ActionReady(ThrillOfBattle) && //Thrill is ready
+                            PlayerHealthPercentageHp() < 70) //Player's health is below 80%
+                            return ThrillOfBattle;
 
-                        if (HasEffect(Buffs.PrimalRuinationReady) && //has Primal Ruination ready
-                            LevelChecked(PrimalRuination)) //Primal Ruination is available
-                            return PrimalRuination;
+                        //Equilibrium
+                        if (ActionReady(Equilibrium) && //Equilibrium is ready
+                            PlayerHealthPercentageHp() < 50) //Player's health is below 30%
+                            return Equilibrium;
 
-                        if (LevelChecked(InnerBeast)) //Inner Beast is available
-                        {
-                            if (HasEffect(Buffs.InnerReleaseStacks) || (HasEffect(Buffs.NascentChaos) && LevelChecked(InnerChaos))) //has IR stacks or Nascent Chaos and Inner Chaos
-                                return OriginalHook(InnerBeast);
-
-                            if (HasEffect(Buffs.NascentChaos) && //has Nascent Chaos
-                                !LevelChecked(InnerChaos) && //does not have Inner Chaos
-                                gauge >= 50) //gauge is greater than or equal to 50
-                                return OriginalHook(Decimate);
-                        }
+                        //Bloodwhetting
+                        if (ActionReady(OriginalHook(RawIntuition)) && //Bloodwhetting
+                            PlayerHealthPercentageHp() < 90) //Player's health is below 95%
+                            return OriginalHook(Bloodwhetting);
                     }
 
-                    if (ComboTimer > 0) //in combo window
-                    {
-                        if (LevelChecked(InnerBeast) && //Inner Beast is available
-                            gauge >= 90 && //gauge is greater than or equal to 90
-                            (!LevelChecked(StormsEye) || HasEffectAny(Buffs.SurgingTempest))) //does not have Storm's Eye or has Surging Tempest
-                            return OriginalHook(InnerBeast);
+                }
+                #endregion
 
-                        if (LevelChecked(Maim) && //Maim is available
-                            ComboAction == HeavySwing) //last combo move was Heavy Swing
-                            return Maim;
+                if (LevelChecked(Tomahawk) && //Tomahawk is available
+                    !InMeleeRange() && //not in melee range
+                    HasBattleTarget()) //has a target
+                    return Tomahawk;
 
-                        if (LevelChecked(StormsPath) && //Storm's Path is available
-                            ComboAction == Maim) //last combo move was Maim
-                        {
-                            if (LevelChecked(StormsEye) && //Storm's Eye is available
-                                GetBuffRemainingTime(Buffs.SurgingTempest) <= 29) //Surging Tempest is about to expire
-                                return StormsEye;
-                            return StormsPath;
-                        }
-                    }
+                if (CanWeave()) //in weave window
+                {
+                    if (InCombat() && //in combat
+                        ActionReady(Infuriate) && //Infuriate is ready
+                        !HasEffect(Buffs.NascentChaos) && //does not have Nascent Chaos
+                        !HasEffect(Buffs.InnerReleaseStacks) && //does not have Inner Release stacks
+                        gauge <= 40) //gauge is less than or equal to 40
+                        return Infuriate;
 
-                    return HeavySwing;
+                    //pre-Surging Tempest IR
+                    if (InCombat() && //in combat
+                        ActionReady(OriginalHook(Berserk)) && //Berserk is ready
+                        !LevelChecked(StormsEye)) //does not have Storm's Eye
+                        return OriginalHook(Berserk);
                 }
 
-                return actionID;
+                if (HasEffect(Buffs.SurgingTempest) && //has Surging Tempest
+                    InCombat()) //in combat
+                {
+                    if (CanWeave()) //in weave window
+                    {
+                        if (ActionReady(OriginalHook(Berserk))) //Berserk is ready
+                            return OriginalHook(Berserk);
+
+                        if (ActionReady(Upheaval)) //Upheaval is ready
+                            return Upheaval;
+
+                        if (LevelChecked(PrimalWrath) && //Primal Wrath is available
+                            HasEffect(Buffs.Wrathful)) //has Wrathful
+                            return PrimalWrath;
+
+                        if (LevelChecked(Onslaught) && //Onslaught is available
+                            GetRemainingCharges(Onslaught) > 1) //has more than 1 charge
+                        {
+                            if (!IsMoving() && //not moving
+                                GetTargetDistance() <= 1 && //within 1y of target
+                                (GetCooldownRemainingTime(InnerRelease) > 40 || !LevelChecked(InnerRelease))) //IR is not ready or available
+                                return Onslaught;
+                        }
+                    }
+
+                    if (HasEffect(Buffs.PrimalRendReady) && //has Primal Rend ready
+                        !JustUsed(InnerRelease) && //has not just used IR
+                        !IsMoving() && //not moving
+                        GetTargetDistance() <= 1) //within 1y of target
+                        return PrimalRend;
+
+                    if (HasEffect(Buffs.PrimalRuinationReady) && //has Primal Ruination ready
+                        LevelChecked(PrimalRuination)) //Primal Ruination is available
+                        return PrimalRuination;
+
+                    if (LevelChecked(InnerBeast)) //Inner Beast is available
+                    {
+                        if (HasEffect(Buffs.InnerReleaseStacks) || (HasEffect(Buffs.NascentChaos) && LevelChecked(InnerChaos))) //has IR stacks or Nascent Chaos and Inner Chaos
+                            return OriginalHook(InnerBeast);
+
+                        if (HasEffect(Buffs.NascentChaos) && //has Nascent Chaos
+                            !LevelChecked(InnerChaos) && //does not have Inner Chaos
+                            gauge >= 50) //gauge is greater than or equal to 50
+                            return OriginalHook(Decimate);
+                    }
+                }
+
+                if (ComboTimer > 0) //in combo window
+                {
+                    if (LevelChecked(InnerBeast) && //Inner Beast is available
+                        gauge >= 90 && //gauge is greater than or equal to 90
+                        (!LevelChecked(StormsEye) || HasEffectAny(Buffs.SurgingTempest))) //does not have Storm's Eye or has Surging Tempest
+                        return OriginalHook(InnerBeast);
+
+                    if (LevelChecked(Maim) && //Maim is available
+                        ComboAction == HeavySwing) //last combo move was Heavy Swing
+                        return Maim;
+
+                    if (LevelChecked(StormsPath) && //Storm's Path is available
+                        ComboAction == Maim) //last combo move was Maim
+                    {
+                        if (LevelChecked(StormsEye) && //Storm's Eye is available
+                            GetBuffRemainingTime(Buffs.SurgingTempest) <= 29) //Surging Tempest is about to expire
+                            return StormsEye;
+                        return StormsPath;
+                    }
+                }
+
+                return HeavySwing;
+
             }
         }
         #endregion
@@ -290,234 +288,232 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == StormsPath) //Our button
+                if (actionID is not StormsPath) return actionID; //Our button
+
+                var gauge = GetJobGauge<WARGauge>().BeastGauge; //WAR gauge
+                bool justMitted = JustUsed(OriginalHook(RawIntuition), 4f) ||
+                                  JustUsed(OriginalHook(Vengeance), 5f) ||
+                                  JustUsed(ThrillOfBattle, 5f) ||
+                                  JustUsed(All.Rampart, 5f) ||
+                                  JustUsed(Holmgang, 9f);
+
+                #region Variant
+                Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+                if (IsEnabled(CustomComboPreset.WAR_Variant_SpiritDart) &&
+                    IsEnabled(Variant.VariantSpiritDart) &&
+                    (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
+                    return Variant.VariantSpiritDart;
+
+                if (IsEnabled(CustomComboPreset.WAR_Variant_Ultimatum) &&
+                    IsEnabled(Variant.VariantUltimatum) &&
+                    CanWeave() &&
+                    ActionReady(Variant.VariantUltimatum))
+                    return Variant.VariantUltimatum;
+
+                if (IsEnabled(CustomComboPreset.WAR_Variant_Cure) &&
+                    IsEnabled(Variant.VariantCure) &&
+                    CanWeave() &&
+                    PlayerHealthPercentageHp() <= GetOptionValue(Config.WAR_VariantCure))
+                    return Variant.VariantCure;
+                #endregion
+
+                #region Mitigations
+                if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Mitigation) && //Mitigation option is enabled
+                    InCombat() && //Player is in combat
+                    !justMitted) //Player has not used a mitigation ability in the last 4-9 seconds
                 {
-                    var gauge = GetJobGauge<WARGauge>().BeastGauge; //WAR gauge
-                    bool justMitted = JustUsed(OriginalHook(RawIntuition), 4f) ||
-                                      JustUsed(OriginalHook(Vengeance), 5f) ||
-                                      JustUsed(ThrillOfBattle, 5f) ||
-                                      JustUsed(All.Rampart, 5f) ||
-                                      JustUsed(Holmgang, 9f);
+                    //Holmgang
+                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Holmgang) && //Holmgang option is enabled
+                        ActionReady(Holmgang) && //Holmgang is ready
+                        PlayerHealthPercentageHp() <= Config.WAR_ST_Holmgang_Health && //Player's health is below selected threshold
+                        (Config.WAR_ST_Holmgang_SubOption == 0 || //Holmgang is enabled for all targets
+                         (TargetIsBoss() && Config.WAR_ST_Holmgang_SubOption == 1))) //Holmgang is enabled for bosses only
+                        return Holmgang;
 
-                    #region Variant
-                    Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
-                    if (IsEnabled(CustomComboPreset.WAR_Variant_SpiritDart) &&
-                        IsEnabled(Variant.VariantSpiritDart) &&
-                        (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
-                        return Variant.VariantSpiritDart;
-
-                    if (IsEnabled(CustomComboPreset.WAR_Variant_Ultimatum) &&
-                        IsEnabled(Variant.VariantUltimatum) &&
-                        CanWeave() &&
-                        ActionReady(Variant.VariantUltimatum))
-                        return Variant.VariantUltimatum;
-
-                    if (IsEnabled(CustomComboPreset.WAR_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        CanWeave() &&
-                        PlayerHealthPercentageHp() <= GetOptionValue(Config.WAR_VariantCure))
-                        return Variant.VariantCure;
-                    #endregion
-
-                    #region Mitigations
-                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Mitigation) && //Mitigation option is enabled
-                        InCombat() && //Player is in combat
-                        !justMitted) //Player has not used a mitigation ability in the last 4-9 seconds
+                    if (IsPlayerTargeted())
                     {
-                        //Holmgang
-                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Holmgang) && //Holmgang option is enabled
-                            ActionReady(Holmgang) && //Holmgang is ready
-                            PlayerHealthPercentageHp() <= Config.WAR_ST_Holmgang_Health && //Player's health is below selected threshold
-                            (Config.WAR_ST_Holmgang_SubOption == 0 || //Holmgang is enabled for all targets
-                            (TargetIsBoss() && Config.WAR_ST_Holmgang_SubOption == 1))) //Holmgang is enabled for bosses only
-                            return Holmgang;
+                        //Vengeance / Damnation
+                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Vengeance) && //Vengeance option is enabled
+                            ActionReady(OriginalHook(Vengeance)) && //Vengeance is ready
+                            PlayerHealthPercentageHp() <= Config.WAR_ST_Vengeance_Health && //Player's health is below selected threshold
+                            (Config.WAR_ST_Vengeance_SubOption == 0 || //Vengeance is enabled for all targets
+                             (TargetIsBoss() && Config.WAR_ST_Vengeance_SubOption == 1))) //Vengeance is enabled for bosses only
+                            return OriginalHook(Vengeance);
 
-                        if (IsPlayerTargeted())
-                        {
-                            //Vengeance / Damnation
-                            if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Vengeance) && //Vengeance option is enabled
-                                ActionReady(OriginalHook(Vengeance)) && //Vengeance is ready
-                                PlayerHealthPercentageHp() <= Config.WAR_ST_Vengeance_Health && //Player's health is below selected threshold
-                                (Config.WAR_ST_Vengeance_SubOption == 0 || //Vengeance is enabled for all targets
-                                (TargetIsBoss() && Config.WAR_ST_Vengeance_SubOption == 1))) //Vengeance is enabled for bosses only
-                                return OriginalHook(Vengeance);
+                        //Rampart
+                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Rampart) && //Rampart option is enabled
+                            ActionReady(All.Rampart) && //Rampart is ready
+                            PlayerHealthPercentageHp() <= Config.WAR_ST_Rampart_Health && //Player's health is below selected threshold
+                            (Config.WAR_ST_Rampart_SubOption == 0 || //Rampart is enabled for all targets
+                             (TargetIsBoss() && Config.WAR_ST_Rampart_SubOption == 1))) //Rampart is enabled for bosses only
+                            return All.Rampart;
 
-                            //Rampart
-                            if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Rampart) && //Rampart option is enabled
-                                ActionReady(All.Rampart) && //Rampart is ready
-                                PlayerHealthPercentageHp() <= Config.WAR_ST_Rampart_Health && //Player's health is below selected threshold
-                                (Config.WAR_ST_Rampart_SubOption == 0 || //Rampart is enabled for all targets
-                                (TargetIsBoss() && Config.WAR_ST_Rampart_SubOption == 1))) //Rampart is enabled for bosses only
-                                return All.Rampart;
+                        //Reprisal
+                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Reprisal) && //Reprisal option is enabled
+                            ActionReady(All.Reprisal) && //Reprisal is ready
+                            InActionRange(All.Reprisal) && //Player is in range of Reprisal
+                            PlayerHealthPercentageHp() <= Config.WAR_ST_Reprisal_Health && //Player's health is below selected threshold
+                            (Config.WAR_ST_Reprisal_SubOption == 0 || //Reprisal is enabled for all targets
+                             (TargetIsBoss() && Config.WAR_ST_Reprisal_SubOption == 1))) //Reprisal is enabled for bosses only
+                            return All.Reprisal;
 
-                            //Reprisal
-                            if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Reprisal) && //Reprisal option is enabled
-                                ActionReady(All.Reprisal) && //Reprisal is ready
-                                InActionRange(All.Reprisal) && //Player is in range of Reprisal
-                                PlayerHealthPercentageHp() <= Config.WAR_ST_Reprisal_Health && //Player's health is below selected threshold
-                                (Config.WAR_ST_Reprisal_SubOption == 0 || //Reprisal is enabled for all targets
-                                (TargetIsBoss() && Config.WAR_ST_Reprisal_SubOption == 1))) //Reprisal is enabled for bosses only
-                                return All.Reprisal;
-
-                            //Arms Length
-                            if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_ArmsLength) && //Arms Length option is enabled
-                                ActionReady(All.ArmsLength) && //Arms Length is ready
-                                PlayerHealthPercentageHp() <= Config.WAR_ST_ArmsLength_Health && //Player's health is below selected threshold
-                                !InBossEncounter()) //target is not a boss
-                                return All.ArmsLength;
-                        }
-
-                        //Thrill
-                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Thrill) && //Thrill option is enabled
-                            ActionReady(ThrillOfBattle) && //Thrill is ready
-                            PlayerHealthPercentageHp() <= Config.WAR_ST_Thrill_Health && //Player's health is below selected threshold
-                            (Config.WAR_ST_Thrill_SubOption == 0 || //Thrill is enabled for all targets
-                            (TargetIsBoss() && Config.WAR_ST_Thrill_SubOption == 1))) //Thrill is enabled for bosses only
-                            return ThrillOfBattle;
-
-                        //Equilibrium
-                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Equilibrium) && //Equilibrium option is enabled
-                            ActionReady(Equilibrium) && //Equilibrium is ready
-                            PlayerHealthPercentageHp() <= Config.WAR_ST_Equilibrium_Health && //Player's health is below selected threshold
-                            (Config.WAR_ST_Equilibrium_SubOption == 0 || //Equilibrium is enabled for all targets
-                            (TargetIsBoss() && Config.WAR_ST_Equilibrium_SubOption == 1))) //Equilibrium is enabled for bosses only
-                            return Equilibrium;
-
-                        //Bloodwhetting
-                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Bloodwhetting) && //Bloodwhetting option is enabled
-                            ActionReady(OriginalHook(RawIntuition)) && //Bloodwhetting is ready
-                            PlayerHealthPercentageHp() <= Config.WAR_AoE_Bloodwhetting_Health && //Player's health is below selected threshold
-                            (Config.WAR_AoE_Bloodwhetting_SubOption == 0 || //Bloodwhetting is enabled for all targets
-                            (TargetIsBoss() && Config.WAR_AoE_Bloodwhetting_SubOption == 1))) //Bloodwhetting is enabled for bosses only
-                            return OriginalHook(RawIntuition);
-                    }
-                    #endregion
-
-                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_RangedUptime) && //Ranged uptime option is enabled
-                        LevelChecked(Tomahawk) && //Tomahawk is available
-                        !InMeleeRange() && //not in melee range
-                        HasBattleTarget()) //has a target
-                        return Tomahawk;
-
-                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_BalanceOpener) && 
-                        ContentCheck.IsInConfiguredContent(Config.WAR_BalanceOpener_Content, ContentCheck.ListSet.BossOnly))
-                    {
-                        if (Opener().FullOpener(ref actionID))
-                            return actionID;
+                        //Arms Length
+                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_ArmsLength) && //Arms Length option is enabled
+                            ActionReady(All.ArmsLength) && //Arms Length is ready
+                            PlayerHealthPercentageHp() <= Config.WAR_ST_ArmsLength_Health && //Player's health is below selected threshold
+                            !InBossEncounter()) //target is not a boss
+                            return All.ArmsLength;
                     }
 
-                    if (CanWeave()) //in weave window
-                    {
-                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Infuriate) && //Infuriate option is enabled
-                            InCombat() && //in combat
-                            ActionReady(Infuriate) && //Infuriate is ready
-                            !HasEffect(Buffs.NascentChaos) && //does not have Nascent Chaos
-                            !HasEffect(Buffs.InnerReleaseStacks) && //does not have Inner Release stacks
-                            gauge <= Config.WAR_InfuriateSTGauge && //gauge is less than or equal to selected threshold
-                            GetRemainingCharges(Infuriate) > Config.WAR_KeepInfuriateCharges) //has more than selected charges
-                            return Infuriate;
+                    //Thrill
+                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Thrill) && //Thrill option is enabled
+                        ActionReady(ThrillOfBattle) && //Thrill is ready
+                        PlayerHealthPercentageHp() <= Config.WAR_ST_Thrill_Health && //Player's health is below selected threshold
+                        (Config.WAR_ST_Thrill_SubOption == 0 || //Thrill is enabled for all targets
+                         (TargetIsBoss() && Config.WAR_ST_Thrill_SubOption == 1))) //Thrill is enabled for bosses only
+                        return ThrillOfBattle;
 
-                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_InnerRelease) && //Inner Release option is enabled 
-                            InCombat() && //in combat
-                            ActionReady(OriginalHook(Berserk)) && //Berserk is ready
-                            !LevelChecked(StormsEye)) //does not have Storm's Eye
-                            return OriginalHook(Berserk);
-                    }
+                    //Equilibrium
+                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Equilibrium) && //Equilibrium option is enabled
+                        ActionReady(Equilibrium) && //Equilibrium is ready
+                        PlayerHealthPercentageHp() <= Config.WAR_ST_Equilibrium_Health && //Player's health is below selected threshold
+                        (Config.WAR_ST_Equilibrium_SubOption == 0 || //Equilibrium is enabled for all targets
+                         (TargetIsBoss() && Config.WAR_ST_Equilibrium_SubOption == 1))) //Equilibrium is enabled for bosses only
+                        return Equilibrium;
 
-                    if (InCombat() && //in combat
-                        HasEffect(Buffs.SurgingTempest)) //has Surging Tempest
-                    {
-                        if (CanWeave()) //in weave window
-                        {
-                            if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_InnerRelease) && //Inner Release option is enabled
-                                ActionReady(OriginalHook(Berserk))) //Berserk is ready
-                                return OriginalHook(Berserk);
+                    //Bloodwhetting
+                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Bloodwhetting) && //Bloodwhetting option is enabled
+                        ActionReady(OriginalHook(RawIntuition)) && //Bloodwhetting is ready
+                        PlayerHealthPercentageHp() <= Config.WAR_AoE_Bloodwhetting_Health && //Player's health is below selected threshold
+                        (Config.WAR_AoE_Bloodwhetting_SubOption == 0 || //Bloodwhetting is enabled for all targets
+                         (TargetIsBoss() && Config.WAR_AoE_Bloodwhetting_SubOption == 1))) //Bloodwhetting is enabled for bosses only
+                        return OriginalHook(RawIntuition);
+                }
+                #endregion
 
-                            if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Upheaval) && //Upheaval option is enabled
-                                ActionReady(Upheaval)) //Upheaval is ready
-                                return Upheaval;
+                if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_RangedUptime) && //Ranged uptime option is enabled
+                    LevelChecked(Tomahawk) && //Tomahawk is available
+                    !InMeleeRange() && //not in melee range
+                    HasBattleTarget()) //has a target
+                    return Tomahawk;
 
-                            if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_PrimalWrath) && //Primal Wrath option is enabled
-                                LevelChecked(PrimalWrath) && //Primal Wrath is available
-                                HasEffect(Buffs.Wrathful)) //has Wrathful
-                                return PrimalWrath;
-
-                            if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Onslaught) && //Onslaught option is enabled
-                                LevelChecked(Onslaught) && //Onslaught is available
-                                GetRemainingCharges(Onslaught) > Config.WAR_KeepOnslaughtCharges) //has more than selected charges
-                            {
-                                if (IsNotEnabled(CustomComboPreset.WAR_ST_Advanced_Onslaught_MeleeSpender) || //Melee spender option is disabled
-                                    (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Onslaught_MeleeSpender) && //Melee spender option is enabled
-                                    !IsMoving() && GetTargetDistance() <= 1 && //not moving and within 1y of target
-                                    (GetCooldownRemainingTime(InnerRelease) > 40 || !LevelChecked(InnerRelease)))) //IR is not ready or available
-                                    return Onslaught;
-                            }
-                        }
-
-                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_PrimalRend) && //Primal Rend option is enabled
-                            HasEffect(Buffs.PrimalRendReady) && //has Primal Rend ready
-                            !JustUsed(InnerRelease)) //has not just used IR
-                        {
-                            if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_PrimalRend_Late) && //Primal Rend late option is enabled
-                                GetBuffStacks(Buffs.InnerReleaseStacks) is 0 && //does not have IR stacks
-                                GetBuffStacks(Buffs.BurgeoningFury) is 0 && //does not have Burgeoning Fury stacks
-                                !HasEffect(Buffs.Wrathful)) //does not have Wrathful
-                                return PrimalRend;
-
-                            if (IsNotEnabled(CustomComboPreset.WAR_ST_Advanced_PrimalRend_Late) && //Primal Rend late option is disabled
-                                !IsMoving() && GetTargetDistance() <= 1) //not moving & within 1y of target
-                                return PrimalRend;
-                        }
-
-                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_PrimalRuination) && //Primal Ruination option is enabled
-                            LevelChecked(PrimalRuination) && //Primal Ruination is available
-                            HasEffect(Buffs.PrimalRuinationReady)) //has Primal Ruination ready
-                            return PrimalRuination;
-
-                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_FellCleave) && //Fell Cleave option is enabled
-                            LevelChecked(InnerBeast)) //Inner Beast is available
-                        {
-                            if (HasEffect(Buffs.InnerReleaseStacks) || (HasEffect(Buffs.NascentChaos) && LevelChecked(InnerChaos))) //has IR stacks or Nascent Chaos and Inner Chaos
-                                return OriginalHook(InnerBeast);
-
-                            if (HasEffect(Buffs.NascentChaos) && //has Nascent Chaos
-                                !LevelChecked(InnerChaos) && //Inner Chaos is not available
-                                gauge >= 50) //gauge is greater than or equal to 50
-                                return OriginalHook(Decimate);
-                        }
-                    }
-
-                    if (ComboTimer > 0) //in combo window
-                    {
-                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_FellCleave) && //Fell Cleave option is enabled
-                            LevelChecked(InnerBeast) && //Inner Beast is available
-                            (!LevelChecked(StormsEye) || HasEffectAny(Buffs.SurgingTempest)) && //does not have Storm's Eye or has Surging Tempest
-                            gauge >= Config.WAR_FellCleaveGauge) //gauge is greater than or equal to selected threshold
-                            return OriginalHook(InnerBeast);
-
-                        if (LevelChecked(Maim) && //Maim is available
-                            ComboAction == HeavySwing) //last combo move was Heavy Swing
-                            return Maim;
-
-                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_StormsEye) && //Storm's Eye option is enabled
-                            LevelChecked(StormsPath) &&  //Storm's Path is available
-                            ComboAction == Maim) //last combo move was Maim
-                        {
-                            if (LevelChecked(StormsEye) && //Storm's Eye is available
-                                GetBuffRemainingTime(Buffs.SurgingTempest) <= Config.WAR_SurgingRefreshRange) //Surging Tempest less than or equal to selected threshold
-                                return StormsEye; //Storm's Eye
-                            return StormsPath; //Storm's Path instead if conditions are not met
-                        }
-                        if (IsNotEnabled(CustomComboPreset.WAR_ST_Advanced_StormsEye) && //Storm's Eye option is disabled
-                            LevelChecked(StormsPath) && //Storm's Path is available
-                            ComboAction == Maim) //last combo move was Maim
-                            return StormsPath;
-                    }
-
-                    return HeavySwing;
+                if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_BalanceOpener) &&
+                    ContentCheck.IsInConfiguredContent(Config.WAR_BalanceOpener_Content, ContentCheck.ListSet.BossOnly))
+                {
+                    if (Opener().FullOpener(ref actionID))
+                        return actionID;
                 }
 
-                return actionID;
+                if (CanWeave()) //in weave window
+                {
+                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Infuriate) && //Infuriate option is enabled
+                        InCombat() && //in combat
+                        ActionReady(Infuriate) && //Infuriate is ready
+                        !HasEffect(Buffs.NascentChaos) && //does not have Nascent Chaos
+                        !HasEffect(Buffs.InnerReleaseStacks) && //does not have Inner Release stacks
+                        gauge <= Config.WAR_InfuriateSTGauge && //gauge is less than or equal to selected threshold
+                        GetRemainingCharges(Infuriate) > Config.WAR_KeepInfuriateCharges) //has more than selected charges
+                        return Infuriate;
+
+                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_InnerRelease) && //Inner Release option is enabled
+                        InCombat() && //in combat
+                        ActionReady(OriginalHook(Berserk)) && //Berserk is ready
+                        !LevelChecked(StormsEye)) //does not have Storm's Eye
+                        return OriginalHook(Berserk);
+                }
+
+                if (InCombat() && //in combat
+                    HasEffect(Buffs.SurgingTempest)) //has Surging Tempest
+                {
+                    if (CanWeave()) //in weave window
+                    {
+                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_InnerRelease) && //Inner Release option is enabled
+                            ActionReady(OriginalHook(Berserk))) //Berserk is ready
+                            return OriginalHook(Berserk);
+
+                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Upheaval) && //Upheaval option is enabled
+                            ActionReady(Upheaval)) //Upheaval is ready
+                            return Upheaval;
+
+                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_PrimalWrath) && //Primal Wrath option is enabled
+                            LevelChecked(PrimalWrath) && //Primal Wrath is available
+                            HasEffect(Buffs.Wrathful)) //has Wrathful
+                            return PrimalWrath;
+
+                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Onslaught) && //Onslaught option is enabled
+                            LevelChecked(Onslaught) && //Onslaught is available
+                            GetRemainingCharges(Onslaught) > Config.WAR_KeepOnslaughtCharges) //has more than selected charges
+                        {
+                            if (IsNotEnabled(CustomComboPreset.WAR_ST_Advanced_Onslaught_MeleeSpender) || //Melee spender option is disabled
+                                (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Onslaught_MeleeSpender) && //Melee spender option is enabled
+                                 !IsMoving() && GetTargetDistance() <= 1 && //not moving and within 1y of target
+                                 (GetCooldownRemainingTime(InnerRelease) > 40 || !LevelChecked(InnerRelease)))) //IR is not ready or available
+                                return Onslaught;
+                        }
+                    }
+
+                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_PrimalRend) && //Primal Rend option is enabled
+                        HasEffect(Buffs.PrimalRendReady) && //has Primal Rend ready
+                        !JustUsed(InnerRelease)) //has not just used IR
+                    {
+                        if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_PrimalRend_Late) && //Primal Rend late option is enabled
+                            GetBuffStacks(Buffs.InnerReleaseStacks) is 0 && //does not have IR stacks
+                            GetBuffStacks(Buffs.BurgeoningFury) is 0 && //does not have Burgeoning Fury stacks
+                            !HasEffect(Buffs.Wrathful)) //does not have Wrathful
+                            return PrimalRend;
+
+                        if (IsNotEnabled(CustomComboPreset.WAR_ST_Advanced_PrimalRend_Late) && //Primal Rend late option is disabled
+                            !IsMoving() && GetTargetDistance() <= 1) //not moving & within 1y of target
+                            return PrimalRend;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_PrimalRuination) && //Primal Ruination option is enabled
+                        LevelChecked(PrimalRuination) && //Primal Ruination is available
+                        HasEffect(Buffs.PrimalRuinationReady)) //has Primal Ruination ready
+                        return PrimalRuination;
+
+                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_FellCleave) && //Fell Cleave option is enabled
+                        LevelChecked(InnerBeast)) //Inner Beast is available
+                    {
+                        if (HasEffect(Buffs.InnerReleaseStacks) || (HasEffect(Buffs.NascentChaos) && LevelChecked(InnerChaos))) //has IR stacks or Nascent Chaos and Inner Chaos
+                            return OriginalHook(InnerBeast);
+
+                        if (HasEffect(Buffs.NascentChaos) && //has Nascent Chaos
+                            !LevelChecked(InnerChaos) && //Inner Chaos is not available
+                            gauge >= 50) //gauge is greater than or equal to 50
+                            return OriginalHook(Decimate);
+                    }
+                }
+
+                if (ComboTimer > 0) //in combo window
+                {
+                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_FellCleave) && //Fell Cleave option is enabled
+                        LevelChecked(InnerBeast) && //Inner Beast is available
+                        (!LevelChecked(StormsEye) || HasEffectAny(Buffs.SurgingTempest)) && //does not have Storm's Eye or has Surging Tempest
+                        gauge >= Config.WAR_FellCleaveGauge) //gauge is greater than or equal to selected threshold
+                        return OriginalHook(InnerBeast);
+
+                    if (LevelChecked(Maim) && //Maim is available
+                        ComboAction == HeavySwing) //last combo move was Heavy Swing
+                        return Maim;
+
+                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_StormsEye) && //Storm's Eye option is enabled
+                        LevelChecked(StormsPath) &&  //Storm's Path is available
+                        ComboAction == Maim) //last combo move was Maim
+                    {
+                        if (LevelChecked(StormsEye) && //Storm's Eye is available
+                            GetBuffRemainingTime(Buffs.SurgingTempest) <= Config.WAR_SurgingRefreshRange) //Surging Tempest less than or equal to selected threshold
+                            return StormsEye; //Storm's Eye
+                        return StormsPath; //Storm's Path instead if conditions are not met
+                    }
+                    if (IsNotEnabled(CustomComboPreset.WAR_ST_Advanced_StormsEye) && //Storm's Eye option is disabled
+                        LevelChecked(StormsPath) && //Storm's Path is available
+                        ComboAction == Maim) //last combo move was Maim
+                        return StormsPath;
+                }
+
+                return HeavySwing;
+
             }
         }
         #endregion
@@ -529,139 +525,137 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == Overpower) //Our button
+                if (actionID is not Overpower) return actionID; //Our button
+
+                var gauge = GetJobGauge<WARGauge>().BeastGauge; //WAR gauge
+                bool justMitted = JustUsed(OriginalHook(RawIntuition), 4f) ||
+                                  JustUsed(OriginalHook(Vengeance), 5f) ||
+                                  JustUsed(ThrillOfBattle, 5f) ||
+                                  JustUsed(All.Rampart, 5f) ||
+                                  JustUsed(Holmgang, 9f);
+
+                #region Variant
+                Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+                if (IsEnabled(CustomComboPreset.WAR_Variant_SpiritDart) &&
+                    IsEnabled(Variant.VariantSpiritDart) &&
+                    (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
+                    return Variant.VariantSpiritDart;
+
+                if (IsEnabled(CustomComboPreset.WAR_Variant_Ultimatum) &&
+                    IsEnabled(Variant.VariantUltimatum) &&
+                    CanWeave() &&
+                    ActionReady(Variant.VariantUltimatum))
+                    return Variant.VariantUltimatum;
+
+                if (IsEnabled(CustomComboPreset.WAR_Variant_Cure) &&
+                    IsEnabled(Variant.VariantCure) &&
+                    CanWeave() &&
+                    PlayerHealthPercentageHp() <= GetOptionValue(Config.WAR_VariantCure))
+                    return Variant.VariantCure;
+                #endregion
+
+                #region Mitigations
+                if (Config.WAR_AoE_MitsOptions != 1)
                 {
-                    var gauge = GetJobGauge<WARGauge>().BeastGauge; //WAR gauge
-                    bool justMitted = JustUsed(OriginalHook(RawIntuition), 4f) ||
-                                      JustUsed(OriginalHook(Vengeance), 5f) ||
-                                      JustUsed(ThrillOfBattle, 5f) ||
-                                      JustUsed(All.Rampart, 5f) ||
-                                      JustUsed(Holmgang, 9f);
-
-                    #region Variant
-                    Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
-                    if (IsEnabled(CustomComboPreset.WAR_Variant_SpiritDart) &&
-                        IsEnabled(Variant.VariantSpiritDart) &&
-                        (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
-                        return Variant.VariantSpiritDart;
-
-                    if (IsEnabled(CustomComboPreset.WAR_Variant_Ultimatum) &&
-                        IsEnabled(Variant.VariantUltimatum) &&
-                        CanWeave() &&
-                        ActionReady(Variant.VariantUltimatum))
-                        return Variant.VariantUltimatum;
-
-                    if (IsEnabled(CustomComboPreset.WAR_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        CanWeave() &&
-                        PlayerHealthPercentageHp() <= GetOptionValue(Config.WAR_VariantCure))
-                        return Variant.VariantCure;
-                    #endregion
-
-                    #region Mitigations
-                    if (Config.WAR_AoE_MitsOptions != 1)
-                    {
-                        if (InCombat() && //Player is in combat
+                    if (InCombat() && //Player is in combat
                         !justMitted) //Player has not used a mitigation ability in the last 4-9 seconds
+                    {
+                        //Holmgang
+                        if (ActionReady(Holmgang) && //Holmgang is ready
+                            PlayerHealthPercentageHp() < 30) //Player's health is below 30%
+                            return Holmgang;
+
+                        if (IsPlayerTargeted())
                         {
-                            //Holmgang
-                            if (ActionReady(Holmgang) && //Holmgang is ready
-                                PlayerHealthPercentageHp() < 30) //Player's health is below 30%
-                                return Holmgang;
+                            //Vengeance / Damnation
+                            if (ActionReady(OriginalHook(Vengeance)) && //Vengeance is ready
+                                PlayerHealthPercentageHp() < 60) //Player's health is below 60%
+                                return OriginalHook(Vengeance);
 
-                            if (IsPlayerTargeted())
-                            {
-                                //Vengeance / Damnation
-                                if (ActionReady(OriginalHook(Vengeance)) && //Vengeance is ready
-                                    PlayerHealthPercentageHp() < 60) //Player's health is below 60%
-                                    return OriginalHook(Vengeance);
+                            //Rampart
+                            if (ActionReady(All.Rampart) && //Rampart is ready
+                                PlayerHealthPercentageHp() < 80) //Player's health is below 80%
+                                return All.Rampart;
 
-                                //Rampart
-                                if (ActionReady(All.Rampart) && //Rampart is ready
-                                    PlayerHealthPercentageHp() < 80) //Player's health is below 80%
-                                    return All.Rampart;
-
-                                //Reprisal
-                                if (ActionReady(All.Reprisal) && //Reprisal is ready
-                                    GetTargetDistance() <= 5 && //within 5y of target
-                                    PlayerHealthPercentageHp() < 90) //Player's health is below 90%
-                                    return All.Reprisal;
-                            }
-
-                            //Thrill
-                            if (ActionReady(ThrillOfBattle) && //Thrill is ready
-                                PlayerHealthPercentageHp() < 70) //Player's health is below 80%
-                                return ThrillOfBattle;
-
-                            //Equilibrium
-                            if (ActionReady(Equilibrium) && //Equilibrium is ready
-                                PlayerHealthPercentageHp() < 50) //Player's health is below 30%
-                                return Equilibrium;
-
-                            //Bloodwhetting
-                            if (ActionReady(OriginalHook(RawIntuition)) && //Bloodwhetting
-                                PlayerHealthPercentageHp() < 90) //Player's health is below 95%
-                                return OriginalHook(Bloodwhetting);
+                            //Reprisal
+                            if (ActionReady(All.Reprisal) && //Reprisal is ready
+                                GetTargetDistance() <= 5 && //within 5y of target
+                                PlayerHealthPercentageHp() < 90) //Player's health is below 90%
+                                return All.Reprisal;
                         }
 
-                    }
-                    #endregion
+                        //Thrill
+                        if (ActionReady(ThrillOfBattle) && //Thrill is ready
+                            PlayerHealthPercentageHp() < 70) //Player's health is below 80%
+                            return ThrillOfBattle;
 
-                    if (CanWeave()) //in weave window
-                    {
-                        if (InCombat() && //in combat
-                           ActionReady(Infuriate) && //Infuriate is ready
-                           !HasEffect(Buffs.NascentChaos) && //does not have Nascent Chaos
-                           !HasEffect(Buffs.InnerReleaseStacks) && //does not have Inner Release stacks 
-                           gauge <= 40) //gauge is less than or equal to 40
-                            return Infuriate;
+                        //Equilibrium
+                        if (ActionReady(Equilibrium) && //Equilibrium is ready
+                            PlayerHealthPercentageHp() < 50) //Player's health is below 30%
+                            return Equilibrium;
 
-                        if (InCombat() && //in combat
-                            ActionReady(OriginalHook(Berserk)) && //Berserk is ready 
-                            !LevelChecked(MythrilTempest)) //does not have Mythril Tempest
-                            return OriginalHook(Berserk);
+                        //Bloodwhetting
+                        if (ActionReady(OriginalHook(RawIntuition)) && //Bloodwhetting
+                            PlayerHealthPercentageHp() < 90) //Player's health is below 95%
+                            return OriginalHook(Bloodwhetting);
                     }
+
+                }
+                #endregion
+
+                if (CanWeave()) //in weave window
+                {
+                    if (InCombat() && //in combat
+                        ActionReady(Infuriate) && //Infuriate is ready
+                        !HasEffect(Buffs.NascentChaos) && //does not have Nascent Chaos
+                        !HasEffect(Buffs.InnerReleaseStacks) && //does not have Inner Release stacks
+                        gauge <= 40) //gauge is less than or equal to 40
+                        return Infuriate;
 
                     if (InCombat() && //in combat
-                        HasEffect(Buffs.SurgingTempest)) //has Surging Tempest
-                    {
-                        if (CanWeave()) //in weave window
-                        {
-                            if (ActionReady(OriginalHook(Berserk))) //Berserk is ready
-                                return OriginalHook(Berserk);
-
-                            if (ActionReady(Orogeny)) //Orogeny is ready
-                                return Orogeny;
-
-                            if (LevelChecked(PrimalWrath) && //Primal Wrath is available
-                                HasEffect(Buffs.Wrathful)) //has Wrathful
-                                return PrimalWrath;
-                        }
-
-                        if (LevelChecked(PrimalRend) && //Primal Rend is available
-                            HasEffect(Buffs.PrimalRendReady)) //has Primal Rend ready
-                            return PrimalRend;
-
-                        if (LevelChecked(PrimalRuination) && //Primal Ruination is available
-                            HasEffect(Buffs.PrimalRuinationReady)) //has Primal Ruination ready
-                            return PrimalRuination;
-
-                        if (LevelChecked(SteelCyclone) && //Steel Cyclone is available
-                            (gauge >= 90 || HasEffect(Buffs.InnerReleaseStacks) || HasEffect(Buffs.NascentChaos))) //gauge is greater than or equal to 90 or has IR stacks or Nascent Chaos
-                            return OriginalHook(SteelCyclone);
-                    }
-
-                    if (ComboTimer > 0) //in combo window
-                    {
-                        if (LevelChecked(MythrilTempest) && //Mythril Tempest is available
-                            ComboAction == Overpower) //last combo move was Overpower
-                            return MythrilTempest;
-                    }
-
-                    return Overpower;
+                        ActionReady(OriginalHook(Berserk)) && //Berserk is ready
+                        !LevelChecked(MythrilTempest)) //does not have Mythril Tempest
+                        return OriginalHook(Berserk);
                 }
 
-                return actionID;
+                if (InCombat() && //in combat
+                    HasEffect(Buffs.SurgingTempest)) //has Surging Tempest
+                {
+                    if (CanWeave()) //in weave window
+                    {
+                        if (ActionReady(OriginalHook(Berserk))) //Berserk is ready
+                            return OriginalHook(Berserk);
+
+                        if (ActionReady(Orogeny)) //Orogeny is ready
+                            return Orogeny;
+
+                        if (LevelChecked(PrimalWrath) && //Primal Wrath is available
+                            HasEffect(Buffs.Wrathful)) //has Wrathful
+                            return PrimalWrath;
+                    }
+
+                    if (LevelChecked(PrimalRend) && //Primal Rend is available
+                        HasEffect(Buffs.PrimalRendReady)) //has Primal Rend ready
+                        return PrimalRend;
+
+                    if (LevelChecked(PrimalRuination) && //Primal Ruination is available
+                        HasEffect(Buffs.PrimalRuinationReady)) //has Primal Ruination ready
+                        return PrimalRuination;
+
+                    if (LevelChecked(SteelCyclone) && //Steel Cyclone is available
+                        (gauge >= 90 || HasEffect(Buffs.InnerReleaseStacks) || HasEffect(Buffs.NascentChaos))) //gauge is greater than or equal to 90 or has IR stacks or Nascent Chaos
+                        return OriginalHook(SteelCyclone);
+                }
+
+                if (ComboTimer > 0) //in combo window
+                {
+                    if (LevelChecked(MythrilTempest) && //Mythril Tempest is available
+                        ComboAction == Overpower) //last combo move was Overpower
+                        return MythrilTempest;
+                }
+
+                return Overpower;
+
             }
         }
         #endregion
@@ -673,171 +667,169 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == Overpower) //Our button
+                if (actionID is not Overpower) return actionID; //Our button
+
+                var gauge = GetJobGauge<WARGauge>().BeastGauge; //WAR gauge
+                bool justMitted = JustUsed(OriginalHook(RawIntuition), 4f) ||
+                                  JustUsed(OriginalHook(Vengeance), 5f) ||
+                                  JustUsed(ThrillOfBattle, 5f) ||
+                                  JustUsed(All.Rampart, 5f) ||
+                                  JustUsed(Holmgang, 9f);
+
+                #region Variant
+                Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+                if (IsEnabled(CustomComboPreset.WAR_Variant_SpiritDart) &&
+                    IsEnabled(Variant.VariantSpiritDart) &&
+                    (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
+                    return Variant.VariantSpiritDart;
+
+                if (IsEnabled(CustomComboPreset.WAR_Variant_Ultimatum) &&
+                    IsEnabled(Variant.VariantUltimatum) &&
+                    CanWeave() &&
+                    ActionReady(Variant.VariantUltimatum))
+                    return Variant.VariantUltimatum;
+
+                if (IsEnabled(CustomComboPreset.WAR_Variant_Cure) &&
+                    IsEnabled(Variant.VariantCure) &&
+                    CanWeave() &&
+                    PlayerHealthPercentageHp() <= GetOptionValue(Config.WAR_VariantCure))
+                    return Variant.VariantCure;
+                #endregion
+
+                #region Mitigations
+                if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Mitigation) && //Mitigation option is enabled
+                    InCombat() && //Player is in combat
+                    !justMitted) //Player has not used a mitigation ability in the last 4-9 seconds
                 {
-                    var gauge = GetJobGauge<WARGauge>().BeastGauge; //WAR gauge
-                    bool justMitted = JustUsed(OriginalHook(RawIntuition), 4f) ||
-                                      JustUsed(OriginalHook(Vengeance), 5f) ||
-                                      JustUsed(ThrillOfBattle, 5f) ||
-                                      JustUsed(All.Rampart, 5f) ||
-                                      JustUsed(Holmgang, 9f);
+                    //Holmgang
+                    if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Holmgang) && //Holmgang option is enabled
+                        ActionReady(Holmgang) && //Holmgang is ready
+                        PlayerHealthPercentageHp() <= Config.WAR_AoE_Holmgang_Health && //Player's health is below selected threshold
+                        (Config.WAR_AoE_Holmgang_SubOption == 0 || //Holmgang is enabled for all targets
+                         (TargetIsBoss() && Config.WAR_AoE_Holmgang_SubOption == 1))) //Holmgang is enabled for bosses only
+                        return Holmgang;
 
-                    #region Variant
-                    Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
-                    if (IsEnabled(CustomComboPreset.WAR_Variant_SpiritDart) &&
-                        IsEnabled(Variant.VariantSpiritDart) &&
-                        (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
-                        return Variant.VariantSpiritDart;
-
-                    if (IsEnabled(CustomComboPreset.WAR_Variant_Ultimatum) &&
-                        IsEnabled(Variant.VariantUltimatum) &&
-                        CanWeave() &&
-                        ActionReady(Variant.VariantUltimatum))
-                        return Variant.VariantUltimatum;
-
-                    if (IsEnabled(CustomComboPreset.WAR_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        CanWeave() &&
-                        PlayerHealthPercentageHp() <= GetOptionValue(Config.WAR_VariantCure))
-                        return Variant.VariantCure;
-                    #endregion
-
-                    #region Mitigations
-                    if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Mitigation) && //Mitigation option is enabled
-                        InCombat() && //Player is in combat
-                        !justMitted) //Player has not used a mitigation ability in the last 4-9 seconds
+                    if (IsPlayerTargeted())
                     {
-                        //Holmgang
-                        if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Holmgang) && //Holmgang option is enabled
-                            ActionReady(Holmgang) && //Holmgang is ready
-                            PlayerHealthPercentageHp() <= Config.WAR_AoE_Holmgang_Health && //Player's health is below selected threshold
-                            (Config.WAR_AoE_Holmgang_SubOption == 0 || //Holmgang is enabled for all targets
-                            (TargetIsBoss() && Config.WAR_AoE_Holmgang_SubOption == 1))) //Holmgang is enabled for bosses only
-                            return Holmgang;
+                        //Vengeance / Damnation
+                        if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Vengeance) && //Vengeance option is enabled
+                            ActionReady(OriginalHook(Vengeance)) && //Vengeance is ready
+                            PlayerHealthPercentageHp() <= Config.WAR_AoE_Vengeance_Health && //Player's health is below selected threshold
+                            (Config.WAR_AoE_Vengeance_SubOption == 0 || //Vengeance is enabled for all targets
+                             (TargetIsBoss() && Config.WAR_AoE_Vengeance_SubOption == 1))) //Vengeance is enabled for bosses only
+                            return OriginalHook(Vengeance);
 
-                        if (IsPlayerTargeted())
-                        {
-                            //Vengeance / Damnation
-                            if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Vengeance) && //Vengeance option is enabled
-                                ActionReady(OriginalHook(Vengeance)) && //Vengeance is ready
-                                PlayerHealthPercentageHp() <= Config.WAR_AoE_Vengeance_Health && //Player's health is below selected threshold
-                                (Config.WAR_AoE_Vengeance_SubOption == 0 || //Vengeance is enabled for all targets
-                                (TargetIsBoss() && Config.WAR_AoE_Vengeance_SubOption == 1))) //Vengeance is enabled for bosses only
-                                return OriginalHook(Vengeance);
+                        //Rampart
+                        if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Rampart) && //Rampart option is enabled
+                            ActionReady(All.Rampart) && //Rampart is ready
+                            PlayerHealthPercentageHp() <= Config.WAR_AoE_Rampart_Health && //Player's health is below selected threshold
+                            (Config.WAR_AoE_Rampart_SubOption == 0 || //Rampart is enabled for all targets
+                             (TargetIsBoss() && Config.WAR_AoE_Rampart_SubOption == 1))) //Rampart is enabled for bosses only
+                            return All.Rampart;
 
-                            //Rampart
-                            if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Rampart) && //Rampart option is enabled
-                                ActionReady(All.Rampart) && //Rampart is ready
-                                PlayerHealthPercentageHp() <= Config.WAR_AoE_Rampart_Health && //Player's health is below selected threshold
-                                (Config.WAR_AoE_Rampart_SubOption == 0 || //Rampart is enabled for all targets
-                                (TargetIsBoss() && Config.WAR_AoE_Rampart_SubOption == 1))) //Rampart is enabled for bosses only
-                                return All.Rampart;
+                        //Reprisal
+                        if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Reprisal) && //Reprisal option is enabled
+                            ActionReady(All.Reprisal) && //Reprisal is ready
+                            GetTargetDistance() <= 5 && //within 5y of target
+                            PlayerHealthPercentageHp() <= Config.WAR_AoE_Reprisal_Health && //Player's health is below selected threshold
+                            (Config.WAR_AoE_Reprisal_SubOption == 0 || //Reprisal is enabled for all targets
+                             (TargetIsBoss() && Config.WAR_AoE_Reprisal_SubOption == 1))) //Reprisal is enabled for bosses only
+                            return All.Reprisal;
 
-                            //Reprisal
-                            if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Reprisal) && //Reprisal option is enabled
-                                ActionReady(All.Reprisal) && //Reprisal is ready
-                                GetTargetDistance() <= 5 && //within 5y of target
-                                PlayerHealthPercentageHp() <= Config.WAR_AoE_Reprisal_Health && //Player's health is below selected threshold
-                                (Config.WAR_AoE_Reprisal_SubOption == 0 || //Reprisal is enabled for all targets
-                                (TargetIsBoss() && Config.WAR_AoE_Reprisal_SubOption == 1))) //Reprisal is enabled for bosses only
-                                return All.Reprisal;
-
-                            //Arms Length
-                            if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_ArmsLength) && //Arms Length option is enabled
-                                ActionReady(All.ArmsLength) && //Arms Length is ready
-                                PlayerHealthPercentageHp() <= Config.WAR_AoE_ArmsLength_Health && //Player's health is below selected threshold
-                                !InBossEncounter()) //target is not a boss
-                                return All.ArmsLength;
-                        }
-                        //Thrill
-                        if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Thrill) && //Thrill option is enabled
-                                ActionReady(ThrillOfBattle) && //Thrill is ready
-                                PlayerHealthPercentageHp() <= Config.WAR_AoE_Thrill_Health && //Player's health is below selected threshold
-                                (Config.WAR_AoE_Thrill_SubOption == 0 || //Thrill is enabled for all targets
-                                (TargetIsBoss() && Config.WAR_AoE_Thrill_SubOption == 1))) //Thrill is enabled for bosses only
-                                return ThrillOfBattle;
-
-                            //Equilibrium
-                            if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Equilibrium) && //Equilibrium option is enabled
-                                ActionReady(Equilibrium) && //Equilibrium is ready
-                                PlayerHealthPercentageHp() <= Config.WAR_AoE_Equilibrium_Health && //Player's health is below selected threshold
-                                (Config.WAR_AoE_Equilibrium_SubOption == 0 || //Equilibrium is enabled for all targets
-                                (TargetIsBoss() && Config.WAR_AoE_Equilibrium_SubOption == 1))) //Equilibrium is enabled for bosses only
-                                return Equilibrium;
-
-                            //Bloodwhetting
-                            if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Bloodwhetting) && //Bloodwhetting option is enabled
-                                ActionReady(OriginalHook(RawIntuition)) && //Bloodwhetting is ready
-                                PlayerHealthPercentageHp() <= Config.WAR_AoE_Bloodwhetting_Health && //Player's health is below selected threshold
-                                (Config.WAR_AoE_Bloodwhetting_SubOption == 0 || //Bloodwhetting is enabled for all targets
-                                (TargetIsBoss() && Config.WAR_AoE_Bloodwhetting_SubOption == 1))) //Bloodwhetting is enabled for bosses only
-                                return OriginalHook(RawIntuition);
+                        //Arms Length
+                        if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_ArmsLength) && //Arms Length option is enabled
+                            ActionReady(All.ArmsLength) && //Arms Length is ready
+                            PlayerHealthPercentageHp() <= Config.WAR_AoE_ArmsLength_Health && //Player's health is below selected threshold
+                            !InBossEncounter()) //target is not a boss
+                            return All.ArmsLength;
                     }
-                    #endregion
+                    //Thrill
+                    if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Thrill) && //Thrill option is enabled
+                        ActionReady(ThrillOfBattle) && //Thrill is ready
+                        PlayerHealthPercentageHp() <= Config.WAR_AoE_Thrill_Health && //Player's health is below selected threshold
+                        (Config.WAR_AoE_Thrill_SubOption == 0 || //Thrill is enabled for all targets
+                         (TargetIsBoss() && Config.WAR_AoE_Thrill_SubOption == 1))) //Thrill is enabled for bosses only
+                        return ThrillOfBattle;
 
-                    if (CanWeave()) //in weave window
-                    {
-                        if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Infuriate) && //Infuriate option is enabled
-                            InCombat() && //in combat
-                            ActionReady(Infuriate) && //Infuriate is ready
-                            !HasEffect(Buffs.NascentChaos) && //does not have Nascent Chaos
-                            !HasEffect(Buffs.InnerReleaseStacks) && //does not have Inner Release stacks
-                            gauge <= Config.WAR_InfuriateSTGauge) //gauge is less than or equal to selected threshold
-                            return Infuriate;
+                    //Equilibrium
+                    if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Equilibrium) && //Equilibrium option is enabled
+                        ActionReady(Equilibrium) && //Equilibrium is ready
+                        PlayerHealthPercentageHp() <= Config.WAR_AoE_Equilibrium_Health && //Player's health is below selected threshold
+                        (Config.WAR_AoE_Equilibrium_SubOption == 0 || //Equilibrium is enabled for all targets
+                         (TargetIsBoss() && Config.WAR_AoE_Equilibrium_SubOption == 1))) //Equilibrium is enabled for bosses only
+                        return Equilibrium;
 
-                        if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_InnerRelease) && //Inner Release option is enabled
-                            InCombat() && //in combat
-                            ActionReady(OriginalHook(Berserk)) && //Berserk is ready
-                            !LevelChecked(MythrilTempest)) //does not have Mythril Tempest
-                            return OriginalHook(Berserk);
-                    }
+                    //Bloodwhetting
+                    if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Bloodwhetting) && //Bloodwhetting option is enabled
+                        ActionReady(OriginalHook(RawIntuition)) && //Bloodwhetting is ready
+                        PlayerHealthPercentageHp() <= Config.WAR_AoE_Bloodwhetting_Health && //Player's health is below selected threshold
+                        (Config.WAR_AoE_Bloodwhetting_SubOption == 0 || //Bloodwhetting is enabled for all targets
+                         (TargetIsBoss() && Config.WAR_AoE_Bloodwhetting_SubOption == 1))) //Bloodwhetting is enabled for bosses only
+                        return OriginalHook(RawIntuition);
+                }
+                #endregion
 
-                    if (InCombat() && //in combat
-                        HasEffect(Buffs.SurgingTempest)) //has Surging Tempest
-                    {
-                        if (CanWeave()) //in weave window
-                        {
-                            if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_InnerRelease) && //Inner Release option is enabled
-                                ActionReady(OriginalHook(Berserk))) //Berserk is ready
-                                return OriginalHook(Berserk);
+                if (CanWeave()) //in weave window
+                {
+                    if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Infuriate) && //Infuriate option is enabled
+                        InCombat() && //in combat
+                        ActionReady(Infuriate) && //Infuriate is ready
+                        !HasEffect(Buffs.NascentChaos) && //does not have Nascent Chaos
+                        !HasEffect(Buffs.InnerReleaseStacks) && //does not have Inner Release stacks
+                        gauge <= Config.WAR_InfuriateSTGauge) //gauge is less than or equal to selected threshold
+                        return Infuriate;
 
-                            if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Orogeny) && //Orogeny option is enabled
-                                ActionReady(Orogeny)) //Orogeny is ready
-                                return Orogeny;
-
-                            if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_PrimalWrath) && //Primal Wrath option is enabled
-                                LevelChecked(PrimalWrath) && //Primal Wrath is available
-                                HasEffect(Buffs.Wrathful)) //has Wrathful
-                                return PrimalWrath;
-                        }
-
-                        if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_PrimalRend) && //Primal Rend option is enabled
-                            LevelChecked(PrimalRend) && //Primal Rend is available
-                            HasEffect(Buffs.PrimalRendReady)) //has Primal Rend ready
-                            return PrimalRend;
-
-                        if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_PrimalRuination) && //Primal Ruination option is enabled
-                            HasEffect(Buffs.PrimalRuinationReady) && //has Primal Ruination ready
-                            LevelChecked(PrimalRuination)) //Primal Ruination is available
-                            return PrimalRuination;
-
-                        if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Decimate) && //Decimate option is enabled
-                            LevelChecked(SteelCyclone) && //Steel Cyclone is available 
-                            (gauge >= Config.WAR_DecimateGauge || HasEffect(Buffs.InnerReleaseStacks) || HasEffect(Buffs.NascentChaos))) //gauge is greater than or equal to selected threshold or has IR stacks or Nascent Chaos
-                            return OriginalHook(SteelCyclone);
-                    }
-
-                    if (ComboTimer > 0) //in combo window
-                    {
-                        if (LevelChecked(MythrilTempest) && //Mythril Tempest is available
-                            ComboAction == Overpower) //last combo move was Overpower
-                            return MythrilTempest;
-                    }
-
-                    return Overpower;
+                    if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_InnerRelease) && //Inner Release option is enabled
+                        InCombat() && //in combat
+                        ActionReady(OriginalHook(Berserk)) && //Berserk is ready
+                        !LevelChecked(MythrilTempest)) //does not have Mythril Tempest
+                        return OriginalHook(Berserk);
                 }
 
-                return actionID;
+                if (InCombat() && //in combat
+                    HasEffect(Buffs.SurgingTempest)) //has Surging Tempest
+                {
+                    if (CanWeave()) //in weave window
+                    {
+                        if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_InnerRelease) && //Inner Release option is enabled
+                            ActionReady(OriginalHook(Berserk))) //Berserk is ready
+                            return OriginalHook(Berserk);
+
+                        if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Orogeny) && //Orogeny option is enabled
+                            ActionReady(Orogeny)) //Orogeny is ready
+                            return Orogeny;
+
+                        if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_PrimalWrath) && //Primal Wrath option is enabled
+                            LevelChecked(PrimalWrath) && //Primal Wrath is available
+                            HasEffect(Buffs.Wrathful)) //has Wrathful
+                            return PrimalWrath;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_PrimalRend) && //Primal Rend option is enabled
+                        LevelChecked(PrimalRend) && //Primal Rend is available
+                        HasEffect(Buffs.PrimalRendReady)) //has Primal Rend ready
+                        return PrimalRend;
+
+                    if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_PrimalRuination) && //Primal Ruination option is enabled
+                        HasEffect(Buffs.PrimalRuinationReady) && //has Primal Ruination ready
+                        LevelChecked(PrimalRuination)) //Primal Ruination is available
+                        return PrimalRuination;
+
+                    if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Decimate) && //Decimate option is enabled
+                        LevelChecked(SteelCyclone) && //Steel Cyclone is available
+                        (gauge >= Config.WAR_DecimateGauge || HasEffect(Buffs.InnerReleaseStacks) || HasEffect(Buffs.NascentChaos))) //gauge is greater than or equal to selected threshold or has IR stacks or Nascent Chaos
+                        return OriginalHook(SteelCyclone);
+                }
+
+                if (ComboTimer > 0) //in combo window
+                {
+                    if (LevelChecked(MythrilTempest) && //Mythril Tempest is available
+                        ComboAction == Overpower) //last combo move was Overpower
+                        return MythrilTempest;
+                }
+
+                return Overpower;
+
             }
         }
         #endregion
@@ -849,11 +841,10 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == StormsPath)
-                {
-                    if (GetBuffRemainingTime(Buffs.SurgingTempest) <= Config.WAR_EyePath_Refresh) //Surging Tempest less than or equal to selected threshold
-                        return StormsEye;
-                }
+                if (actionID != StormsPath) return actionID;
+
+                if (GetBuffRemainingTime(Buffs.SurgingTempest) <= Config.WAR_EyePath_Refresh) //Surging Tempest less than or equal to selected threshold
+                    return StormsEye;
 
                 return actionID;
             }
@@ -867,23 +858,21 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == StormsEye)
+                if (actionID is not StormsEye) return actionID;
+
+                if (ComboTimer > 0) //In combo
                 {
-                    if (ComboTimer > 0) //In combo
-                    {
-                        if (ComboAction == HeavySwing && //Last move was Heavy Swing
-                            LevelChecked(Maim)) //Maim is available
-                            return Maim;
+                    if (ComboAction == HeavySwing && //Last move was Heavy Swing
+                        LevelChecked(Maim)) //Maim is available
+                        return Maim;
 
-                        if (ComboAction == Maim && //Last move was Maim
-                            LevelChecked(StormsEye)) //Storm's Eye is available
-                            return StormsEye;
-                    }
-
-                    return HeavySwing;
+                    if (ComboAction == Maim && //Last move was Maim
+                        LevelChecked(StormsEye)) //Storm's Eye is available
+                        return StormsEye;
                 }
 
-                return actionID;
+                return HeavySwing;
+
             }
         }
         #endregion
@@ -895,16 +884,15 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == OriginalHook(Berserk))
-                {
-                    if (LevelChecked(PrimalRend) && //Primal Rend is available
-                        HasEffect(Buffs.PrimalRendReady)) //Primal Rend is ready
-                        return PrimalRend;
+                if (actionID != OriginalHook(Berserk)) return OriginalHook(actionID);
 
-                    if (LevelChecked(PrimalRuination) && //Primal Ruination is available
-                        HasEffect(Buffs.PrimalRuinationReady)) //Primal Ruination is ready
-                        return PrimalRuination;
-                }
+                if (LevelChecked(PrimalRend) && //Primal Rend is available
+                    HasEffect(Buffs.PrimalRendReady)) //Primal Rend is ready
+                    return PrimalRend;
+
+                if (LevelChecked(PrimalRuination) && //Primal Ruination is available
+                    HasEffect(Buffs.PrimalRuinationReady)) //Primal Ruination is ready
+                    return PrimalRuination;
 
                 return OriginalHook(actionID);
             }
@@ -918,19 +906,19 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID is InnerBeast or FellCleave or SteelCyclone or Decimate)
-                {
-                    var gauge = GetJobGauge<WARGauge>();
-                    var hasNascent = HasEffect(Buffs.NascentChaos);
-                    var hasInnerRelease = HasEffect(Buffs.InnerReleaseStacks);
+                if (actionID is not (InnerBeast or FellCleave or SteelCyclone or Decimate))
+                    return actionID;
 
-                    if (InCombat() && //is in combat
-                        gauge.BeastGauge <= Config.WAR_InfuriateRange && //Beast Gauge is below selected threshold
-                        ActionReady(Infuriate) && //Infuriate is ready
-                        !hasNascent //does not have Nascent Chaos
-                        && ((!hasInnerRelease) || IsNotEnabled(CustomComboPreset.WAR_InfuriateFellCleave_IRFirst))) //does not have Inner Release stacks or IRFirst option is disabled
-                        return OriginalHook(Infuriate);
-                }
+                var gauge = GetJobGauge<WARGauge>();
+                var hasNascent = HasEffect(Buffs.NascentChaos);
+                var hasInnerRelease = HasEffect(Buffs.InnerReleaseStacks);
+
+                if (InCombat() && //is in combat
+                    gauge.BeastGauge <= Config.WAR_InfuriateRange && //Beast Gauge is below selected threshold
+                    ActionReady(Infuriate) && //Infuriate is ready
+                    !hasNascent //does not have Nascent Chaos
+                    && ((!hasInnerRelease) || IsNotEnabled(CustomComboPreset.WAR_InfuriateFellCleave_IRFirst))) //does not have Inner Release stacks or IRFirst option is disabled
+                    return OriginalHook(Infuriate);
 
                 return actionID;
             }
@@ -965,14 +953,12 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == NascentFlash)
-                {
-                    if (LevelChecked(NascentFlash))
-                        return NascentFlash;
-                    return RawIntuition;
-                }
+                if (actionID is not NascentFlash) return actionID;
 
-                return actionID;
+                if (LevelChecked(NascentFlash))
+                    return NascentFlash;
+                return RawIntuition;
+
             }
         }
         #endregion
@@ -984,20 +970,17 @@ namespace WrathCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID)
             {
-                if (actionID == ThrillOfBattle)
-                {
-                    if (!IsEnabled(CustomComboPreset.WAR_ThrillEquilibrium_BuffOnly) &&
-                        IsOnCooldown(ThrillOfBattle))
-                        return Equilibrium;
+                if (actionID is not ThrillOfBattle) return actionID;
 
-                    if (IsEnabled(CustomComboPreset.WAR_ThrillEquilibrium_BuffOnly) &&
-                        HasEffect(Buffs.ThrillOfBattle))
-                        return Equilibrium;
+                if (!IsEnabled(CustomComboPreset.WAR_ThrillEquilibrium_BuffOnly) &&
+                    IsOnCooldown(ThrillOfBattle))
+                    return Equilibrium;
 
-                    return ThrillOfBattle;
-                }
+                if (IsEnabled(CustomComboPreset.WAR_ThrillEquilibrium_BuffOnly) &&
+                    HasEffect(Buffs.ThrillOfBattle))
+                    return Equilibrium;
 
-                return actionID;
+                return ThrillOfBattle;
             }
         }
         #endregion

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -136,15 +136,14 @@ internal partial class WHM
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is All.Swiftcast)
-            {
-                bool thinAirReady = !HasEffect(Buffs.ThinAir) && LevelChecked(ThinAir) && HasCharges(ThinAir);
+            if (actionID is not All.Swiftcast) return actionID;
 
-                if (HasEffect(All.Buffs.Swiftcast))
-                    return IsEnabled(CustomComboPreset.WHM_ThinAirRaise) && thinAirReady
-                        ? ThinAir
-                        : Raise;
-            }
+            bool thinAirReady = !HasEffect(Buffs.ThinAir) && LevelChecked(ThinAir) && HasCharges(ThinAir);
+
+            if (HasEffect(All.Buffs.Swiftcast))
+                return IsEnabled(CustomComboPreset.WHM_ThinAirRaise) && thinAirReady
+                    ? ThinAir
+                    : Raise;
 
             return actionID;
         }
@@ -170,78 +169,78 @@ internal partial class WHM
                 ActionFound = StoneGlareList.Contains(actionID); //default handling
             }
 
-            if (ActionFound)
+            // If the action is not in the list, return the actionID
+            if (!ActionFound) return actionID;
+
+            if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Opener))
+                if (Opener().FullOpener(ref actionID))
+                    return actionID;
+
+            bool liliesFull = gauge.Lily == 3;
+            bool liliesNearlyFull = gauge.Lily == 2 && gauge.LilyTimer >= 17000;
+
+            if (CanSpellWeave())
             {
-                if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Opener))
-                    if (Opener().FullOpener(ref actionID))
-                        return actionID;
+                bool lucidReady = ActionReady(All.LucidDreaming) && LevelChecked(All.LucidDreaming) &&
+                                  LocalPlayer.CurrentMp <= Config.WHM_STDPS_Lucid;
+                bool pomReady = LevelChecked(PresenceOfMind) && IsOffCooldown(PresenceOfMind);
+                bool assizeReady = LevelChecked(Assize) && IsOffCooldown(Assize);
+                bool pomEnabled = IsEnabled(CustomComboPreset.WHM_ST_MainCombo_PresenceOfMind);
+                bool assizeEnabled = IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Assize);
+                bool lucidEnabled = IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Lucid);
 
-                bool liliesFull = gauge.Lily == 3;
-                bool liliesNearlyFull = gauge.Lily == 2 && gauge.LilyTimer >= 17000;
+                if (IsEnabled(CustomComboPreset.WHM_DPS_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart) &&
+                    CanSpellWeave())
+                    return Variant.VariantRampart;
 
-                if (CanSpellWeave())
+                if (pomEnabled && pomReady)
+                    return PresenceOfMind;
+
+                if (assizeEnabled && assizeReady)
+                    return Assize;
+
+                if (lucidEnabled && lucidReady)
+                    return All.LucidDreaming;
+            }
+
+            if (InCombat())
+            {
+                // DoTs
+                if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_DoT) && LevelChecked(Aero) && HasBattleTarget() &&
+                    AeroList.TryGetValue(OriginalHook(Aero), out ushort dotDebuffID))
                 {
-                    bool lucidReady = ActionReady(All.LucidDreaming) && LevelChecked(All.LucidDreaming) &&
-                                      LocalPlayer.CurrentMp <= Config.WHM_STDPS_Lucid;
-                    bool pomReady = LevelChecked(PresenceOfMind) && IsOffCooldown(PresenceOfMind);
-                    bool assizeReady = LevelChecked(Assize) && IsOffCooldown(Assize);
-                    bool pomEnabled = IsEnabled(CustomComboPreset.WHM_ST_MainCombo_PresenceOfMind);
-                    bool assizeEnabled = IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Assize);
-                    bool lucidEnabled = IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Lucid);
-
-                    if (IsEnabled(CustomComboPreset.WHM_DPS_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
+                    if (IsEnabled(CustomComboPreset.WHM_DPS_Variant_SpiritDart) &&
+                        IsEnabled(Variant.VariantSpiritDart) &&
+                        GetDebuffRemainingTime(Variant.Debuffs.SustainedDamage) <= 3 &&
                         CanSpellWeave())
-                        return Variant.VariantRampart;
+                        return Variant.VariantSpiritDart;
 
-                    if (pomEnabled && pomReady)
-                        return PresenceOfMind;
+                    // DoT Uptime & HP% threshold
+                    float refreshtimer =
+                        Config.WHM_ST_MainCombo_DoT_Adv ? Config.WHM_ST_MainCombo_DoT_Threshold : 3;
 
-                    if (assizeEnabled && assizeReady)
-                        return Assize;
-
-                    if (lucidEnabled && lucidReady)
-                        return All.LucidDreaming;
+                    if (GetDebuffRemainingTime(dotDebuffID) <= refreshtimer &&
+                        GetTargetHPPercent() > Config.WHM_STDPS_MainCombo_DoT)
+                        return OriginalHook(Aero);
                 }
 
-                if (InCombat())
-                {
-                    // DoTs
-                    if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_DoT) && LevelChecked(Aero) && HasBattleTarget() &&
-                        AeroList.TryGetValue(OriginalHook(Aero), out ushort dotDebuffID))
-                    {
-                        if (IsEnabled(CustomComboPreset.WHM_DPS_Variant_SpiritDart) &&
-                            IsEnabled(Variant.VariantSpiritDart) &&
-                            GetDebuffRemainingTime(Variant.Debuffs.SustainedDamage) <= 3 &&
-                            CanSpellWeave())
-                            return Variant.VariantSpiritDart;
+                // Glare IV
+                if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_GlareIV)
+                    && HasEffect(Buffs.SacredSight)
+                    && GetBuffStacks(Buffs.SacredSight) > 0)
+                    return OriginalHook(Glare4);
 
-                        // DoT Uptime & HP% threshold
-                        float refreshtimer =
-                            Config.WHM_ST_MainCombo_DoT_Adv ? Config.WHM_ST_MainCombo_DoT_Threshold : 3;
+                if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_LilyOvercap) && LevelChecked(AfflatusRapture) &&
+                    (liliesFull || liliesNearlyFull))
+                    return AfflatusRapture;
 
-                        if (GetDebuffRemainingTime(dotDebuffID) <= refreshtimer &&
-                            GetTargetHPPercent() > Config.WHM_STDPS_MainCombo_DoT)
-                            return OriginalHook(Aero);
-                    }
+                if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Misery_oGCD) && LevelChecked(AfflatusMisery) &&
+                    gauge.BloodLily >= 3)
+                    return AfflatusMisery;
 
-                    // Glare IV
-                    if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_GlareIV)
-                        && HasEffect(Buffs.SacredSight)
-                        && GetBuffStacks(Buffs.SacredSight) > 0)
-                        return OriginalHook(Glare4);
-
-                    if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_LilyOvercap) && LevelChecked(AfflatusRapture) &&
-                        (liliesFull || liliesNearlyFull))
-                        return AfflatusRapture;
-
-                    if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Misery_oGCD) && LevelChecked(AfflatusMisery) &&
-                        gauge.BloodLily >= 3)
-                        return AfflatusMisery;
-
-                    return OriginalHook(Stone1);
-                }
+                return OriginalHook(Stone1);
             }
 
             return actionID;
@@ -254,65 +253,64 @@ internal partial class WHM
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Medica1)
-            {
-                bool thinAirReady = LevelChecked(ThinAir) && !HasEffect(Buffs.ThinAir) &&
-                                    GetRemainingCharges(ThinAir) > Config.WHM_AoEHeals_ThinAir;
-                bool canWeave = CanSpellWeave(0.3);
-                bool lucidReady = ActionReady(All.LucidDreaming) && LocalPlayer.CurrentMp <= Config.WHM_AoEHeals_Lucid;
+            if (actionID is not Medica1) return actionID;
 
-                bool plenaryReady = ActionReady(PlenaryIndulgence) &&
-                                    (!Config.WHM_AoEHeals_PlenaryWeave ||
-                                     (Config.WHM_AoEHeals_PlenaryWeave && canWeave));
-                bool divineCaressReady = ActionReady(DivineCaress) && HasEffect(Buffs.DivineGrace);
+            bool thinAirReady = LevelChecked(ThinAir) && !HasEffect(Buffs.ThinAir) &&
+                                GetRemainingCharges(ThinAir) > Config.WHM_AoEHeals_ThinAir;
+            bool canWeave = CanSpellWeave(0.3);
+            bool lucidReady = ActionReady(All.LucidDreaming) && LocalPlayer.CurrentMp <= Config.WHM_AoEHeals_Lucid;
 
-                bool assizeReady = ActionReady(Assize) &&
-                                   (!Config.WHM_AoEHeals_AssizeWeave || (Config.WHM_AoEHeals_AssizeWeave && canWeave));
+            bool plenaryReady = ActionReady(PlenaryIndulgence) &&
+                                (!Config.WHM_AoEHeals_PlenaryWeave ||
+                                 (Config.WHM_AoEHeals_PlenaryWeave && canWeave));
+            bool divineCaressReady = ActionReady(DivineCaress) && HasEffect(Buffs.DivineGrace);
 
-                IGameObject? healTarget = OptionalTarget ??
-                                          (Config.WHM_AoEHeals_MedicaMO
-                                              ? GetHealTarget(Config.WHM_AoEHeals_MedicaMO)
-                                              : LocalPlayer);
-                Status? hasMedica2 = FindEffect(Buffs.Medica2, healTarget, LocalPlayer?.GameObjectId);
-                Status? hasMedica3 = FindEffect(Buffs.Medica3, healTarget, LocalPlayer?.GameObjectId);
+            bool assizeReady = ActionReady(Assize) &&
+                               (!Config.WHM_AoEHeals_AssizeWeave || (Config.WHM_AoEHeals_AssizeWeave && canWeave));
 
-                if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Assize) && assizeReady)
-                    return Assize;
+            IGameObject? healTarget = OptionalTarget ??
+                                      (Config.WHM_AoEHeals_MedicaMO
+                                          ? GetHealTarget(Config.WHM_AoEHeals_MedicaMO)
+                                          : LocalPlayer);
+            Status? hasMedica2 = FindEffect(Buffs.Medica2, healTarget, LocalPlayer?.GameObjectId);
+            Status? hasMedica3 = FindEffect(Buffs.Medica3, healTarget, LocalPlayer?.GameObjectId);
 
-                if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Plenary) && plenaryReady)
-                    return PlenaryIndulgence;
+            if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Assize) && assizeReady)
+                return Assize;
 
-                if (IsEnabled(CustomComboPreset.WHM_AoEHeals_DivineCaress) && divineCaressReady)
-                    return OriginalHook(DivineCaress);
+            if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Plenary) && plenaryReady)
+                return PlenaryIndulgence;
 
-                if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Lucid) && canWeave && lucidReady)
-                    return All.LucidDreaming;
+            if (IsEnabled(CustomComboPreset.WHM_AoEHeals_DivineCaress) && divineCaressReady)
+                return OriginalHook(DivineCaress);
 
-                if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Misery) && gauge.BloodLily == 3)
-                    return AfflatusMisery;
+            if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Lucid) && canWeave && lucidReady)
+                return All.LucidDreaming;
 
-                if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Rapture) && LevelChecked(AfflatusRapture) &&
-                    gauge.Lily > 0)
-                    return AfflatusRapture;
+            if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Misery) && gauge.BloodLily == 3)
+                return AfflatusMisery;
 
-                if (IsEnabled(CustomComboPreset.WHM_AoEHeals_ThinAir) && thinAirReady)
-                    return ThinAir;
+            if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Rapture) && LevelChecked(AfflatusRapture) &&
+                gauge.Lily > 0)
+                return AfflatusRapture;
 
-                if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Medica2)
-                    && ((hasMedica2 == null && hasMedica3 == null) // No Medica buffs
-                        || (hasMedica2 != null &&
-                            hasMedica2.RemainingTime <=
-                            Config.WHM_AoEHeals_MedicaTime) // Medica buff, but falling off soon
-                        || (hasMedica3 != null && hasMedica3.RemainingTime <= Config.WHM_AoEHeals_MedicaTime)) // ^
-                    && (ActionReady(Medica2) || ActionReady(Medica3)))
-                    return LevelChecked(Medica3) ? Medica3 : Medica2;
+            if (IsEnabled(CustomComboPreset.WHM_AoEHeals_ThinAir) && thinAirReady)
+                return ThinAir;
 
-                if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Cure3)
-                    && ActionReady(Cure3)
-                    && (LocalPlayer.CurrentMp >= Config.WHM_AoEHeals_Cure3MP
-                        || HasEffect(Buffs.ThinAir)))
-                    return Cure3;
-            }
+            if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Medica2)
+                && ((hasMedica2 == null && hasMedica3 == null) // No Medica buffs
+                    || (hasMedica2 != null &&
+                        hasMedica2.RemainingTime <=
+                        Config.WHM_AoEHeals_MedicaTime) // Medica buff, but falling off soon
+                    || (hasMedica3 != null && hasMedica3.RemainingTime <= Config.WHM_AoEHeals_MedicaTime)) // ^
+                && (ActionReady(Medica2) || ActionReady(Medica3)))
+                return LevelChecked(Medica3) ? Medica3 : Medica2;
+
+            if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Cure3)
+                && ActionReady(Cure3)
+                && (LocalPlayer.CurrentMp >= Config.WHM_AoEHeals_Cure3MP
+                    || HasEffect(Buffs.ThinAir)))
+                return Cure3;
 
             return actionID;
         }
@@ -324,49 +322,48 @@ internal partial class WHM
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Cure)
+            if (actionID is not Cure) return actionID;
+
+            IGameObject? healTarget = OptionalTarget ?? GetHealTarget(Config.WHM_STHeals_UIMouseOver);
+
+            bool thinAirReady = LevelChecked(ThinAir) && !HasEffect(Buffs.ThinAir) &&
+                                GetRemainingCharges(ThinAir) > Config.WHM_STHeals_ThinAir;
+
+            bool regenReady = ActionReady(Regen) && (FindEffectOnMember(Buffs.Regen, healTarget) is null ||
+                                                     FindEffectOnMember(Buffs.Regen, healTarget)?.RemainingTime <=
+                                                     Config.WHM_STHeals_RegenTimer);
+
+            if (IsEnabled(CustomComboPreset.WHM_STHeals_Esuna) && ActionReady(All.Esuna) &&
+                GetTargetHPPercent(healTarget, Config.WHM_STHeals_IncludeShields) >= Config.WHM_STHeals_Esuna &&
+                HasCleansableDebuff(healTarget))
+                return All.Esuna;
+
+            if (IsEnabled(CustomComboPreset.WHM_STHeals_Lucid) &&
+                All.CanUseLucid(actionID, Config.WHM_STHeals_Lucid))
+                return All.LucidDreaming;
+
+            foreach (int prio in Config.WHM_ST_Heals_Priority.Items.OrderBy(x => x))
             {
-                IGameObject? healTarget = OptionalTarget ?? GetHealTarget(Config.WHM_STHeals_UIMouseOver);
+                int index = Config.WHM_ST_Heals_Priority.IndexOf(prio);
+                int config = WHMHelper.GetMatchingConfigST(index, OptionalTarget, out uint spell, out bool enabled);
 
-                bool thinAirReady = LevelChecked(ThinAir) && !HasEffect(Buffs.ThinAir) &&
-                                    GetRemainingCharges(ThinAir) > Config.WHM_STHeals_ThinAir;
-
-                bool regenReady = ActionReady(Regen) && (FindEffectOnMember(Buffs.Regen, healTarget) is null ||
-                                                         FindEffectOnMember(Buffs.Regen, healTarget)?.RemainingTime <=
-                                                         Config.WHM_STHeals_RegenTimer);
-
-                if (IsEnabled(CustomComboPreset.WHM_STHeals_Esuna) && ActionReady(All.Esuna) &&
-                    GetTargetHPPercent(healTarget, Config.WHM_STHeals_IncludeShields) >= Config.WHM_STHeals_Esuna &&
-                    HasCleansableDebuff(healTarget))
-                    return All.Esuna;
-
-                if (IsEnabled(CustomComboPreset.WHM_STHeals_Lucid) &&
-                    All.CanUseLucid(actionID, Config.WHM_STHeals_Lucid))
-                    return All.LucidDreaming;
-
-                foreach (int prio in Config.WHM_ST_Heals_Priority.Items.OrderBy(x => x))
-                {
-                    int index = Config.WHM_ST_Heals_Priority.IndexOf(prio);
-                    int config = WHMHelper.GetMatchingConfigST(index, OptionalTarget, out uint spell, out bool enabled);
-
-                    if (enabled)
-                        if (GetTargetHPPercent(healTarget, Config.WHM_STHeals_IncludeShields) <= config &&
-                            ActionReady(spell))
-                            return spell;
-                }
-
-                if (IsEnabled(CustomComboPreset.WHM_STHeals_Regen) && regenReady)
-                    return Regen;
-
-                if (IsEnabled(CustomComboPreset.WHM_STHeals_Solace) && gauge.Lily > 0 && ActionReady(AfflatusSolace))
-                    return AfflatusSolace;
-
-                if (IsEnabled(CustomComboPreset.WHM_STHeals_ThinAir) && thinAirReady)
-                    return ThinAir;
-
-                if (ActionReady(Cure2))
-                    return Cure2;
+                if (enabled)
+                    if (GetTargetHPPercent(healTarget, Config.WHM_STHeals_IncludeShields) <= config &&
+                        ActionReady(spell))
+                        return spell;
             }
+
+            if (IsEnabled(CustomComboPreset.WHM_STHeals_Regen) && regenReady)
+                return Regen;
+
+            if (IsEnabled(CustomComboPreset.WHM_STHeals_Solace) && gauge.Lily > 0 && ActionReady(AfflatusSolace))
+                return AfflatusSolace;
+
+            if (IsEnabled(CustomComboPreset.WHM_STHeals_ThinAir) && thinAirReady)
+                return ThinAir;
+
+            if (ActionReady(Cure2))
+                return Cure2;
 
             return actionID;
         }
@@ -380,62 +377,61 @@ internal partial class WHM
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Holy or Holy3)
+            if (actionID is not (Holy or Holy3)) return actionID;
+
+            bool liliesFullNoBlood = gauge.Lily == 3 && gauge.BloodLily < 3;
+            bool liliesNearlyFull = gauge.Lily == 2 && gauge.LilyTimer >= 17000;
+            bool PresenceOfMindReady = ActionReady(PresenceOfMind) && !Config.WHM_AoEDPS_PresenceOfMindWeave;
+
+            if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_SwiftHoly) &&
+                ActionReady(All.Swiftcast) &&
+                AssizeCount == 0 && !IsMoving() && InCombat())
+                return All.Swiftcast;
+
+            if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_SwiftHoly) &&
+                WasLastAction(All.Swiftcast))
+                return actionID;
+
+            if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_Assize) && ActionReady(Assize))
+                return Assize;
+
+            if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_PresenceOfMind) && PresenceOfMindReady)
+                return PresenceOfMind;
+
+            if (IsEnabled(CustomComboPreset.WHM_DPS_Variant_Rampart) &&
+                IsEnabled(Variant.VariantRampart) &&
+                IsOffCooldown(Variant.VariantRampart))
+                return Variant.VariantRampart;
+
+            if (IsEnabled(CustomComboPreset.WHM_DPS_Variant_SpiritDart) &&
+                IsEnabled(Variant.VariantSpiritDart) &&
+                GetDebuffRemainingTime(Variant.Debuffs.SustainedDamage) <= 3 &&
+                HasBattleTarget())
+                return Variant.VariantSpiritDart;
+
+            if (CanSpellWeave() || IsMoving())
             {
-                bool liliesFullNoBlood = gauge.Lily == 3 && gauge.BloodLily < 3;
-                bool liliesNearlyFull = gauge.Lily == 2 && gauge.LilyTimer >= 17000;
-                bool PresenceOfMindReady = ActionReady(PresenceOfMind) && !Config.WHM_AoEDPS_PresenceOfMindWeave;
-
-                if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_SwiftHoly) &&
-                    ActionReady(All.Swiftcast) &&
-                    AssizeCount == 0 && !IsMoving() && InCombat())
-                    return All.Swiftcast;
-
-                if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_SwiftHoly) &&
-                    WasLastAction(All.Swiftcast))
-                    return actionID;
-
-                if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_Assize) && ActionReady(Assize))
-                    return Assize;
-
-                if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_PresenceOfMind) && PresenceOfMindReady)
+                if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_PresenceOfMind) && ActionReady(PresenceOfMind))
                     return PresenceOfMind;
 
-                if (IsEnabled(CustomComboPreset.WHM_DPS_Variant_Rampart) &&
-                    IsEnabled(Variant.VariantRampart) &&
-                    IsOffCooldown(Variant.VariantRampart))
-                    return Variant.VariantRampart;
-
-                if (IsEnabled(CustomComboPreset.WHM_DPS_Variant_SpiritDart) &&
-                    IsEnabled(Variant.VariantSpiritDart) &&
-                    GetDebuffRemainingTime(Variant.Debuffs.SustainedDamage) <= 3 &&
-                    HasBattleTarget())
-                    return Variant.VariantSpiritDart;
-
-                if (CanSpellWeave() || IsMoving())
-                {
-                    if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_PresenceOfMind) && ActionReady(PresenceOfMind))
-                        return PresenceOfMind;
-
-                    if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_Lucid) && ActionReady(All.LucidDreaming) &&
-                        LocalPlayer.CurrentMp <= Config.WHM_AoEDPS_Lucid)
-                        return All.LucidDreaming;
-                }
-
-                // Glare IV
-                if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_GlareIV)
-                    && HasEffect(Buffs.SacredSight)
-                    && GetBuffStacks(Buffs.SacredSight) > 0)
-                    return OriginalHook(Glare4);
-
-                if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_LilyOvercap) && LevelChecked(AfflatusRapture) &&
-                    (liliesFullNoBlood || liliesNearlyFull))
-                    return AfflatusRapture;
-
-                if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_Misery) && LevelChecked(AfflatusMisery) &&
-                    gauge.BloodLily >= 3 && HasBattleTarget())
-                    return AfflatusMisery;
+                if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_Lucid) && ActionReady(All.LucidDreaming) &&
+                    LocalPlayer.CurrentMp <= Config.WHM_AoEDPS_Lucid)
+                    return All.LucidDreaming;
             }
+
+            // Glare IV
+            if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_GlareIV)
+                && HasEffect(Buffs.SacredSight)
+                && GetBuffStacks(Buffs.SacredSight) > 0)
+                return OriginalHook(Glare4);
+
+            if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_LilyOvercap) && LevelChecked(AfflatusRapture) &&
+                (liliesFullNoBlood || liliesNearlyFull))
+                return AfflatusRapture;
+
+            if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_Misery) && LevelChecked(AfflatusMisery) &&
+                gauge.BloodLily >= 3 && HasBattleTarget())
+                return AfflatusMisery;
 
             return actionID;
         }


### PR DESCRIPTION
> Apologies for doing this after the codeowner addition, but it needed to be after a full merge.

The point of this endeavor was to ensure that all combos had action checks **before** logic started being applied, which is a drain on FPS.
While doing this, I also made all of the action checks consistent with each other in the following ways:
- Inverted any that had nesting
- Used "is" verbage for all of them, since that is what was dominant, and it is the same IL code in these cases

In doing this, <ins>**11**</ins> combos were fixed to no longer do any substantial logic before checking the action, <ins>**2**</ins> of which were particularly egregious
Just for reference, these combos were across:
- DNC
- MCH
- PCT
- RDM
- RPR
- SGE !
- SMN !

Most of these changes were very much a simple inversion, only RDM, SMN, and MCH need to be double-checked.