### PR TITLE
[Core] Local Image

### DIFF
--- a/WrathCombo/Window/ConfigWindow.cs
+++ b/WrathCombo/Window/ConfigWindow.cs
@@ -8,6 +8,7 @@ using PunishLib;
 using PunishLib.ImGuiMethods;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Numerics;
 using Dalamud.Interface.Colors;
@@ -114,7 +115,23 @@ namespace WrathCombo.Window
 
             using (var leftChild = ImRaii.Child($"###WrathLeftSide", regionSize with { Y = topLeftSideHeight }, false, ImGuiWindowFlags.NoDecoration))
             {
-                if (ThreadLoadImageHandler.TryGetTextureWrap(PunishLibMain.PluginManifest.IconUrl ?? "", out var logo)) //todo update
+                string? imagePath;
+                try
+                {
+                    // Use the local image over a remote one
+                    imagePath = Path.Combine(
+                        Svc.PluginInterface.AssemblyLocation.Directory?.FullName!,
+                        "images\\wrathcombo.png");
+                    if (!File.Exists(imagePath))
+                        throw new FileNotFoundException();
+                }
+                catch (Exception)
+                {
+                    // Fallback to the remote icon if there are any issues
+                    imagePath = PunishLibMain.PluginManifest.IconUrl ?? "";
+                }
+
+                if (ThreadLoadImageHandler.TryGetTextureWrap(imagePath, out var logo))
                 {
                     ImGuiEx.LineCentered("###WrathLogo", () =>
                     {


### PR DESCRIPTION
- [X] Restores the behavior of using the local image instead of fetching a remote one.
      The image is present for all users, not just developers, as it's loaded into the Project in the `.csproj`; this can be double-checked by verifying the presence of the `images/wrathcombo.png` file in the [release zip](https://puni.sh/api/plugins/download/60/WrathCombo/versions/latest.zip).
      This behavior was originally in c57078d, but immediately overwritten.