### PR TITLE
[IPC] Fix UI, Add `Set` status codes

### DIFF
--- a/WrathCombo/Services/IPC/Enums.cs
+++ b/WrathCombo/Services/IPC/Enums.cs
@@ -117,23 +117,60 @@ public enum ComboSimplicityLevelKeys
 public enum CancellationReason
 {
     [Description("The Wrath user manually elected to revoke your lease.")]
-    WrathUserManuallyCancelled,
+    WrathUserManuallyCancelled = 0,
 
     [Description("Your plugin was detected as having been disabled, " +
                  "not that you're likely to see this.")]
-    LeaseePluginDisabled,
+    LeaseePluginDisabled = 1,
 
     [Description("The Wrath plugin is being disabled.")]
-    WrathPluginDisabled,
+    WrathPluginDisabled = 2,
 
     [Description("Your lease was released by IPC call, " +
                  "theoretically this was done by you.")]
-    LeaseeReleased,
+    LeaseeReleased = 3,
 
     [Description("IPC Services have been disabled remotely. " +
                  "Please see the commit history for /res/ipc_status.txt.\n " +
                  "https://github.com/PunishXIV/WrathCombo/commits/main/res/ipc_status.txt")]
-    AllServicesSuspended,
+    AllServicesSuspended = 4,
+}
+
+public enum SetResult
+{
+    [Description("A default value that shouldn't ever be seen.")]
+    IGNORED = -1,
+
+    // Success Statuses
+
+    [Description("The configuration was set successfully.")]
+    Okay = 0,
+
+    [Description("The configuration will be set, it is working asynchronously.")]
+    OkayWorking = 1,
+
+    // Error Statuses
+
+    [Description("IPC services are currently disabled.")]
+    IPCDisabled = 10,
+
+    [Description("Invalid lease.")]
+    InvalidLease = 11,
+
+    [Description("Blacklisted lease.")]
+    BlacklistedLease = 12,
+
+    [Description("Configuration you are trying to set is already set.")]
+    Duplicate = 13,
+
+    [Description("Player object is not available.")]
+    PlayerNotAvailable = 14,
+
+    [Description("The configuration you are trying to set is not available.")]
+    InvalidConfiguration = 15,
+
+    [Description("The value you are trying to set is invalid.")]
+    InvalidValue = 16,
 }
 
 #region Auto-Rotation Configuration Options

--- a/WrathCombo/Services/IPC/HelpAutoRotConfig.cs
+++ b/WrathCombo/Services/IPC/HelpAutoRotConfig.cs
@@ -40,13 +40,14 @@ public partial class Leasing
     /// <param name="option">The Auto-Rotation option to set.</param>
     /// <param name="value">The type-juggled value to set it to.</param>
     /// <seealso cref="Provider.SetAutoRotationConfigState" />
-    internal void AddRegistrationForAutoRotationConfig
+    internal SetResult AddRegistrationForAutoRotationConfig
         (Guid lease, AutoRotationConfigOption option, int value)
     {
         var registration = Registrations[lease];
 
-        if (registration.AutoRotationConfigsControlled.ContainsKey(option) && registration.AutoRotationConfigsControlled[option] == value)
-            return;
+        if (registration.AutoRotationConfigsControlled.ContainsKey(option) &&
+            registration.AutoRotationConfigsControlled[option] == value)
+            return SetResult.Duplicate;
 
         registration.AutoRotationConfigsControlled[option] = value;
 
@@ -54,6 +55,7 @@ public partial class Leasing
         AutoRotationConfigsUpdated = DateTime.Now;
 
         Logging.Log($"{registration.PluginName}: Registered Auto-Rotation Config ({option} to {value})");
+        return SetResult.Okay;
     }
 }
 

--- a/WrathCombo/Services/IPC/Helper.cs
+++ b/WrathCombo/Services/IPC/Helper.cs
@@ -21,17 +21,21 @@ public partial class Helper(ref Leasing leasing)
     /// <summary>
     ///     Checks for typical bail conditions at the time of a set.
     /// </summary>
+    /// <param name="result">
+    ///     The result to set if the method should bail.
+    /// </param>
     /// <param name="lease">
     ///     Your lease ID from <see cref="Provider.RegisterForLease(string,string)" />
     /// </param>
     /// <returns>If the method should bail.</returns>
     internal bool CheckForBailConditionsAtSetTime
