### PR TITLE
[Tanks] Add interrupt into the combos, [Core] Rework settings tab

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1333,6 +1333,8 @@ public enum CustomComboPreset
 
     #region DARK KNIGHT
 
+    // Last value = 5055
+
     #region Simple Mode
 
     //TODO
@@ -1364,6 +1366,10 @@ public enum CustomComboPreset
     DRK_ST_BalanceOpener = 5041,
 
     [ParentCombo(DRK_ST_Combo)]
+    [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", DRK.JobID)]
+    DRK_ST_Interrupt = 5017,
+
+    [ParentCombo(DRK_ST_Combo)]
     [CustomComboInfo("Unmend Uptime Option", "Adds Unmend to the rotation when you are out of range.", DRK.JobID)]
     DRK_ST_RangedUptime = 5015,
 
@@ -1390,8 +1396,6 @@ public enum CustomComboPreset
     DRK_ST_Delirium_Chain = 5003,
 
     #endregion
-
-    // Last value = 5003
 
     #region Cooldowns
 
@@ -1441,8 +1445,6 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last value = 5010
-
     #region Mana Overcap Options
 
     [ParentCombo(DRK_ST_Combo)]
@@ -1463,8 +1465,6 @@ public enum CustomComboPreset
     DRK_ST_DarkArtsDropPrevention = 5032,
 
     #endregion
-
-    // Last value = 5032
 
     #region Mitigation Options
 
@@ -1487,11 +1487,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last value = 5036
-
     #endregion
-
-    // Last value = 5015
 
     #region Advanced Multi Target Combo
 
@@ -1501,6 +1497,14 @@ public enum CustomComboPreset
         "Replaces Unleash with a full one-button AoE rotation.\nThese features are ideal if you want to customize the rotation.",
         DRK.JobID)]
     DRK_AoE_Combo = 5016,
