### PR TITLE
[RDM & SGE] Tweaks

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -4653,11 +4653,6 @@ public enum CustomComboPreset
         "Prognosis becomes Eukrasian Prognosis if the shield is not applied.", SGE.JobID)]
     SGE_AoE_Heal_EPrognosis = 14028,
 
-    [ParentCombo(SGE_AoE_Heal_EPrognosis)]
-    [CustomComboInfo("Ignore Shield Check",
-        "Warning, will force the use of Eukrasia Prognosis, and normal Prognosis will be unavailable.", SGE.JobID)]
-    SGE_AoE_Heal_EPrognosis_IgnoreShield = 14029,
-
     [ParentCombo(SGE_AoE_Heal)]
     [CustomComboInfo("Rhizomata Option", "Adds Rhizomata when Addersgall is 0.", SGE.JobID)]
     SGE_AoE_Heal_Rhizomata = 14036,

--- a/WrathCombo/Combos/PvE/ALL/ALL.cs
+++ b/WrathCombo/Combos/PvE/ALL/ALL.cs
@@ -85,11 +85,10 @@ internal class All
     /// <summary>
     ///     Quick Level, Offcooldown, spellweave, and MP check of Lucid Dreaming
     /// </summary>
-    /// <param name="actionID">action id to check weave</param>
     /// <param name="MPThreshold">Player MP less than Threshold check</param>
     /// <param name="weave">Spell Weave check by default</param>
     /// <returns></returns>
-    public static bool CanUseLucid(uint actionID, int MPThreshold, bool weave = true) => 
+    public static bool CanUseLucid(int MPThreshold, bool weave = true) => 
         CustomComboFunctions.ActionReady(LucidDreaming)
         && CustomComboFunctions.LocalPlayer.CurrentMp <= MPThreshold
         && (!weave || CustomComboFunctions.CanSpellWeave());

--- a/WrathCombo/Combos/PvE/RDM/RDM.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM.cs
@@ -37,32 +37,34 @@ internal partial class RDM
                 CanSpellWeave())
                 return Variant.VariantRampart;
 
+            uint NewActionID = 0;
+
             //oGCDs
-            if (TryOGCDs(actionID, true, out uint oGCDAction))
-                return oGCDAction;
+            if (TryOGCDs(actionID, true, ref NewActionID))
+                return NewActionID;
 
             //Lucid Dreaming
-            if (TryLucidDreaming(actionID, 6500, ComboAction))
+            if (TryLucidDreaming(6500, ComboAction))
                 return All.LucidDreaming;
 
             //Melee Finisher
-            if (MeleeCombo.TryMeleeFinisher(out uint finisherAction))
-                return finisherAction;
+            if (MeleeCombo.TryMeleeFinisher(ref NewActionID))
+                return NewActionID;
 
             //Melee Combo
             //  Manafication/Embolden Code
-            if (MeleeCombo.TrySTManaEmbolden(actionID, out uint ManaEmbolden))
-                return ManaEmbolden;
-            if (MeleeCombo.TrySTMeleeCombo(actionID, out uint MeleeComboID))
-                return MeleeComboID;
-            if (MeleeCombo.TrySTMeleeStart(actionID, out uint MeleeID))
-                return MeleeID;
+            if (MeleeCombo.TrySTManaEmbolden(ref NewActionID))
+                return NewActionID;
+            if (MeleeCombo.TrySTMeleeCombo(ref NewActionID))
+                return NewActionID;
+            if (MeleeCombo.TrySTMeleeStart(ref NewActionID))
+                return NewActionID;
 
             //Normal Spell Rotation
-            if (SpellCombo.TryAcceleration(actionID, out uint Accel))
-                return Accel;
-            if (SpellCombo.TrySTSpellRotation(actionID, out uint SpellID))
-                return SpellID;
+            if (SpellCombo.TryAcceleration(ref NewActionID))
+                return NewActionID;
+            if (SpellCombo.TrySTSpellRotation(ref NewActionID))
+                return NewActionID;
 
             //NO_CONDITIONS_MET
             return actionID;
@@ -78,6 +80,8 @@ internal partial class RDM
             if (actionID is not (Jolt or Jolt2 or Jolt3) &&
                 actionID is not (Fleche or Riposte or Reprise))
                 return actionID;