-        (Guid? lease = null)
+        (out SetResult result, Guid? lease = null)
     {
         // Bail if IPC is disabled
         if (!IPCEnabled)
         {
             Logging.Warn(BailMessages.LiveDisabled);
+            result = SetResult.IPCDisabled;
             return true;
         }
 
@@ -40,6 +44,7 @@ public partial class Helper(ref Leasing leasing)
             !_leasing.CheckLeaseExists(lease.Value))
         {
             Logging.Warn(BailMessages.InvalidLease);
+            result = SetResult.InvalidLease;
             return true;
         }
 
@@ -48,9 +53,11 @@ public partial class Helper(ref Leasing leasing)
             _leasing.CheckBlacklist(lease.Value))
         {
             Logging.Warn(BailMessages.BlacklistedLease);
+            result = SetResult.BlacklistedLease;
             return true;
         }
 
+        result = SetResult.IGNORED;
         return false;
     }
 

--- a/WrathCombo/Services/IPC/Leasing.cs
+++ b/WrathCombo/Services/IPC/Leasing.cs
@@ -299,7 +299,7 @@ public partial class Leasing
     /// </param>
     /// <param name="newState">Whether to enabled Auto-Rotation.</param>
     /// <seealso cref="Provider.SetAutoRotationState" />
-    internal void AddRegistrationForAutoRotation(Guid lease, bool newState)
+    internal SetResult AddRegistrationForAutoRotation(Guid lease, bool newState)
     {
         var registration = Registrations[lease];
 
@@ -308,7 +308,7 @@ public partial class Leasing
         {
             Logging.Log(
                 $"{registration.PluginName}: You are already controlling Auto-Rotation");
-            return;
+            return SetResult.Duplicate;
         }
 
         // Always [0], not an actual add
@@ -318,6 +318,7 @@ public partial class Leasing
         AutoRotationStateUpdated = DateTime.Now;
 
         Logging.Log($"{registration.PluginName}: Auto-Rotation state updated");
+        return SetResult.Okay;
     }
 
     /// <summary>
@@ -353,7 +354,7 @@ public partial class Leasing
     /// </param>
     /// <param name="jobOverride">A manual override, only used in testing</param>
     /// <seealso cref="Provider.SetCurrentJobAutoRotationReady" />
-    internal void AddRegistrationForCurrentJob(Guid lease, Job? jobOverride = null)
+    internal SetResult AddRegistrationForCurrentJob(Guid lease, Job? jobOverride = null)
     {
         var registration = Registrations[lease];
 
@@ -361,7 +362,7 @@ public partial class Leasing
         {
             Logging.Error(
                 "Failed to register current job: player object does not exist!");
-            return;
+            return SetResult.PlayerNotAvailable;
         }
 
         // Convert current job/class to a job, if it is a class
@@ -380,7 +381,7 @@ public partial class Leasing
         {
             Logging.Log(
                 $"{registration.PluginName}: You are already controlling the current job ({job})");
-            return;
+            return SetResult.Duplicate;
         }
 
         Logging.Log(
@@ -442,6 +443,7 @@ public partial class Leasing
             CombosUpdated = DateTime.Now;
             OptionsUpdated = DateTime.Now;
         });
+        return SetResult.OkayWorking;
     }
 
     /// <summary>
@@ -527,7 +529,7 @@ public partial class Leasing
     /// <param name="newState">The state to set the preset to.</param>
     /// <param name="newAutoState">The state to set the Auto-Mode to.</param>
     /// <seealso cref="Provider.SetComboState" />
