### PR TITLE
[MNK] Dragon Kick added to Solar Lunar Opener

### DIFF
--- a/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
@@ -181,6 +181,7 @@ internal static partial class MNK
 
         public override List<uint> OpenerActions { get; set; } =
         [
+            DragonKick,
             PerfectBalance,
             TwinSnakes,
             Demolish,


### PR DESCRIPTION
I am submitting this pull request because an element is missing, probably due to a mistake.

If this opener is intended to start with a perfect balance, then this change is not necessary.