### PR TITLE
[Core] Process Config saves as a queue

### DIFF
--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -245,6 +245,7 @@ namespace WrathCombo
             BlueMageService.PopulateBLUSpells();
             TargetHelper.Draw();
             AutoRotationController.Run();
+            PluginConfiguration.ProcessSaveQueue();
 
             // Skip the IPC checking if hidden
             if (DtrBarEntry.UserHidden) return;
@@ -343,6 +344,15 @@ namespace WrathCombo
         public void Dispose()
         {
             ConfigWindow?.Dispose();
+
+            // Try to force a config save if there are some pending
+            if (PluginConfiguration.SaveQueue.Count > 0)
+                lock (PluginConfiguration.SaveQueue)
+                {
+                    PluginConfiguration.SaveQueue.Clear();
+                    Service.Configuration.Save();
+                    PluginConfiguration.ProcessSaveQueue();
+                }
 
             ws.RemoveAllWindows();
             Svc.DtrBar.Remove("Wrath Combo");


### PR DESCRIPTION
- [X] Changes Config saving to be processed as a queue
  - Instead of immediately saving the plugin config it will now be added to a queue.\
    Each framework update this queue gets worked, trying to save the queued configuration, and letting it retry a couple times.\
    This fixes an issue where new-job-setups, where dozens of configs are being initialized and added to the plugin configuration at a time causes some file conflicts.
  - This could likely be more efficient, such as batching saves, or only saving every X seconds, or something, but it is more efficient than it was before; this is the least-vast change to saving so as to minimize any sort of disruption.\
    This does not require a change anywhere `Save()` is called.