### PR TITLE
[IPC] Add `OnlyAttackInCombat`, various improvements

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationConfigIPCWrapper.cs
+++ b/WrathCombo/AutoRotation/AutoRotationConfigIPCWrapper.cs
@@ -93,13 +93,23 @@ public class DPSSettingsIPCWrapper(DPSSettings settings)
         }
     }
 
+    public bool OnlyAttackInCombat
+    {
+        get
+        {
+            var checkControlled =
+                P.UIHelper.AutoRotationConfigControlled("OnlyAttackInCombat");
+            return checkControlled is not null
+                ? checkControlled.Value.state == 1
+                : settings.QuestPriority;
+        }
+    }
+
     #region Direct Pass-Throughs (no IPC check)
 
     public int? DPSAoETargets => settings.DPSAoETargets;
 
     public bool PreferNonCombat => settings.PreferNonCombat;
-
-    public bool OnlyAttackInCombat => settings.OnlyAttackInCombat;
 
     public float MaxDistance => settings.MaxDistance;
 

--- a/WrathCombo/Services/IPC/Enums.cs
+++ b/WrathCombo/Services/IPC/Enums.cs
@@ -184,6 +184,9 @@ public enum AutoRotationConfigOption
 
     /// <seealso cref="HealerSettings.IncludeNPCs"/>
     [ConfigValueType(typeof(bool))] IncludeNPCs = 12,
+
+    /// <seealso cref="DPSSettings.OnlyAttackInCombat" />
+    [ConfigValueType(typeof(bool))] OnlyAttackInCombat = 13,
 }
 
 #region Type Attribute

--- a/WrathCombo/Services/IPC/Helper.cs
+++ b/WrathCombo/Services/IPC/Helper.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Net.Http;
 using ECommons.ExcelServices;
 using ECommons.EzIpcManager;
-using ECommons.GameHelpers;
 using ECommons.Logging;
 using WrathCombo.CustomComboNS.Functions;
 
@@ -25,10 +24,9 @@ public partial class Helper(ref Leasing leasing)
     /// <param name="lease">
     ///     Your lease ID from <see cref="Provider.RegisterForLease(string,string)" />
     /// </param>
-    /// <param name="setCost">The cost of the <c>set</c> method.</param>
     /// <returns>If the method should bail.</returns>
     internal bool CheckForBailConditionsAtSetTime
-        (Guid? lease = null, int? setCost = null)
+        (Guid? lease = null)
     {
         // Bail if IPC is disabled
         if (!IPCEnabled)
@@ -50,15 +48,6 @@ public partial class Helper(ref Leasing leasing)
             _leasing.CheckBlacklist(lease.Value))
         {
             Logging.Warn(BailMessages.BlacklistedLease);
-            return true;
-        }
-
-        // Bail if the lease does not have enough configuration left for this set
-        if (lease is not null &&
-            setCost is not null &&
-            _leasing.CheckLeaseConfigurationsAvailable(lease.Value) < setCost.Value)
-        {
-            Logging.Warn(BailMessages.NotEnoughConfigurations);
             return true;
         }
 
@@ -96,7 +85,7 @@ public partial class Helper(ref Leasing leasing)
             currentRealJob =
                 CustomComboFunctions.JobIDs.ClassToJob(currentJobRow.RowId);
 