-    internal void AddRegistrationForCombo
+    internal SetResult AddRegistrationForCombo
         (Guid lease, string combo, bool newState, bool newAutoState)
     {
         var registration = Registrations[lease];
@@ -538,13 +540,18 @@ public partial class Leasing
 
         if (CheckBlacklist(Registrations[lease].ConfigurationsHash) &&
             Registrations[lease].SetsLeased > 4)
-            RemoveRegistration(lease, CancellationReasonEnum.WrathUserManuallyCancelled,
+        {
+            RemoveRegistration(lease,
+                CancellationReasonEnum.WrathUserManuallyCancelled,
                 "Matched currently-blacklisted configuration");
+            return SetResult.BlacklistedLease;
+        }
 
         registration.LastUpdated = DateTime.Now;
         CombosUpdated = DateTime.Now;
 
         Logging.Log($"{registration.PluginName}: Registered Combo ({combo})");
+        return SetResult.Okay;
     }
 
     /// <summary>
@@ -585,7 +592,7 @@ public partial class Leasing
     /// <param name="option">The option internal name to register control of.</param>
     /// <param name="newState">The state to set the preset to.</param>
     /// <seealso cref="Provider.SetComboOptionState" />
-    internal void AddRegistrationForOption
+    internal SetResult AddRegistrationForOption
         (Guid lease, string option, bool newState)
     {
         var registration = Registrations[lease];
@@ -596,13 +603,18 @@ public partial class Leasing
 
         if (CheckBlacklist(Registrations[lease].ConfigurationsHash) &&
             Registrations[lease].SetsLeased > 4)
-            RemoveRegistration(lease, CancellationReasonEnum.WrathUserManuallyCancelled,
+        {
+            RemoveRegistration(lease,
+                CancellationReasonEnum.WrathUserManuallyCancelled,
                 "Matched currently-blacklisted configuration");
+            return SetResult.BlacklistedLease;
+        }
 
         registration.LastUpdated = DateTime.Now;
         OptionsUpdated = DateTime.Now;
 
         Logging.Log($"{registration.PluginName}: Registered Option ({option})");
+        return SetResult.Okay;
     }
 
     #endregion

--- a/WrathCombo/Services/IPC/ProvideAutoRotConfig.cs
+++ b/WrathCombo/Services/IPC/ProvideAutoRotConfig.cs
@@ -94,11 +94,12 @@ public partial class Provider
     /// </param>
     /// <seealso cref="AutoRotationConfigOption"/>
     [EzIPC]
-    public void SetAutoRotationConfigState(Guid lease, object passedOption, object value)
+    public int SetAutoRotationConfigState
+        (Guid lease, object passedOption, object value)
     {
         // Bail for standard conditions
-        if (Helper.CheckForBailConditionsAtSetTime(lease))
-            return;
+        if (Helper.CheckForBailConditionsAtSetTime(out var result, lease))
+            return (int)result;
 
         // Try to cast the input to an Auto-Rotation Configuration option
         arcOption option;
@@ -117,7 +118,7 @@ public partial class Provider
             Logging.Warn("Invalid or not-yet-implemented `option` of " +
                           $"'{passedOption}'. Please refer to " +
                           "WrathCombo.Services.IPC.AutoRotationConfigOption");
-            return;
+            return (int)SetResult.InvalidConfiguration;
         }
 
         object convertedValue;
@@ -136,7 +137,7 @@ public partial class Provider
                           "Value likely out of range for option that wanted an enum. " +
                           $"Expected type: {type}.\n" +
                           e.Message);
-            return;
+            return (int)SetResult.InvalidValue;
         }
 
         // Handle converting bool->int, which doesn't work for some reason, despite
@@ -144,7 +145,7 @@ public partial class Provider
         if (type == typeof(bool))
             convertedValue = (bool)convertedValue ? 1 : 0;
 
-        Leasing.AddRegistrationForAutoRotationConfig(
+        return (int)Leasing.AddRegistrationForAutoRotationConfig(
             lease, option, (int)convertedValue);
     }
 }

--- a/WrathCombo/Services/IPC/ProvideAutoRotConfig.cs
+++ b/WrathCombo/Services/IPC/ProvideAutoRotConfig.cs
@@ -92,14 +92,18 @@ public partial class Provider
     ///     The value you want to set the option to.<br />
     ///     All valid options can be parsed from an int, or the exact expected types.
     /// </param>
+    /// <returns>
+    ///     The <see cref="SetResult" /> status code indicating the result of the
+    ///     operation.
+    /// </returns>
     /// <seealso cref="AutoRotationConfigOption"/>
     [EzIPC]
-    public int SetAutoRotationConfigState
+    public SetResult SetAutoRotationConfigState
         (Guid lease, object passedOption, object value)
     {
         // Bail for standard conditions
         if (Helper.CheckForBailConditionsAtSetTime(out var result, lease))
-            return (int)result;
+            return result;
 
         // Try to cast the input to an Auto-Rotation Configuration option
         arcOption option;
@@ -118,7 +122,7 @@ public partial class Provider
             Logging.Warn("Invalid or not-yet-implemented `option` of " +
                           $"'{passedOption}'. Please refer to " +
                           "WrathCombo.Services.IPC.AutoRotationConfigOption");
-            return (int)SetResult.InvalidConfiguration;
+            return SetResult.InvalidConfiguration;
         }
 
         object convertedValue;
