### PR TITLE
[MCH] Hypercharge conditionals

### DIFF
--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -67,7 +67,7 @@ internal partial class MCH
                             // Only Hypercharge when tools are on cooldown
                             if (DrillCD && AnchorCD && SawCD &&
                                 (LevelChecked(Wildfire) &&
-                                 (!InBossEncounter() ||
+                                 (!InBossEncounter() && IsOffCooldown(Wildfire) ||
                                   InBossEncounter() && GetCooldownRemainingTime(Wildfire) > 40) ||
                                  !LevelChecked(Wildfire)))
                                 return Hypercharge;
@@ -227,11 +227,10 @@ internal partial class MCH
 
                             // Only Hypercharge when tools are on cooldown
                             if (DrillCD && AnchorCD && SawCD &&
-                                (LevelChecked(Wildfire) &&
-                                 (!InBossEncounter() ||
+                                (LevelChecked(Wildfire) && 
+                                 (!InBossEncounter() && IsOffCooldown(Wildfire) ||
                                   (Config.MCH_ST_Adv_Wildfire_SubOption == 0 ||
-                                   Config.MCH_ST_Adv_Wildfire_SubOption == 1 && InBossEncounter()) &&
-                                  GetCooldownRemainingTime(Wildfire) > 40) ||
+                                   Config.MCH_ST_Adv_Wildfire_SubOption == 1 && InBossEncounter()) && GetCooldownRemainingTime(Wildfire) > 40) ||
                                  !LevelChecked(Wildfire)))
                                 return Hypercharge;
                         }

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -22,7 +22,11 @@ internal partial class MCH
 
             //Reassemble to start before combat
             if (!HasEffect(Buffs.Reassembled) && ActionReady(Reassemble) &&
-                !InCombat() && TargetIsHostile())
+                !InCombat() && TargetIsHostile() &&
+                (ActionReady(Excavator) ||
+                 ActionReady(Chainsaw) ||
+                 LevelChecked(AirAnchor) && IsOffCooldown(AirAnchor) ||
+                 ActionReady(Drill)))
                 return Reassemble;
 
             // Interrupt
@@ -87,11 +91,11 @@ internal partial class MCH
                             JustUsed(Drill, 2f) ||
                             JustUsed(Excavator, 2f))
                         {
-                            if (ActionReady(OriginalHook(GaussRound)) &&
+                            if (ActionReady(GaussRound) &&
                                 !JustUsed(OriginalHook(GaussRound), 2f))
                                 return OriginalHook(GaussRound);
 
-                            if (ActionReady(OriginalHook(Ricochet)) &&
+                            if (ActionReady(Ricochet) &&
                                 !JustUsed(OriginalHook(Ricochet), 2f))
                                 return OriginalHook(Ricochet);
                         }
@@ -105,13 +109,14 @@ internal partial class MCH
                 // Gauss Round and Ricochet during HC
                 if (JustUsed(OriginalHook(Heatblast), 1f) && HasNotWeaved)
                 {
-                    if (ActionReady(OriginalHook(GaussRound)) &&
+                    if (ActionReady(GaussRound) &&
                         GetRemainingCharges(OriginalHook(GaussRound)) >=
                         GetRemainingCharges(OriginalHook(Ricochet)))
                         return OriginalHook(GaussRound);
 
-                    if (ActionReady(OriginalHook(Ricochet)) &&
-                        GetRemainingCharges(OriginalHook(Ricochet)) > GetRemainingCharges(OriginalHook(GaussRound)))
+                    if (ActionReady(Ricochet) &&
+                        GetRemainingCharges(OriginalHook(Ricochet)) >
+                        GetRemainingCharges(OriginalHook(GaussRound)))
                         return OriginalHook(Ricochet);
                 }
             }
@@ -124,7 +129,7 @@ internal partial class MCH
                 return FullMetalField;
 
             // Heatblast
-            if (Gauge.IsOverheated && LevelChecked(OriginalHook(Heatblast)))
+            if (Gauge.IsOverheated && ActionReady(Heatblast))
                 return OriginalHook(Heatblast);
 
             //Tools
@@ -134,14 +139,14 @@ internal partial class MCH
             // 1-2-3 Combo
             if (ComboTimer > 0)
             {
-                if (ComboAction is SplitShot && LevelChecked(OriginalHook(SlugShot)))
+                if (ComboAction is SplitShot && ActionReady(SlugShot))
                     return OriginalHook(SlugShot);
 
                 if (ComboAction == OriginalHook(SlugShot) &&
                     !LevelChecked(Drill) && !HasEffect(Buffs.Reassembled) && ActionReady(Reassemble))
                     return Reassemble;
 
-                if (ComboAction is SlugShot && LevelChecked(OriginalHook(CleanShot)))
+                if (ComboAction is SlugShot && ActionReady(CleanShot))
                     return OriginalHook(CleanShot);
             }
             return actionID;
@@ -170,7 +175,11 @@ internal partial class MCH
             //Reassemble to start before combat
             if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble) &&
                 !HasEffect(Buffs.Reassembled) && ActionReady(Reassemble) &&
-                !InCombat() && TargetIsHostile())
+                !InCombat() && TargetIsHostile() &&
+                (ActionReady(Excavator) && Config.MCH_ST_Reassembled[0] ||
+                 ActionReady(Chainsaw) && Config.MCH_ST_Reassembled[1] ||
+                 LevelChecked(AirAnchor) && IsOffCooldown(AirAnchor) && Config.MCH_ST_Reassembled[2] ||
+                 ActionReady(Drill) && Config.MCH_ST_Reassembled[3]))
                 return Reassemble;
 
             // Interrupt
