### PR TITLE
[BRD] Remove Radiant Option from CCP

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -772,10 +772,6 @@ public enum CustomComboPreset
     BRD_Adv_Buffs = 3017,
 
     [ParentCombo(BRD_ST_AdvMode)]
-    [CustomComboInfo("Buffs - Radiant Option", "Adds Radiant Finale to the Advanced Bard feature.", BRD.JobID)]
-    BRD_Adv_BuffsRadiant = 3018,
-
-    [ParentCombo(BRD_ST_AdvMode)]
     [CustomComboInfo("Resonant Option", "Adds Resonant Arrow to the Rotation after Barrage.", BRD.JobID)]
     BRD_Adv_BuffsResonant = 3041,
 


### PR DESCRIPTION
The option is not actually being used in code and allowing such would cause issues

The buffs rely on radiant for timing in the 2 min window. Enabling buffs but not radiant throws off the burst window if people do not properly late weave radiant at the right time. It is just another buff and is already covered by the buffs section. 