### PR TITLE
[Tanks] update One-Button Mitigations to have more HP% checks

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6102,10 +6102,6 @@ public enum CustomComboPreset
     [ParentCombo(WAR_Mit_OneButton)]
     [CustomComboInfo("Vengeance Option", "Adds Vengeance to the one-button mitigation.", WAR.JobID)]
     WAR_Mit_Vengeance = 18054,
-
-    [ParentCombo(WAR_Mit_OneButton)]
-    [CustomComboInfo("Holmgang Option", "Adds Holmgang to the one-button mitigation.", WAR.JobID)]
-    WAR_Mit_Holmgang = 18059,
     #endregion
 
     #region Misc

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -2315,10 +2315,6 @@ public enum CustomComboPreset
     [ParentCombo(GNB_Mit_OneButton)]
     [CustomComboInfo("Nebula Option", "Adds Nebula to the one-button mitigation.", GNB.JobID)]
     GNB_Mit_Nebula = 7083,
-
-    [ParentCombo(GNB_Mit_OneButton)]
-    [CustomComboInfo("Superbolide Option", "Adds Superbolide to the one-button mitigation.", GNB.JobID)]
-    GNB_Mit_Superbolide = 7084,
     #endregion
 
     #region Gnashing Fang

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1718,10 +1718,6 @@ public enum CustomComboPreset
     [CustomComboInfo("Shadow Wall / Vigil Option", "Adds Shadow Wall / Vigil to the one-button mitigation.", DRK.JobID)]
     DRK_Mit_ShadowWall = 5051,
 
-    [ParentCombo(DRK_Mit_OneButton)]
-    [CustomComboInfo("Living Dead Option", "Adds Living Dead to the one-button mitigation.", DRK.JobID)]
-    DRK_Mit_LivingDead = 5052,
-
     #endregion
 
     // Last value = 5052

--- a/WrathCombo/Combos/PvE/DRK/DRK.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK.cs
@@ -532,6 +532,15 @@ internal partial class DRK
         {
             if (actionID is not DarkMind) return actionID;
 
+            if (IsEnabled(CustomComboPreset.DRK_Mit_LivingDead_Max) &&
+                ActionReady(LivingDead) &&
+                PlayerHealthPercentageHp() <= Config.DRK_Mit_LivingDead_Health &&
+                ContentCheck.IsInConfiguredContent(
+                    Config.DRK_Mit_EmergencyLivingDead_Difficulty,
+                    Config.DRK_Mit_EmergencyLivingDead_DifficultyListSet
+                ))
+                return LivingDead;
+
             foreach (var priority in Config.DRK_Mit_Priorities.Items.OrderBy(x => x))
             {
                 var index = Config.DRK_Mit_Priorities.IndexOf(priority);

--- a/WrathCombo/Combos/PvE/DRK/DRK_Config.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Config.cs
@@ -1,7 +1,6 @@
 #region
 
 using System.Numerics;
-using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility;
 using ECommons.ImGuiMethods;
 using ImGuiNET;
@@ -194,28 +193,24 @@ internal partial class DRK
 
                 case CustomComboPreset.DRK_Mit_LivingDead_Max:
                     UserConfig.DrawDifficultyMultiChoice(
-                        DRK_Mit_LivingDead_Difficulty,
-                        DRK_Mit_LivingDead_DifficultyListSet,
-                        "Select what difficulties Living Dead should be used in:"
+                        DRK_Mit_EmergencyLivingDead_Difficulty,
+                        DRK_Mit_EmergencyLivingDead_DifficultyListSet,
+                        "Select what difficulties Emergency Living Dead should be used in:"
                     );
 
                     UserConfig.DrawSliderInt(5, 30, DRK_Mit_LivingDead_Health,
                         startUsingAtDescription,
                         itemWidth: medium, sliderIncrement: SliderIncrements.Fives);
 
-                    ImGui.BeginDisabled();
-                    UserConfig.DrawPriorityInput(DRK_Mit_Priorities,
-                        numberMitigationOptions, 0,
-                        "Emergency Living Dead Priority:");
-                    ImGui.EndDisabled();
-                    if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-                        ImGui.SetTooltip("Should always be 1, the highest priority");
-
                     break;
 
                 case CustomComboPreset.DRK_Mit_TheBlackestNight:
+                    UserConfig.DrawSliderInt(10, 100, DRK_Mit_TBN_Health,
+                        startUsingAtDescription + " (100 = Disable check)",
+                        itemWidth: medium, sliderIncrement: SliderIncrements.Tens);
+
                     UserConfig.DrawPriorityInput(DRK_Mit_Priorities,
-                        numberMitigationOptions, 1,
+                        numberMitigationOptions, 0,
                         "The Blackest Night Priority:");
 
                     break;
@@ -226,14 +221,14 @@ internal partial class DRK
                         itemWidth: little, sliderIncrement: SliderIncrements.Ones);
 
                     UserConfig.DrawPriorityInput(DRK_Mit_Priorities,
-                        numberMitigationOptions, 2,
+                        numberMitigationOptions, 1,
                         "Oblation Priority:");
 
                     break;
 
                 case CustomComboPreset.DRK_Mit_Reprisal:
                     UserConfig.DrawPriorityInput(DRK_Mit_Priorities,
-                        numberMitigationOptions, 3,
+                        numberMitigationOptions, 2,
                         "Reprisal Priority:");
 
                     break;
@@ -253,21 +248,25 @@ internal partial class DRK
                         outputValue: (int)PartyRequirement.No, itemWidth: medium);
 
                     UserConfig.DrawPriorityInput(DRK_Mit_Priorities,
-                        numberMitigationOptions, 4,
+                        numberMitigationOptions, 3,
                         "Dark Missionary Priority:");
 
                     break;
 
                 case CustomComboPreset.DRK_Mit_Rampart:
+                    UserConfig.DrawSliderInt(40, 100, DRK_Mit_Rampart_Health,
+                        startUsingAtDescription + " (100 = Disable check)",
+                        itemWidth: medium, sliderIncrement: SliderIncrements.Fives);
+
                     UserConfig.DrawPriorityInput(DRK_Mit_Priorities,
-                        numberMitigationOptions, 5,
+                        numberMitigationOptions, 4,
                         "Rampart Priority:");
 
                     break;
 
                 case CustomComboPreset.DRK_Mit_DarkMind:
                     UserConfig.DrawPriorityInput(DRK_Mit_Priorities,
-                        numberMitigationOptions, 6,
+                        numberMitigationOptions, 5,
                         "Dark Mind Priority:");
 
                     break;
@@ -289,36 +288,19 @@ internal partial class DRK
                         itemWidth: little, sliderIncrement: SliderIncrements.Ones);
 
                     UserConfig.DrawPriorityInput(DRK_Mit_Priorities,
-                        numberMitigationOptions, 7,
+                        numberMitigationOptions, 6,
                         "Arm's Length Priority:");
 
                     break;
 
                 case CustomComboPreset.DRK_Mit_ShadowWall:
