### PR TITLE
[All] Use `All.SavageBlade` over `11`

### DIFF
--- a/WrathCombo/Combos/PvE/ALL/ALL.cs
+++ b/WrathCombo/Combos/PvE/ALL/ALL.cs
@@ -169,7 +169,7 @@ internal class All
 
         protected override uint Invoke(uint actionID) =>
             actionID is Reprisal && TargetHasEffectAny(Debuffs.Reprisal) && IsOffCooldown(Reprisal)
-                ? OriginalHook(11)
+                ? SavageBlade
                 : actionID;
     }
 
@@ -208,7 +208,7 @@ internal class All
 
         protected override uint Invoke(uint actionID) =>
             actionID is Addle && TargetHasEffectAny(Debuffs.Addle) && IsOffCooldown(Addle)
-                ? OriginalHook(11)
+                ? SavageBlade
                 : actionID;
     }
 
@@ -248,7 +248,7 @@ internal class All
 
         protected override uint Invoke(uint actionID) =>
             actionID is Feint && TargetHasEffectAny(Debuffs.Feint) && IsOffCooldown(Feint)
-                ? OriginalHook(11)
+                ? SavageBlade
                 : actionID;
     }
 
@@ -258,7 +258,7 @@ internal class All
 
         protected override uint Invoke(uint actionID) =>
             actionID is TrueNorth && HasEffect(Buffs.TrueNorth)
-                ? OriginalHook(11)
+                ? SavageBlade
                 : actionID;
     }
 
@@ -272,7 +272,7 @@ internal class All
             (HasEffectAny(BRD.Buffs.Troubadour) || HasEffectAny(MCH.Buffs.Tactician) ||
              HasEffectAny(DNC.Buffs.ShieldSamba)) &&
             IsOffCooldown(actionID)
-                ? OriginalHook(11)
+                ? SavageBlade
                 : actionID;
     }
 

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -815,7 +815,7 @@ internal partial class BLM
 
         protected override uint Invoke(uint actionID) =>
             actionID is Triplecast && HasEffect(Buffs.Triplecast) && LevelChecked(Triplecast)
-                ? OriginalHook(11)
+                ? All.SavageBlade
                 : actionID;
     }
 

--- a/WrathCombo/Combos/PvE/BLU/BLU.cs
+++ b/WrathCombo/Combos/PvE/BLU/BLU.cs
@@ -486,7 +486,7 @@ internal partial class BLU
                     return OriginalHook(PhantomFlurry);
 
                 if (HasEffect(Buffs.MoonFlute))
-                    return OriginalHook(11);
+                    return All.SavageBlade;
             }
 
             return actionID;

--- a/WrathCombo/Combos/PvE/GNB/GNB.cs
+++ b/WrathCombo/Combos/PvE/GNB/GNB.cs
@@ -2413,7 +2413,7 @@ internal partial class GNB
                 return actionID;
             if ((HasFriendlyTarget() && TargetHasEffectAny(Buffs.Aurora)) ||
                 (!HasFriendlyTarget() && HasEffectAny(Buffs.Aurora)))
-                return OriginalHook(11);
+                return All.SavageBlade;
             return actionID;
         }
     }

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -334,7 +334,7 @@ internal partial class MCH
                 return Variant.VariantCure;
 
             if (HasEffect(Buffs.Flamethrower) || JustUsed(Flamethrower, 10f))
-                return OriginalHook(11);
+                return All.SavageBlade;
 
             if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
                 IsEnabled(Variant.VariantRampart) &&
@@ -470,7 +470,7 @@ internal partial class MCH
                 return Variant.VariantCure;
 
             if (HasEffect(Buffs.Flamethrower) || JustUsed(Flamethrower, 10f))
-                return OriginalHook(11);
+                return All.SavageBlade;
 
             if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
                 IsEnabled(Variant.VariantRampart) &&
@@ -759,7 +759,7 @@ internal partial class MCH
 
         protected override uint Invoke(uint actionID) =>
             actionID is Dismantle && TargetHasEffectAny(Debuffs.Dismantled) && IsOffCooldown(Dismantle)
-                ? OriginalHook(11)
+                ? All.SavageBlade
                 : actionID;
     }
 }

--- a/WrathCombo/Combos/PvE/RDM/RDM.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM.cs
@@ -408,7 +408,7 @@ internal partial class RDM
         protected override uint Invoke(uint actionID) =>
             actionID is Embolden &&
             ActionReady(Embolden) &&
-            HasEffectAny(Buffs.EmboldenOthers) ? OriginalHook(11) : actionID;
+            HasEffectAny(Buffs.EmboldenOthers) ? All.SavageBlade : actionID;
     }
 
     internal class RDM_MagickProtection : CustomCombo
@@ -417,6 +417,6 @@ internal partial class RDM
         protected override uint Invoke(uint actionID) =>
             actionID is MagickBarrier &&
             ActionReady(MagickBarrier) &&
-            HasEffectAny(Buffs.MagickBarrier) ? OriginalHook(11) : actionID;
+            HasEffectAny(Buffs.MagickBarrier) ? All.SavageBlade : actionID;
     }
 }

--- a/WrathCombo/Combos/PvE/SAM/SAM.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM.cs
@@ -941,7 +941,7 @@ internal partial class SAM
 
         protected override uint Invoke(uint actionID) =>
             actionID is MeikyoShisui && HasEffect(Buffs.MeikyoShisui) && LevelChecked(MeikyoShisui)