+
+            uint NewActionID = 0;
 
             if (actionID is Jolt or Jolt2 or Jolt3)
             {
@@ -116,8 +120,8 @@ internal partial class RDM
 
                 if (ActionFound && LevelChecked(Corpsacorps))
                 {
-                    if (TryOGCDs(actionID, true, out uint oGCDAction, true))
-                        return oGCDAction;
+                    if (TryOGCDs(actionID, true, ref NewActionID, true))
+                        return NewActionID;
                 }
             }
             //END_RDM_OGCD
@@ -125,7 +129,7 @@ internal partial class RDM
             //Lucid Dreaming
             if (IsEnabled(CustomComboPreset.RDM_ST_Lucid)
                 && actionID is Jolt or Jolt2 or Jolt3
-                && TryLucidDreaming(actionID, Config.RDM_ST_Lucid_Threshold, ComboAction)) //Don't interupt certain combos
+                && TryLucidDreaming(Config.RDM_ST_Lucid_Threshold, ComboAction)) //Don't interupt certain combos
                 return All.LucidDreaming;
 
             //RDM_MELEEFINISHER
@@ -141,8 +145,8 @@ internal partial class RDM
                     (Config.RDM_ST_MeleeFinisher_Adv &&
                         (useJoltsAdv || useRiposteAdv || useVerMagicAdv));
 
-                if (ActionFound && MeleeCombo.TryMeleeFinisher(out uint finisherAction))
-                    return finisherAction;
+                if (ActionFound && MeleeCombo.TryMeleeFinisher(ref NewActionID))
+                    return NewActionID;
             }
             //END_RDM_MELEEFINISHER
 
@@ -163,25 +167,25 @@ internal partial class RDM
                 if (ActionFound)
                 {
                     if (MeleeCombo.TrySTManaEmbolden(
-                        actionID, out uint ManaEmboldenID, IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_ManaEmbolden), IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_CorpsGapCloser),
+                        ref NewActionID, IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_ManaEmbolden), IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_CorpsGapCloser),
                         IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_ManaEmbolden_DoubleCombo),
                         IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_UnbalanceMana)))
-                        return ManaEmboldenID;
+                        return NewActionID;
                 }
 
                 //Zwerchhau & Redoublement. Force to Jolts if Auto Rotation
                 if (ActionFound || (isAutoRotOn && isJoltAction))
                 {
-                    if (MeleeCombo.TrySTMeleeCombo(actionID, out uint MeleeComboID, Config.RDM_ST_MeleeEnforced))
-                        return MeleeComboID;
+                    if (MeleeCombo.TrySTMeleeCombo(ref NewActionID, Config.RDM_ST_MeleeEnforced))
+                        return NewActionID;
                 }
 
                 //Start the Combo
                 if (ActionFound)
                 {
-                    if (MeleeCombo.TrySTMeleeStart(actionID, out uint MeleeID, IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_CorpsGapCloser),
+                    if (MeleeCombo.TrySTMeleeStart(ref NewActionID, IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_CorpsGapCloser),
                         IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_UnbalanceMana)))
-                        return MeleeID;
+                        return NewActionID;
                 }
             }
 