@@ -137,7 +141,7 @@ public partial class Provider
                           "Value likely out of range for option that wanted an enum. " +
                           $"Expected type: {type}.\n" +
                           e.Message);
-            return (int)SetResult.InvalidValue;
+            return SetResult.InvalidValue;
         }
 
         // Handle converting bool->int, which doesn't work for some reason, despite
@@ -145,7 +149,7 @@ public partial class Provider
         if (type == typeof(bool))
             convertedValue = (bool)convertedValue ? 1 : 0;
 
-        return (int)Leasing.AddRegistrationForAutoRotationConfig(
+        return Leasing.AddRegistrationForAutoRotationConfig(
             lease, option, (int)convertedValue);
     }
 }

--- a/WrathCombo/Services/IPC/Provider.cs
+++ b/WrathCombo/Services/IPC/Provider.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using WrathCombo.Combos;
 
+// ReSharper disable UnusedMethodReturnValue.Global
 // ReSharper disable UnusedMember.Global
 
 #endregion
@@ -143,7 +144,7 @@ public partial class Provider : IDisposable
     ///     </list>
     /// </returns>
     /// <remarks>
-    ///     None of this will work correctly -or sometimes at all- with PvP.
+    ///     None of this will work correctly - or sometimes at all - with PvP.
     /// </remarks>
     /// <seealso cref="RegisterForLeaseWithCallback" />
     /// <seealso cref="RegisterForLease(string,string,Action{int,string})" />