+                    UserConfig.DrawSliderInt(30, 100, DRK_Mit_ShadowWall_Health,
+                        startUsingAtDescription + " (100 = Disable check)",
+                        itemWidth: medium, sliderIncrement: SliderIncrements.Fives);
+
                     UserConfig.DrawPriorityInput(DRK_Mit_Priorities,
-                        numberMitigationOptions, 8,
+                        numberMitigationOptions, 7,
                         "Shadow Wall / Vigil Priority:");
-
-                    break;
-
-                case CustomComboPreset.DRK_Mit_LivingDead:
-                    if (CustomComboFunctions.IsEnabled(CustomComboPreset.DRK_Mit_LivingDead_Max))
-                    {
-                        ImGui.TextColored(ImGuiColors.DalamudYellow,
-                            "Select what difficulties Living Dead should be used in above,");
-                        ImGui.TextColored(ImGuiColors.DalamudYellow,
-                            "under the 'Emergency Living Dead' option.");
-                    }
-                    else
-                        UserConfig.DrawDifficultyMultiChoice(
-                            DRK_Mit_LivingDead_Difficulty,
-                            DRK_Mit_LivingDead_DifficultyListSet,
-                            "Select what difficulties Living Dead should be used in:"
-                        );
-
-                    UserConfig.DrawPriorityInput(DRK_Mit_Priorities,
-                        numberMitigationOptions, 9,
-                        "Living Dead Priority:");
 
                     break;
 
@@ -329,7 +311,7 @@ internal partial class DRK
         #region Constants
 
         /// Number of Mitigation Options
-        private const int numberMitigationOptions = 10;
+        private const int numberMitigationOptions = 8;
 
         /// Smallest bar width
         private const float little = 100f;
@@ -699,11 +681,57 @@ internal partial class DRK
         #region One-Button Mitigation
 
         /// <summary>
-        ///    Mitigation Ability Priority List.
+        ///     Difficulty of Emergency Living Dead for Mitigation.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: <see cref="ContentCheck.BottomHalfContent" /> <br />
+        ///     <b>Options</b>: <see cref="ContentCheck.BottomHalfContent" />
+        ///     and/or <see cref="ContentCheck.TopHalfContent" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.DRK_Mit_LivingDead_Max" />
+        public static readonly UserBoolArray
+            DRK_Mit_EmergencyLivingDead_Difficulty =
+                new("DRK_Mit_EmergencyLivingDead_Difficulty", [true, false]);
+
+        /// <summary>
+        ///     What Difficulty List Set
+        ///     <see cref="DRK_Mit_EmergencyLivingDead_Difficulty" /> is set to.
+        /// </summary>
+        /// <seealso cref="CustomComboPreset.DRK_Mit_LivingDead_Max" />
+        public static readonly ContentCheck.ListSet
+            DRK_Mit_EmergencyLivingDead_DifficultyListSet =
+                ContentCheck.ListSet.Halved;
+
+        /// <summary>
+        ///     Self HP% to use Living Dead below in the Mitigation Rotation.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 20 <br />
+        ///     <b>Range</b>: 5 - 30 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Fives" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.DRK_Mit_LivingDead_Max" />
+        public static UserInt DRK_Mit_LivingDead_Health =
+            new("DRK_Mit_LivingDead_Health", 20);
+
+        /// <summary>
+        ///     Mitigation Ability Priority List.
         /// </summary>
         public static readonly UserIntArray
             DRK_Mit_Priorities =
                 new("DRK_Mit_Priorities");
+
+        /// <summary>
+        ///     Self HP% to use The Blackest Night below in the Mitigation Rotation.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 60 <br />
+        ///     <b>Range</b>: 10 - 100 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Tens" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.DRK_Mit_TheBlackestNight" />
+        public static UserInt DRK_Mit_TBN_Health =
+            new("DRK_Mit_TBN_Health", 60);
 
         /// <summary>
         ///     Party requirement for using Dark Missionary in the Mitigation Rotation.
@@ -716,6 +744,18 @@ internal partial class DRK
             DRK_Mit_DarkMissionary_PartyRequirement =
                 new("DRK_Mit_DarkMissionary_PartyRequirement",
                     (int)PartyRequirement.Yes);
+
+        /// <summary>
+        ///     Self HP% to use Rampart below in the Mitigation Rotation.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 65 <br />
+        ///     <b>Range</b>: 40 - 100 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Fives" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.DRK_Mit_Rampart" />
+        public static UserInt DRK_Mit_Rampart_Health =
+            new("DRK_Mit_Rampart_Health", 65);
 
         /// <summary>
         ///     Arm's Length Boss Restriction for Mitigation.
@@ -741,40 +781,16 @@ internal partial class DRK
             new("DRK_Mit_ArmsLength_EnemyCount", 0);
 
         /// <summary>
-        ///     Difficulty of Living Dead for Mitigation.
+        ///     Self HP% to use Shadow Wall below in the Mitigation Rotation.
         /// </summary>
         /// <value>
-        ///     <b>Default</b>: <see cref="ContentCheck.BottomHalfContent" /> <br />
-        ///     <b>Options</b>: <see cref="ContentCheck.BottomHalfContent" />
-        ///     and/or <see cref="ContentCheck.TopHalfContent" />
-        /// </value>
-        /// <seealso cref="CustomComboPreset.DRK_Mit_LivingDead_Max" />
-        /// <seealso cref="CustomComboPreset.DRK_Mit_LivingDead" />
-        public static readonly UserBoolArray
-            DRK_Mit_LivingDead_Difficulty =
-                new("DRK_Mit_LivingDead_Difficulty", [true, false]);
-
-        /// <summary>
-        ///     What Difficulty List Set
-        ///     <see cref="DRK_Mit_LivingDead_Difficulty" /> is set to.
-        /// </summary>
-        /// <seealso cref="CustomComboPreset.DRK_Mit_LivingDead_Max" />
-        /// <seealso cref="CustomComboPreset.DRK_Mit_LivingDead" />
-        public static readonly ContentCheck.ListSet
-            DRK_Mit_LivingDead_DifficultyListSet =
-                ContentCheck.ListSet.Halved;
-
-        /// <summary>
-        ///     Self HP% to use Living Dead below in the Mitigation Rotation.
-        /// </summary>
-        /// <value>
-        ///     <b>Default</b>: 20 <br />
-        ///     <b>Range</b>: 5 - 30 <br />
+        ///     <b>Default</b>: 45 <br />
+        ///     <b>Range</b>: 30 - 100 <br />
         ///     <b>Step</b>: <see cref="SliderIncrements.Fives" />
         /// </value>
-        /// <seealso cref="CustomComboPreset.DRK_Mit_LivingDead_Max" />
-        public static UserInt DRK_Mit_LivingDead_Health =
-            new("DRK_Mit_LivingDead_Health", 20);
+        /// <seealso cref="CustomComboPreset.DRK_Mit_ShadowWall" />
+        public static UserInt DRK_Mit_ShadowWall_Health =
+            new("DRK_Mit_ShadowWall_Health", 45);
 
         /// <summary>
         ///     The number of Oblation charges to keep for manual use.

