### PR TITLE
[RDM] AutoRot Edits, Start of PvP Config

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -4246,7 +4246,7 @@ public enum CustomComboPreset
     #region Single Target DPS
 
     [AutoAction(false, false)]
-    [ReplaceSkill(RDM.Jolt, RDM.Jolt2)]
+    [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Jolt3)]
     [ConflictingCombos(RDM_ST_SimpleMode)]
     [CustomComboInfo("Advanced Mode - Single Target",
         "Replaces Jolt with a full one-button single target rotation.\nThese features are ideal if you want to customize the rotation.",
@@ -4319,12 +4319,6 @@ public enum CustomComboPreset
     [CustomComboInfo("Melee combo overcap protection",
         "Adds melee combo to the rotation when mana is at a certain threshold.", RDM.JobID)]
     RDM_ST_Melee_Overcap_Protection = 13660,
-
-    [ParentCombo(RDM_ST_MeleeCombo)]
-    [CustomComboInfo("Melee Combo Fill Option",
-        "Adds the melee combo to the rotation." + "\nRiposte itself must be initiated manually when using this option.",
-        RDM.JobID)]
-    RDM_ST_Adv_MeleeFill = 13710,
 
     #region AoE DPS
 

--- a/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
@@ -4,7 +4,6 @@ using WrathCombo.CustomComboNS.Functions;
 using static WrathCombo.Extensions.UIntExtensions;
 using static WrathCombo.Window.Functions.UserConfig;
 using static WrathCombo.Window.Functions.SliderIncrements;
-using WrathCombo.Combos.PvP;
 
 namespace WrathCombo.Combos.PvE
 {
@@ -105,6 +104,10 @@ namespace WrathCombo.Combos.PvE
                             ImGui.Indent(); ImGui.Spacing();
                             DrawHorizontalMultiChoice(RDM_ST_MeleeCombo_OnAction, $"{Jolt.ActionName()}s", "", 2, 0, descriptionColor: ImGuiColors.DalamudYellow);
                             DrawHorizontalMultiChoice(RDM_ST_MeleeCombo_OnAction, Riposte.ActionName(), "", 2, 1, descriptionColor: ImGuiColors.DalamudYellow);
+                            if (P.IPC.GetComboOptionState(CustomComboPreset.RDM_ST_MeleeCombo.ToString()))
+                            {
+                                ImGui.TextColored(ImGuiColors.DalamudYellow,$"Auto-Mode is enabled for this option.\n{Zwerchhau.ActionName()} & {Redoublement.ActionName()} will be placed on {Jolt.ActionName()}");
+                            }
                             ImGui.Unindent();
                         }
                         break;
@@ -178,46 +181,6 @@ namespace WrathCombo.Combos.PvE
 
                     case CustomComboPreset.RDM_Variant_Cure:
                         DrawSliderInt(1, 100, RDM_VariantCure, "HP% to be at or under", 200);
-                        break;
-
-                    // PvP
-
-                    // Resolution
-                    case CustomComboPreset.RDMPvP_Resolution:
-                        DrawSliderInt(10, 100, RDMPvP.Config.RDMPvP_Resolution_TargetHP, "Target HP%", 210);
-
-                        break;
-
-                    // Embolden / Prefulgence
-                    case CustomComboPreset.RDMPvP_Embolden:
-                        DrawAdditionalBoolChoice(RDMPvP.Config.RDMPvP_Embolden_SubOption, "Prefulgence Option",
-                            "Uses Prefulgence when available.");
-
-                        break;
-
-                    // Corps-a-Corps
-                    case CustomComboPreset.RDMPvP_Corps:
-                        DrawSliderInt(0, 1, RDMPvP.Config.RDMPvP_Corps_Charges, "Charges to Keep", 178);
-                        DrawSliderInt(5, 10, RDMPvP.Config.RDMPvP_Corps_Range, "Maximum Range", 173);
-
-                        break;
-
-                    // Displacement
-                    case CustomComboPreset.RDMPvP_Displacement:
-                        DrawSliderInt(0, 1, RDMPvP.Config.RDMPvP_Displacement_Charges, "Charges to Keep", 178);
-                        ImGui.Spacing();
-                        DrawAdditionalBoolChoice(RDMPvP.Config.RDMPvP_Displacement_SubOption, "No Movement Option",
-                            "Uses Displacement only when not moving.");
-
-                        break;
-
-                    // Forte / Vice of Thorns
-                    case CustomComboPreset.RDMPvP_Forte:
-                        DrawSliderInt(10, 100, RDMPvP.Config.RDMPvP_Forte_PlayerHP, "Player HP%", 210);
-                        ImGui.Spacing();
-                        DrawAdditionalBoolChoice(RDMPvP.Config.RDMPvP_Forte_SubOption, "Vice of Thorns Option",
-                            "Uses Vice of Thorns when available.");
-
                         break;
                 }
             }

