### PR TITLE
[BRD] Openers and Adjustments

### DIFF
--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -633,7 +633,7 @@ namespace WrathCombo.Combos.PvE
                         if (gauge.Repertoire == 3 || gauge.Repertoire == 2 && GetCooldownRemainingTime(EmpyrealArrow) < 2)
                             return OriginalHook(PitchPerfect);
 
-                        if (ActionReady(HeartbreakShot))
+                        if (ActionReady(HeartbreakShot) && HasEffect(Buffs.RagingStrikes))
                             return HeartbreakShot;
                     }
 

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -610,6 +610,7 @@ namespace WrathCombo.Combos.PvE
                 int targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_NoWasteHPPercentage);
                 bool isEnemyHealthHigh = !IsEnabled(CustomComboPreset.BRD_Adv_NoWaste) || GetTargetHPPercent() > targetHPThreshold;
                 bool hasTarget = HasBattleTarget();
+                bool buffTime = GetCooldownRemainingTime(RagingStrikes) < 2.7;
 
 
                 #region Variants
@@ -630,13 +631,13 @@ namespace WrathCombo.Combos.PvE
                 {
                     if (ActionWatching.GetAttackType(Opener().CurrentOpenerAction) != ActionWatching.ActionAttackType.Ability && canWeave)
                     {
-                        if (gauge.Repertoire == 3 || gauge.Repertoire == 2 && GetCooldownRemainingTime(EmpyrealArrow) < 2)
+                        if (HasEffect(Buffs.RagingStrikes) && (gauge.Repertoire == 3 || gauge.Repertoire == 2 && GetCooldownRemainingTime(EmpyrealArrow) < 2))
                             return OriginalHook(PitchPerfect);
 
                         if (ActionReady(HeartbreakShot) && HasEffect(Buffs.RagingStrikes))
                             return HeartbreakShot;
                     }
-
+                    
                     return actionID;
 
                 }
@@ -649,9 +650,6 @@ namespace WrathCombo.Combos.PvE
                     // Limit optimisation to when you are high enough level to benefit from it.
                     if (LevelChecked(WanderersMinuet))
                     {
-                        if (ActionReady(EmpyrealArrow) && JustUsed(WanderersMinuet)) // Used to ensure Empyreal arrow goes off as soon as possible in opener
-                            return EmpyrealArrow;
-
                         if (canWeave || !hasTarget)
                         {
                             if (songNone && InCombat())
@@ -711,19 +709,18 @@ namespace WrathCombo.Combos.PvE
                 if (IsEnabled(CustomComboPreset.BRD_Adv_Buffs) && (!songNone || !LevelChecked(MagesBallad)) && isEnemyHealthHigh)
                 {
                     float ragingCD = GetCooldownRemainingTime(RagingStrikes);
-
-                    // Late weave Battle voice logic first, timed with raging strikes cd to keep buffs tight.
-                    if (canWeaveDelayed && ActionReady(BattleVoice) && songWanderer && (ragingCD < 3 || ActionReady(RagingStrikes)))
-                        return BattleVoice;
-
+                    
                     // Radiant next, must have battlevoice buff for it to fire
-                    if (canWeave && ActionReady(RadiantFinale) &&
-                        (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet)) &&
-                        HasEffect(Buffs.BattleVoice))
+                    if (canWeaveDelayed && ActionReady(RadiantFinale) && ragingCD < 2.3 &&
+                    (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet)))                        
                         return RadiantFinale;
 
+                    // Late weave Battle voice logic first, timed with raging strikes cd to keep buffs tight.
+                    if (canWeave && ActionReady(BattleVoice) && (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale)))
+                        return BattleVoice;
+
                     // Late weave Raging last, must have battle voice buff OR not be high enough level for Battlecoice
-                    if (canWeave && ActionReady(RagingStrikes) && (HasEffect(Buffs.BattleVoice) || !LevelChecked(BattleVoice)))
+                    if (canWeave && ActionReady(RagingStrikes) && (JustUsed(BattleVoice) || !LevelChecked(BattleVoice) || HasEffect(Buffs.BattleVoice)))
                         return RagingStrikes;
 
                     // Barrage Logic to check for raging for low level reasons and it doesn't really need to check for the other buffs
@@ -736,15 +733,16 @@ namespace WrathCombo.Combos.PvE
 
                 #region OGCD
 