@@ -190,7 +199,7 @@ internal partial class MCH
                 {
                     if (IsEnabled(CustomComboPreset.MCH_ST_Adv_QueenOverdrive) &&
                         Gauge.IsRobotActive && GetTargetHPPercent() <= Config.MCH_ST_QueenOverDrive &&
-                        ActionReady(OriginalHook(RookOverdrive)))
+                        ActionReady(RookOverdrive))
                         return OriginalHook(RookOverdrive);
 
                     // Wildfire
@@ -253,11 +262,11 @@ internal partial class MCH
                              JustUsed(Drill, 2f) ||
                              JustUsed(Excavator, 2f)))
                         {
-                            if (ActionReady(OriginalHook(GaussRound)) &&
+                            if (ActionReady(GaussRound) &&
                                 !JustUsed(OriginalHook(GaussRound), 2f))
                                 return OriginalHook(GaussRound);
 
-                            if (ActionReady(OriginalHook(Ricochet)) &&
+                            if (ActionReady(Ricochet) &&
                                 !JustUsed(OriginalHook(Ricochet), 2f))
                                 return OriginalHook(Ricochet);
                         }
@@ -274,12 +283,12 @@ internal partial class MCH
                 if (IsEnabled(CustomComboPreset.MCH_ST_Adv_GaussRicochet) &&
                     JustUsed(OriginalHook(Heatblast), 1f) && HasNotWeaved)
                 {
-                    if (ActionReady(OriginalHook(GaussRound)) &&
+                    if (ActionReady(GaussRound) &&
                         GetRemainingCharges(OriginalHook(GaussRound)) >=
                         GetRemainingCharges(OriginalHook(Ricochet)))
                         return OriginalHook(GaussRound);
 
-                    if (ActionReady(OriginalHook(Ricochet)) &&
+                    if (ActionReady(Ricochet) &&
                         GetRemainingCharges(OriginalHook(Ricochet)) >
                         GetRemainingCharges(OriginalHook(GaussRound)))
                         return OriginalHook(Ricochet);
@@ -298,7 +307,7 @@ internal partial class MCH
 
             // Heatblast
             if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Heatblast) &&
-                Gauge.IsOverheated && LevelChecked(OriginalHook(Heatblast)))
+                Gauge.IsOverheated && ActionReady(Heatblast))
                 return OriginalHook(Heatblast);
 
             //Tools
@@ -308,7 +317,7 @@ internal partial class MCH
             // 1-2-3 Combo
             if (ComboTimer > 0)
             {
-                if (ComboAction is SplitShot && LevelChecked(OriginalHook(SlugShot)))
+                if (ComboAction is SplitShot && ActionReady(SlugShot))
                     return OriginalHook(SlugShot);
 
                 if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble) && Config.MCH_ST_Reassembled[4] &&
@@ -316,7 +325,7 @@ internal partial class MCH
                     !LevelChecked(Drill) && !HasEffect(Buffs.Reassembled) && ActionReady(Reassemble))
                     return Reassemble;
 
-                if (ComboAction is SlugShot && LevelChecked(OriginalHook(CleanShot)))
+                if (ComboAction is SlugShot && ActionReady(CleanShot))
                     return OriginalHook(CleanShot);
             }
             return actionID;