--- a/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
@@ -145,14 +145,9 @@ internal partial class DRK
     private static (uint Action, CustomComboPreset Preset, System.Func<bool> Logic)[]
         PrioritizedMitigation =>
     [
-        (LivingDead, CustomComboPreset.DRK_Mit_LivingDead_Max,
-            () => PlayerHealthPercentageHp() <= Config.DRK_Mit_LivingDead_Health &&
-                  ContentCheck.IsInConfiguredContent(
-                      Config.DRK_Mit_LivingDead_Difficulty,
-                      Config.DRK_Mit_LivingDead_DifficultyListSet
-                  )),
         (BlackestNight, CustomComboPreset.DRK_Mit_TheBlackestNight,
-            () => !HasAnyTBN && LocalPlayer.CurrentMp > 3000),
+            () => !HasAnyTBN && LocalPlayer.CurrentMp > 3000 &&
+                  PlayerHealthPercentageHp() <= Config.DRK_Mit_TBN_Health),
         (Oblation, CustomComboPreset.DRK_Mit_Oblation,
             () => (!((HasFriendlyTarget() && TargetHasEffectAny(Buffs.Oblation)) ||
                      (!HasFriendlyTarget() && HasEffectAny(Buffs.Oblation)))) &&
@@ -163,18 +158,15 @@ internal partial class DRK
             () => Config.DRK_Mit_DarkMissionary_PartyRequirement ==
                   (int)Config.PartyRequirement.No ||
                   IsInParty()),
-        (All.Rampart, CustomComboPreset.DRK_Mit_Rampart, () => true),
+        (All.Rampart, CustomComboPreset.DRK_Mit_Rampart,
+            () => PlayerHealthPercentageHp() <= Config.DRK_Mit_Rampart_Health),
         (DarkMind, CustomComboPreset.DRK_Mit_DarkMind, () => true),
         (All.ArmsLength, CustomComboPreset.DRK_Mit_ArmsLength,
             () => CanCircleAoe(7) >= Config.DRK_Mit_ArmsLength_EnemyCount &&
                   (Config.DRK_Mit_ArmsLength_Boss == (int)Config.BossAvoidance.Off ||
                    InBossEncounter())),
-        (OriginalHook(ShadowWall), CustomComboPreset.DRK_Mit_ShadowWall, () => true),
-        (LivingDead, CustomComboPreset.DRK_Mit_LivingDead,
-            () => ContentCheck.IsInConfiguredContent(
-                Config.DRK_Mit_LivingDead_Difficulty,
-                Config.DRK_Mit_LivingDead_DifficultyListSet
-            )),
+        (OriginalHook(ShadowWall), CustomComboPreset.DRK_Mit_ShadowWall,
+            () => PlayerHealthPercentageHp() <= Config.DRK_Mit_ShadowWall_Health),
     ];
 
     /// <summary>
@@ -197,7 +189,7 @@ internal partial class DRK
         (int index, out uint action)
     {
         action = PrioritizedMitigation[index].Action;
-        return ActionReady(action) && LevelChecked(action) &&
+        return ActionReady(action) &&
                PrioritizedMitigation[index].Logic() &&
                IsEnabled(PrioritizedMitigation[index].Preset);
     }

--- a/WrathCombo/Combos/PvE/GNB/GNB.cs
+++ b/WrathCombo/Combos/PvE/GNB/GNB.cs
@@ -6,6 +6,7 @@ using Dalamud.Game.ClientState.Statuses;
 using WrathCombo.Combos.PvE.Content;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
+using WrathCombo.Data;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 #endregion
 