-                if (canWeave && IsEnabled(CustomComboPreset.BRD_ST_Adv_oGCD))
+                if (canWeave && IsEnabled(CustomComboPreset.BRD_ST_Adv_oGCD) && 
+                    (!buffTime || !IsEnabled(CustomComboPreset.BRD_Adv_Buffs)))
                 {
-                    if (ActionReady(EmpyrealArrow))
-                        return EmpyrealArrow;
-
-                    // Pitch Perfect loogic to use when full or when Empyreal arrow might overcap it.
+                    // Pitch Perfect logic to use when full or when Empyreal arrow might overcap it.
                     if (LevelChecked(PitchPerfect) && songWanderer &&
                         (gauge.Repertoire == 3 || (LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && GetCooldownRemainingTime(EmpyrealArrow) < 2)))
                         return OriginalHook(PitchPerfect);
+
+                    if (ActionReady(EmpyrealArrow))
+                        return EmpyrealArrow;
 
                     // Sidewinder logic to use in burst window with buffs or on cd on the 1 minutes
                     if (ActionReady(Sidewinder))
@@ -859,7 +857,7 @@ namespace WrathCombo.Combos.PvE
 
                 if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore))
                 {
-                    if (HasEffect(Buffs.RadiantEncoreReady) && GetBuffRemainingTime(Buffs.RadiantFinale) < 15) // Delay Encore enough for buff window
+                    if (HasEffect(Buffs.RadiantEncoreReady) && HasEffect(Buffs.RagingStrikes)) // Delay Encore enough for buff window
                         return OriginalHook(RadiantEncore);
                 }
 

--- a/WrathCombo/Combos/PvE/BRD/BRD_Config.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Config.cs
@@ -1,4 +1,5 @@
 using WrathCombo.CustomComboNS.Functions;
+using WrathCombo.Window.Functions;
 using static WrathCombo.Window.Functions.UserConfig;
 
 namespace WrathCombo.Combos.PvE;
@@ -15,6 +16,7 @@ internal partial class BRD
             BRD_AoESecondWindThreshold = new("BRD_AoESecondWindThreshold"),
             BRD_VariantCure = new("BRD_VariantCure"),
             BRDPvP_HarmonicArrowCharges = new("BRDPvP_HarmonicArrowCharges"),
+            BRD_Adv_Opener_Selection = new("BRD_Adv_Opener_Selection", 0),
             BRD_Balance_Content = new("BRD_Balance_Content", 1);
 
         internal static void Draw(CustomComboPreset preset)
@@ -22,8 +24,13 @@ internal partial class BRD
             switch (preset)
             {
                 case CustomComboPreset.BRD_ST_Adv_Balance_Standard:
-                    DrawBossOnlyChoice(BRD_Balance_Content);
-                    break;
+                    UserConfig.DrawRadioButton(BRD_Adv_Opener_Selection, $"Standard Opener", "", 0);
+                    UserConfig.DrawRadioButton(BRD_Adv_Opener_Selection, $"2.48 Adjusted Standard Opener", "", 1);
+                    UserConfig.DrawRadioButton(BRD_Adv_Opener_Selection, $"2.49 Standard Comfy", "", 2);
+
+                    UserConfig.DrawBossOnlyChoice(BRD_Balance_Content);
+                    break;                
+
                 case CustomComboPreset.BRD_Adv_RagingJaws:
                     DrawSliderInt(3, 10, BRD_RagingJawsRenewTime,
                         "Remaining time (In seconds). Recommended 5, increase little by little if refresh is outside of radiant window");

--- a/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
@@ -7,17 +7,25 @@ namespace WrathCombo.Combos.PvE;
 
 internal partial class BRD
 {
-    public static BRDOpenerMaxLevel1 Opener1 = new();
-    public static WrathOpener Opener()
+    public static BRDStandard Opener1 = new();
+    public static BRDAdjusted Opener2 = new();
+    public static BRDComfy Opener3 = new();
+    internal static WrathOpener Opener()
     {
-        if (Opener1.LevelChecked) return Opener1;
+        if (CustomComboFunctions.IsEnabled(CustomComboPreset.BRD_ST_AdvMode))
+        {
+            if (Config.BRD_Adv_Opener_Selection == 0 && Opener1.LevelChecked) return Opener1;
+            if (Config.BRD_Adv_Opener_Selection == 1 && Opener2.LevelChecked) return Opener2;
+            if (Config.BRD_Adv_Opener_Selection == 2 && Opener3.LevelChecked) return Opener3;
+        }
 
+        if (Opener1.LevelChecked) return Opener1;
         return WrathOpener.Dummy;
     }
 
 
 
-    internal class BRDOpenerMaxLevel1 : WrathOpener
+    internal class BRDStandard : WrathOpener
     {
         public override List<uint> OpenerActions { get; set; } =
         [
@@ -44,7 +52,7 @@ internal partial class BRD
 
         public override List<(int[], uint, Func<bool>)> SubstitutionSteps { get; set; } =
         [
-            ([6, 9, 16, 17, 20], RefulgentArrow, () => CustomComboFunctions.HasEffect(Buffs.HawksEye)),
+            ([6, 9, 16, 17, 19], RefulgentArrow, () => CustomComboFunctions.HasEffect(Buffs.HawksEye)),
         ];
 
         public override List<int> DelayedWeaveSteps { get; set; } =
@@ -64,7 +72,122 @@ internal partial class BRD
             if (!CustomComboFunctions.ActionReady(BattleVoice))
                 return false;
 
+            if (!CustomComboFunctions.ActionReady(RadiantFinale))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(RagingStrikes))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(Barrage))
+                return false;
+
+
+            return true;
+        }
+    }
+    internal class BRDAdjusted : WrathOpener
+    {
+        public override List<uint> OpenerActions { get; set; } =
+        [
+            HeartbreakShot,
+            Stormbite,
+            WanderersMinuet,
+            EmpyrealArrow,
+            CausticBite,
+            BattleVoice,
+            BurstShot,
+            RadiantFinale,
+            RagingStrikes,
+            BurstShot,
+            Barrage,
+            RefulgentArrow,
+            Sidewinder,
+            RadiantEncore,
+            ResonantArrow,
+            EmpyrealArrow,
+            BurstShot,
+            BurstShot,
+            IronJaws,
+            BurstShot,
+        ];
+
+        public override List<(int[], uint, Func<bool>)> SubstitutionSteps { get; set; } =
+        [
+            ([7, 10, 17, 18, 20], RefulgentArrow, () => CustomComboFunctions.HasEffect(Buffs.HawksEye)),
+        ];
+
+        public override List<int> DelayedWeaveSteps { get; set; } =
+        [
+            6
+        ];
+        public override int MinOpenerLevel => 100;
+        public override int MaxOpenerLevel => 109;
+
+        internal override UserData? ContentCheckConfig => Config.BRD_Balance_Content;
+
+        public override bool HasCooldowns()
+        {
             if (!CustomComboFunctions.ActionReady(WanderersMinuet))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(BattleVoice))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(RadiantFinale))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(RagingStrikes))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(Barrage))