@@ -189,17 +193,17 @@ internal partial class RDM
             if (IsEnabled(CustomComboPreset.RDM_ST_ThunderAero) && IsEnabled(CustomComboPreset.RDM_ST_ThunderAero_Accel)
                 && actionID is Jolt or Jolt2 or Jolt3)
             {
-                if (SpellCombo.TryAcceleration(actionID, out uint AccID, IsEnabled(CustomComboPreset.RDM_ST_ThunderAero_Accel_Swiftcast)))
-                    return AccID;
+                if (SpellCombo.TryAcceleration(ref NewActionID, IsEnabled(CustomComboPreset.RDM_ST_ThunderAero_Accel_Swiftcast)))
+                    return NewActionID;
             }
 
             if (actionID is Jolt or Jolt2 or Jolt3)
             {
 
-                if (SpellCombo.TrySTSpellRotation(actionID, out uint SpellID,
+                if (SpellCombo.TrySTSpellRotation(ref NewActionID,
                     IsEnabled(CustomComboPreset.RDM_ST_FireStone),
                     IsEnabled(CustomComboPreset.RDM_ST_ThunderAero)))
-                    return SpellID;
+                    return NewActionID;
             }
 
             //NO_CONDITIONS_MET
@@ -227,29 +231,31 @@ internal partial class RDM
                 CanSpellWeave())
                 return Variant.VariantRampart;
 
+            uint NewActionID = 0;
+
             //RDM_OGCD
-            if (TryOGCDs(actionID, true, out uint oGCDAction, true))
-                return oGCDAction;
+            if (TryOGCDs(actionID, true, ref NewActionID, true))
+                return NewActionID;
 
             // LUCID
-            if (TryLucidDreaming(actionID, 6500, ComboAction))
+            if (TryLucidDreaming(6500, ComboAction))
                 return All.LucidDreaming;
 
             //RDM_MELEEFINISHER
-            if (MeleeCombo.TryMeleeFinisher(out uint finisherAction))
-                return finisherAction;
+            if (MeleeCombo.TryMeleeFinisher(ref NewActionID))
+                return NewActionID;
 
-            if (MeleeCombo.TryAoEManaEmbolden(actionID, out uint ManaEmbolden))
-                return ManaEmbolden;
+            if (MeleeCombo.TryAoEManaEmbolden(ref NewActionID))
+                return NewActionID;
 
-            if (MeleeCombo.TryAoEMeleeCombo(actionID, out uint AoEMeleeID))
-                return AoEMeleeID;
+            if (MeleeCombo.TryAoEMeleeCombo(ref NewActionID))
+                return NewActionID;
 
-            if (SpellCombo.TryAcceleration(actionID, out uint AccelID))
-                return AccelID;
+            if (SpellCombo.TryAcceleration(ref NewActionID))
+                return NewActionID;
 
-            if (SpellCombo.TryAoESpellRotation(actionID, out uint SpellID))
-                return SpellID;
+            if (SpellCombo.TryAoESpellRotation(ref NewActionID))
+                return NewActionID;
             return actionID;
         }
     }
@@ -259,6 +265,12 @@ internal partial class RDM
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_AoE_DPS;
         protected override uint Invoke(uint actionID)
         {
+            if (actionID is not (Scatter or Impact) &&
+                actionID is not (Moulinet or Veraero2 or Verthunder2))
+                return actionID;
+
+            uint NewActionID = 0;
+
             if (actionID is Scatter or Impact)
             {
                 //VARIANTS
@@ -276,12 +288,12 @@ internal partial class RDM
                 //RDM_OGCD
                 if (IsEnabled(CustomComboPreset.RDM_AoE_oGCD)
                     && LevelChecked(Corpsacorps)
-                    && TryOGCDs(actionID, true, out uint oGCDAction, true))
-                    return oGCDAction;
+                    && TryOGCDs(actionID, true, ref NewActionID, true))
+                    return NewActionID;
 
                 // LUCID
                 if (IsEnabled(CustomComboPreset.RDM_AoE_Lucid)
-                    && TryLucidDreaming(actionID, Config.RDM_AoE_Lucid_Threshold, ComboAction))
+                    && TryLucidDreaming(Config.RDM_AoE_Lucid_Threshold, ComboAction))
                     return All.LucidDreaming;
             }
 
@@ -295,8 +307,8 @@ internal partial class RDM
                          (Config.RDM_AoE_MeleeFinisher_OnAction[1] && actionID is Moulinet) ||
                          (Config.RDM_AoE_MeleeFinisher_OnAction[2] && actionID is Veraero2 or Verthunder2)));
 
-                if (ActionFound && MeleeCombo.TryMeleeFinisher(out uint finisherAction))
-                    return finisherAction;
+                if (ActionFound && MeleeCombo.TryMeleeFinisher(ref NewActionID))
+                    return NewActionID;
             }
             //END_RDM_MELEEFINISHER
 
@@ -312,24 +324,24 @@ internal partial class RDM
                 if (ActionFound)
                 {
                     if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo_ManaEmbolden)
-                        && MeleeCombo.TryAoEManaEmbolden(actionID, out uint ManaEmbolen, Config.RDM_AoE_MoulinetRange))
-                        return ManaEmbolen;
+                        && MeleeCombo.TryAoEManaEmbolden(ref NewActionID, Config.RDM_AoE_MoulinetRange))
+                        return NewActionID;
 