@@ -2522,6 +2523,15 @@ namespace WrathCombo.Combos.PvE
             protected override uint Invoke(uint actionID)
             {
                 if (actionID is not Camouflage) return actionID;
+
+                if (IsEnabled(CustomComboPreset.GNB_Mit_Superbolide_Max) &&
+                    ActionReady(Superbolide) &&
+                    PlayerHealthPercentageHp() <= Config.GNB_Mit_Superbolide_Health &&
+                    ContentCheck.IsInConfiguredContent(
+                        Config.GNB_Mit_Superbolide_Difficulty,
+                        Config.GNB_Mit_Superbolide_DifficultyListSet
+                    ))
+                    return Superbolide;
 
                 foreach (var priority in Config.GNB_Mit_Priorities.Items.OrderBy(x => x))
                 {

--- a/WrathCombo/Combos/PvE/GNB/GNB_Config.cs
+++ b/WrathCombo/Combos/PvE/GNB/GNB_Config.cs
@@ -13,7 +13,7 @@ internal partial class GNB
 {
     internal static class Config
     {
-        private const int numberMitigationOptions = 10;
+        private const int numberMitigationOptions = 8;
 
         internal enum PartyRequirement
         {
@@ -73,10 +73,14 @@ internal partial class GNB
 
             //One-Button Mitigation
             GNB_Mit_Superbolide_Health = new("GNB_Mit_Superbolide_Health", 30),
+            GNB_Mit_Corundum_Health = new("GNB_Mit_Corundum_Health", 60),
             GNB_Mit_Aurora_Charges = new("GNB_Mit_Aurora_Charges", 0),
+            GNB_Mit_Aurora_Health = new("GNB_Mit_Aurora_Health", 60),
             GNB_Mit_HeartOfLight_PartyRequirement = new("GNB_Mit_HeartOfLight_PartyRequirement", (int)PartyRequirement.Yes),
+            GNB_Mit_Rampart_Health = new("GNB_Mit_Rampart_Health", 65),
             GNB_Mit_ArmsLength_Boss = new("GNB_Mit_ArmsLength_Boss", (int)BossAvoidance.On),
             GNB_Mit_ArmsLength_EnemyCount = new("GNB_Mit_ArmsLength_EnemyCount", 0),
+            GNB_Mit_Nebula_Health = new("GNB_Mit_Nebula_Health", 50),
 
             //Bozja
             GNB_Bozja_LostCure_Health = new("GNB_Bozja_LostCure_Health", 50),
@@ -357,19 +361,15 @@ internal partial class GNB
                     UserConfig.DrawSliderInt(5, 30, GNB_Mit_Superbolide_Health,
                         "Player HP% to be \nless than or equal to:",
                         200, SliderIncrements.Fives);
-
-                    ImGui.BeginDisabled();
-                    UserConfig.DrawPriorityInput(GNB_Mit_Priorities,
-                        numberMitigationOptions, 0,
-                        "Emergency Superbolide Priority:");
-                    ImGui.EndDisabled();
-                    if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-                        ImGui.SetTooltip("Should always be 1, the highest priority");
                     break;
 
                 case CustomComboPreset.GNB_Mit_Corundum:
+                    UserConfig.DrawSliderInt(60, 100, GNB_Mit_Corundum_Health,
+                        "HP% to use at or below (100 = Disable check)",
+                        sliderIncrement: SliderIncrements.Fives);
+
                     UserConfig.DrawPriorityInput(GNB_Mit_Priorities,
-                        numberMitigationOptions, 1,
+                        numberMitigationOptions, 0,
                         "Heart of Corundum Priority:");
                     break;
 
@@ -377,20 +377,24 @@ internal partial class GNB
                     UserConfig.DrawSliderInt(0, 1, GNB_Mit_Aurora_Charges,
                         "How many charges to keep ready?\n (0 = Use All)");
 
+                    UserConfig.DrawSliderInt(40, 100, GNB_Mit_Aurora_Health,
+                        "HP% to use at or below (100 = Disable check)",
+                        sliderIncrement: SliderIncrements.Fives);
+
                     UserConfig.DrawPriorityInput(GNB_Mit_Priorities,
-                        numberMitigationOptions, 2,
+                        numberMitigationOptions, 1,
                         "Aurora Priority:");
                     break;
 
                 case CustomComboPreset.GNB_Mit_Camouflage:
                     UserConfig.DrawPriorityInput(GNB_Mit_Priorities,
-                        numberMitigationOptions, 3,
+                        numberMitigationOptions, 2,
                         "Camouflage Priority:");
                     break;
 
                 case CustomComboPreset.GNB_Mit_Reprisal:
                     UserConfig.DrawPriorityInput(GNB_Mit_Priorities,
-                        numberMitigationOptions, 4,
+                        numberMitigationOptions, 3,
                         "Reprisal Priority:");
                     break;
 
@@ -409,13 +413,17 @@ internal partial class GNB
                         outputValue: (int)PartyRequirement.No);
 
                     UserConfig.DrawPriorityInput(GNB_Mit_Priorities,
-                        numberMitigationOptions, 5,
+                        numberMitigationOptions, 4,
                         "Heart of Light Priority:");
                     break;
 
                 case CustomComboPreset.GNB_Mit_Rampart:
+                    UserConfig.DrawSliderInt(40, 100, GNB_Mit_Rampart_Health,
+                        "HP% to use at or below (100 = Disable check)",
+                        sliderIncrement: SliderIncrements.Fives);
+
                     UserConfig.DrawPriorityInput(GNB_Mit_Priorities,
-                        numberMitigationOptions, 6,
+                        numberMitigationOptions, 5,
                         "Rampart Priority:");
                     break;
 
@@ -435,34 +443,18 @@ internal partial class GNB
                         "How many enemies should be nearby? (0 = No Requirement)");
 
                     UserConfig.DrawPriorityInput(GNB_Mit_Priorities,
-                        numberMitigationOptions, 7,
+                        numberMitigationOptions, 6,
                         "Arm's Length Priority:");
                     break;
 
                 case CustomComboPreset.GNB_Mit_Nebula:
+                    UserConfig.DrawSliderInt(40, 100, GNB_Mit_Nebula_Health,
+                        "HP% to use at or below (100 = Disable check)",
+                        sliderIncrement: SliderIncrements.Fives);
+
                     UserConfig.DrawPriorityInput(GNB_Mit_Priorities,
-                        numberMitigationOptions, 8,
+                        numberMitigationOptions, 7,
                         "Arm's Length Priority:");
-                    break;
-
-                case CustomComboPreset.GNB_Mit_Superbolide:
-                    if (CustomComboFunctions.IsEnabled(CustomComboPreset.GNB_Mit_Superbolide_Max))
-                    {
-                        ImGui.TextColored(ImGuiColors.DalamudYellow,
-                            "Select what difficulties Superbolide should be used in above,");
-                        ImGui.TextColored(ImGuiColors.DalamudYellow,
-                            "under the 'Emergency Superbolide' option.");
-                    }
-                    else
-                        UserConfig.DrawDifficultyMultiChoice(
-                            GNB_Mit_Superbolide_Difficulty,
-                            GNB_Mit_Superbolide_DifficultyListSet,
-                            "Select what difficulties Superbolide should be used in:"
-                        );
-
-                    UserConfig.DrawPriorityInput(GNB_Mit_Priorities,
-                        numberMitigationOptions, 9,
-                        "Superbolide Priority:");
                     break;
 
                 #endregion

--- a/WrathCombo/Combos/PvE/GNB/GNB_Helper.cs
+++ b/WrathCombo/Combos/PvE/GNB/GNB_Helper.cs
@@ -47,22 +47,17 @@ internal partial class GNB
     private static (uint Action, CustomComboPreset Preset, System.Func<bool> Logic)[]
         PrioritizedMitigation =>
     [
-        //Emergency Superbolide
-        (Superbolide, CustomComboPreset.GNB_Mit_Superbolide_Max,
-            () => PlayerHealthPercentageHp() <= Config.GNB_Mit_Superbolide_Health &&
-                  ContentCheck.IsInConfiguredContent(
-                      Config.GNB_Mit_Superbolide_Difficulty,
-                      Config.GNB_Mit_Superbolide_DifficultyListSet
-                  )),
         //Heart of Corundum
         (OriginalHook(HeartOfStone), CustomComboPreset.GNB_Mit_Corundum,
             () => FindEffect(Buffs.HeartOfCorundum) is null &&
-                  FindEffect(Buffs.HeartOfStone) is null),
+                  FindEffect(Buffs.HeartOfStone) is null &&
+                  PlayerHealthPercentageHp() <= Config.GNB_Mit_Corundum_Health),
         //Aurora
         (Aurora, CustomComboPreset.GNB_Mit_Aurora,
             () => (!((HasFriendlyTarget() && TargetHasEffectAny(Buffs.Aurora)) ||
                      (!HasFriendlyTarget() && HasEffectAny(Buffs.Aurora)))) &&
-                  GetRemainingCharges(Aurora) > Config.GNB_Mit_Aurora_Charges),
+                  GetRemainingCharges(Aurora) > Config.GNB_Mit_Aurora_Charges &&
+                  PlayerHealthPercentageHp() <= Config.GNB_Mit_Aurora_Health),
         //Camouflage
         (Camouflage, CustomComboPreset.GNB_Mit_Camouflage, () => true),
         // Reprisal
@@ -74,20 +69,16 @@ internal partial class GNB
                   (int)Config.PartyRequirement.No ||
                   IsInParty()),
         //Rampart
-        (All.Rampart, CustomComboPreset.GNB_Mit_Rampart, () => true),
+        (All.Rampart, CustomComboPreset.GNB_Mit_Rampart,
+            () => PlayerHealthPercentageHp() <= Config.GNB_Mit_Rampart_Health),
         //Arm's Length
         (All.ArmsLength, CustomComboPreset.GNB_Mit_ArmsLength,
             () => CanCircleAoe(7) >= Config.GNB_Mit_ArmsLength_EnemyCount &&
                   (Config.GNB_Mit_ArmsLength_Boss == (int)Config.BossAvoidance.Off ||
                    InBossEncounter())),
         //Nebula
-        (OriginalHook(Nebula), CustomComboPreset.GNB_Mit_Nebula, () => true),
-        //Superbolide
-        (Superbolide, CustomComboPreset.GNB_Mit_Superbolide,
-            () => ContentCheck.IsInConfiguredContent(
-                Config.GNB_Mit_Superbolide_Difficulty,
-                Config.GNB_Mit_Superbolide_DifficultyListSet
-            )),
+        (OriginalHook(Nebula), CustomComboPreset.GNB_Mit_Nebula,
+            () => PlayerHealthPercentageHp() <= Config.GNB_Mit_Nebula_Health),
     ];
 
     /// <summary>