@@ -389,12 +398,12 @@ internal partial class MCH
                 if ((JustUsed(OriginalHook(AutoCrossbow), 1f) ||
                      JustUsed(OriginalHook(Heatblast), 1f)) && HasNotWeaved)
                 {
-                    if (ActionReady(OriginalHook(GaussRound)) &&
+                    if (ActionReady(GaussRound) &&
                         GetRemainingCharges(OriginalHook(GaussRound)) >=
                         GetRemainingCharges(OriginalHook(Ricochet)))
                         return OriginalHook(GaussRound);
 
-                    if (ActionReady(OriginalHook(Ricochet)) &&
+                    if (ActionReady(Ricochet) &&
                         GetRemainingCharges(OriginalHook(Ricochet)) >
                         GetRemainingCharges(OriginalHook(GaussRound)))
                         return OriginalHook(Ricochet);
@@ -524,11 +533,11 @@ internal partial class MCH
                     if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_GaussRicochet) &&
                         Config.MCH_AoE_Hypercharge)
                     {
-                        if (ActionReady(OriginalHook(GaussRound)) &&
+                        if (ActionReady(GaussRound) &&
                             !JustUsed(OriginalHook(GaussRound), 2.5f))
                             return OriginalHook(GaussRound);
 
-                        if (ActionReady(OriginalHook(Ricochet)) &&
+                        if (ActionReady(Ricochet) &&
                             !JustUsed(OriginalHook(Ricochet), 2.5f))
                             return OriginalHook(Ricochet);
                     }
@@ -544,12 +553,12 @@ internal partial class MCH
                     (JustUsed(OriginalHook(AutoCrossbow), 1f) ||
                      JustUsed(OriginalHook(Heatblast), 1f)) && HasNotWeaved)
                 {
-                    if (ActionReady(OriginalHook(GaussRound)) &&
+                    if (ActionReady(GaussRound) &&
                         GetRemainingCharges(OriginalHook(GaussRound)) >=
                         GetRemainingCharges(OriginalHook(Ricochet)))
                         return OriginalHook(GaussRound);
 
-                    if (ActionReady(OriginalHook(Ricochet)) &&
+                    if (ActionReady(Ricochet) &&
                         GetRemainingCharges(OriginalHook(Ricochet)) >
                         GetRemainingCharges(OriginalHook(GaussRound)))
                         return OriginalHook(Ricochet);
@@ -619,7 +628,7 @@ internal partial class MCH
                 return BarrelStabilizer;
 
             if (IsEnabled(CustomComboPreset.MCH_Heatblast_Wildfire) &&
-                ActionReady(Wildfire) && JustUsed(Hypercharge))
+                ActionReady(Wildfire) && JustUsed(Hypercharge) && !HasEffect(Buffs.Wildfire))
                 return Wildfire;
 
             if (!Gauge.IsOverheated && LevelChecked(Hypercharge) &&
@@ -631,12 +640,12 @@ internal partial class MCH
                 JustUsed(OriginalHook(Heatblast), 1f) &&
                 HasNotWeaved)
             {
-                if (ActionReady(OriginalHook(GaussRound)) &&
+                if (ActionReady(GaussRound) &&
                     GetRemainingCharges(OriginalHook(GaussRound)) >=
                     GetRemainingCharges(OriginalHook(Ricochet)))
                     return OriginalHook(GaussRound);
 
-                if (ActionReady(OriginalHook(Ricochet)) &&
+                if (ActionReady(Ricochet) &&
                     GetRemainingCharges(OriginalHook(Ricochet)) >
                     GetRemainingCharges(OriginalHook(GaussRound)))
                     return OriginalHook(Ricochet);
@@ -668,22 +677,20 @@ internal partial class MCH
                 return Hypercharge;
 
             if (IsEnabled(CustomComboPreset.MCH_AutoCrossbow_GaussRound) &&
-                CanWeave() &&
-                JustUsed(OriginalHook(AutoCrossbow), 1f) &&
-                HasNotWeaved)
+                CanWeave() && JustUsed(OriginalHook(AutoCrossbow), 1f) && HasNotWeaved)
             {
-                if (ActionReady(OriginalHook(GaussRound)) &&
+                if (ActionReady(GaussRound) &&
                     GetRemainingCharges(OriginalHook(GaussRound)) >=
                     GetRemainingCharges(OriginalHook(Ricochet)))
                     return OriginalHook(GaussRound);
 
-                if (ActionReady(OriginalHook(Ricochet)) &&
+                if (ActionReady(Ricochet) &&
                     GetRemainingCharges(OriginalHook(Ricochet)) >
                     GetRemainingCharges(OriginalHook(GaussRound)))
                     return OriginalHook(Ricochet);
             }
 
-            if (Gauge.IsOverheated && LevelChecked(OriginalHook(AutoCrossbow)))
+            if (Gauge.IsOverheated && ActionReady(AutoCrossbow))
                 return OriginalHook(AutoCrossbow);
 
             return actionID;
@@ -699,12 +706,12 @@ internal partial class MCH
             if (actionID is not (GaussRound or Ricochet or CheckMate or DoubleCheck))
                 return actionID;
 
-            if (ActionReady(OriginalHook(GaussRound)) &&
+            if (ActionReady(GaussRound) &&
                 GetRemainingCharges(OriginalHook(GaussRound)) >=
                 GetRemainingCharges(OriginalHook(Ricochet)))
                 return OriginalHook(GaussRound);
 
-            if (ActionReady(OriginalHook(Ricochet)) &&
+            if (ActionReady(Ricochet) &&
                 GetRemainingCharges(OriginalHook(Ricochet)) >
                 GetRemainingCharges(OriginalHook(GaussRound)))
                 return OriginalHook(Ricochet);

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -19,7 +19,7 @@ internal partial class MCH
                 IsEnabled(Variant.VariantCure) &&
                 PlayerHealthPercentageHp() <= Config.MCH_VariantCure)
                 return Variant.VariantCure;
-            
+
             //Reassemble to start before combat
             if (!HasEffect(Buffs.Reassembled) && ActionReady(Reassemble) &&
                 !InCombat() && TargetIsHostile())
@@ -36,7 +36,7 @@ internal partial class MCH
                     IsEnabled(Variant.VariantRampart) &&
                     IsOffCooldown(Variant.VariantRampart))
                     return Variant.VariantRampart;
-                
+
                 if (!ActionWatching.HasDoubleWeaved())
                 {
                     // Wildfire
@@ -161,7 +161,7 @@ internal partial class MCH
                 IsEnabled(Variant.VariantCure) &&
                 PlayerHealthPercentageHp() <= Config.MCH_VariantCure)
                 return Variant.VariantCure;
-            
+
             // Opener
             if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Opener) && TargetIsHostile())
                 if (Opener().FullOpener(ref actionID))
@@ -185,7 +185,7 @@ internal partial class MCH
                     IsEnabled(Variant.VariantRampart) &&
                     IsOffCooldown(Variant.VariantRampart))
                     return Variant.VariantRampart;
-                
+
                 if (!ActionWatching.HasDoubleWeaved())
                 {
                     if (IsEnabled(CustomComboPreset.MCH_ST_Adv_QueenOverdrive) &&

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -19,13 +19,7 @@ internal partial class MCH
                 IsEnabled(Variant.VariantCure) &&
                 PlayerHealthPercentageHp() <= Config.MCH_VariantCure)
                 return Variant.VariantCure;
-
-            if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
-                IsEnabled(Variant.VariantRampart) &&
-                IsOffCooldown(Variant.VariantRampart) &&
-                CanWeave())
-                return Variant.VariantRampart;
-
+            
             //Reassemble to start before combat
             if (!HasEffect(Buffs.Reassembled) && ActionReady(Reassemble) &&
                 !InCombat() && TargetIsHostile())
@@ -38,11 +32,17 @@ internal partial class MCH
             // All weaves
             if (CanWeave())
             {
+                if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart))
+                    return Variant.VariantRampart;
+                
                 if (!ActionWatching.HasDoubleWeaved())
                 {
                     // Wildfire
                     if (JustUsed(Hypercharge) &&
                         ActionReady(Wildfire) &&
+                        !HasEffect(Buffs.Wildfire) &&
                         InBossEncounter())
                         return Wildfire;
 
@@ -66,7 +66,9 @@ internal partial class MCH
 
                             // Only Hypercharge when tools are on cooldown
                             if (DrillCD && AnchorCD && SawCD &&
-                                (GetCooldownRemainingTime(Wildfire) > 40 && LevelChecked(Wildfire) ||
+                                (LevelChecked(Wildfire) &&
+                                 (!InBossEncounter() ||
+                                  InBossEncounter() && GetCooldownRemainingTime(Wildfire) > 40) ||
                                  !LevelChecked(Wildfire)))
                                 return Hypercharge;
                         }
@@ -159,13 +161,7 @@ internal partial class MCH
                 IsEnabled(Variant.VariantCure) &&
                 PlayerHealthPercentageHp() <= Config.MCH_VariantCure)
                 return Variant.VariantCure;
-
-            if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
-                IsEnabled(Variant.VariantRampart) &&
-                IsOffCooldown(Variant.VariantRampart) &&
-                CanWeave())
-                return Variant.VariantRampart;
-
+            
             // Opener
             if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Opener) && TargetIsHostile())
                 if (Opener().FullOpener(ref actionID))
@@ -185,6 +181,11 @@ internal partial class MCH
             // All weaves
             if (CanWeave())
             {
+                if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart))
+                    return Variant.VariantRampart;
+                
                 if (!ActionWatching.HasDoubleWeaved())
                 {
                     if (IsEnabled(CustomComboPreset.MCH_ST_Adv_QueenOverdrive) &&
@@ -196,7 +197,7 @@ internal partial class MCH
                     if (IsEnabled(CustomComboPreset.MCH_ST_Adv_WildFire) &&
                         (Config.MCH_ST_Adv_Wildfire_SubOption == 0 ||
                          Config.MCH_ST_Adv_Wildfire_SubOption == 1 && InBossEncounter()) &&
-                        JustUsed(Hypercharge) && ActionReady(Wildfire) &&
+                        JustUsed(Hypercharge) && ActionReady(Wildfire) && !HasEffect(Buffs.Wildfire) &&
                         GetTargetHPPercent() >= Config.MCH_ST_WildfireHP)
                         return Wildfire;
 
@@ -226,7 +227,11 @@ internal partial class MCH
 
                             // Only Hypercharge when tools are on cooldown
                             if (DrillCD && AnchorCD && SawCD &&
-                                (GetCooldownRemainingTime(Wildfire) > 40 && LevelChecked(Wildfire) ||
+                                (LevelChecked(Wildfire) &&
+                                 (!InBossEncounter() ||
+                                  (Config.MCH_ST_Adv_Wildfire_SubOption == 0 ||
+                                   Config.MCH_ST_Adv_Wildfire_SubOption == 1 && InBossEncounter()) &&
+                                  GetCooldownRemainingTime(Wildfire) > 40) ||
                                  !LevelChecked(Wildfire)))
                                 return Hypercharge;
                         }
@@ -336,12 +341,6 @@ internal partial class MCH
             if (HasEffect(Buffs.Flamethrower) || JustUsed(Flamethrower, 10f))
                 return OriginalHook(11);
 
-            if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
-                IsEnabled(Variant.VariantRampart) &&
-                IsOffCooldown(Variant.VariantRampart) &&
-                CanWeave())
-                return Variant.VariantRampart;
-
             // Interrupt
             if (InterruptReady)
                 return All.HeadGraze;
@@ -349,6 +348,11 @@ internal partial class MCH
             // All weaves
             if (CanWeave())
             {
+                if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart))
+                    return Variant.VariantRampart;
+
                 if (!ActionWatching.HasDoubleWeaved() && !Gauge.IsOverheated)
                 {
                     // BarrelStabilizer
@@ -472,19 +476,19 @@ internal partial class MCH
             if (HasEffect(Buffs.Flamethrower) || JustUsed(Flamethrower, 10f))
                 return OriginalHook(11);
 
-            if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
-                IsEnabled(Variant.VariantRampart) &&
-                IsOffCooldown(Variant.VariantRampart) &&
-                CanWeave())
-                return Variant.VariantRampart;
-
             // Interrupt