+                return false;
+
+
+            return true;
+        }
+    }
+    internal class BRDComfy : WrathOpener
+    {
+        public override List<uint> OpenerActions { get; set; } =
+        [
+            Stormbite,
+            HeartbreakShot,
+            WanderersMinuet,
+            CausticBite,
+            EmpyrealArrow,
+            RadiantFinale,
+            BurstShot,
+            BattleVoice,            
+            RagingStrikes,
+            BurstShot,
+            Barrage,
+            RefulgentArrow,
+            Sidewinder,
+            RadiantEncore,            
+            ResonantArrow,            
+            BurstShot,
+            EmpyrealArrow,
+            BurstShot,
+            IronJaws,
+            BurstShot,
+        ];
+
+        public override List<(int[], uint, Func<bool>)> SubstitutionSteps { get; set; } =
+        [
+            ([7, 10, 16, 18, 20], RefulgentArrow, () => CustomComboFunctions.HasEffect(Buffs.HawksEye)),
+        ];
+               
+        public override int MinOpenerLevel => 100;
+        public override int MaxOpenerLevel => 109;
+
+        internal override UserData? ContentCheckConfig => Config.BRD_Balance_Content;
+
+        public override bool HasCooldowns()
+        {
+            if (!CustomComboFunctions.ActionReady(WanderersMinuet))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(BattleVoice))
                 return false;
 
             if (!CustomComboFunctions.ActionReady(RadiantFinale))

--- a/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
@@ -40,8 +40,6 @@ internal partial class BRD
             BurstShot,
             IronJaws,
             BurstShot,
-            PitchPerfect
-
         ];
 
         public override List<(int[], uint, Func<bool>)> SubstitutionSteps { get; set; } =


### PR DESCRIPTION
- [x] Tweaked standard openers heartbreak shot to not try and use them before buffs are out
- [x] Removed the unneeded pitch perfect at the end of opener as pitch perfect is fluid based on charges and handled via override
- [x] Added 2.48 adjusted standard opener
- [x] Added 2.49 Comfy standard opener, this just makes life nicer so we pot right before pull. Its what bard has been for months
- [x] Adjusted the buffs to work for all 3 on the 2 min windows. Added failsafes to ogcds to keep them from interfering. Any empy drift gets pushed into 2 empys in the buff window. Win