--- a/WrathCombo/Combos/PvE/PLD/PLD.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD.cs
@@ -830,6 +830,15 @@ namespace WrathCombo.Combos.PvE
             {
                 if (actionID is not Bulwark) return actionID;
 
+                if (IsEnabled(CustomComboPreset.PLD_Mit_HallowedGround_Max) &&
+                    ActionReady(HallowedGround) &&
+                    PlayerHealthPercentageHp() <= Config.PLD_Mit_HallowedGround_Max_Health &&
+                    ContentCheck.IsInConfiguredContent(
+                        Config.PLD_Mit_HallowedGround_Max_Difficulty,
+                        Config.PLD_Mit_HallowedGround_Max_DifficultyListSet
+                    ))
+                    return HallowedGround;
+
                 foreach (var priority in Config.PLD_Mit_Priorities.Items.OrderBy(x => x))
                 {
                     var index = Config.PLD_Mit_Priorities.IndexOf(priority);

--- a/WrathCombo/Combos/PvE/PLD/PLD_Config.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD_Config.cs
@@ -12,7 +12,7 @@ internal partial class PLD
 {
     internal static class Config
     {
-        private const int numberMitigationOptions = 10;
+        private const int numberMitigationOptions = 9;
 
         internal enum PartyRequirement
         {
@@ -59,21 +59,30 @@ internal partial class PLD
             PLD_AoE_MitsOptions = new("PLD_AoE_MitsOptions", 0),
 
             //One-Button Mitigation
+            PLD_Mit_HallowedGround_Max_Health = new("PLD_Mit_HallowedGround_Max_Health", 20),
             PLD_Mit_DivineVeil_PartyRequirement = new("PLD_Mit_DivineVeil_PartyRequirement", (int)PartyRequirement.Yes),
+            PLD_Mit_Rampart_Health = new("PLD_Mit_Rampart_Health", 65),
+            PLD_Mit_Sentinel_Health = new("PLD_Mit_Sentinel_Health", 60),
             PLD_Mit_ArmsLength_Boss = new("PLD_Mit_ArmsLength_Boss", (int)BossAvoidance.On),
             PLD_Mit_ArmsLength_EnemyCount = new("PLD_Mit_ArmsLength_EnemyCount", 0),
-            PLD_Mit_HallowedGround_Health = new("PLD_Mit_HallowedGround_Health", 30);
+            PLD_Mit_Bulwark_Health = new("PLD_Mit_Bulwark_Health", 50),
+            PLD_Mit_HallowedGround_Health = new("PLD_Mit_HallowedGround_Health", 35),
+            PLD_Mit_Clemency_Health = new("PLD_Mit_Clemency_Health", 40);
 
         public static UserIntArray
             PLD_Mit_Priorities = new("PLD_Mit_Priorities");
 
         public static UserBoolArray
-            PLD_Mit_HallowedGround_Difficulty = new("PLD_Mit_HallowedGround_Difficulty",
+            PLD_Mit_HallowedGround_Max_Difficulty = new(
+                "PLD_Mit_HallowedGround_Max_Difficulty",
+                [true, true]),
+            PLD_Mit_HallowedGround_Difficulty = new(
+                "PLD_Mit_HallowedGround_Difficulty",
                 [true, false]);
 
         public static readonly ContentCheck.ListSet
-            PLD_Mit_HallowedGround_DifficultyListSet =
-                ContentCheck.ListSet.Halved;
+            PLD_Mit_HallowedGround_Max_DifficultyListSet = ContentCheck.ListSet.Halved,
+            PLD_Mit_HallowedGround_DifficultyListSet = ContentCheck.ListSet.Halved;
 
         internal static void Draw(CustomComboPreset preset)
         {
@@ -282,33 +291,25 @@ internal partial class PLD
 
                 case CustomComboPreset.PLD_Mit_HallowedGround_Max:
                     UserConfig.DrawDifficultyMultiChoice(
-                        PLD_Mit_HallowedGround_Difficulty,
-                        PLD_Mit_HallowedGround_DifficultyListSet,
+                        PLD_Mit_HallowedGround_Max_Difficulty,
+                        PLD_Mit_HallowedGround_Max_DifficultyListSet,
                         "Select what difficulties Hallowed Ground should be used in:"
                     );
 
-                    UserConfig.DrawSliderInt(5, 30, PLD_Mit_HallowedGround_Health,
+                    UserConfig.DrawSliderInt(5, 30, PLD_Mit_HallowedGround_Max_Health,
                         "Player HP% to be \nless than or equal to:",
                         200, SliderIncrements.Fives);
-
-                    ImGui.BeginDisabled();
-                    UserConfig.DrawPriorityInput(PLD_Mit_Priorities,
-                        numberMitigationOptions, 0,
-                        "Emergency Hallowed Ground Priority:");
-                    ImGui.EndDisabled();
-                    if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-                        ImGui.SetTooltip("Should always be 1, the highest priority");
                     break;
 
                 case CustomComboPreset.PLD_Mit_Sheltron:
                     UserConfig.DrawPriorityInput(PLD_Mit_Priorities,
-                        numberMitigationOptions, 1,
+                        numberMitigationOptions, 0,
                         "Sheltron Priority:");
                     break;
 
                 case CustomComboPreset.PLD_Mit_Reprisal:
                     UserConfig.DrawPriorityInput(PLD_Mit_Priorities,
-                        numberMitigationOptions, 2,
+                        numberMitigationOptions, 1,
                         "Reprisal Priority:");
                     break;
 
@@ -327,19 +328,27 @@ internal partial class PLD
                         outputValue: (int)PartyRequirement.No);
 
                     UserConfig.DrawPriorityInput(PLD_Mit_Priorities,
-                        numberMitigationOptions, 3,
+                        numberMitigationOptions, 2,
                         "Divine Veil Priority:");
                     break;
 
                 case CustomComboPreset.PLD_Mit_Rampart:
+                    UserConfig.DrawSliderInt(40, 100, PLD_Mit_Rampart_Health,
+                        "HP% to use at or below (100 = Disable check)",
+                        SliderIncrements.Fives);
+
                     UserConfig.DrawPriorityInput(PLD_Mit_Priorities,
-                        numberMitigationOptions, 4,
+                        numberMitigationOptions, 3,
                         "Rampart Priority:");
                     break;
 
                 case CustomComboPreset.PLD_Mit_Sentinel:
+                    UserConfig.DrawSliderInt(40, 100, PLD_Mit_Sentinel_Health,
+                        "HP% to use at or below (100 = Disable check)",
+                        SliderIncrements.Fives);
+
                     UserConfig.DrawPriorityInput(PLD_Mit_Priorities,
-                        numberMitigationOptions, 5,
+                        numberMitigationOptions, 4,
                         "Sentinel Priority:");
                     break;
 
@@ -359,39 +368,43 @@ internal partial class PLD
                         "How many enemies should be nearby? (0 = No Requirement)");
 
                     UserConfig.DrawPriorityInput(PLD_Mit_Priorities,
-                        numberMitigationOptions, 6,
+                        numberMitigationOptions, 5,
                         "Arm's Length Priority:");
                     break;
 
                 case CustomComboPreset.PLD_Mit_Bulwark:
+                    UserConfig.DrawSliderInt(40, 100, PLD_Mit_Bulwark_Health,
+                        "HP% to use at or below (100 = Disable check)",
+                        SliderIncrements.Fives);
+
                     UserConfig.DrawPriorityInput(PLD_Mit_Priorities,
-                        numberMitigationOptions, 7,
+                        numberMitigationOptions, 6,
                         "Bulwark Priority:");
                     break;
 
                 case CustomComboPreset.PLD_Mit_HallowedGround:
-                    if (CustomComboFunctions.IsEnabled(CustomComboPreset.PLD_Mit_HallowedGround_Max))
-                    {
-                        ImGui.TextColored(ImGuiColors.DalamudYellow,
-                            "Select what difficulties Hallowed Ground should be used in above,");
-                        ImGui.TextColored(ImGuiColors.DalamudYellow,
-                            "under the 'Emergency Hallowed Ground' option.");
-                    }
-                    else
-                        UserConfig.DrawDifficultyMultiChoice(
-                            PLD_Mit_HallowedGround_Difficulty,
-                            PLD_Mit_HallowedGround_DifficultyListSet,
-                            "Select what difficulties Hallowed Ground should be used in:"
-                        );
+                    UserConfig.DrawDifficultyMultiChoice(
+                        PLD_Mit_HallowedGround_Difficulty,
+                        PLD_Mit_HallowedGround_DifficultyListSet,
+                        "Select what difficulties Hallowed Ground should be used in:"
+                    );
+
+                    UserConfig.DrawSliderInt(20, 80, PLD_Mit_HallowedGround_Health,
+                        "HP% to use at or below",
+                        SliderIncrements.Fives);
 
                     UserConfig.DrawPriorityInput(PLD_Mit_Priorities,
-                        numberMitigationOptions, 8,
+                        numberMitigationOptions, 7,
                         "Hallowed Ground Priority:");
                     break;
 
                 case CustomComboPreset.PLD_Mit_Clemency:
+                    UserConfig.DrawSliderInt(20, 100, PLD_Mit_Clemency_Health,
+                        "HP% to use at or below (100 = Disable check)",
+                        SliderIncrements.Fives);
+
                     UserConfig.DrawPriorityInput(PLD_Mit_Priorities,
-                        numberMitigationOptions, 9,
+                        numberMitigationOptions, 8,
                         "Clemency Priority:");
                     break;
 

--- a/WrathCombo/Combos/PvE/PLD/PLD_Config.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD_Config.cs
@@ -389,7 +389,7 @@ internal partial class PLD
                         "Select what difficulties Hallowed Ground should be used in:"
                     );
 
-                    UserConfig.DrawSliderInt(20, 80, PLD_Mit_HallowedGround_Health,
+                    UserConfig.DrawSliderInt(30, 80, PLD_Mit_HallowedGround_Health,
                         "HP% to use at or below",
                         SliderIncrements.Fives);
 

--- a/WrathCombo/Combos/PvE/PLD/PLD_Config.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD_Config.cs
@@ -335,7 +335,7 @@ internal partial class PLD
                 case CustomComboPreset.PLD_Mit_Rampart:
                     UserConfig.DrawSliderInt(40, 100, PLD_Mit_Rampart_Health,
                         "HP% to use at or below (100 = Disable check)",
-                        SliderIncrements.Fives);
+                        sliderIncrement: SliderIncrements.Fives);
 
                     UserConfig.DrawPriorityInput(PLD_Mit_Priorities,
                         numberMitigationOptions, 3,
@@ -345,7 +345,7 @@ internal partial class PLD
                 case CustomComboPreset.PLD_Mit_Sentinel:
                     UserConfig.DrawSliderInt(40, 100, PLD_Mit_Sentinel_Health,
                         "HP% to use at or below (100 = Disable check)",
-                        SliderIncrements.Fives);
+                        sliderIncrement: SliderIncrements.Fives);
 
                     UserConfig.DrawPriorityInput(PLD_Mit_Priorities,
                         numberMitigationOptions, 4,
@@ -375,7 +375,7 @@ internal partial class PLD
                 case CustomComboPreset.PLD_Mit_Bulwark:
                     UserConfig.DrawSliderInt(40, 100, PLD_Mit_Bulwark_Health,
                         "HP% to use at or below (100 = Disable check)",
-                        SliderIncrements.Fives);
+                        sliderIncrement: SliderIncrements.Fives);
 
                     UserConfig.DrawPriorityInput(PLD_Mit_Priorities,
                         numberMitigationOptions, 6,
@@ -391,7 +391,7 @@ internal partial class PLD
 
                     UserConfig.DrawSliderInt(30, 80, PLD_Mit_HallowedGround_Health,
                         "HP% to use at or below",
-                        SliderIncrements.Fives);
+                        sliderIncrement: SliderIncrements.Fives);
 
                     UserConfig.DrawPriorityInput(PLD_Mit_Priorities,
                         numberMitigationOptions, 7,
@@ -401,7 +401,7 @@ internal partial class PLD
                 case CustomComboPreset.PLD_Mit_Clemency:
                     UserConfig.DrawSliderInt(20, 100, PLD_Mit_Clemency_Health,
                         "HP% to use at or below (100 = Disable check)",
-                        SliderIncrements.Fives);
+                        sliderIncrement: SliderIncrements.Fives);
 
                     UserConfig.DrawPriorityInput(PLD_Mit_Priorities,
                         numberMitigationOptions, 8,

--- a/WrathCombo/Combos/PvE/PLD/PLD_Helper.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD_Helper.cs
@@ -37,13 +37,6 @@ internal partial class PLD
     private static (uint Action, CustomComboPreset Preset, System.Func<bool> Logic)[]
         PrioritizedMitigation =>
     [
-        //Emergency Hallowed Ground
-        (HallowedGround, CustomComboPreset.PLD_Mit_HallowedGround_Max,
-            () => PlayerHealthPercentageHp() <= Config.PLD_Mit_HallowedGround_Health &&
-                  ContentCheck.IsInConfiguredContent(
-                      Config.PLD_Mit_HallowedGround_Difficulty,
-                      Config.PLD_Mit_HallowedGround_DifficultyListSet
-                  )),
         //Sheltron
         (OriginalHook(Sheltron), CustomComboPreset.PLD_Mit_Sheltron,
             () => Gauge.OathGauge >= 50),
@@ -56,26 +49,30 @@ internal partial class PLD
                   (int)Config.PartyRequirement.No ||
                   IsInParty()),
         //Rampart
-        (All.Rampart, CustomComboPreset.PLD_Mit_Rampart, () => true),
+        (All.Rampart, CustomComboPreset.PLD_Mit_Rampart,
+            () => PlayerHealthPercentageHp() <= Config.PLD_Mit_Rampart_Health),
         //Sentinel
         (OriginalHook(Sentinel), CustomComboPreset.PLD_Mit_Sentinel,
-            () => true),
+            () => PlayerHealthPercentageHp() <= Config.PLD_Mit_Sentinel_Health),
         //Arm's Length
         (All.ArmsLength, CustomComboPreset.PLD_Mit_ArmsLength,
             () => CanCircleAoe(7) >= Config.PLD_Mit_ArmsLength_EnemyCount &&
                   (Config.PLD_Mit_ArmsLength_Boss == (int)Config.BossAvoidance.Off ||
                    InBossEncounter())),
         //Bulwark
-        (Bulwark, CustomComboPreset.PLD_Mit_Bulwark, () => true),
+        (Bulwark, CustomComboPreset.PLD_Mit_Bulwark,
+            () => PlayerHealthPercentageHp() <= Config.PLD_Mit_Bulwark_Health),
         //Hallowed Ground
         (HallowedGround, CustomComboPreset.PLD_Mit_HallowedGround,
-            () => ContentCheck.IsInConfiguredContent(
-                Config.PLD_Mit_HallowedGround_Difficulty,
-                Config.PLD_Mit_HallowedGround_DifficultyListSet
-            )),
+            () => PlayerHealthPercentageHp() <= Config.PLD_Mit_HallowedGround_Health &&
+                  ContentCheck.IsInConfiguredContent(
+                      Config.PLD_Mit_HallowedGround_Difficulty,
+                      Config.PLD_Mit_HallowedGround_DifficultyListSet
+                  )),
         //Clemency
         (Clemency, CustomComboPreset.PLD_Mit_Clemency,
-            () => LocalPlayer.CurrentMp >= 2000),
+            () => LocalPlayer.CurrentMp >= 2000 &&
+                  PlayerHealthPercentageHp() <= Config.PLD_Mit_Clemency_Health),
     ];
 
     /// <summary>

--- a/WrathCombo/Combos/PvE/WAR/WAR.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR.cs
@@ -946,6 +946,15 @@ namespace WrathCombo.Combos.PvE
             {
                 if (actionID is not ThrillOfBattle) return actionID; //Our button
 
+                if (IsEnabled(CustomComboPreset.WAR_Mit_Holmgang_Max) &&
+                    ActionReady(Holmgang) &&
+                    PlayerHealthPercentageHp() <= Config.WAR_Mit_Holmgang_Health &&
+                    ContentCheck.IsInConfiguredContent(
+                        Config.WAR_Mit_Holmgang_Difficulty,
+                        Config.WAR_Mit_Holmgang_DifficultyListSet
+                    ))
+                    return Holmgang;
+
                 foreach (var priority in Config.WAR_Mit_Priorities.Items.OrderBy(x => x))
                 {
                     var index = Config.WAR_Mit_Priorities.IndexOf(priority);

--- a/WrathCombo/Combos/PvE/WAR/WAR_Config.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR_Config.cs
@@ -14,7 +14,7 @@ internal partial class WAR
 {
     internal static class Config
     {
-        private const int numberMitigationOptions = 10;
+        private const int numberMitigationOptions = 8;
 
         internal enum PartyRequirement
         {
@@ -74,9 +74,14 @@ internal partial class WAR
 
             //One-Button Mitigation
             WAR_Mit_Holmgang_Health = new("WAR_Mit_Holmgang_Health", 30),
+            WAR_Mit_Bloodwhetting_Health = new("WAR_Mit_Bloodwhetting_Health", 70),
+            WAR_Mit_Equilibrium_Health = new("WAR_Mit_Equilibrium_Health", 45),
+            WAR_Mit_ThrillOfBattle_Health = new("WAR_Mit_ThrillOfBattle_Health", 60),
+            WAR_Mit_Rampart_Health = new("WAR_Mit_Rampart_Health", 65),
             WAR_Mit_ShakeItOff_PartyRequirement = new("WAR_Mit_ShakeItOff_PartyRequirement", (int)PartyRequirement.Yes),
             WAR_Mit_ArmsLength_Boss = new("WAR_Mit_ArmsLength_Boss", (int)BossAvoidance.On),
-            WAR_Mit_ArmsLength_EnemyCount = new("WAR_Mit_ArmsLength_EnemyCount", 0);
+            WAR_Mit_ArmsLength_EnemyCount = new("WAR_Mit_ArmsLength_EnemyCount", 0),
+            WAR_Mit_Vengeance_Health = new("WAR_Mit_Vengeance_Health", 50);
 
         public static UserIntArray
             WAR_Mit_Priorities = new("WAR_Mit_Priorities");
@@ -382,43 +387,51 @@ internal partial class WAR
                     UserConfig.DrawSliderInt(5, 30, WAR_Mit_Holmgang_Health,
                         "Player HP% to be \nless than or equal to:",
                         200, SliderIncrements.Fives);
-
-                    ImGui.BeginDisabled();
-                    UserConfig.DrawPriorityInput(WAR_Mit_Priorities,
-                        numberMitigationOptions, 0,
-                        "Emergency Holmgang Priority:");
-                    ImGui.EndDisabled();
-                    if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-                        ImGui.SetTooltip("Should always be 1, the highest priority");
                     break;
 
                 case CustomComboPreset.WAR_Mit_Bloodwhetting:
+                    UserConfig.DrawSliderInt(40, 85, WAR_Mit_Bloodwhetting_Health,
+                        "HP% to use at or below",
+                        sliderIncrement: SliderIncrements.Fives);
+
                     UserConfig.DrawPriorityInput(WAR_Mit_Priorities,
-                        numberMitigationOptions, 1,
+                        numberMitigationOptions, 0,
                         "Bloodwhetting Priority:");
                     break;
 
                 case CustomComboPreset.WAR_Mit_Equilibrium:
+                    UserConfig.DrawSliderInt(15, 75, WAR_Mit_Equilibrium_Health,
+                        "HP% to use at or below",
+                        sliderIncrement: SliderIncrements.Fives);
+
                     UserConfig.DrawPriorityInput(WAR_Mit_Priorities,
-                        numberMitigationOptions, 2,
+                        numberMitigationOptions, 1,
                         "Equilibrium Priority:");
                     break;
 
                 case CustomComboPreset.WAR_Mit_Reprisal:
                     UserConfig.DrawPriorityInput(WAR_Mit_Priorities,
-                        numberMitigationOptions, 3,
+                        numberMitigationOptions, 2,
                         "Reprisal Priority:");
                     break;
 
                 case CustomComboPreset.WAR_Mit_ThrillOfBattle:
+                    UserConfig.DrawSliderInt(40, 100, WAR_Mit_ThrillOfBattle_Health,
+                        "HP% to use at or below (100 = Disable check)",
+                        sliderIncrement: SliderIncrements.Fives);
+
                     UserConfig.DrawPriorityInput(WAR_Mit_Priorities,
-                        numberMitigationOptions, 4,
+                        numberMitigationOptions, 3,
                         "Thrill Of Battle Priority:");
                     break;
 
                 case CustomComboPreset.WAR_Mit_Rampart:
+                    UserConfig.DrawSliderInt(40, 100, WAR_Mit_Rampart_Health,
+                        "HP% to use at or below (100 = Disable check)",
+                        sliderIncrement: SliderIncrements.Fives);
+
                     UserConfig.DrawPriorityInput(WAR_Mit_Priorities,
-                        numberMitigationOptions, 5,
+                        numberMitigationOptions, 4,
                         "Rampart Priority:");
                     break;
 
@@ -437,7 +450,7 @@ internal partial class WAR
                         outputValue: (int)PartyRequirement.No);
 
                     UserConfig.DrawPriorityInput(WAR_Mit_Priorities,
-                        numberMitigationOptions, 6,
+                        numberMitigationOptions, 5,
                         "Shake It Off Priority:");
                     break;
 
@@ -457,34 +470,18 @@ internal partial class WAR
                         "How many enemies should be nearby? (0 = No Requirement)");
 
                     UserConfig.DrawPriorityInput(WAR_Mit_Priorities,
-                        numberMitigationOptions, 7,
+                        numberMitigationOptions, 6,
                         "Arm's Length Priority:");
                     break;
 
                 case CustomComboPreset.WAR_Mit_Vengeance:
+                    UserConfig.DrawSliderInt(40, 100, WAR_Mit_Vengeance_Health,
+                        "HP% to use at or below (100 = Disable check)",
+                        sliderIncrement: SliderIncrements.Fives);
+
                     UserConfig.DrawPriorityInput(WAR_Mit_Priorities,
-                        numberMitigationOptions, 8,
+                        numberMitigationOptions, 7,
                         "Vengeance Priority:");
-                    break;
-
-                case CustomComboPreset.WAR_Mit_Holmgang:
-                    if (CustomComboFunctions.IsEnabled(CustomComboPreset.WAR_Mit_Holmgang_Max))
-                    {
-                        ImGui.TextColored(ImGuiColors.DalamudYellow,
-                            "Select what difficulties Holmgang should be used in above,");
-                        ImGui.TextColored(ImGuiColors.DalamudYellow,
-                            "under the 'Emergency Holmgang' option.");
-                    }
-                    else
-                        UserConfig.DrawDifficultyMultiChoice(
-                            WAR_Mit_Holmgang_Difficulty,
-                            WAR_Mit_Holmgang_DifficultyListSet,
-                            "Select what difficulties Holmgang should be used in:"
-                        );
-
-                    UserConfig.DrawPriorityInput(WAR_Mit_Priorities,
-                        numberMitigationOptions, 9,
-                        "Holmgang Priority:");
                     break;
 
                 #endregion

--- a/WrathCombo/Combos/PvE/WAR/WAR_Helper.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR_Helper.cs
@@ -38,26 +38,23 @@ internal partial class WAR
     private static (uint Action, CustomComboPreset Preset, System.Func<bool> Logic)[]
         PrioritizedMitigation =>
     [
-        //Emergency Holmgang
-        (Holmgang, CustomComboPreset.WAR_Mit_Holmgang_Max,
-            () => PlayerHealthPercentageHp() <= Config.WAR_Mit_Holmgang_Health &&
-                  ContentCheck.IsInConfiguredContent(
-                      Config.WAR_Mit_Holmgang_Difficulty,
-                      Config.WAR_Mit_Holmgang_DifficultyListSet
-                  )),
         //Bloodwhetting
         (OriginalHook(RawIntuition), CustomComboPreset.WAR_Mit_Bloodwhetting,
             () => FindEffect(Buffs.RawIntuition) is null &&
-                  FindEffect(Buffs.BloodwhettingDefenseLong) is null),
+                  FindEffect(Buffs.BloodwhettingDefenseLong) is null &&
+                  PlayerHealthPercentageHp() <= Config.WAR_Mit_Bloodwhetting_Health),
         //Equilibrium
-        (Equilibrium, CustomComboPreset.WAR_Mit_Equilibrium, () => true),
+        (Equilibrium, CustomComboPreset.WAR_Mit_Equilibrium,
+            () => PlayerHealthPercentageHp() <= Config.WAR_Mit_Equilibrium_Health),
         // Reprisal
         (All.Reprisal, CustomComboPreset.WAR_Mit_Reprisal,
             () => InActionRange(All.Reprisal)),
         //Thrill of Battle
-        (ThrillOfBattle, CustomComboPreset.WAR_Mit_ThrillOfBattle, () => true),
+        (ThrillOfBattle, CustomComboPreset.WAR_Mit_ThrillOfBattle,
+            () => PlayerHealthPercentageHp() <= Config.WAR_Mit_ThrillOfBattle_Health),
         //Rampart
-        (All.Rampart, CustomComboPreset.WAR_Mit_Rampart, () => true),
+        (All.Rampart, CustomComboPreset.WAR_Mit_Rampart,
+            () => PlayerHealthPercentageHp() <= Config.WAR_Mit_Rampart_Health),
         //Shake it Off
         (ShakeItOff, CustomComboPreset.WAR_Mit_ShakeItOff,
             () => FindEffect(Buffs.ShakeItOff) is null &&
@@ -70,13 +67,8 @@ internal partial class WAR
                   (Config.WAR_Mit_ArmsLength_Boss == (int)Config.BossAvoidance.Off ||
                    InBossEncounter())),
         //Vengeance
-        (OriginalHook(Vengeance), CustomComboPreset.WAR_Mit_Vengeance, () => true),
-        //Holmgang
-        (Holmgang, CustomComboPreset.WAR_Mit_Holmgang,
-            () => ContentCheck.IsInConfiguredContent(
-                Config.WAR_Mit_Holmgang_Difficulty,
-                Config.WAR_Mit_Holmgang_DifficultyListSet
-            )),
+        (OriginalHook(Vengeance), CustomComboPreset.WAR_Mit_Vengeance,
+            () => PlayerHealthPercentageHp() <= Config.WAR_Mit_Vengeance_Health),
     ];
 
     /// <summary>


### PR DESCRIPTION
- [X] Updated DRK
  - [X] Removed Emergency `Living Dead` from Priority list
  - [X] Removed standard rotation `Living Dead`
  - [X] Added HP% check to abilities you may want to save:
    - [X] `The Blackest Night`
    - [X] `Rampart`
    - [X] `Shadow Wall` / Vigil
- [X] Updated GNB
  - [X] Removed Emergency `Superbolide` from Priority list
  - [X] Removed standard rotation `Superbolide`
  - [X] Added HP% check to abilities you may want to save:
    - [X] `Heart of Corundum`
    - [X] `Aurora`
    - [X] `Rampart`
    - [X] `Nebula`
- [X] Updated PLD
  - [X] Removed Emergency `Hallowed Ground` from Priority list
  - [X] Added HP% check to abilities you may want to save:
    - [X] `Rampart`
    - [X] `Sentinel`
    - [X] `Bulwark`
    - [X] Standard rotation `Hallowed Ground`
    - [X] `Clemency`
- [X] Updated WAR
  - [X] Removed Emergency `Holmgang` from Priority list
  - [X] Removed standard rotation `Holmgang`
  - [X] Added HP% check to abilities you may want to save:
    - [X] `Bloodwhetting`
    - [X] `Equilibrum`
    - [X] `Thrill of Battle`
    - [X] `Rampart`
    - [X] `Vengeance`