-                ? OriginalHook(11)
+                ? All.SavageBlade
                 : actionID;
     }
 }

--- a/WrathCombo/Combos/PvP/PVPCommon.cs
+++ b/WrathCombo/Combos/PvP/PVPCommon.cs
@@ -1,5 +1,6 @@
 ﻿using Dalamud.Game.ClientState.Objects.Types;
 using System.Collections.Generic;
+using WrathCombo.Combos.PvE;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
@@ -76,7 +77,7 @@ namespace WrathCombo.Combos.PvP
                 if ((HasEffect(Buffs.Guard) || JustUsed(Guard)) && IsEnabled(CustomComboPreset.PvP_MashCancel))
                 {
                     if (actionID == Guard) return Guard;
-                    else return OriginalHook(11);
+                    return All.SavageBlade;
                 }
 
                 if (Execute() &&
@@ -121,14 +122,14 @@ namespace WrathCombo.Combos.PvP
                             return Recuperate;
                         return Guard;
                     }
-                    return OriginalHook(11);
+                    return All.SavageBlade;
                 }
 
                 if (Execute() &&
                     InPvP() &&
                     !GlobalSkills.Contains(actionID) &&
                     !MovmentSkills.Contains(actionID))
-                    return OriginalHook(Guard);
+                    return All.SavageBlade;
 
                 return actionID;
             }
@@ -160,7 +161,7 @@ namespace WrathCombo.Combos.PvP
                 if ((HasEffect(Buffs.Guard) || JustUsed(Guard)) && IsEnabled(CustomComboPreset.PvP_MashCancel))
                 {
                     if (actionID == Guard) return Guard;
-                    else return OriginalHook(11);
+                    return All.SavageBlade;
                 }
 
                 if (Execute() &&

--- a/WrathCombo/Combos/PvP/RDMPVP.cs
+++ b/WrathCombo/Combos/PvP/RDMPVP.cs
@@ -1,4 +1,5 @@
 ﻿using ImGuiNET;
+using WrathCombo.Combos.PvE;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using static WrathCombo.Window.Functions.UserConfig;
@@ -215,7 +216,7 @@ namespace WrathCombo.Combos.PvP
                     }
 
                     // Grand Impact / Jolt III
-                    return hasGrandImpact || !isMoving ? OriginalHook(actionID) : OriginalHook(11);
+                    return hasGrandImpact || !isMoving ? OriginalHook(actionID) : All.SavageBlade;
                 }
 
                 return actionID;

--- a/WrathCombo/Core/IconReplacer.cs
+++ b/WrathCombo/Core/IconReplacer.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using WrathCombo.Combos.PvE;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Extensions;
@@ -91,7 +92,7 @@ namespace WrathCombo.Core
                     {
                         if (Service.Configuration.BlockSpellOnMove && ActionManager.GetAdjustedCastTime(ActionType.Action, newActionID) > 0 && CustomComboFunctions.TimeMoving.Ticks > 0)
                         {
-                            return OriginalHook(11);
+                            return All.SavageBlade;
                         }
                         return newActionID;
                     }

--- a/WrathCombo/CustomCombo/CustomCombo.cs
+++ b/WrathCombo/CustomCombo/CustomCombo.cs
@@ -67,7 +67,7 @@ namespace WrathCombo.CustomComboNS
 
             if (!Svc.ClientState.IsPvP && ActionManager.Instance()->QueuedActionType == ActionType.Action && ActionManager.Instance()->QueuedActionId != actionID)
             {
-                if (resultingActionID != OriginalHook(11) && WrathOpener.CurrentOpener?.OpenerStep <= 1)
+                if (resultingActionID != All.SavageBlade && WrathOpener.CurrentOpener?.OpenerStep <= 1)
                     return false;
             }
             newActionID = resultingActionID;

--- a/WrathCombo/CustomCombo/WrathOpener.cs
+++ b/WrathCombo/CustomCombo/WrathOpener.cs
@@ -178,7 +178,7 @@ namespace WrathCombo.CustomComboNS
                     {
                         if (!CanDelayedWeave())
                         {
-                            actionID = 11;
+                            actionID = All.SavageBlade;
                             return true;
                         }
                     }
@@ -205,7 +205,7 @@ namespace WrathCombo.CustomComboNS
                         if ((DateTime.Now - DelayedAt).TotalSeconds < HoldDelay && !PartyInCombat())
                         {
                             ActionWatching.TimeLastActionUsed = DateTime.Now; //Hacky workaround for TN jobs
-                            actionID = 11;
+                            actionID = All.SavageBlade;
                             return true;
                         }
                     }

--- a/WrathCombo/CustomCombo/WrathOpener.cs
+++ b/WrathCombo/CustomCombo/WrathOpener.cs
@@ -123,8 +123,8 @@ namespace WrathCombo.CustomComboNS
         public uint CurrentOpenerAction { get; 
             set 
             {
-                if (value != 11)
-                field = value;
+                if (value != All.SavageBlade)
+                    field = value;
             } 
         }
         public uint PreviousOpenerAction { get; set; }


### PR DESCRIPTION
- [X] Just switch uses of `Savage Blade` to call a constant,\
      to make it easier to spot and easier to track down all instances of this behavior
- [X] Removed the needless `OriginalHook` call around it.\
      It's an action no longer in any job we use when we want to block input, it's not going to Action-Change, and we don't care if it does.