-            if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Interrupt) && InterruptReady)
+            if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Interrupt) &&
+                InterruptReady)
                 return All.HeadGraze;
 
             // All weaves
             if (CanWeave())
             {
+                if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
+                    IsEnabled(Variant.VariantRampart) &&
+                    IsOffCooldown(Variant.VariantRampart))
+                    return Variant.VariantRampart;
+
                 if (!ActionWatching.HasDoubleWeaved() && !Gauge.IsOverheated)
                 {
                     // BarrelStabilizer
@@ -531,8 +535,7 @@ internal partial class MCH
                     }
 
                     if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_SecondWind) &&
-                        PlayerHealthPercentageHp() <= Config.MCH_AoE_SecondWindThreshold &&
-                        ActionReady(All.SecondWind))
+                        PlayerHealthPercentageHp() <= Config.MCH_AoE_SecondWindThreshold && ActionReady(All.SecondWind))
                         return All.SecondWind;
                 }
 

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -67,7 +67,7 @@ internal partial class MCH
                             // Only Hypercharge when tools are on cooldown
                             if (DrillCD && AnchorCD && SawCD &&
                                 (LevelChecked(Wildfire) &&
-                                 (!InBossEncounter() && IsOffCooldown(Wildfire) ||
+                                 (!InBossEncounter() && IsOffCooldown(Wildfire) && !HasEffect(Buffs.FullMetalMachinist) ||
                                   InBossEncounter() && GetCooldownRemainingTime(Wildfire) > 40) ||
                                  !LevelChecked(Wildfire)))
                                 return Hypercharge;
@@ -227,8 +227,8 @@ internal partial class MCH
 
                             // Only Hypercharge when tools are on cooldown
                             if (DrillCD && AnchorCD && SawCD &&
-                                (LevelChecked(Wildfire) && 
-                                 (!InBossEncounter() && IsOffCooldown(Wildfire) ||
+                                (LevelChecked(Wildfire) &&
+                                 (!InBossEncounter() && IsOffCooldown(Wildfire) && !HasEffect(Buffs.FullMetalMachinist) ||
                                   (Config.MCH_ST_Adv_Wildfire_SubOption == 0 ||
                                    Config.MCH_ST_Adv_Wildfire_SubOption == 1 && InBossEncounter()) && GetCooldownRemainingTime(Wildfire) > 40) ||
                                  !LevelChecked(Wildfire)))

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -85,7 +85,7 @@ internal partial class MCH
     internal static bool UseQueen(MCHGauge gauge)
     {
         if (!ActionWatching.HasDoubleWeaved() && !HasEffect(Buffs.Wildfire) &&
-            !JustUsed(OriginalHook(Heatblast)) && LevelChecked(OriginalHook(RookAutoturret)) &&
+            !JustUsed(OriginalHook(Heatblast)) && ActionReady(RookAutoturret) &&
             gauge is { IsRobotActive: false, Battery: >= 50 })
         {
             if ((Config.MCH_ST_Adv_Turret_SubOption == 0 ||


### PR DESCRIPTION
- [x] Add conditionals to hypercharge.
 Fixes bug where it wont use hypercharge when wildfire is not on cooldown.
- [x] Test pre lvl 100
- [x] Update Reassemble usage when not in combat
- [x] Update originalhook usage