--- a/WrathCombo/Combos/PvE/RDM/RDM_Helper.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM_Helper.cs
@@ -292,8 +292,8 @@ namespace WrathCombo.Combos.PvE
                 return false;
             }
 
-            internal static bool TrySTMeleeCombo(uint actionID, out uint newActionID,                 //Simple Mode Values
-                bool MeleeEnforced = true, bool GapCloser = false, bool UnbalanceMana = true)
+            internal static bool TrySTMeleeCombo(uint actionID, out uint newActionID,
+                bool MeleeEnforced = true)
             {
                 //Normal Combo
                 if (GetTargetDistance() <= 3 || MeleeEnforced)
@@ -309,12 +309,18 @@ namespace WrathCombo.Combos.PvE
                     if (ComboAction is Zwerchhau
                         && LevelChecked(Redoublement)
                         && ComboTimer > 0f)
-                    { 
-                        newActionID= OriginalHook(Redoublement);
+                    {
+                        newActionID = OriginalHook(Redoublement);
                         return true;
                     }
                 }
+                newActionID = actionID;
+                return false;
+            }
 
+            internal static bool TrySTMeleeStart(uint actionID, out uint newActionID,                 //Simple Mode Values
+                bool GapCloser = false, bool UnbalanceMana = true)
+            {
                 if (((RDMMana.Min >= 50 && LevelChecked(Redoublement))
                     || (RDMMana.Min >= 35 && !LevelChecked(Redoublement))
                     || (RDMMana.Min >= 20 && !LevelChecked(Zwerchhau)))

--- a/WrathCombo/Combos/PvP/RDMPVP.cs
+++ b/WrathCombo/Combos/PvP/RDMPVP.cs
@@ -1,5 +1,7 @@
-﻿using WrathCombo.CustomComboNS;
+﻿using ImGuiNET;
+using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
+using static WrathCombo.Window.Functions.UserConfig;
 
 namespace WrathCombo.Combos.PvP
 {
@@ -56,6 +58,52 @@ namespace WrathCombo.Combos.PvP
                 RDMPvP_Forte_SubOption = new("RDMPvP_Forte_SubOption"),
                 RDMPvP_Embolden_SubOption = new("RDMPvP_Embolden_SubOption"),
                 RDMPvP_Displacement_SubOption = new("RDMPvP_Displacement_SubOption");
+
+            internal static void Draw(CustomComboPreset preset)
+            {
+                switch (preset)
+                {
+                    // PvP
+
+                    // Resolution
+                    case CustomComboPreset.RDMPvP_Resolution:
+                        DrawSliderInt(10, 100, RDMPvP.Config.RDMPvP_Resolution_TargetHP, "Target HP%", 210);
+
+                        break;
+
+                    // Embolden / Prefulgence
+                    case CustomComboPreset.RDMPvP_Embolden:
+                        DrawAdditionalBoolChoice(RDMPvP.Config.RDMPvP_Embolden_SubOption, "Prefulgence Option",
+                            "Uses Prefulgence when available.");
+
+                        break;
+
+                    // Corps-a-Corps
+                    case CustomComboPreset.RDMPvP_Corps:
+                        DrawSliderInt(0, 1, RDMPvP.Config.RDMPvP_Corps_Charges, "Charges to Keep", 178);
+                        DrawSliderInt(5, 10, RDMPvP.Config.RDMPvP_Corps_Range, "Maximum Range", 173);
+
+                        break;
+
+                    // Displacement
+                    case CustomComboPreset.RDMPvP_Displacement:
+                        DrawSliderInt(0, 1, RDMPvP.Config.RDMPvP_Displacement_Charges, "Charges to Keep", 178);
+                        ImGui.Spacing();
+                        DrawAdditionalBoolChoice(RDMPvP.Config.RDMPvP_Displacement_SubOption, "No Movement Option",
+                            "Uses Displacement only when not moving.");
+
+                        break;
+
+                    // Forte / Vice of Thorns
+                    case CustomComboPreset.RDMPvP_Forte:
+                        DrawSliderInt(10, 100, RDMPvP.Config.RDMPvP_Forte_PlayerHP, "Player HP%", 210);
+                        ImGui.Spacing();
+                        DrawAdditionalBoolChoice(RDMPvP.Config.RDMPvP_Forte_SubOption, "Vice of Thorns Option",
+                            "Uses Vice of Thorns when available.");
+
+                        break;
+                }
+            }
         }
 
         internal class RDMPvP_BurstMode : CustomCombo

--- a/WrathCombo/Window/Functions/Presets.cs
+++ b/WrathCombo/Window/Functions/Presets.cs
@@ -19,6 +19,7 @@ using WrathCombo.Data;
 using WrathCombo.Extensions;
 using WrathCombo.Services;
 using System;
+using WrathCombo.Combos.PvP;
 
 namespace WrathCombo.Window.Functions
 {
@@ -69,8 +70,8 @@ namespace WrathCombo.Window.Functions
                 PresetAttributes attributes = new(preset);
                 Attributes[preset] = attributes;
             }
-            var enabled = PresetStorage.IsEnabled(preset);
-            var secret = Attributes[preset].IsPvP;
+            bool enabled = PresetStorage.IsEnabled(preset);
+            bool pvp = Attributes[preset].IsPvP;
             var conflicts = Attributes[preset].Conflicts;
             var parent = Attributes[preset].Parent;
             var blueAttr = Attributes[preset].BlueInactive;
@@ -285,34 +286,69 @@ namespace WrathCombo.Window.Functions
             }
             if (enabled)
             {
-                switch (info.JobID)
+                if (!pvp)
                 {
-                  //  case All.JobID: All.Config.Draw(preset); break;
-                    case AST.JobID: AST.Config.Draw(preset); break;
-                    case BLM.JobID: BLM.Config.Draw(preset); break;
-                    case BLU.JobID: BLU.Config.Draw(preset); break;
-                    case BRD.JobID: BRD.Config.Draw(preset); break;
-                    case DNC.JobID: DNC.Config.Draw(preset); break;
-                    case DOL.JobID: DOL.Config.Draw(preset); break;
-                    case DRG.JobID: DRG.Config.Draw(preset); break;
-                    case DRK.JobID: DRK.Config.Draw(preset); break;
-                    case GNB.JobID: GNB.Config.Draw(preset); break;
-                    case MCH.JobID: MCH.Config.Draw(preset); break;
-                    case MNK.JobID: MNK.Config.Draw(preset); break;
-                    case NIN.JobID: NIN.Config.Draw(preset); break;
-                    case PCT.JobID: PCT.Config.Draw(preset); break;
-                    case PLD.JobID: PLD.Config.Draw(preset); break;
-                    case RPR.JobID: RPR.Config.Draw(preset); break;
-                    case RDM.JobID: RDM.Config.Draw(preset); break;
-                    case SAM.JobID: SAM.Config.Draw(preset); break;
-                    case SCH.JobID: SCH.Config.Draw(preset); break;
-                    case SGE.JobID: SGE.Config.Draw(preset); break;
-                    case SMN.JobID: SMN.Config.Draw(preset); break;
-                    case VPR.JobID: VPR.Config.Draw(preset); break;
-                    case WAR.JobID: WAR.Config.Draw(preset); break;
-                    case WHM.JobID: WHM.Config.Draw(preset); break;
-                    default: UserConfigItems.Draw(preset, enabled); break;
+                    switch (info.JobID)
+                    {
+                        //  case All.JobID: All.Config.Draw(preset); break;
+                        case AST.JobID: AST.Config.Draw(preset); break;
+                        case BLM.JobID: BLM.Config.Draw(preset); break;
+                        case BLU.JobID: BLU.Config.Draw(preset); break;
+                        case BRD.JobID: BRD.Config.Draw(preset); break;
+                        case DNC.JobID: DNC.Config.Draw(preset); break;
+                        case DOL.JobID: DOL.Config.Draw(preset); break;
+                        case DRG.JobID: DRG.Config.Draw(preset); break;
+                        case DRK.JobID: DRK.Config.Draw(preset); break;
+                        case GNB.JobID: GNB.Config.Draw(preset); break;
+                        case MCH.JobID: MCH.Config.Draw(preset); break;
+                        case MNK.JobID: MNK.Config.Draw(preset); break;
+                        case NIN.JobID: NIN.Config.Draw(preset); break;
+                        case PCT.JobID: PCT.Config.Draw(preset); break;
+                        case PLD.JobID: PLD.Config.Draw(preset); break;
+                        case RPR.JobID: RPR.Config.Draw(preset); break;
+                        case RDM.JobID: RDM.Config.Draw(preset); break;
+                        case SAM.JobID: SAM.Config.Draw(preset); break;
+                        case SCH.JobID: SCH.Config.Draw(preset); break;
+                        case SGE.JobID: SGE.Config.Draw(preset); break;
+                        case SMN.JobID: SMN.Config.Draw(preset); break;
+                        case VPR.JobID: VPR.Config.Draw(preset); break;
+                        case WAR.JobID: WAR.Config.Draw(preset); break;
+                        case WHM.JobID: WHM.Config.Draw(preset); break;
+                        default: UserConfigItems.Draw(preset, enabled); break;
+                    }
                 }
+                else
+                {
+                    switch (info.JobID)
+                    {
+                        //  case All.JobID: All.Config.Draw(preset); break;
+                        case AST.JobID: AST.Config.Draw(preset); break;
+                        case BLM.JobID: BLM.Config.Draw(preset); break;
+                        case BLU.JobID: BLU.Config.Draw(preset); break;
+                        case BRD.JobID: BRD.Config.Draw(preset); break;
+                        case DNC.JobID: DNC.Config.Draw(preset); break;
+                        //case DOL.JobID: DOL.Config.Draw(preset); break;
+                        case DRG.JobID: DRG.Config.Draw(preset); break;
+                        case DRK.JobID: DRK.Config.Draw(preset); break;
+                        case GNB.JobID: GNB.Config.Draw(preset); break;
+                        case MCH.JobID: MCH.Config.Draw(preset); break;
+                        case MNK.JobID: MNK.Config.Draw(preset); break;
+                        case NIN.JobID: NIN.Config.Draw(preset); break;
+                        case PCT.JobID: PCT.Config.Draw(preset); break;
+                        case PLD.JobID: PLD.Config.Draw(preset); break;
+                        case RPR.JobID: RPR.Config.Draw(preset); break;
+                        case RDM.JobID: RDMPvP.Config.Draw(preset); break;
+                        case SAM.JobID: SAM.Config.Draw(preset); break;
+                        case SCH.JobID: SCH.Config.Draw(preset); break;
+                        case SGE.JobID: SGE.Config.Draw(preset); break;
+                        case SMN.JobID: SMN.Config.Draw(preset); break;
+                        case VPR.JobID: VPR.Config.Draw(preset); break;
+                        case WAR.JobID: WAR.Config.Draw(preset); break;
+                        case WHM.JobID: WHM.Config.Draw(preset); break;
+                        default: UserConfigItems.Draw(preset, enabled); break;
+                    }
+                }
+
             }
 
             ConfigWindow.currentPreset++;


### PR DESCRIPTION
- Refactored TrySTMeleeCombo for AutoRot / Manual Riposte setup
  - Kept Zwerchhau & Redoublement combo in TrySTMeleeCombo
  - Rest of it (Riposte) to TrySTMeleeStart
- Riposte override + AutoRotation Detection
  - Using Riposte to manually start the melee combo with Auto Rotation was broken
  - Zwerchhau & Redoublement will now be placed on Jolts if Auto Rotation is active.
- Removed RDMPvP.Config Drawing from RDM_Config. Placed directly in RDMPvP
- Presets now has a PvP section for migrating PvP User Options Draw