+
+    [ParentCombo(DRK_AoE_Combo)]
+    [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", DRK.JobID)]
+    DRK_AoE_Interrupt = 5054,
+
+    [ParentCombo(DRK_AoE_Combo)]
+    [CustomComboInfo("Interrupt with Stun Option", "Adds Low Blow to the rotation when your target is casting, interruptible or not.", DRK.JobID)]
+    DRK_AoE_Stun = 5055,
 
     [ParentCombo(DRK_AoE_Combo)]
     [CustomComboInfo("Blood Gauge Overcap Option", "Adds Quietus to the rotation when at 90 blood gauge or higher.",
@@ -1513,15 +1517,13 @@ public enum CustomComboPreset
     [CustomComboInfo("Delirium Option",
         "Adds Delirium (or Blood Weapon at lower levels) to the rotation on cooldown and when Darkside is up.",
         DRK.JobID)]
-    DRK_AoE_Delirium = 5017,
+    DRK_AoE_Delirium = 5053,
 
     [ParentCombo(DRK_AoE_Delirium)]
     [CustomComboInfo("Impalement Option", "Adds Impalement to the rotation when Delirium is activated.", DRK.JobID)]
     DRK_AoE_Delirium_Chain = 5018,
 
     #endregion
-
-    // Last value = 5018
 
     #region Cooldowns
 
@@ -1560,8 +1562,6 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last value = 5024
-
     [ParentCombo(DRK_AoE_Combo)]
     [CustomComboInfo("Flood of Shadow Overcap Option",
         "Uses Flood of Shadow if you are above 8,500 mana, Darkside is about to expire (<10s), or if you have Dark Arts.",
@@ -1589,11 +1589,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last value = 5040
-
     #endregion
-
-    // Last value = 5038
 
     #region One-Button Mitigation
 
@@ -1643,8 +1639,6 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last value = 5052
-
     #region oGCD Feature
 
     [ReplaceSkill(DRK.CarveAndSpit, DRK.AbyssalDrain)]
@@ -1658,8 +1652,6 @@ public enum CustomComboPreset
     DRK_Shadowbringer_oGCD = 5028,
 
     #endregion
-
-    // Last value = 5028
 
     #region Variant
 
@@ -1680,8 +1672,6 @@ public enum CustomComboPreset
     DRK_Variant_Ultimatum = 5031,
 
     #endregion
-
-    // Last value = 5031
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5819,6 +5819,10 @@ public enum CustomComboPreset
     WAR_ST_Advanced_BalanceOpener = 18058,
 
     [ParentCombo(WAR_ST_Advanced)]
+    [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", WAR.JobID)]
+    WAR_ST_Interrupt = 18066,
+
+    [ParentCombo(WAR_ST_Advanced)]
     [CustomComboInfo("Storm's Eye Option", "Adds Storms Eye into the rotation.", WAR.JobID)]
     WAR_ST_Advanced_StormsEye = 18005,
 
@@ -5921,6 +5925,14 @@ public enum CustomComboPreset
         "Replaces Overpower with a full one-button AoE rotation.\nThese features are ideal if you want to customize the rotation.",
         WAR.JobID)]
     WAR_AoE_Advanced = 18016,
+
+    [ParentCombo(WAR_AoE_Advanced)]
+    [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", WAR.JobID)]
+    WAR_AoE_Interrupt = 18067,
+
+    [ParentCombo(WAR_AoE_Advanced)]
+    [CustomComboInfo("Interrupt with Stun Option", "Adds Low Blow to the rotation when your target is casting, interruptible or not.", WAR.JobID)]
+    WAR_AoE_Stun = 18068,
 
     [ReplaceSkill(WAR.NascentFlash)]
     [CustomComboInfo("Nascent Flash Feature", "Replace Nascent Flash with Raw intuition when level synced below 76.",
@@ -6093,7 +6105,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last value = 18065
+    // Last value = 18068
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -3634,6 +3634,10 @@ public enum CustomComboPreset
     PLD_ST_AdvancedMode_BalanceOpener = 11046,
 
     [ParentCombo(PLD_ST_AdvancedMode)]
+    [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", PLD.JobID)]
+    PLD_ST_Interrupt = 11058,
+
+    [ParentCombo(PLD_ST_AdvancedMode)]
     [CustomComboInfo("Fight or Flight Option",
         "Adds Fight or Flight to Advanced Mode.\n- Uses after Royal Authority during opener.\n- Afterward, on cooldown alongside Requiescat.\n- Target HP must be at or above:",
         PLD.JobID)]
@@ -3740,6 +3744,14 @@ public enum CustomComboPreset
         "Replaces Total Eclipse with a full one-button AoE rotation.\nThese features are ideal if you want to customize the rotation.",
         PLD.JobID)]
     PLD_AoE_AdvancedMode = 11015,
+
+    [ParentCombo(PLD_AoE_AdvancedMode)]
+    [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", PLD.JobID)]
+    PLD_AoE_Interrupt = 11059,
+
+    [ParentCombo(PLD_AoE_AdvancedMode)]
+    [CustomComboInfo("Interrupt with Stun Option", "Adds Low Blow or Shield Bash to the rotation when your target is casting, interruptible or not.", PLD.JobID)]
+    PLD_AoE_Stun = 11060,
 
     [ParentCombo(PLD_AoE_AdvancedMode)]
     [CustomComboInfo("Fight or Flight Option",
@@ -3911,7 +3923,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    //// Last value = 11056
+    //// Last value = 11060
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1974,6 +1974,10 @@ public enum CustomComboPreset
     [CustomComboInfo("Balance Opener (Level 100)", "Adds the Balance opener at level 100. Switches between 2 different openers depending on skillspeed.", GNB.JobID)]
     GNB_ST_Advanced_Opener = 7006,
 
+    [ParentCombo(GNB_ST_Advanced)]
+    [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", GNB.JobID)]
+    GNB_ST_Interrupt = 7084,
+
     #region Cooldowns
 
     [ParentCombo(GNB_ST_Advanced)]
@@ -2091,6 +2095,14 @@ public enum CustomComboPreset
         "Replaces Demon Slice with a full one-button AoE rotation.\nThese features are ideal if you want to customize the rotation.",
         GNB.JobID)]
     GNB_AoE_Advanced = 7200,
+
+    [ParentCombo(GNB_AoE_Advanced)]
+    [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", GNB.JobID)]
+    GNB_AoE_Interrupt = 7222,
+
+    [ParentCombo(GNB_AoE_Advanced)]
+    [CustomComboInfo("Interrupt with Stun Option", "Adds Low Blow to the rotation when your target is casting, interruptible or not.", GNB.JobID)]
+    GNB_AoE_Stun = 7223,
 
     [ConflictingCombos(GNB_NM_Features)]
     [ParentCombo(GNB_AoE_Advanced)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1367,7 +1367,7 @@ public enum CustomComboPreset
 
     [ParentCombo(DRK_ST_Combo)]
     [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", DRK.JobID)]
-    DRK_ST_Interrupt = 5017,
+    DRK_ST_Interrupt = 5053,
 
     [ParentCombo(DRK_ST_Combo)]
     [CustomComboInfo("Unmend Uptime Option", "Adds Unmend to the rotation when you are out of range.", DRK.JobID)]
@@ -1517,7 +1517,7 @@ public enum CustomComboPreset
     [CustomComboInfo("Delirium Option",
         "Adds Delirium (or Blood Weapon at lower levels) to the rotation on cooldown and when Darkside is up.",
         DRK.JobID)]
-    DRK_AoE_Delirium = 5053,
+    DRK_AoE_Delirium = 5017,
 
     [ParentCombo(DRK_AoE_Delirium)]
     [CustomComboInfo("Impalement Option", "Adds Impalement to the rotation when Delirium is activated.", DRK.JobID)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1333,8 +1333,6 @@ public enum CustomComboPreset
 
     #region DARK KNIGHT
 
-    // Last value = 5055
-
     #region Simple Mode
 
     //TODO
@@ -1366,10 +1364,6 @@ public enum CustomComboPreset
     DRK_ST_BalanceOpener = 5041,
 
     [ParentCombo(DRK_ST_Combo)]
-    [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", DRK.JobID)]
-    DRK_ST_Interrupt = 5017,
-
-    [ParentCombo(DRK_ST_Combo)]
     [CustomComboInfo("Unmend Uptime Option", "Adds Unmend to the rotation when you are out of range.", DRK.JobID)]
     DRK_ST_RangedUptime = 5015,
 
@@ -1396,6 +1390,8 @@ public enum CustomComboPreset
     DRK_ST_Delirium_Chain = 5003,
 
     #endregion
+
+    // Last value = 5003
 
     #region Cooldowns
 
@@ -1445,6 +1441,8 @@ public enum CustomComboPreset
 
     #endregion
 
+    // Last value = 5010
+
     #region Mana Overcap Options
 
     [ParentCombo(DRK_ST_Combo)]
@@ -1465,6 +1463,8 @@ public enum CustomComboPreset
     DRK_ST_DarkArtsDropPrevention = 5032,
 
     #endregion
+
+    // Last value = 5032
 
     #region Mitigation Options
 
@@ -1487,7 +1487,11 @@ public enum CustomComboPreset
 
     #endregion
 
+    // Last value = 5036
+
     #endregion
+
+    // Last value = 5015
 
     #region Advanced Multi Target Combo
 
@@ -1497,14 +1501,6 @@ public enum CustomComboPreset
         "Replaces Unleash with a full one-button AoE rotation.\nThese features are ideal if you want to customize the rotation.",
         DRK.JobID)]
     DRK_AoE_Combo = 5016,
-
-    [ParentCombo(DRK_AoE_Combo)]
-    [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", DRK.JobID)]
-    DRK_AoE_Interrupt = 5054,
-
-    [ParentCombo(DRK_AoE_Combo)]
-    [CustomComboInfo("Interrupt with Stun Option", "Adds Low Blow to the rotation when your target is casting, interruptible or not.", DRK.JobID)]
-    DRK_AoE_Stun = 5055,
 
     [ParentCombo(DRK_AoE_Combo)]
     [CustomComboInfo("Blood Gauge Overcap Option", "Adds Quietus to the rotation when at 90 blood gauge or higher.",
@@ -1517,13 +1513,15 @@ public enum CustomComboPreset
     [CustomComboInfo("Delirium Option",
         "Adds Delirium (or Blood Weapon at lower levels) to the rotation on cooldown and when Darkside is up.",
         DRK.JobID)]
-    DRK_AoE_Delirium = 5053,
+    DRK_AoE_Delirium = 5017,
 
     [ParentCombo(DRK_AoE_Delirium)]
     [CustomComboInfo("Impalement Option", "Adds Impalement to the rotation when Delirium is activated.", DRK.JobID)]
     DRK_AoE_Delirium_Chain = 5018,
 
     #endregion
+
+    // Last value = 5018
 
     #region Cooldowns
 
@@ -1562,6 +1560,8 @@ public enum CustomComboPreset
 
     #endregion
 
+    // Last value = 5024
+
     [ParentCombo(DRK_AoE_Combo)]
     [CustomComboInfo("Flood of Shadow Overcap Option",
         "Uses Flood of Shadow if you are above 8,500 mana, Darkside is about to expire (<10s), or if you have Dark Arts.",
@@ -1589,7 +1589,11 @@ public enum CustomComboPreset
 
     #endregion
 
+    // Last value = 5040
+
     #endregion
+
+    // Last value = 5038
 
     #region One-Button Mitigation
 
@@ -1639,6 +1643,8 @@ public enum CustomComboPreset
 
     #endregion
 
+    // Last value = 5052
+
     #region oGCD Feature
 
     [ReplaceSkill(DRK.CarveAndSpit, DRK.AbyssalDrain)]
@@ -1652,6 +1658,8 @@ public enum CustomComboPreset
     DRK_Shadowbringer_oGCD = 5028,
 
     #endregion
+
+    // Last value = 5028
 
     #region Variant
 
@@ -1672,6 +1680,8 @@ public enum CustomComboPreset
     DRK_Variant_Ultimatum = 5031,
 
     #endregion
+
+    // Last value = 5031
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1367,7 +1367,7 @@ public enum CustomComboPreset
 
     [ParentCombo(DRK_ST_Combo)]
     [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", DRK.JobID)]
-    DRK_ST_Interrupt = 5053,
+    DRK_ST_Interrupt = 5017,
 
     [ParentCombo(DRK_ST_Combo)]
     [CustomComboInfo("Unmend Uptime Option", "Adds Unmend to the rotation when you are out of range.", DRK.JobID)]
@@ -1517,7 +1517,7 @@ public enum CustomComboPreset
     [CustomComboInfo("Delirium Option",
         "Adds Delirium (or Blood Weapon at lower levels) to the rotation on cooldown and when Darkside is up.",
         DRK.JobID)]
-    DRK_AoE_Delirium = 5017,
+    DRK_AoE_Delirium = 5053,
 
     [ParentCombo(DRK_AoE_Delirium)]
     [CustomComboInfo("Impalement Option", "Adds Impalement to the rotation when Delirium is activated.", DRK.JobID)]

--- a/WrathCombo/Combos/PvE/DRK/DRK.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK.cs
@@ -47,6 +47,12 @@ internal partial class DRK
 
             #endregion
 
+            // Interrupt
+            if (IsEnabled(CustomComboPreset.DRK_ST_Interrupt)
+                && ActionReady(All.Interject)
+                && CanInterruptEnemy())
+                return All.Interject;
+
             // Variant Cure - Heal: Priority to save your life
             if (IsEnabled(CustomComboPreset.DRK_Variant_Cure)
                 && IsEnabled(Variant.VariantCure)
@@ -322,6 +328,18 @@ internal partial class DRK
                 && PlayerHealthPercentageHp() <=
                 GetOptionValue(Config.DRK_VariantCure))
                 return Variant.VariantCure;
+
+            // Interrupt
+            if (IsEnabled(CustomComboPreset.DRK_AoE_Interrupt)
+                && ActionReady(All.Interject)
+                && CanInterruptEnemy())
+                return All.Interject;
+
+            // Stun
+            if (IsEnabled(CustomComboPreset.DRK_AoE_Stun)
+                && ActionReady(All.LowBlow)
+                && TargetIsCasting())
+                return All.LowBlow;
 
             // Disesteem
             if (LevelChecked(LivingShadow)

--- a/WrathCombo/Combos/PvE/DRK/DRK.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK.cs
@@ -47,12 +47,6 @@ internal partial class DRK
 
             #endregion
 
-            // Interrupt
-            if (IsEnabled(CustomComboPreset.DRK_ST_Interrupt)
-                && ActionReady(All.Interject)
-                && CanInterruptEnemy())
-                return All.Interject;
-
             // Variant Cure - Heal: Priority to save your life
             if (IsEnabled(CustomComboPreset.DRK_Variant_Cure)
                 && IsEnabled(Variant.VariantCure)
@@ -328,18 +322,6 @@ internal partial class DRK
                 && PlayerHealthPercentageHp() <=
                 GetOptionValue(Config.DRK_VariantCure))
                 return Variant.VariantCure;
-
-            // Interrupt
-            if (IsEnabled(CustomComboPreset.DRK_AoE_Interrupt)
-                && ActionReady(All.Interject)
-                && CanInterruptEnemy())
-                return All.Interject;
-
-            // Stun
-            if (IsEnabled(CustomComboPreset.DRK_AoE_Stun)
-                && ActionReady(All.LowBlow)
-                && TargetIsCasting())
-                return All.LowBlow;
 
             // Disesteem
             if (LevelChecked(LivingShadow)

--- a/WrathCombo/Combos/PvE/GNB/GNB.cs
+++ b/WrathCombo/Combos/PvE/GNB/GNB.cs
@@ -81,6 +81,11 @@ internal partial class GNB
             if (Opener().FullOpener(ref actionID))
                 return actionID;
 
+            // Interrupt
+            if (ActionReady(All.Interject)
+                && CanInterruptEnemy())
+                return All.Interject;
+
             #region Mitigations
             if (Config.GNB_ST_MitsOptions != 1)
             {
@@ -607,6 +612,12 @@ internal partial class GNB
             if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Opener) &&
                 Opener().FullOpener(ref actionID))
                 return actionID;
+
+            // Interrupt
+            if (IsEnabled(CustomComboPreset.GNB_ST_Interrupt)
+                && ActionReady(All.Interject)
+                && CanInterruptEnemy())
+                return All.Interject;
 
             #region Mitigations
             if (IsEnabled(CustomComboPreset.GNB_ST_Mitigation) && //Mitigation option is enabled
@@ -1142,6 +1153,20 @@ internal partial class GNB
             #endregion
             #endregion
 
+            #region Stuns
+
+            // Interrupt
+            if (ActionReady(All.Interject)
+                && CanInterruptEnemy())
+                return All.Interject;
+
+            // Stun
+            if (ActionReady(All.LowBlow)
+                && TargetIsCasting())
+                return All.LowBlow;
+
+            #endregion
+
             #region Mitigations
             if (Config.GNB_AoE_MitsOptions != 1)
             {
@@ -1535,6 +1560,22 @@ internal partial class GNB
                            GunStep == 0 && //Gnashing Fang or Reign combo is not already active
                            hasReign; //Ready To Reign is active
             #endregion
+            #endregion
+
+            #region Stuns
+
+            // Interrupt
+            if (IsEnabled(CustomComboPreset.GNB_AoE_Interrupt)
+                && ActionReady(All.Interject)
+                && CanInterruptEnemy())
+                return All.Interject;
+
+            // Stun
+            if (IsEnabled(CustomComboPreset.GNB_AoE_Stun)
+                && ActionReady(All.LowBlow)
+                && TargetIsCasting())
+                return All.LowBlow;
+
             #endregion
 
             #region Mitigations

--- a/WrathCombo/Combos/PvE/PLD/PLD.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD.cs
@@ -50,6 +50,11 @@ internal partial class PLD
                              JustUsed(HallowedGround, 9f);
             #endregion
 
+            // Interrupt
+            if (ActionReady(All.Interject)
+                && CanInterruptEnemy())
+                return All.Interject;
+
             // Variant Cure
             if (IsEnabled(CustomComboPreset.PLD_Variant_Cure) && IsEnabled(Variant.VariantCure) &&
                 PlayerHealthPercentageHp() <= Config.PLD_VariantCure)
@@ -242,6 +247,18 @@ internal partial class PLD
                              JustUsed(HallowedGround, 9f);
             #endregion
 
+            // Interrupt
+            if (ActionReady(All.Interject)
+                && CanInterruptEnemy())
+                return All.Interject;
+
+            // Stun
+            if (TargetIsCasting())
+                if (ActionReady(ShieldBash))
+                    return ShieldBash;
+                else if (ActionReady(All.LowBlow))
+                    return All.LowBlow;
+
             // Variant Cure
             if (IsEnabled(CustomComboPreset.PLD_Variant_Cure) && IsEnabled(Variant.VariantCure) &&
                 PlayerHealthPercentageHp() <= Config.PLD_VariantCure)
@@ -386,6 +403,12 @@ internal partial class PLD
                                        (HasEffect(Buffs.SupplicationReady) && GetBuffRemainingTime(Buffs.SupplicationReady) < 6) ||
                                        (HasEffect(Buffs.SepulchreReady) && GetBuffRemainingTime(Buffs.SepulchreReady) < 6);
             #endregion
+
+            // Interrupt
+            if (IsEnabled(CustomComboPreset.PLD_ST_Interrupt)
+                && ActionReady(All.Interject)
+                && CanInterruptEnemy())
+                return All.Interject;
 
             // Variant Cure
             if (IsEnabled(CustomComboPreset.PLD_Variant_Cure) && IsEnabled(Variant.VariantCure) &&
@@ -583,6 +606,19 @@ internal partial class PLD
             bool isAboveMPReserve = IsNotEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_MP_Reserve) ||
                                     (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_MP_Reserve) && playerMP >= GetResourceCost(HolySpirit) + Config.PLD_AoE_MP_Reserve);
             #endregion
+
+            // Interrupt
+            if (IsEnabled(CustomComboPreset.PLD_AoE_Interrupt)
+                && ActionReady(All.Interject)
+                && CanInterruptEnemy())
+                return All.Interject;
+
+            // Stun
+            if (IsEnabled(CustomComboPreset.PLD_AoE_Stun) && TargetIsCasting())
+                if (ActionReady(ShieldBash))
+                    return ShieldBash;
+                else if (ActionReady(All.LowBlow))
+                    return All.LowBlow;
 
             // Variant Cure
             if (IsEnabled(CustomComboPreset.PLD_Variant_Cure) && IsEnabled(Variant.VariantCure) &&

--- a/WrathCombo/Combos/PvE/WAR/WAR.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR.cs
@@ -26,6 +26,11 @@ internal partial class WAR
                               JustUsed(All.Rampart, 5f) ||
                               JustUsed(Holmgang, 9f);
 
+            // Interrupt
+            if (ActionReady(All.Interject)
+                && CanInterruptEnemy())
+                return All.Interject;
+
             #region Variant
             Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
             if (IsEnabled(CustomComboPreset.WAR_Variant_SpiritDart) &&
@@ -204,6 +209,12 @@ internal partial class WAR
                               JustUsed(ThrillOfBattle, 5f) ||
                               JustUsed(All.Rampart, 5f) ||
                               JustUsed(Holmgang, 9f);
+
+            // Interrupt
+            if (IsEnabled(CustomComboPreset.WAR_ST_Interrupt)
+                && ActionReady(All.Interject)
+                && CanInterruptEnemy())
+                return All.Interject;
 
             #region Variant
             Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
@@ -442,6 +453,20 @@ internal partial class WAR
                               JustUsed(All.Rampart, 5f) ||
                               JustUsed(Holmgang, 9f);
 
+            #region Stuns
+
+            // Interrupt
+            if (ActionReady(All.Interject)
+                && CanInterruptEnemy())
+                return All.Interject;
+
+            // Stun
+            if (ActionReady(All.LowBlow)
+                && TargetIsCasting())
+                return All.LowBlow;
+
+            #endregion
+
             #region Variant
             Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
             if (IsEnabled(CustomComboPreset.WAR_Variant_SpiritDart) &&
@@ -582,6 +607,22 @@ internal partial class WAR
                               JustUsed(ThrillOfBattle, 5f) ||
                               JustUsed(All.Rampart, 5f) ||
                               JustUsed(Holmgang, 9f);
+
+            #region Stuns
+
+            // Interrupt
+            if (IsEnabled(CustomComboPreset.WAR_AoE_Interrupt)
+                && ActionReady(All.Interject)
+                && CanInterruptEnemy())
+                return All.Interject;
+
+            // Stun
+            if (IsEnabled(CustomComboPreset.WAR_AoE_Stun)
+                && ActionReady(All.LowBlow)
+                && TargetIsCasting())
+                return All.LowBlow;
+
+            #endregion
 
             #region Variant
             Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);

--- a/WrathCombo/Core/PluginConfiguration.cs
+++ b/WrathCombo/Core/PluginConfiguration.cs
@@ -57,6 +57,8 @@ namespace WrathCombo.Core
 
         public bool PerformanceMode = false;
 
+        public double InterruptDelay  = 0.0f;
+
         #endregion
 
         #region AutoAction Settings

--- a/WrathCombo/CustomCombo/Functions/Target.cs
+++ b/WrathCombo/CustomCombo/Functions/Target.cs
@@ -169,28 +169,60 @@ namespace WrathCombo.CustomComboNS.Functions
             return healTarget;
         }
 
-        /// <summary> Determines if the enemy is casting an action. Optionally, limit by total cast time. </summary>
-        /// <param name="minTotalCast"> The minimum total cast time required, in seconds. </param>
-        /// <returns> Bool indicating whether they are casting an action or not. </returns>
-        public static bool TargetIsCasting(float? minTotalCast = null)
+        /// <summary>
+        ///     Determines if the enemy is casting an action. Optionally, limit by percentage of cast time.
+        /// </summary>
+        /// <param name="minCastPercentage">
+        ///     The minimum percentage of the cast time completed required.<br/>
+        ///     Default is 0%.<br/>
+        ///     As a float representation of a percentage, value should be between
+        ///     0.0f (0%) and 1.0f (100%).
+        /// </param>
+        /// <returns>
+        ///     Bool indicating whether they are casting an action or not.<br/>
+        ///     (and if the cast time is over the percentage specified)
+        /// </returns>
+        public static bool TargetIsCasting(float? minCastPercentage = null)
         {
-            if (CurrentTarget is null || CurrentTarget is not IBattleChara chara) return false;
+            if (CurrentTarget is not IBattleChara chara) return false;
 
-            if (chara.IsCasting) return minTotalCast == null || chara.TotalCastTime >= minTotalCast;
+            minCastPercentage ??= 0.0f;
+            minCastPercentage = Math.Clamp((float)minCastPercentage, 0.0f, 1.0f);
+            var castPercentage = chara.CurrentCastTime / chara.TotalCastTime;
 
-            else return false;
+            if (chara.IsCasting)
+                return minCastPercentage <= castPercentage;
+
+            return false;
         }
 
-        /// <summary> Determines if the enemy is casting an action that can be interrupted. Optionally, limit by current cast time. </summary>
-        /// <param name="minCurrentCast"> The minimum current cast time required, in seconds. </param>
-        /// <returns> Bool indicating whether they can be interrupted or not. </returns>
-        public static bool CanInterruptEnemy(float? minCurrentCast = null)
+        /// <summary>
+        ///     Determines if the enemy is casting an action that can be interrupted.
+        ///     <br/>
+        ///     Optionally limited by percentage of cast time.
+        /// </summary>
+        /// <param name="minCastPercentage">
+        ///     The minimum percentage of the cast time completed required.<br/>
+        ///     Default is 0%.<br/>
+        ///     As a float representation of a percentage, value should be between
+        ///     0.0f (0%) and 1.0f (100%).
+        /// </param>
+        /// <returns>
+        ///     Bool indicating whether they can be interrupted or not.<br/>
+        ///     (and if the cast time is over the percentage specified)
+        /// </returns>
+        public static bool CanInterruptEnemy(float? minCastPercentage = null)
         {
-            if (CurrentTarget is null || CurrentTarget is not IBattleChara chara) return false;
+            if (CurrentTarget is not IBattleChara chara) return false;
 
-            if (chara.IsCasting && chara.IsCastInterruptible) return minCurrentCast == null || chara.CurrentCastTime >= minCurrentCast;
+            minCastPercentage ??= 0.0f; // todo: Setting for default Interrupt Delay
+            minCastPercentage = Math.Clamp((float)minCastPercentage, 0.0f, 1.0f);
+            var castPercentage = chara.CurrentCastTime / chara.TotalCastTime;
 
-            else return false;
+            if (chara is { IsCasting: true, IsCastInterruptible: true })
+                return minCastPercentage >= castPercentage;
+
+            return false;
         }
 
         /// <summary> Sets the player's target. </summary>

--- a/WrathCombo/CustomCombo/Functions/Target.cs
+++ b/WrathCombo/CustomCombo/Functions/Target.cs
@@ -182,13 +182,13 @@ namespace WrathCombo.CustomComboNS.Functions
         ///     Bool indicating whether they are casting an action or not.<br/>
         ///     (and if the cast time is over the percentage specified)
         /// </returns>
-        public static bool TargetIsCasting(float? minCastPercentage = null)
+        public static bool TargetIsCasting(double? minCastPercentage = null)
         {
             if (CurrentTarget is not IBattleChara chara) return false;
 
             minCastPercentage ??= 0.0f;
-            minCastPercentage = Math.Clamp((float)minCastPercentage, 0.0f, 1.0f);
-            var castPercentage = chara.CurrentCastTime / chara.TotalCastTime;
+            minCastPercentage = Math.Clamp((double)minCastPercentage, 0.0d, 1.0d);
+            double castPercentage = chara.CurrentCastTime / chara.TotalCastTime;
 
             if (chara.IsCasting)
                 return minCastPercentage <= castPercentage;
@@ -211,13 +211,13 @@ namespace WrathCombo.CustomComboNS.Functions
         ///     Bool indicating whether they can be interrupted or not.<br/>
         ///     (and if the cast time is over the percentage specified)
         /// </returns>
-        public static bool CanInterruptEnemy(float? minCastPercentage = null)
+        public static bool CanInterruptEnemy(double? minCastPercentage = null)
         {
             if (CurrentTarget is not IBattleChara chara) return false;
 
-            minCastPercentage ??= 0.0f; // todo: Setting for default Interrupt Delay
-            minCastPercentage = Math.Clamp((float)minCastPercentage, 0.0f, 1.0f);
-            var castPercentage = chara.CurrentCastTime / chara.TotalCastTime;
+            minCastPercentage ??= Service.Configuration.InterruptDelay;
+            minCastPercentage = Math.Clamp((double)minCastPercentage, 0.0d, 1.0d);
+            double castPercentage = chara.CurrentCastTime / chara.TotalCastTime;
 
             if (chara is { IsCasting: true, IsCastInterruptible: true })
                 return minCastPercentage >= castPercentage;

--- a/WrathCombo/Window/Tabs/Settings.cs
+++ b/WrathCombo/Window/Tabs/Settings.cs
@@ -2,23 +2,31 @@
 using Dalamud.Interface.Utility.Raii;
 using ImGuiNET;
 using System.Numerics;
+using Dalamud.Interface.Colors;
+using ECommons.ImGuiMethods;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Services;
+using WrathCombo.Window.Functions;
 
 namespace WrathCombo.Window.Tabs
 {
     internal class Settings : ConfigWindow
     {
-        internal static new void Draw()
+        internal new static void Draw()
         {
             PvEFeatures.HasToOpenJob = true;
-            using (var child = ImRaii.Child("main", new Vector2(0, 0), true))
+            using (ImRaii.Child("main", new Vector2(0, 0), true))
             {
-                ImGui.Text("This tab allows you to customise your options when enabling features.");
+                ImGui.Text("This tab allows you to customise your options for Wrath Combo.");
+
+                #region UI Options
+
+                ImGui.Dummy(new Vector2(20f));
+                ImGuiEx.TextUnderlined("Main UI Options");
 
                 #region SubCombos
 
-                bool hideChildren = Service.Configuration.HideChildren;
+                var hideChildren = Service.Configuration.HideChildren;
 
                 if (ImGui.Checkbox("Hide SubCombo Options", ref hideChildren))
                 {
@@ -26,13 +34,7 @@ namespace WrathCombo.Window.Tabs
                     Service.Configuration.Save();
                 }
 
-                if (ImGui.IsItemHovered())
-                {
-                    ImGui.BeginTooltip();
-                    ImGui.TextUnformatted("Hides the sub-options of disabled features.");
-                    ImGui.EndTooltip();
-                }
-                ImGui.NextColumn();
+                ImGuiComponents.HelpMarker("Hides the sub-options of disabled features.");
 
                 #endregion
 
@@ -45,52 +47,27 @@ namespace WrathCombo.Window.Tabs
                     Service.Configuration.Save();
                 }
 
-                if (ImGui.IsItemHovered())
-                {
-                    ImGui.BeginTooltip();
-                    ImGui.TextUnformatted("Hides any combos that conflict with others you have selected.");
-                    ImGui.EndTooltip();
-                }
+                ImGuiComponents.HelpMarker("Hides any combos that conflict with others you have selected.");
 
                 #endregion
 
-                #region Combat Log
+                #region Shorten DTR bar text
 
-                bool showCombatLog = Service.Configuration.EnabledOutputLog;
+                bool shortDTRText = Service.Configuration.ShortDTRText;
 
-                if (ImGui.Checkbox("Output Log to Chat", ref showCombatLog))
+                if (ImGui.Checkbox("Shorten Server Info Bar Text", ref shortDTRText))
                 {
-                    Service.Configuration.EnabledOutputLog = showCombatLog;
+                    Service.Configuration.ShortDTRText = shortDTRText;
                     Service.Configuration.Save();
                 }
 
-                if (ImGui.IsItemHovered())
-                {
-                    ImGui.BeginTooltip();
-                    ImGui.TextUnformatted("Every time you use an action, the plugin will print it to the chat.");
-                    ImGui.EndTooltip();
-                }
-                #endregion
+                ImGuiComponents.HelpMarker(
+                    "By default, the Server Info Bar for Wrath Combo shows whether Auto-Rotation is on or off, " +
+                    "\nthen -if on- it will show how many active Auto-Mode combos you have enabled. " +
+                    "\nAnd finally, it will also show if another plugin is controlling that value." +
+                    "\nThis option will make the number of active Auto-Mode combos not show."
+                );
 
-                #region Melee Offset
-                float offset = (float)Service.Configuration.MeleeOffset;
-                ImGui.PushItemWidth(75);
-
-                bool inputChangedeth = false;
-                inputChangedeth |= ImGui.InputFloat("Melee Distance Offset", ref offset);
-
-                if (inputChangedeth)
-                {
-                    Service.Configuration.MeleeOffset = (double)offset;
-                    Service.Configuration.Save();
-                }
-
-                if (ImGui.IsItemHovered())
-                {
-                    ImGui.BeginTooltip();
-                    ImGui.TextUnformatted("Offset of melee check distance for features that use it.\r\nFor those who don't want to immediately use their ranged attack if the boss walks slightly out of range.");
-                    ImGui.EndTooltip();
-                }
                 #endregion
 
                 #region Message of the Day
@@ -103,13 +80,7 @@ namespace WrathCombo.Window.Tabs
                     Service.Configuration.Save();
                 }
 
-                if (ImGui.IsItemHovered())
-                {
-                    ImGui.BeginTooltip();
-                    ImGui.TextUnformatted("Disables the Message of the Day message in your chat when you login.");
-                    ImGui.EndTooltip();
-                }
-                ImGui.NextColumn();
+                ImGuiComponents.HelpMarker("Disables the Message of the Day message in your chat when you login.");
 
                 #endregion
 
@@ -122,57 +93,115 @@ namespace WrathCombo.Window.Tabs
                     Service.Configuration.Save();
                 }
 
-                if (ImGui.IsItemHovered())
-                {
-                    ImGui.BeginTooltip();
-                    ImGui.TextUnformatted($"Used for {CustomComboFunctions.JobIDs.JobIDToName(33)} card targeting features.\r\nSet Alpha to 0 to hide the box.");
-                    ImGui.EndTooltip();
-                }
+                ImGuiComponents.HelpMarker("Draws a box around party members in the vanilla Party List, as targeted by certain features.\nSet Alpha to 0 to hide the box.");
+
+                ImGui.SameLine();
+                ImGui.TextColored(ImGuiColors.DalamudGrey, $"(Only used by {CustomComboFunctions.JobIDs.JobIDToName(33)} currently)");
 
                 #endregion
 
-                if (ImGui.Checkbox($"Block spells if moving", ref Service.Configuration.BlockSpellOnMove))
-                    Service.Configuration.Save();
-
-                if (ImGui.Checkbox($"Output opener status to chat", ref Service.Configuration.OutputOpenerLogs))
-                    Service.Configuration.Save();
-
-                #region Shorten DTR bar text
-
-                bool shortDTRText = Service.Configuration.ShortDTRText;
-
-                if (ImGui.Checkbox("Shorten Server Info Bar Text", ref shortDTRText))
-                {
-                    Service.Configuration.ShortDTRText = shortDTRText;
-                    Service.Configuration.Save();
-                }
-
-                if (ImGui.IsItemHovered())
-                {
-                    ImGui.BeginTooltip();
-                    ImGui.TextUnformatted(
-                        "By default, the Server Info Bar for Wrath Combo shows whether Auto-Rotation is on or off, " +
-                        "\nthen -if on- it will show how many active Auto-Mode combos you have enabled. " +
-                        "\nAnd finally, it will also show if another plugin is controlling that value." +
-                        "\nThis option will make the number of active Auto-Mode combos not show.");
-                    ImGui.EndTooltip();
-                }
                 #endregion
 
-                if (ImGui.InputFloat("Movement Check Delay", ref Service.Configuration.MovementLeeway))
-                    Service.Configuration.Save();
+                #region Rotation Behavior Options
 
-                ImGuiComponents.HelpMarker("Many features check if you are moving to decide actions. This will allow you to set a delay on how long you need to be moving before it recognizes you as moving.");
+                ImGui.Dummy(new Vector2(20f));
+                ImGuiEx.TextUnderlined("Rotation Behavior Options");
 
-                if (ImGui.InputFloat("Opener Failure Timeout", ref Service.Configuration.OpenerTimeout))
-                    Service.Configuration.Save();
-
-                ImGuiComponents.HelpMarker("During an opener, if this amount of seconds has passed since your last action, it will fail the opener and resume with non-opener functionality.");
+                #region Performance Mode
 
                 if (ImGui.Checkbox("Performance Mode", ref Service.Configuration.PerformanceMode))
                     Service.Configuration.Save();
 
                 ImGuiComponents.HelpMarker("This mode will disable actions being changed on your hotbar, but will still continue to work in the background as you press your buttons.");
+
+                #endregion
+
+                #region Spells while Moving
+
+                if (ImGui.Checkbox("Block spells if moving", ref Service.Configuration.BlockSpellOnMove))
+                    Service.Configuration.Save();
+
+                ImGuiComponents.HelpMarker("Completely blocks spells from being used if you are moving.\nThis would supersede combo-specific movement options, available for most jobs.");
+
+                #endregion
+
+                #region Movement Check Delay
+
+                ImGui.PushItemWidth(75);
+                if (ImGui.InputFloat("seconds    -    Movement Check Delay", ref Service.Configuration.MovementLeeway))
+                    Service.Configuration.Save();
+
+                ImGuiComponents.HelpMarker("Many features check if you are moving to decide actions, this will allow you to set a delay on how long you need to be moving before it recognizes you as moving.\nThis allows you to not have to worry about small movements affecting your rotation, primarily for casters.\n\nIt is recommended to keep this value between 0 and 1 seconds.");
+
+                #endregion
+
+                #region Opener Failure Timeout
+
+                if (ImGui.InputFloat("seconds    -    Opener Failure Timeout", ref Service.Configuration.OpenerTimeout))
+                    Service.Configuration.Save();
+
+                ImGuiComponents.HelpMarker("During an opener, if this amount of time has passed since your last action, it will fail the opener and resume with non-opener functionality.");
+
+                #endregion
+
+                #region Melee Offset
+                var offset = (float)Service.Configuration.MeleeOffset;
+
+                if (ImGui.InputFloat("yalms    -    Melee Distance Offset", ref offset))
+                {
+                    Service.Configuration.MeleeOffset = (double)offset;
+                    Service.Configuration.Save();
+                }
+
+                ImGuiComponents.HelpMarker("Offset of melee check distance.\nFor those who don't want to immediately use their ranged attack if the boss walks slightly out of range.\n\nFor example, a value of -0.5 would make you have to be 0.5 yalms closer to the target,\nor a value of 2 would disable triggering of ranged features until you are 2 yalms further from the hitbox.\n\nIt is recommended to keep this value at 0.");
+                #endregion
+
+                #region Interrupt Delay
+
+                var delay = (int)(Service.Configuration.InterruptDelay * 100d);
+
+                if (ImGui.SliderInt("percent of cast    -    Interrupt Delay",
+                    ref delay, 0, 100))
+                {
+                    delay = delay.RoundOff(SliderIncrements.Fives);
+
+                    Service.Configuration.InterruptDelay = ((double)delay) / 100d;
+                    Service.Configuration.Save();
+                }
+
+                ImGuiComponents.HelpMarker("The percentage of a total cast time to wait before interrupting.\nApplies to all interrupts, in every job's combos.\n\nIt is recommend to keep this value below 50%.");
+
+                #endregion
+
+                #endregion
+
+                #region Logging Options
+
+                ImGui.Dummy(new Vector2(20f));
+                ImGuiEx.TextUnderlined("Troubleshooting / Analysis Options");
+
+                #region Combat Log
+
+                bool showCombatLog = Service.Configuration.EnabledOutputLog;
+
+                if (ImGui.Checkbox("Output Log to Chat", ref showCombatLog))
+                {
+                    Service.Configuration.EnabledOutputLog = showCombatLog;
+                    Service.Configuration.Save();
+                }
+
+                ImGuiComponents.HelpMarker("Every time you use an action, the plugin will print it to the chat.");
+                #endregion
+
+                #region Opener Log
+
+                if (ImGui.Checkbox($"Output opener status to chat", ref Service.Configuration.OutputOpenerLogs))
+                    Service.Configuration.Save();
+
+                ImGuiComponents.HelpMarker("Every time your class's opener ir ready, fails, or finishes as expected, it will print to the chat.");
+                #endregion
+
+                #endregion
             }
         }
     }

--- a/WrathCombo/Window/Tabs/Settings.cs
+++ b/WrathCombo/Window/Tabs/Settings.cs
@@ -121,7 +121,7 @@ namespace WrathCombo.Window.Tabs
                 if (ImGui.Checkbox("Block spells if moving", ref Service.Configuration.BlockSpellOnMove))
                     Service.Configuration.Save();
 
-                ImGuiComponents.HelpMarker("Completely blocks spells from being used if you are moving.\nThis would supersede combo-specific movement options, available for most jobs.");
+                ImGuiComponents.HelpMarker("Completely blocks spells from being used if you are moving.\nThis is superseded by most job-specific movement options, so you may not always see this take effect.\n(spells are blocked by Savage Blade)");
 
                 #endregion
 


### PR DESCRIPTION
- [X] Adds Interrupting to all tanks' combos
      ST: added option to interject if the target's cast is interruptible
      ST Simple: interrupts if the target's cast is interruptible
      AoE: added options to interject if the target's cast is interruptible, or to stun if the target is casting
      AoE Simple: interrupts if the target's cast is interruptible, and stuns if the target is casting
  - [ ] DRK (handled in #320 to avoid conflicts)
  - [X] GNB
  - [X] PLD (Included `Shield Bash` in the Stun option, in addition to `Low Blow`)
  - [X] WAR
- [X] Adds new Setting for Interrupt Delay.
      Which delays interrupts by X% of the total cast.
      If a value is not passed to `CanInterruptEnemy()` then it will use this setting, and only return `true` if the cast is over that percentage done.
- [X] Reworked the settings tab. Was getting cramped.
      ![new settings tab](https://github.com/user-attachments/assets/45f58fe2-cded-41ec-bb82-0b4507eb4278)