-        P.IPCSearch.ComboStatesByJobCategorized.TryGetValue(Player.Job,
+        P.IPCSearch.ComboStatesByJobCategorized.TryGetValue((Job)currentRealJob,
             out var comboStates);
 
         if (comboStates is null)

--- a/WrathCombo/Services/IPC/Helper.cs
+++ b/WrathCombo/Services/IPC/Helper.cs
@@ -1,14 +1,14 @@
 ﻿#region
 
-using ECommons.ExcelServices;
-using ECommons.EzIpcManager;
-using ECommons.GameHelpers;
-using ECommons.Logging;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
+using ECommons.ExcelServices;
+using ECommons.EzIpcManager;
+using ECommons.GameHelpers;
+using ECommons.Logging;
 using WrathCombo.CustomComboNS.Functions;
 
 #endregion
@@ -341,11 +341,23 @@ internal static class Logging
     {
         get
         {
-            var frame = StackTrace.GetFrame(3); // Get the calling method frame
-            var method = frame.GetMethod();
-            var className = method.DeclaringType.Name;
-            var methodName = method.Name;
-            return $"[{className}.{methodName}] ";
+            for (var i = 3; i >= 0; i--)
+            {
+                try
+                {
+                    var frame = StackTrace.GetFrame(i);
+                    var method = frame.GetMethod();
+                    var className = method.DeclaringType.Name;
+                    var methodName = method.Name;
+                    return $"[{className}.{methodName}] ";
+                }
+                catch
+                {
+                    // Continue to the next index
+                }
+            }
+
+            return "[Unknown Method] ";
         }
     }
 

--- a/WrathCombo/Services/IPC/Helper.cs
+++ b/WrathCombo/Services/IPC/Helper.cs
@@ -152,7 +152,8 @@ public partial class Helper(ref Leasing leasing)
             var stAdvanced = comboStates[ComboTargetTypeKeys.SingleTarget]
                 [ComboSimplicityLevelKeys.Advanced].First().Key;
             combos.Add(stAdvanced);
-            combos.AddRange(P.IPCSearch.OptionNamesByJob[job][stAdvanced]);
+            if (includeOptions)
+                combos.AddRange(P.IPCSearch.OptionNamesByJob[job][stAdvanced]);
         }
 
         #endregion
@@ -172,7 +173,8 @@ public partial class Helper(ref Leasing leasing)
             var mtAdvanced = comboStates[ComboTargetTypeKeys.MultiTarget]
                 [ComboSimplicityLevelKeys.Advanced].First().Key;
             combos.Add(mtAdvanced);
-            combos.AddRange(P.IPCSearch.OptionNamesByJob[job][mtAdvanced]);
+            if (includeOptions)
+                combos.AddRange(P.IPCSearch.OptionNamesByJob[job][mtAdvanced]);
         }
 
         #endregion
@@ -187,7 +189,8 @@ public partial class Helper(ref Leasing leasing)
         {
             var healSTPreset = comboStates[ComboTargetTypeKeys.HealST]
                 [ComboSimplicityLevelKeys.Other].First().Key;
-            combos.AddRange(P.IPCSearch.OptionNamesByJob[job][healSTPreset]);
+            if (includeOptions)
+                combos.AddRange(P.IPCSearch.OptionNamesByJob[job][healSTPreset]);
         }
 
         if (comboStates.TryGetValue(ComboTargetTypeKeys.HealMT, out healResults))
@@ -198,7 +201,8 @@ public partial class Helper(ref Leasing leasing)
         {
             var healMTPreset = comboStates[ComboTargetTypeKeys.HealMT]
                 [ComboSimplicityLevelKeys.Other].First().Key;
-            combos.AddRange(P.IPCSearch.OptionNamesByJob[job][healMTPreset]);
+            if (includeOptions)
+                combos.AddRange(P.IPCSearch.OptionNamesByJob[job][healMTPreset]);
         }
 
         #endregion