-                    if (MeleeCombo.TryAoEMeleeCombo(actionID, out uint AoEMelee, Config.RDM_AoE_MoulinetRange, IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo_CorpsGapCloser),
+                    if (MeleeCombo.TryAoEMeleeCombo(ref NewActionID, Config.RDM_AoE_MoulinetRange, IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo_CorpsGapCloser),
                         false)) //Melee range enforced
-                        return AoEMelee;
+                        return NewActionID;
                 }
             }
 
             if (actionID is Scatter or Impact)
             {
                 if (IsEnabled(CustomComboPreset.RDM_AoE_Accel)
-                    && SpellCombo.TryAcceleration(actionID, out uint AccelID, IsEnabled(CustomComboPreset.RDM_AoE_Accel_Swiftcast),
+                    && SpellCombo.TryAcceleration(ref NewActionID, IsEnabled(CustomComboPreset.RDM_AoE_Accel_Swiftcast),
                     IsEnabled(CustomComboPreset.RDM_AoE_Accel_Weave)))
-                    return AccelID;
+                    return NewActionID;
 
-                if (SpellCombo.TryAoESpellRotation(actionID, out uint SpellID))
-                    return SpellID;
+                if (SpellCombo.TryAoESpellRotation(ref NewActionID))
+                    return NewActionID;
 
             }
 

--- a/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
@@ -114,6 +114,7 @@ internal partial class RDM
                         }
                         ImGui.Unindent();
                     }
+                    DrawAdditionalBoolChoice(RDM_ST_MeleeEnforced, "Enforced Melee Check", "Once the melee combo has started, don't switch away even if target is out of range.");
                     break;
 
                 case CustomComboPreset.RDM_ST_MeleeFinisher:
@@ -168,7 +169,6 @@ internal partial class RDM
                         DrawHorizontalMultiChoice(RDM_AoE_MeleeCombo_OnAction, Moulinet.ActionName(), "", 2, 1, descriptionColor: ImGuiColors.DalamudYellow);
                         ImGui.Unindent();
                     }
-                    DrawAdditionalBoolChoice(RDM_ST_MeleeEnforced, "Enforced Melee Check", "Once the melee combo has started, don't switch away even if target is out of range.");
                     break;
 
                 case CustomComboPreset.RDM_AoE_MeleeFinisher:

--- a/WrathCombo/Combos/PvE/RDM/RDM_Helper.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM_Helper.cs
@@ -1,6 +1,5 @@
 ﻿using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.JobGauge.Types;
-using ECommons.DalamudServices;
 using ECommons.GameHelpers;
 using System;
 using System.Collections.Generic;
