### PR TITLE
[DNC] Buffcheck fix

### DIFF
--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -295,7 +295,7 @@ internal partial class DNC
             #region GCD
 
             // ST Technical Step
-            if (needToTech)
+            if (needToTech && !HasEffect(Buffs.FlourishingFinish))
                 return TechnicalStep;
 
             // ST Last Dance
@@ -598,7 +598,7 @@ internal partial class DNC
             #region GCD
 
             // ST Technical Step
-            if (needToTech)
+            if (needToTech && !HasEffect(Buffs.FlourishingFinish))
                 return TechnicalStep;
 
             // ST Last Dance
@@ -868,7 +868,7 @@ internal partial class DNC
             #region GCD
 
             // AoE Technical Step
-            if (needToTech)
+            if (needToTech && !HasEffect(Buffs.FlourishingFinish))
                 return TechnicalStep;
 
             // AoE Last Dance
@@ -1127,7 +1127,7 @@ internal partial class DNC
             #region GCD
 
             // AoE Technical Step
-            if (needToTech)
+            if (needToTech && !HasEffect(Buffs.FlourishingFinish))
                 return TechnicalStep;
 
             // AoE Last Dance


### PR DESCRIPTION
Oddly aoe only, no idea why. After technical finish it was locking on tech step as long as Tiliana was usable through the flourishing finish buff.

Buffcheck issue from techstep turning into Tiliana Added normal fix to the needtotech line. Fixes issue but doesnt explain why it wasn't happening to st, added there just to be safe though. 