--- a/WrathCombo/Services/IPC/Leasing.cs
+++ b/WrathCombo/Services/IPC/Leasing.cs
@@ -85,13 +85,10 @@ public class Lease(
 
     /// <summary>
     ///     The number of sets leased by this registration currently.
-    ///     Maximum is <c>60</c>.
     /// </summary>
-    /// <seealso cref="Provider.RegisterForLease(string,string)" />
-    /// <seealso cref="Leasing.MaxLeaseConfigurations" />
     public int SetsLeased =>
         AutoRotationControlled.Count +
-        //JobsControlled.Count +
+        JobsControlled.Count +
         CombosControlled.Count +
         OptionsControlled.Count;
 
@@ -154,14 +151,6 @@ public class Lease(
 
 public partial class Leasing
 {
-    /// <summary>
-    ///     The number of sets allowed per lease.
-    /// </summary>
-    /// <seealso cref="Provider.RegisterForLease(string,string)" />
-    /// <seealso cref="CheckLeaseConfigurationsAvailable" />
-    /// <seealso cref="Lease.SetsLeased" />
-    internal const int MaxLeaseConfigurations = 60;
-
     /// <summary>
     ///     Active leases.
     /// </summary>
@@ -353,6 +342,7 @@ public partial class Leasing
     /// <param name="lease">
     ///     Your lease ID from <see cref="Provider.RegisterForLease(string,string)" />
     /// </param>
+    /// <param name="jobOverride">A manual override, only used in testing</param>
     /// <seealso cref="Provider.SetCurrentJobAutoRotationReady" />
     internal void AddRegistrationForCurrentJob(Guid lease, Job? jobOverride = null)
     {
@@ -614,22 +604,6 @@ public partial class Leasing
     /// <returns>Whether the lease exists.</returns>
     internal bool CheckLeaseExists(Guid lease) =>
         Registrations.ContainsKey(lease);
-
-    /// <summary>
-    ///     Checks how many sets are still available for a lease.
-    /// </summary>
-    /// <param name="lease">
-    ///     Your lease ID from <see cref="Provider.RegisterForLease(string,string)" />
-    /// </param>
-    /// <returns>
-    ///     The number of sets available for the lease, or <c>null</c> if the lease
-    ///     does not exist.
-    /// </returns>
-    /// <seealso cref="MaxLeaseConfigurations" />
-    internal int? CheckLeaseConfigurationsAvailable(Guid lease) =>
-        Registrations.TryGetValue(lease, out var value)
-            ? MaxLeaseConfigurations - value.SetsLeased
-            : null;
 
     /// <summary>
     ///     Suspend all leases. Called when IPC is disabled remotely.

--- a/WrathCombo/Services/IPC/Leasing.cs
+++ b/WrathCombo/Services/IPC/Leasing.cs
@@ -300,7 +300,11 @@ public partial class Leasing
         var registration = Registrations[lease];
 
         if (registration.AutoRotationConfigsControlled.Count > 0 && registration.AutoRotationControlled[0] == newState)
+        {
+            Logging.Log(
+                $"{registration.PluginName}: You are already controlling Auto-Rotation");
             return;
+        }
 
         // Always [0], not an actual add
         registration.AutoRotationControlled[0] = newState;
@@ -366,10 +370,13 @@ public partial class Leasing
         if (jobOverride is not null)
             currentJob = jobOverride.Value;
         var job = currentJob.ToString();
-        if (registration.JobsControlled.ContainsKey(currentJob))
-            return;
 
-        registration.JobsControlled[currentJob] = true;
+        if (!registration.JobsControlled.TryAdd(currentJob, true))
+        {
+            Logging.Log(
+                $"{registration.PluginName}: You are already controlling the current job ({job})");
+            return;
+        }
 
         Logging.Log(
             $"{registration.PluginName}: Registering Current Job ({job}) ...");

--- a/WrathCombo/Services/IPC/Leasing.cs
+++ b/WrathCombo/Services/IPC/Leasing.cs
@@ -228,7 +228,11 @@ public partial class Leasing
     {
         // Bail if the plugin is temporarily blacklisted
         if (CheckBlacklist(internalPluginName))
+        {
+            Logging.Warn(
+                $"{pluginName}: Plugin is temporarily blacklisted, cannot register for a lease");
             return null;
+        }
 
         // Make sure the lease ID is unique
         // (unnecessary, but could save a big headache)

--- a/WrathCombo/Services/IPC/Leasing.cs
+++ b/WrathCombo/Services/IPC/Leasing.cs
@@ -299,7 +299,8 @@ public partial class Leasing
     {
         var registration = Registrations[lease];
 
-        if (registration.AutoRotationConfigsControlled.Count > 0 && registration.AutoRotationControlled[0] == newState)
+        if (registration.AutoRotationConfigsControlled.Count > 0 &&
+            registration.AutoRotationControlled[0] == newState)
         {
             Logging.Log(
                 $"{registration.PluginName}: You are already controlling Auto-Rotation");
@@ -398,8 +399,10 @@ public partial class Leasing
             else
             {
                 locking = false;
-                stringKeys = registration.CombosControlled.Keys
-                    .Select(k => k.ToString()).ToArray();
+                stringKeys = combos.Select(k => k.ToString())
+                    .Concat(registration.CombosControlled.Keys
+                        .Select(k => k.ToString()).ToArray())
+                    .ToArray();
             }
 
             // Register all combos

--- a/WrathCombo/Services/IPC/Leasing.cs
+++ b/WrathCombo/Services/IPC/Leasing.cs
@@ -354,7 +354,7 @@ public partial class Leasing
     ///     Your lease ID from <see cref="Provider.RegisterForLease(string,string)" />
     /// </param>
     /// <seealso cref="Provider.SetCurrentJobAutoRotationReady" />
-    internal void AddRegistrationForCurrentJob(Guid lease)
+    internal void AddRegistrationForCurrentJob(Guid lease, Job? jobOverride = null)
     {
         var registration = Registrations[lease];
 
@@ -373,6 +373,8 @@ public partial class Leasing
                 CustomComboFunctions.JobIDs.ClassToJob(currentJobRow.RowId);
 
         var currentJob = (Job)currentRealJob;
+        if (jobOverride is not null)
+            currentJob = jobOverride.Value;
         var job = currentJob.ToString();
         if (registration.JobsControlled.ContainsKey(currentJob))
             return;

--- a/WrathCombo/Services/IPC/ProvideAutoRotConfig.cs
+++ b/WrathCombo/Services/IPC/ProvideAutoRotConfig.cs
@@ -20,7 +20,7 @@ public partial class Provider
         var type = Helper.GetAutoRotationConfigType(option);
 
         // Check if the config is overriden by a lease
-        var checkControlled = _leasing.CheckAutoRotationConfigControlled(option);
+        var checkControlled = Leasing.CheckAutoRotationConfigControlled(option);
         if (checkControlled is not null)
         {
             return type.IsEnum
@@ -77,14 +77,13 @@ public partial class Provider
     ///     The value you want to set the option to.<br />
     ///     All valid options can be parsed from an int, or the exact expected types.
     /// </param>
-    /// <value>+1 <c>set</c></value>
     /// <seealso cref="AutoRotationConfigOption"/>
     [EzIPC]
     public void SetAutoRotationConfigState
         (Guid lease, AutoRotationConfigOption option, object value)
     {
         // Bail for standard conditions
-        if (_helper.CheckForBailConditionsAtSetTime(lease, 1))
+        if (Helper.CheckForBailConditionsAtSetTime(lease))
             return;
 
         // Try to convert the value to the correct type
@@ -112,7 +111,7 @@ public partial class Provider
         if (type == typeof(bool))
             convertedValue = (bool)convertedValue ? 1 : 0;
 
-        _leasing.AddRegistrationForAutoRotationConfig(
+        Leasing.AddRegistrationForAutoRotationConfig(
             lease, option, (int)convertedValue);
     }
 }

--- a/WrathCombo/Services/IPC/ProvideAutoRotConfig.cs
+++ b/WrathCombo/Services/IPC/ProvideAutoRotConfig.cs
@@ -52,16 +52,16 @@ public partial class Provider
                 AutoRotationConfigOption.AutoCleanse => arcH.AutoCleanse,
                 _ => throw new ArgumentOutOfRangeException(nameof(option), option,
                     null)
+                arcOption.IncludeNPCs => arcH.IncludeNPCs,
+                arcOption.OnlyAttackInCombat => arcD.OnlyAttackInCombat,
             };
         }
-#pragma warning disable CS0168 // Variable is declared but never used
-        catch (Exception _)
+        catch (Exception)
         {
             Logging.Error("Invalid `option`. Please refer to " +
                           "WrathCombo.Services.IPC.AutoRotationConfigOption");
             return null;
         }
-#pragma warning restore CS0168 // Variable is declared but never used
     }
 
     /// <summary>
@@ -92,8 +92,10 @@ public partial class Provider
         object convertedValue;
         try
         {
+            // Handle enum values as any number type, and convert it to the real enum
             if (type.IsEnum && typeCode is >= TypeCode.SByte and <= TypeCode.UInt64)
                 convertedValue = Enum.ToObject(type, value);
+            // Convert anything else directly
             else
                 convertedValue = Convert.ChangeType(value, type);
         }

--- a/WrathCombo/Services/IPC/ProvideAutoRotConfig.cs
+++ b/WrathCombo/Services/IPC/ProvideAutoRotConfig.cs
@@ -50,10 +50,10 @@ public partial class Provider
                 AutoRotationConfigOption.AutoRez => arcH.AutoRez,
                 AutoRotationConfigOption.AutoRezDPSJobs => arcH.AutoRezDPSJobs,
                 AutoRotationConfigOption.AutoCleanse => arcH.AutoCleanse,
+                AutoRotationConfigOption.IncludeNPCs => arcH.IncludeNPCs,
+                AutoRotationConfigOption.OnlyAttackInCombat => arcD.OnlyAttackInCombat,
                 _ => throw new ArgumentOutOfRangeException(nameof(option), option,
                     null)
-                arcOption.IncludeNPCs => arcH.IncludeNPCs,
-                arcOption.OnlyAttackInCombat => arcD.OnlyAttackInCombat,
             };
         }
         catch (Exception)

--- a/WrathCombo/Window/Tabs/AutoRotationTab.cs
+++ b/WrathCombo/Window/Tabs/AutoRotationTab.cs
@@ -109,7 +109,8 @@ namespace WrathCombo.Window.Tabs
                 if (cfg.DPSSettings.PreferNonCombat && changed)
                     cfg.DPSSettings.OnlyAttackInCombat = false;
 
-                changed |= ImGui.Checkbox($"Only Attack Targets Already In Combat", ref cfg.DPSSettings.OnlyAttackInCombat);
+                changed |= P.UIHelper.ShowIPCControlledCheckboxIfNeeded(
+                    "Only Attack Targets Already In Combat", ref cfg.InCombatOnly, "OnlyAttackInCombat");
 
                 if (cfg.DPSSettings.OnlyAttackInCombat && changed)
                     cfg.DPSSettings.PreferNonCombat = false;

--- a/WrathCombo/Window/Tabs/Debug.cs
+++ b/WrathCombo/Window/Tabs/Debug.cs
@@ -16,6 +16,7 @@ using ImGuiNET;
 using Lumina.Excel.Sheets;
 using System;
 using System.Linq;
+using System.Numerics;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Data;
 using WrathCombo.Services;
@@ -421,23 +422,29 @@ namespace WrathCombo.Window.Tabs
                 CustomStyleText("Countdown Remaining:", $"{CountdownActive} {CountdownRemaining}");
                 CustomStyleText("Raidwide Inc:", $"{RaidWideCasting()}");
 
+                void WrathIPCCallback (int cancellationReason, string extraInfo)
+                {
+                    WrathLease = null;
+                }
+
                 // IPC
                 if (ImGui.CollapsingHeader("IPC"))
                 {
                     CustomStyleText("Wrath Leased:", WrathLease is not null);
-                    foreach (var registration in P.IPC._leasing.Registrations)
-                    {
-                        CustomStyleText($"{registration.Key}", $"{registration.Value}");
-                    }
                     if (WrathLease is null)
                     {
                         if (ImGui.Button("Register"))
                         {
-                            WrathLease = P.IPC.RegisterForLease("WrathCombo", "WrathCombo");
+                            WrathLease = P.IPC.RegisterForLease("WrathCombo", "WrathCombo", WrathIPCCallback);
                         }
                     }
                     if (WrathLease is not null)
                     {
+                        CustomStyleText("Lease GUID", $"{WrathLease}");
+                        CustomStyleText("Configurations: ",
+                            $"{P.IPC._leasing.Registrations[WrathLease.Value].SetsLeased}" +
+                            $" / {Leasing.MaxLeaseConfigurations}");
+
                         if (ImGui.Button("Release"))
                         {
                             P.IPC.ReleaseControl(WrathLease.Value);
@@ -445,20 +452,41 @@ namespace WrathCombo.Window.Tabs
                         }
                         if (ImGui.Button("Set Autorot For Job"))
                         {
-                            P.IPC.SetCurrentJobAutoRotationReady(WrathLease.Value);
+                            P.IPC.SetCurrentJobAutoRotationReady(WrathLease!.Value);
+                        }
+                        if (ImGui.Button("Set Autorot For  SCH"))
+                        {
+                            P.IPC._leasing.AddRegistrationForCurrentJob(
+                                WrathLease!.Value, Job.SCH);
                         }
                         if (ImGui.Button("Mimic AD IPC"))
                         {
-                            P.IPC.SetCurrentJobAutoRotationReady(WrathLease.Value);
+                            P.IPC.SetCurrentJobAutoRotationReady(WrathLease!.Value);
                             P.IPC.SetAutoRotationState(WrathLease!.Value, true);
-                            P.IPC.SetAutoRotationConfigState(WrathLease.Value, AutoRotationConfigOption.InCombatOnly, false);
-                            P.IPC.SetAutoRotationConfigState(WrathLease.Value, AutoRotationConfigOption.AutoRez, true);
-                            P.IPC.SetAutoRotationConfigState(WrathLease.Value, AutoRotationConfigOption.AutoRezDPSJobs, true);
-                            P.IPC.SetAutoRotationConfigState(WrathLease.Value, AutoRotationConfigOption.IncludeNPCs, true);
-                            P.IPC.SetAutoRotationConfigState(WrathLease.Value, AutoRotationConfigOption.DPSRotationMode, DPSRotationMode.Lowest_Current);
-                            P.IPC.SetAutoRotationConfigState(WrathLease.Value, AutoRotationConfigOption.HealerRotationMode, HealerRotationMode.Lowest_Current);
+                            P.IPC.SetAutoRotationConfigState(WrathLease!.Value, AutoRotationConfigOption.InCombatOnly, false);
+                            P.IPC.SetAutoRotationConfigState(WrathLease!.Value, AutoRotationConfigOption.AutoRez, true);
+                            P.IPC.SetAutoRotationConfigState(WrathLease!.Value, AutoRotationConfigOption.AutoRezDPSJobs, true);
+                            P.IPC.SetAutoRotationConfigState(WrathLease!.Value, AutoRotationConfigOption.IncludeNPCs, true);
+                            P.IPC.SetAutoRotationConfigState(WrathLease!.Value, AutoRotationConfigOption.DPSRotationMode, DPSRotationMode.Lowest_Current);
+                            P.IPC.SetAutoRotationConfigState(WrathLease!.Value, AutoRotationConfigOption.HealerRotationMode, HealerRotationMode.Lowest_Current);
 
                         }
+                    }
+
+                    ImGui.Dummy(new Vector2(10f));
+                    if (P.IPC._leasing.Registrations.Count > 0)
+                    {
+                        CustomStyleText("All Leases:", "");
+                        foreach (var registration in P.IPC._leasing.Registrations)
+                        {
+                            CustomStyleText(
+                                $"{registration.Key}",
+                                $"{registration.Value.PluginName}");
+                        }
+                    }
+                    else
+                    {
+                        CustomStyleText("No current leases", "");
                     }
                 }
 

--- a/WrathCombo/Window/Tabs/Debug.cs
+++ b/WrathCombo/Window/Tabs/Debug.cs
@@ -461,7 +461,7 @@ namespace WrathCombo.Window.Tabs
                         if (ImGui.Button("Mimic AD IPC"))
                         {
                             P.IPC.SetCurrentJobAutoRotationReady(WrathLease!.Value);
-                            P.IPC.SetAutoRotationState(WrathLease!.Value, true);
+                            P.IPC.SetAutoRotationState(WrathLease!.Value);
                             P.IPC.SetAutoRotationConfigState(WrathLease!.Value, AutoRotationConfigOption.InCombatOnly, false);
                             P.IPC.SetAutoRotationConfigState(WrathLease!.Value, AutoRotationConfigOption.AutoRez, true);
                             P.IPC.SetAutoRotationConfigState(WrathLease!.Value, AutoRotationConfigOption.AutoRezDPSJobs, true);

--- a/WrathCombo/Window/Tabs/Debug.cs
+++ b/WrathCombo/Window/Tabs/Debug.cs
@@ -442,8 +442,7 @@ namespace WrathCombo.Window.Tabs
                     {
                         CustomStyleText("Lease GUID", $"{WrathLease}");
                         CustomStyleText("Configurations: ",
-                            $"{P.IPC._leasing.Registrations[WrathLease.Value].SetsLeased}" +
-                            $" / {Leasing.MaxLeaseConfigurations}");
+                            $"{P.IPC.Leasing.Registrations[WrathLease.Value].SetsLeased}");
 
                         if (ImGui.Button("Release"))
                         {
@@ -456,7 +455,7 @@ namespace WrathCombo.Window.Tabs
                         }
                         if (ImGui.Button("Set Autorot For  SCH"))
                         {
-                            P.IPC._leasing.AddRegistrationForCurrentJob(
+                            P.IPC.Leasing.AddRegistrationForCurrentJob(
                                 WrathLease!.Value, Job.SCH);
                         }
                         if (ImGui.Button("Mimic AD IPC"))
@@ -474,10 +473,10 @@ namespace WrathCombo.Window.Tabs
                     }
 
                     ImGui.Dummy(new Vector2(10f));
-                    if (P.IPC._leasing.Registrations.Count > 0)
+                    if (P.IPC.Leasing.Registrations.Count > 0)
                     {
                         CustomStyleText("All Leases:", "");
-                        foreach (var registration in P.IPC._leasing.Registrations)
+                        foreach (var registration in P.IPC.Leasing.Registrations)
                         {
                             CustomStyleText(
                                 $"{registration.Key}",

--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -145,7 +145,7 @@ namespace WrathCombo
             Service.IconReplacer = new IconReplacer();
             ActionWatching.Enable();
             AST.InitCheckCards();
-            IPC = Provider.CreateAsync().Result;
+            IPC = Provider.InitAsync().Result;
 
             ConfigWindow = new ConfigWindow();
             SettingChangeWindow = new SettingChangeWindow();

--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -228,6 +228,8 @@ comments on each method.
     or another plugin
   - The `AutoRotationConfigOption` enum is in the [`AutoRotationConfigOption` enum](https://github.com/PunishXIV/WrathCombo/blob/main/WrathCombo/Services/IPC/Enums.cs#L145)
    and must be copied over to your plugin for use with this method
+    - You can safely pass in enum values that are not yet released; they will 
+      just provide a warning you can ignore.
   - The `object` returned is of the type specified in the enum for the option
 - `void SetAutoRotationConfigState(Guid, AutoRotationConfigOption, object)`
   - The `object` must be of the type specified in the enum for the option

--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -405,6 +405,9 @@ resources below, or the first several sections of this guide.
 
 ## Changelog
 
+- PunishXIV/WrathCombo#293 - `Get` and `SetAutoRotationConfigState` will now safely
+  warn (instead of error out) for unknown enum values (i.e. not-yet-released ones),
+  `1.0.0.10`.
 - PunishXIV/WrathCombo#293 - There is no longer a configuration limit,
   `1.0.0.10`.
 - PunishXIV/WrathCombo#293 - Add `OnlyAttackInCombat` Auto-Rotation Configuration,
@@ -416,8 +419,8 @@ resources below, or the first several sections of this guide.
 - PunishXIV/WrathCombo@0d8faa7 - Added `IncludeNPCs` healer option to the 
   `AutoRotationConfigOption` 
   enum, `1.0.0.8`.
-- PunishXIV/WrathCombo#232 - Fixed capability to request a cancellation callback via your own IPC 
-  method, `1.0.0.7`.
+- PunishXIV/WrathCombo#232 - Fixed capability to request a cancellation callback via 
+  your own IPC method, `1.0.0.7`.
 - PunishXIV/WrathCombo#188 - Initial introduction of the IPC, `1.0.0.6`.
 
 > [!TIP]

--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -84,13 +84,6 @@ big points are **NOT** limited:
 
 With that said, however, there are a variety of arbitrary limitations on the use 
 of the IPC that should be noted:
-- Leases have a configuration limit
-  - This limit is currently `60` individual configurations, with the exact costs 
-    detailed in the Provider files.
-    - The exact, current limit can be seen with the `MaxLeaseConfigurations` field
-      [here](https://github.com/PunishXIV/WrathCombo/blob/main/WrathCombo/Services/IPC/Leasing.cs#L164).
-  - This limit is designed to keep the focus on making the user Auto-Rotation ready,
-    and not on optimizing the user's settings or setting up multiple jobs.
 - Leases cannot share display names
   - This is designed to prevent confusion for the user regarding duplicate names 
     listed as controlling a single setting.
@@ -412,6 +405,8 @@ resources below, or the first several sections of this guide.
 
 ## Changelog
 
+- PunishXIV/WrathCombo#293 - There is no longer a configuration limit,
+  `1.0.0.10`.
 - PunishXIV/WrathCombo#293 - Add `OnlyAttackInCombat` Auto-Rotation Configuration,
   `1.0.0.10`.
 - PunishXIV/WrathCombo@3ef3109 - Methods with specific job parameters are now `uint`,

--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -412,6 +412,8 @@ resources below, or the first several sections of this guide.
 
 ## Changelog
 
+- PunishXIV/WrathCombo#293 - Add `OnlyAttackInCombat` Auto-Rotation Configuration,
+  `1.0.0.10`.
 - PunishXIV/WrathCombo@3ef3109 - Methods with specific job parameters are now `uint`,
   `1.0.0.9`.
 - PunishXIV/WrathCombo@5699d7b - Auto-Rotation Configurations enums are no longer a 


### PR DESCRIPTION
- [X] Add `OnlyAttackInCombat` Auto-Rotation Configuration option.
- [X] Remove Maximum Configuration Limit.
- [X] Fixed issue with logger system.
- [X] Expand upon Debug section for the IPC.
- [X] Add warnings for the duplicate-avoidance added in 5699d7b.
- [X] No longer registers combos as options, or vice versa, when setting a job to be auto-rotation-ready.
- [X] Add warning for attempting to register while still blacklisted.
- [X] Add method to check if options are controlled by the lease already. (per [this discord post](https://discord.com/channels/1001823907193552978/1330920031609032714))
- [X] ~~Support passing of not-yet-implemented Auto-Rotation Configuration options. (per [this discord comment](https://discord.com/channels/1001823907193552978/1330932806297325638/1330980792502976664))~~