### PR TITLE
[VPRPVP] Emergency features / Snake Scales Fix. MCHPVP quickfix.

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6799,11 +6799,6 @@ public enum CustomComboPreset
 
     [PvPCustomCombo]
     [ParentCombo(MCHPvP_BurstMode)]
-    [CustomComboInfo("Blazing Shot Option", "Adds Blazing Shot to Burst Mode.", MCHPvP.JobID)]
-    MCHPvP_BurstMode_BlazingShot = 118010,
-
-    [PvPCustomCombo]
-    [ParentCombo(MCHPvP_BurstMode)]
     [CustomComboInfo("Marksmans Spite Option",
         "Adds Marksmans Spite to Burst Mode when the target is below specified HP.", MCHPvP.JobID)]
     MCHPvP_BurstMode_MarksmanSpite = 118011,

--- a/WrathCombo/Combos/PvP/MCHPVP.cs
+++ b/WrathCombo/Combos/PvP/MCHPVP.cs
@@ -87,10 +87,6 @@ namespace WrathCombo.Combos.PvP
                             }
                         }
 
-                        // If overheated, BlazingShot is the next action
-                        if (IsEnabled(CustomComboPreset.MCHPvP_BurstMode_BlazingShot) && overheated)
-                            return OriginalHook(BlazingShot);
-
                         // Check if primed buffs and analysis conditions are met
                         bool hasPrimedBuffs = HasEffect(Buffs.DrillPrimed) ||
                                               (HasEffect(Buffs.ChainSawPrimed) && !IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AltAnalysis)) ||

--- a/WrathCombo/Combos/PvP/MCHPVP.cs
+++ b/WrathCombo/Combos/PvP/MCHPVP.cs
@@ -63,7 +63,7 @@ namespace WrathCombo.Combos.PvP
                     var overheated = HasEffect(Buffs.Overheated);
                     var FMFOption = PluginConfiguration.GetCustomIntValue(Config.MCHPVP_FMFOption);
 
-                    if (!PvPCommon.TargetImmuneToDamage())
+                    if (!PvPCommon.TargetImmuneToDamage() && HasBattleTarget())
                     {
                         // MarksmanSpite execute condition - todo add config
                         if (IsEnabled(CustomComboPreset.MCHPvP_BurstMode_MarksmanSpite) && EnemyHealthCurrentHp() < GetOptionValue(Config.MCHPVP_MarksmanSpite) && IsLB1Ready)

--- a/WrathCombo/Combos/PvP/PVPCommon.cs
+++ b/WrathCombo/Combos/PvP/PVPCommon.cs
@@ -64,7 +64,7 @@ namespace WrathCombo.Combos.PvP
 
         // Lists of Excluded skills 
         internal static readonly List<uint>
-            MovmentSkills = [WARPvP.Onslaught, NINPvP.Shukuchi, DNCPvP.EnAvant, MNKPvP.ThunderClap, RDMPvP.CorpsACorps, RDMPvP.Displacement, SGEPvP.Icarus, RPRPvP.HellsIngress, RPRPvP.Regress, BRDPvP.RepellingShot, BLMPvP.AetherialManipulation, DRGPvP.ElusiveJump, GNBPvP.RoughDivide],
+            MovmentSkills = [WARPvP.Onslaught, VPRPvP.Slither, NINPvP.Shukuchi, DNCPvP.EnAvant, MNKPvP.ThunderClap, RDMPvP.CorpsACorps, RDMPvP.Displacement, SGEPvP.Icarus, RPRPvP.HellsIngress, RPRPvP.Regress, BRDPvP.RepellingShot, BLMPvP.AetherialManipulation, DRGPvP.ElusiveJump, GNBPvP.RoughDivide],
             GlobalSkills = [Teleport, Guard, Recuperate, Purify, StandardElixir, Sprint];
 
         internal class GlobalEmergencyHeals : CustomCombo
@@ -98,6 +98,7 @@ namespace WrathCombo.Combos.PvP
 
                 if (HasEffect(3180)) return false; //DRG LB buff
                 if (HasEffectAny(1420)) return false; //Rival Wings Mounted
+                if (HasEffect(4096)) return false; //VPR Snakesbane
                 if (HasEffect(DRKPvP.Buffs.UndeadRedemption)) return false;
                 if (LocalPlayer.CurrentMp < 2500) return false;
                 if (remainingPercentage * 100 > threshold) return false;
@@ -140,6 +141,7 @@ namespace WrathCombo.Combos.PvP
                 var remainingPercentage = (float)LocalPlayer.CurrentHp / (float)jobMaxHp;
 
                 if (HasEffect(3180)) return false; //DRG LB buff
+                if (HasEffect(4096)) return false; //VPR Snakesbane
                 if (HasEffectAny(1420)) return false; //Rival Wings Mounted
                 if (HasEffect(DRKPvP.Buffs.UndeadRedemption)) return false;
                 if (HasEffectAny(Debuffs.Unguarded) || HasEffect(WARPvP.Buffs.InnerRelease)) return false;
@@ -176,6 +178,7 @@ namespace WrathCombo.Combos.PvP
                 var selectedStatuses = PluginConfiguration.GetCustomBoolArrayValue(Config.QuickPurifyStatuses);
 
                 if (HasEffect(3180)) return false; //DRG LB buff
+                if (HasEffect(4096)) return false; //VPR Snakesbane
                 if (HasEffectAny(1420)) return false; //Rival Wings Mounted
 
                 if (selectedStatuses.Length == 0) return false;


### PR DESCRIPTION
Added The buff from snake scales to the list of when to ignore the emergency features. Basically, Snake scales is active and none of those buttons can be pressed until you backlash to end it, or it ends on its own. The features were preventing you from backlashing to end it. 

Added Slither to the ignored movement action ids as well because I'm good like that. 

Jr pvp dev when?

Added target check to mch pvp burst as a quick fix Tauren mentioned. It encompasses all of the burst mode instead of the couple lines he already added so it wont use analysis without a target and potentially waste the buffed tool attack. 

Removed blazing shot option while I was at it, the game inherently changes the burst shot to blazing shot. You don't have a choice. Even with the option off, it does it because of the game itself. The option served no purpose. 