@@ -152,7 +153,7 @@ public partial class Provider : IDisposable
         (string internalPluginName, string pluginName)
     {
         // Bail if IPC is disabled
-        if (Helper.CheckForBailConditionsAtSetTime())
+        if (Helper.CheckForBailConditionsAtSetTime(out _))
             return null;
 
         return Leasing.CreateRegistration(internalPluginName, pluginName);
@@ -196,7 +197,7 @@ public partial class Provider : IDisposable
         (string internalPluginName, string pluginName, string? ipcPrefixForCallback)
     {
         // Bail if IPC is disabled
-        if (Helper.CheckForBailConditionsAtSetTime())
+        if (Helper.CheckForBailConditionsAtSetTime(out _))
             return null;
 
         // Assign the IPC prefix if indicated it is the same as the internal name
@@ -234,7 +235,7 @@ public partial class Provider : IDisposable
         Action<int, string> leaseCancelledCallback)
     {
         // Bail if IPC is disabled
-        if (Helper.CheckForBailConditionsAtSetTime())
+        if (Helper.CheckForBailConditionsAtSetTime(out _))
             return null;
 
         return Leasing.CreateRegistration(
@@ -266,19 +267,23 @@ public partial class Provider : IDisposable
     ///     Optionally whether to enable Auto-Rotation.<br />
     ///     Only used to disable Auto-Rotation, as enabling it is the default.
     /// </param>
+    /// <returns>
+    ///     The <c>int</c> value of the <see cref="SetResult" /> status code
+    ///     indicating the result of the operation.
+    /// </returns>
     /// <seealso cref="GetAutoRotationState" />
     /// <remarks>
     ///     This is only the state of Auto-Rotation, not whether any combos are
     ///     enabled in Auto-Mode.
     /// </remarks>
     [EzIPC]
-    public void SetAutoRotationState(Guid lease, bool enabled = true)
+    public int SetAutoRotationState(Guid lease, bool enabled = true)
     {
         // Bail for standard conditions
-        if (Helper.CheckForBailConditionsAtSetTime(lease))
-            return;
+        if (Helper.CheckForBailConditionsAtSetTime(out var result, lease))
+            return (int)result;
 
-        Leasing.AddRegistrationForAutoRotation(lease, enabled);
+        return (int)Leasing.AddRegistrationForAutoRotation(lease, enabled);
     }
 
     /// <summary>
@@ -311,15 +316,22 @@ public partial class Provider : IDisposable
     ///     Your lease ID from
     ///     <see cref="RegisterForLease(string,string)" />
     /// </param>
-    /// <remarks>This can take a little bit to finish.</remarks>
+    /// <returns>
+    ///     The <c>int</c> value of the <see cref="SetResult" /> status code
+    ///     indicating the result of the operation.
+    /// </returns>
+    /// <remarks>
+    ///     This will do the actual <c>set</c>ting asynchronously, and will take a
+    ///     several seconds to complete.
+    /// </remarks>
     [EzIPC]
-    public void SetCurrentJobAutoRotationReady(Guid lease)
+    public int SetCurrentJobAutoRotationReady(Guid lease)
     {
         // Bail for standard conditions
-        if (Helper.CheckForBailConditionsAtSetTime(lease))
-            return;
+        if (Helper.CheckForBailConditionsAtSetTime(out var result, lease))
+            return (int)result;
 
-        Leasing.AddRegistrationForCurrentJob(lease);
+        return (int)Leasing.AddRegistrationForCurrentJob(lease);
     }
 
     /// <summary>
@@ -498,16 +510,20 @@ public partial class Provider : IDisposable
     ///     Only used to disable the combo in Auto-Mode, as enabling it is the
     ///     default.
     /// </param>
+    /// <returns>
+    ///     The <c>int</c> value of the <see cref="SetResult" /> status code
+    ///     indicating the result of the operation.
+    /// </returns>
     [EzIPC]
-    public void SetComboState
+    public int SetComboState
     (Guid lease, string comboInternalName,
         bool comboState = true, bool autoState = true)
     {
         // Bail for standard conditions
-        if (Helper.CheckForBailConditionsAtSetTime(lease))
-            return;
+        if (Helper.CheckForBailConditionsAtSetTime(out var result, lease))
+            return (int)result;
 
-        Leasing.AddRegistrationForCombo(
+        return (int)Leasing.AddRegistrationForCombo(
             lease, comboInternalName, comboState, autoState);
     }
 
@@ -544,14 +560,18 @@ public partial class Provider : IDisposable
     ///     Optionally whether to enable the combo option.<br />
     ///     Only used to disable the combo option, as enabling it is the default.
     /// </param>
+    /// <returns>
+    ///     The <c>int</c> value of the <see cref="SetResult" /> status code
+    ///     indicating the result of the operation.
+    /// </returns>
     [EzIPC]
-    public void SetComboOptionState(Guid lease, string optionName, bool state = true)
+    public int SetComboOptionState(Guid lease, string optionName, bool state = true)
     {
         // Bail for standard conditions
-        if (Helper.CheckForBailConditionsAtSetTime(lease))
-            return;
+        if (Helper.CheckForBailConditionsAtSetTime(out var result, lease))
+            return (int)result;
 
-        Leasing.AddRegistrationForOption(lease, optionName, state);
+        return (int)Leasing.AddRegistrationForOption(lease, optionName, state);
     }
 
     #endregion

--- a/WrathCombo/Services/IPC/Provider.cs
+++ b/WrathCombo/Services/IPC/Provider.cs
@@ -268,8 +268,8 @@ public partial class Provider : IDisposable
     ///     Only used to disable Auto-Rotation, as enabling it is the default.
     /// </param>
     /// <returns>
-    ///     The <c>int</c> value of the <see cref="SetResult" /> status code
-    ///     indicating the result of the operation.
+    ///     The <see cref="SetResult" /> status code indicating the result of the
+    ///     operation.
     /// </returns>
     /// <seealso cref="GetAutoRotationState" />
     /// <remarks>
@@ -277,13 +277,13 @@ public partial class Provider : IDisposable
     ///     enabled in Auto-Mode.
     /// </remarks>
     [EzIPC]
-    public int SetAutoRotationState(Guid lease, bool enabled = true)
+    public SetResult SetAutoRotationState(Guid lease, bool enabled = true)
     {
         // Bail for standard conditions
         if (Helper.CheckForBailConditionsAtSetTime(out var result, lease))
-            return (int)result;
+            return result;
 
-        return (int)Leasing.AddRegistrationForAutoRotation(lease, enabled);
+        return Leasing.AddRegistrationForAutoRotation(lease, enabled);
     }
 
     /// <summary>
@@ -317,21 +317,21 @@ public partial class Provider : IDisposable
     ///     <see cref="RegisterForLease(string,string)" />
     /// </param>
     /// <returns>
-    ///     The <c>int</c> value of the <see cref="SetResult" /> status code
-    ///     indicating the result of the operation.
+    ///     The <see cref="SetResult" /> status code indicating the result of the
+    ///     operation.
     /// </returns>
     /// <remarks>
     ///     This will do the actual <c>set</c>ting asynchronously, and will take a
     ///     several seconds to complete.
     /// </remarks>
     [EzIPC]
-    public int SetCurrentJobAutoRotationReady(Guid lease)
+    public SetResult SetCurrentJobAutoRotationReady(Guid lease)
     {
         // Bail for standard conditions
         if (Helper.CheckForBailConditionsAtSetTime(out var result, lease))
-            return (int)result;
+            return result;
 
-        return (int)Leasing.AddRegistrationForCurrentJob(lease);
+        return Leasing.AddRegistrationForCurrentJob(lease);
     }
 
     /// <summary>
@@ -511,19 +511,23 @@ public partial class Provider : IDisposable
     ///     default.
     /// </param>
     /// <returns>
-    ///     The <c>int</c> value of the <see cref="SetResult" /> status code
-    ///     indicating the result of the operation.
+    ///     The <see cref="SetResult" /> status code indicating the result of the
+    ///     operation.
+    /// </returns>
+    /// <returns>
+    ///     The <see cref="SetResult" /> status code indicating the result of the
+    ///     operation.
     /// </returns>
     [EzIPC]
-    public int SetComboState
+    public SetResult SetComboState
     (Guid lease, string comboInternalName,
         bool comboState = true, bool autoState = true)
     {
         // Bail for standard conditions
         if (Helper.CheckForBailConditionsAtSetTime(out var result, lease))
-            return (int)result;
+            return result;
 
-        return (int)Leasing.AddRegistrationForCombo(
+        return Leasing.AddRegistrationForCombo(
             lease, comboInternalName, comboState, autoState);
     }
 
@@ -561,17 +565,18 @@ public partial class Provider : IDisposable
     ///     Only used to disable the combo option, as enabling it is the default.
     /// </param>
     /// <returns>
-    ///     The <c>int</c> value of the <see cref="SetResult" /> status code
-    ///     indicating the result of the operation.
+    ///     The <see cref="SetResult" /> status code indicating the result of the
+    ///     operation.
     /// </returns>
     [EzIPC]
-    public int SetComboOptionState(Guid lease, string optionName, bool state = true)
+    public SetResult SetComboOptionState
+        (Guid lease, string optionName, bool state = true)
     {
         // Bail for standard conditions
         if (Helper.CheckForBailConditionsAtSetTime(out var result, lease))
-            return (int)result;
+            return result;
 
-        return (int)Leasing.AddRegistrationForOption(lease, optionName, state);
+        return Leasing.AddRegistrationForOption(lease, optionName, state);
     }
 
     #endregion

--- a/WrathCombo/Window/Tabs/AutoRotationTab.cs
+++ b/WrathCombo/Window/Tabs/AutoRotationTab.cs
@@ -110,7 +110,8 @@ namespace WrathCombo.Window.Tabs
                     cfg.DPSSettings.OnlyAttackInCombat = false;
 
                 changed |= P.UIHelper.ShowIPCControlledCheckboxIfNeeded(
-                    "Only Attack Targets Already In Combat", ref cfg.InCombatOnly, "OnlyAttackInCombat");
+                    "Only Attack Targets Already In Combat", ref cfg.DPSSettings.OnlyAttackInCombat,
+                    "OnlyAttackInCombat");
 
                 if (cfg.DPSSettings.OnlyAttackInCombat && changed)
                     cfg.DPSSettings.PreferNonCombat = false;

--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -168,7 +168,7 @@ comments on each method.
     should be setup
 - `bool GetAutoRotationState()`
   - Checks if Auto-Rotation is enabled, whether by the user or another plugin
-- `int SetAutoRotationState(Guid, bool)`
+- `SetResult SetAutoRotationState(Guid, bool)`
   - Requires a lease
   - Sets Auto-Rotation to be enabled or disabled
   - Locks the state away from the user
@@ -176,7 +176,7 @@ comments on each method.
 - `bool IsCurrentJobAutoRotationReady()`
   - Checks if the current job is ready for Auto-Rotation, whether by the user or 
     another plugin
-- `int SetCurrentJobAutoRotationReady(Guid)`
+- `SetResult SetCurrentJobAutoRotationReady(Guid)`
   - Requires a lease
   - Sets the current job to be ready for Auto-Rotation
     - If the job is ready: it will lock all the user's Simple/Advanced settings, and 
@@ -207,13 +207,13 @@ comments on each method.
 - `Dictionary? GetComboState(string)`
   - Gets the state and Auto-Mode state of a combo, whether by the user or another 
     plugin
-- `int SetComboState(Guid, string, bool)`
+- `SetResult SetComboState(Guid, string, bool)`
   - Sets the state and Auto-Mode state of a combo
   - Locks the state away from the user
   - Counts towards the lease's configuration limit
 - `Dictionary? GetComboOptionState(string)`
   - Gets the state of a combo option, whether by the user or another plugin
-- `int SetComboOptionState(Guid, string, bool)`
+- `SetResult SetComboOptionState(Guid, string, bool)`
   - Sets the state of a combo option
   - Locks the state away from the user
   - Counts towards the lease's configuration limit
@@ -226,7 +226,7 @@ comments on each method.
     - You can safely pass in enum values that are not yet released; they will 
       just provide a warning you can ignore.
   - The `object` returned is of the type specified in the enum for the option
-- `int SetAutoRotationConfigState(Guid, AutoRotationConfigOption, object)`
+- `SetResult SetAutoRotationConfigState(Guid, AutoRotationConfigOption, object)`
   - The `object` must be of the type specified in the enum for the option
   - Sets the state of an Auto-Rotation configuration option
   - Locks the state away from the user
@@ -367,12 +367,11 @@ if (WrathIPC.IsEnabled)
     WrathIPC.SetAutoRotationState(WrathIPC.CurrentLease, true);
     var setJobReady = WrathIPC.SetCurrentJobAutoRotationReady(WrathIPC.CurrentLease);
     
-    if (setJobReady == 0 || setJobReady == 1)
+    if (setJobReady == SetResult.Okay || setJobReady == SetResult.OkayWorking)
         PluginLog.Information("Job has been made ready for Auto-Rotation.");
 }
 ```
-Here it is simply compared as the actual `int` return value, but this can be cast to
-your own copy of the [`SetResult` enum here](https://github.com/PunishXIV/WrathCombo/blob/main/WrathCombo/Services/IPC/Enums.cs#L139).
+This does require you to copy over the [`SetResult` enum](https://github.com/PunishXIV/WrathCombo/blob/main/WrathCombo/Services/IPC/Enums.cs#L139).
 
 Or you can make it more advanced, making sure Auto-Rotation settings are as you want
 them to be.
@@ -423,9 +422,9 @@ resources below, or the first several sections of this guide.
 
 ## Changelog
 
-- PunishXIV/WrathCombo#319 - All `Set` methods now return a status code; returned is
-  the `int` cast of the new [`SetResult` enum](https://github.com/PunishXIV/WrathCombo/blob/main/WrathCombo/Services/IPC/Enums.cs#L139)
-  (`0` is "okay", `1` is "okay, but async") `1.0.0.11`.
+- PunishXIV/WrathCombo#319 - All `Set` methods now return a status code from the new 
+  [`SetResult` enum](https://github.com/PunishXIV/WrathCombo/blob/main/WrathCombo/Services/IPC/Enums.cs#L139),
+  `1.0.0.11`.
 - PunishXIV/WrathCombo#293 - `Get` and `SetAutoRotationConfigState` will now safely
   warn (instead of error out) for unknown enum values (i.e. not-yet-released ones),
   `1.0.0.10`.

--- a/docs/IPCExample.cs
+++ b/docs/IPCExample.cs
@@ -44,7 +44,7 @@ public static class YourCode
             WrathIPC.SetAutoRotationConfigState(lease,
                 WrathIPC.AutoRotationConfigOption.SingleTargetHPP, 60);
 
-            if (setJobReady == 0 || setJobReady == 1)
+            if (setJobReady == SetResult.Okay || setJobReady == SetResult.OkayWorking)
                 PluginLog.Information("Job has been made ready for Auto-Rotation.");
         }
         catch (Exception e)
@@ -83,26 +83,45 @@ internal static class WrathIPC
     [EzIPC] internal static readonly Func<string, string, Guid?> RegisterForLease;
     [EzIPC] internal static readonly Func<string, string, string?, Guid?>
         RegisterForLeaseWithCallback;
-    [EzIPC] internal static readonly Func<Guid, bool, int> SetAutoRotationState;
-    [EzIPC] internal static readonly Func<Guid, int> SetCurrentJobAutoRotationReady;
-    [EzIPC] internal static readonly Func<Guid, AutoRotationConfigOption, object, int>
+    [EzIPC] internal static readonly Func<Guid, bool, SetResult>
+        SetAutoRotationState;
+    [EzIPC] internal static readonly Func<Guid, SetResult>
+        SetCurrentJobAutoRotationReady;
+    [EzIPC] internal static readonly
+        Func<Guid, AutoRotationConfigOption, object, SetResult>
         SetAutoRotationConfigState;
     [EzIPC] internal static readonly Action<Guid> ReleaseControl;
 
+    public enum SetResult
+    {
+        Okay = 0,
+        OkayWorking = 1,
+
+        IPCDisabled = 10,
+        InvalidLease = 11,
+        BlacklistedLease = 12,
+        Duplicate = 13,
+        PlayerNotAvailable = 14,
+        InvalidConfiguration = 15,
+        InvalidValue = 16,
+    }
+
     public enum AutoRotationConfigOption
     {
-        InCombatOnly, //bool
-        DPSRotationMode,
-        HealerRotationMode,
-        FATEPriority, //bool
-        QuestPriority,//bool
-        SingleTargetHPP,//int
-        AoETargetHPP,//int
-        SingleTargetRegenHPP,//int
-        ManageKardia,//bool
-        AutoRez,//bool
-        AutoRezDPSJobs,//bool
-        AutoCleanse,//bool
+        InCombatOnly = 0, // bool
+        DPSRotationMode = 1, // enum
+        HealerRotationMode = 2, // enum
+        FATEPriority = 3, // bool
+        QuestPriority = 4, // bool
+        SingleTargetHPP = 5, // int
+        AoETargetHPP = 6, // int
+        SingleTargetRegenHPP = 7, // int
+        ManageKardia = 8, // bool
+        AutoRez = 9, // bool
+        AutoRezDPSJobs = 10, // bool
+        AutoCleanse = 11, // bool
+        IncludeNPCs = 12, // bool
+        OnlyAttackInCombat = 13, //bool
     }
 }
 

--- a/docs/IPCExample.cs
+++ b/docs/IPCExample.cs
@@ -36,13 +36,16 @@ public static class YourCode
         {
             var lease = (Guid)WrathIPC.CurrentLease!;
             WrathIPC.SetAutoRotationState(lease, true);
-            WrathIPC.SetCurrentJobAutoRotationReady(lease);
+            var setJobReady = WrathIPC.SetCurrentJobAutoRotationReady(lease);
             WrathIPC.SetAutoRotationConfigState(lease,
                 WrathIPC.AutoRotationConfigOption.InCombatOnly, false);
             WrathIPC.SetAutoRotationConfigState(lease,
                 WrathIPC.AutoRotationConfigOption.AutoRez, true);
             WrathIPC.SetAutoRotationConfigState(lease,
                 WrathIPC.AutoRotationConfigOption.SingleTargetHPP, 60);
+
+            if (setJobReady == 0 || setJobReady == 1)
+                PluginLog.Information("Job has been made ready for Auto-Rotation.");
         }
         catch (Exception e)
         {
@@ -80,9 +83,9 @@ internal static class WrathIPC
     [EzIPC] internal static readonly Func<string, string, Guid?> RegisterForLease;
     [EzIPC] internal static readonly Func<string, string, string?, Guid?>
         RegisterForLeaseWithCallback;
-    [EzIPC] internal static readonly Action<Guid, bool> SetAutoRotationState;
-    [EzIPC] internal static readonly Action<Guid> SetCurrentJobAutoRotationReady;
-    [EzIPC] internal static readonly Action<Guid, AutoRotationConfigOption, object>
+    [EzIPC] internal static readonly Func<Guid, bool, int> SetAutoRotationState;
+    [EzIPC] internal static readonly Func<Guid, int> SetCurrentJobAutoRotationReady;
+    [EzIPC] internal static readonly Func<Guid, AutoRotationConfigOption, object, int>
         SetAutoRotationConfigState;
     [EzIPC] internal static readonly Action<Guid> ReleaseControl;
 


### PR DESCRIPTION
- [X] Fix AutoRotation UI checking both "in combat" and "dps settings > only attack targets already in combat" boxes at once
- [X] Add status codes for all `Set` methods