@@ -137,7 +136,7 @@ internal partial class RDM
 
     private static bool TryOGCDs(uint actionID, in bool SingleTarget, ref uint newActionID, bool AdvMode = false)
     {
-        newActionID = 0;
+        newActionID = 0; //reset just incase
         if (!CanSpellWeave()) return false;
 
         float distance = GetTargetDistance();
@@ -251,6 +250,8 @@ internal partial class RDM
         internal static bool TrySTManaEmbolden(ref uint newActionID,                 //Simple Mode Values
             bool ManaEmbolden = true, bool GapCloser = true, bool DoubleCombo = true, bool UnBalanceMana = true)
         {
+            if (!CanSpellWeave()) return false;
+
             //RDM_ST_MANAFICATIONEMBOLDEN
             if (ManaEmbolden
                 && LevelChecked(Embolden)
@@ -420,6 +421,7 @@ internal partial class RDM
                     if (HasEffect(Buffs.Acceleration) || WasLastAction(Buffs.Acceleration))
                     {
                         //Run the Mana Balance Computer
+                        //SHUT UP ITS FINE
 #pragma warning disable IDE0042
                         (bool useFire, bool useStone, bool useThunder, bool useAero, bool useThunder2, bool useAero2) actions = SpellCombo.GetSpells();
 #pragma warning restore IDE0042
@@ -437,7 +439,7 @@ internal partial class RDM
                         }
                     }
 
-                    if (HasCharges(Acceleration))
+                    if (HasCharges(Acceleration) && CanSpellWeave())
                     {
                         newActionID = Acceleration;
                         return true;
@@ -456,6 +458,8 @@ internal partial class RDM
         internal static bool TryAoEManaEmbolden(ref uint newActionID,                 //Simple Mode Values
             int MoulinetRange = 6)//idk just making this up
         {
+            if (!CanSpellWeave()) return false;
+
             if (InCombat()
                 && !HasEffect(Buffs.Dualcast)
                 && !HasEffect(All.Buffs.Swiftcast)
@@ -630,6 +634,8 @@ internal partial class RDM
         }
         internal static bool TryAcceleration(ref uint newActionID, bool swiftcast = true, bool AoEWeave = false)
         {
+            if (!CanSpellWeave()) return false;
+
             //RDM_ST_ACCELERATION
             if (InCombat()
                 && LocalPlayer.IsCasting == false
@@ -665,9 +671,7 @@ internal partial class RDM
         internal static bool TrySTSpellRotation(ref uint newActionID, bool FireStone = true, bool ThunderAero = true)
         {
             if (TryGrandImpact(ref newActionID))
-            {
                 return true;
-            }
 
             //SHUT UP ITS FINE
 #pragma warning disable IDE0042

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -372,7 +372,7 @@ internal static partial class SCH
 
             // Lucid Dreaming
             if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Lucid)
-                && All.CanUseLucid(actionID, Config.SCH_AoE_Heal_LucidOption, true))
+                && All.CanUseLucid(Config.SCH_AoE_Heal_LucidOption, true))
                 return All.LucidDreaming;
 
             for (int i = 0; i < Config.SCH_AoE_Heals_Priority.Count; i++)

--- a/WrathCombo/Combos/PvE/SGE/SGE.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE.cs
@@ -215,7 +215,7 @@ internal partial class SGE
 
             // Lucid Dreaming
             if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Lucid) &&
-                All.CanUseLucid(actionID, Config.SGE_ST_DPS_Lucid))
+                All.CanUseLucid(Config.SGE_ST_DPS_Lucid))
                 return All.LucidDreaming;
 
             // Variant
@@ -455,11 +455,6 @@ internal partial class SGE
                         return spell;
                 }
             }
-
-            if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EPrognosis) && LevelChecked(Eukrasia) &&
-                (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EPrognosis_IgnoreShield) ||
-                 FindEffect(Buffs.EukrasianPrognosis) is null))
-                return Eukrasia;
 
             return actionID;
         }

--- a/WrathCombo/Combos/PvE/SGE/SGE_Config.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE_Config.cs
@@ -54,7 +54,8 @@ internal static partial class SGE
             SGE_AoE_Heal_PanhaimaOption = new("SGE_AoE_Heal_PanhaimaOption", 70),
             SGE_AoE_Heal_KeracholeOption = new("SGE_AoE_Heal_KeracholeOption", 70),
             SGE_AoE_Heal_IxocholeOption = new("SGE_AoE_Heal_IxocholeOption", 70),
-            SGE_AoE_Heal_HolosOption = new("SGE_AoE_Heal_HolosOption", 70);
+            SGE_AoE_Heal_HolosOption = new("SGE_AoE_Heal_HolosOption", 70),
+            SGE_AoE_Heal_EPrognosisOption = new("SGE_AoE_Heal_EPrognosisOption", 34);
         public static UserIntArray
             SGE_ST_Heals_Priority = new("SGE_ST_Heals_Priority"),
             SGE_AoE_Heals_Priority = new("SGE_AoE_Heals_Priority");
@@ -194,37 +195,42 @@ internal static partial class SGE
 
                 case CustomComboPreset.SGE_AoE_Heal_Ixochole:
                     DrawSliderInt(0, 100, SGE_AoE_Heal_IxocholeOption, "Start using when below party average HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SGE_AoE_Heals_Priority, 8, 1, $"{Ixochole.ActionName()} Priority: ");
+                    DrawPriorityInput(SGE_AoE_Heals_Priority, 9, 1, $"{Ixochole.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SGE_AoE_Heal_Physis:
                     DrawSliderInt(0, 100, SGE_AoE_Heal_PhysisOption, "Start using when below party average HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SGE_AoE_Heals_Priority, 8, 2, $"{Physis.ActionName()} Priority: ");
+                    DrawPriorityInput(SGE_AoE_Heals_Priority, 9, 2, $"{Physis.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SGE_AoE_Heal_Holos:
                     DrawSliderInt(0, 100, SGE_AoE_Heal_HolosOption, "Start using when below party average HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SGE_AoE_Heals_Priority, 8, 3, $"{Holos.ActionName()} Priority: ");
+                    DrawPriorityInput(SGE_AoE_Heals_Priority, 9, 3, $"{Holos.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SGE_AoE_Heal_Panhaima:
                     DrawSliderInt(0, 100, SGE_AoE_Heal_PanhaimaOption, "Start using when below party average HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SGE_AoE_Heals_Priority, 8, 4, $"{Panhaima.ActionName()} Priority: ");
+                    DrawPriorityInput(SGE_AoE_Heals_Priority, 9, 4, $"{Panhaima.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SGE_AoE_Heal_Pepsis:
                     DrawSliderInt(0, 100, SGE_AoE_Heal_PepsisOption, "Start using when below party average HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SGE_AoE_Heals_Priority, 8, 5, $"{Pepsis.ActionName()} Priority: ");
+                    DrawPriorityInput(SGE_AoE_Heals_Priority, 9, 5, $"{Pepsis.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SGE_AoE_Heal_Philosophia:
                     DrawSliderInt(0, 100, SGE_AoE_Heal_PhilosophiaOption, "Start using when below party average HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SGE_AoE_Heals_Priority, 8, 6, $"{Philosophia.ActionName()} Priority: ");
+                    DrawPriorityInput(SGE_AoE_Heals_Priority, 9, 6, $"{Philosophia.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SGE_AoE_Heal_Zoe:
                     DrawSliderInt(0, 100, SGE_AoE_Heal_ZoeOption, "Start using when below party average HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SGE_AoE_Heals_Priority, 8, 7, $"{Pneuma.ActionName()} Priority: ");
+                    DrawPriorityInput(SGE_AoE_Heals_Priority, 9, 7, $"{Pneuma.ActionName()} Priority: ");
+                    break;
+
+                case CustomComboPreset.SGE_AoE_Heal_EPrognosis:
+                    DrawSliderInt(0, 100, SGE_AoE_Heal_EPrognosisOption, "Shield Check: Percentage of Party Members without shields to check for.", sliderIncrement: 25);
+                    DrawPriorityInput(SGE_AoE_Heals_Priority, 9, 8, $"{EukrasianPrognosis.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SGE_Eukrasia:

--- a/WrathCombo/Combos/PvE/SGE/SGE_Helper.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE_Helper.cs
@@ -1,6 +1,5 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.Types;
-using ECommons.DalamudServices;
 using System.Collections.Generic;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
@@ -231,6 +230,12 @@ internal static partial class SGE
                 action = Zoe;
                 enabled = IsEnabled(CustomComboPreset.SGE_AoE_Heal_Zoe);
                 return Config.SGE_AoE_Heal_ZoeOption;
+            
+            case 8:
+                action = Eukrasia;
+                enabled = IsEnabled(CustomComboPreset.SGE_AoE_Heal_EPrognosis)
+                    && (GetPartyBuffPercent(Buffs.EukrasianDiagnosis) + GetPartyBuffPercent(Buffs.EukrasianPrognosis)) <= Config.SGE_AoE_Heal_EPrognosisOption;
+                return 100; //Don't HP Check
         }
 
         enabled = false;

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -251,7 +251,7 @@ internal partial class WHM
                 return All.Esuna;
 
             if (IsEnabled(CustomComboPreset.WHM_STHeals_Lucid) &&
-                All.CanUseLucid(actionID, Config.WHM_STHeals_Lucid))
+                All.CanUseLucid(Config.WHM_STHeals_Lucid))
                 return All.LucidDreaming;
 
             foreach (int prio in Config.WHM_ST_Heals_Priority.Items.OrderBy(x => x))


### PR DESCRIPTION
- All
  - Removed actionID passing to CanUseLucid (SGE/RDM/SCH/WHM calls updated)

- SGE
  - Removed Ignore AoE Shield Check. Eukrasia Prognosis moved to priority system. Slider checks for total shields (Diagnosis/Prognosis) 
- RDM
  - Cleanup, removed passing of actionID to all rotation functions execpt TryOGCDs. Reduced variables (out to ref) from rotation functions.
  - Prioritized Preflugence in TryOGCDs
  - Prevented Double CorpACorps or Engagments in the same oGCD window (Discord Report)
  - Delayed Vice of Thorns until (hopefully) the next oGCD window (Discord Report)