### PR TITLE
[Core] Add Manual rotation throttle

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -415,7 +415,7 @@ namespace WrathCombo.AutoRotation
                         if (IsMoving() && castTime > 0 && !orbwalking)
                             return false;
 
-                        var ret = ActionManager.Instance()->UseAction(ActionType.Action, Service.IconReplacer.getIconHook.IsEnabled ? gameAct : outAct);
+                        var ret = ActionManager.Instance()->UseAction(ActionType.Action, Service.ActionReplacer.getActionHook.IsEnabled ? gameAct : outAct);
 
                         if (ret)
                             LastHealAt = Environment.TickCount64 + castTime;
@@ -467,7 +467,7 @@ namespace WrathCombo.AutoRotation
                         Svc.GameConfig.Set(Dalamud.Game.Config.UiControlOption.AutoFaceTargetOnAction, original);
                     }
 
-                    var ret = ActionManager.Instance()->UseAction(ActionType.Action, Service.IconReplacer.getIconHook.IsEnabled ? gameAct : outAct, (mustTarget && target != null) || switched ? target.GameObjectId : Player.Object.GameObjectId);
+                    var ret = ActionManager.Instance()->UseAction(ActionType.Action, Service.ActionReplacer.getActionHook.IsEnabled ? gameAct : outAct, (mustTarget && target != null) || switched ? target.GameObjectId : Player.Object.GameObjectId);
 
                     if (outAct is NIN.Ten or NIN.Chi or NIN.Jin or NIN.TenCombo or NIN.ChiCombo or NIN.JinCombo && ret)
                         _ninjaLockedAoE = true;
@@ -515,7 +515,7 @@ namespace WrathCombo.AutoRotation
 
                 if (canUse && (inRange || areaTargeted))
                 {
-                    var ret = ActionManager.Instance()->UseAction(ActionType.Action, Service.IconReplacer.getIconHook.IsEnabled ? gameAct : outAct, canUseTarget ? target.GameObjectId : Player.Object.GameObjectId);
+                    var ret = ActionManager.Instance()->UseAction(ActionType.Action, Service.ActionReplacer.getActionHook.IsEnabled ? gameAct : outAct, canUseTarget ? target.GameObjectId : Player.Object.GameObjectId);
                     if (mode is HealerRotationMode && ret)
                         LastHealAt = Environment.TickCount64 + castTime;
 
@@ -541,7 +541,7 @@ namespace WrathCombo.AutoRotation
                 var outAct = attributes.ReplaceSkill.ActionIDs.FirstOrDefault();
                 foreach (var actToCheck in attributes.ReplaceSkill.ActionIDs)
                 {
-                    var customCombo = Service.IconReplacer.CustomCombos.FirstOrDefault(x => x.Preset == preset);
+                    var customCombo = Service.ActionReplacer.CustomCombos.FirstOrDefault(x => x.Preset == preset);
                     if (customCombo != null)
                     {
                         if (customCombo.TryInvoke(actToCheck, out var changedAct, optionalTarget))

--- a/WrathCombo/Commands.cs
+++ b/WrathCombo/Commands.cs
@@ -286,30 +286,30 @@ public partial class WrathCombo
     {
         if (argument.Length < 2)
         {
-            if (Service.IconReplacer.getIconHook.IsEnabled)
-                Service.IconReplacer.getIconHook.Disable();
+            if (Service.ActionReplacer.getActionHook.IsEnabled)
+                Service.ActionReplacer.getActionHook.Disable();
             else
-                Service.IconReplacer.getIconHook.Enable();
+                Service.ActionReplacer.getActionHook.Enable();
             return;
         }
 
         switch (argument[1])
         {
             case "on":
-                if (!Service.IconReplacer.getIconHook.IsEnabled)
-                    Service.IconReplacer.getIconHook.Enable();
+                if (!Service.ActionReplacer.getActionHook.IsEnabled)
+                    Service.ActionReplacer.getActionHook.Enable();
                 break;
 
             case "off":
-                if (Service.IconReplacer.getIconHook.IsEnabled)
-                    Service.IconReplacer.getIconHook.Disable();
+                if (Service.ActionReplacer.getActionHook.IsEnabled)
+                    Service.ActionReplacer.getActionHook.Disable();
                 break;
 
             case "toggle":
-                if (Service.IconReplacer.getIconHook.IsEnabled)
-                    Service.IconReplacer.getIconHook.Disable();
+                if (Service.ActionReplacer.getActionHook.IsEnabled)
+                    Service.ActionReplacer.getActionHook.Disable();
                 else
-                    Service.IconReplacer.getIconHook.Enable();
+                    Service.ActionReplacer.getActionHook.Enable();
                 break;
 
             default:

--- a/WrathCombo/Core/ActionReplacer.cs
+++ b/WrathCombo/Core/ActionReplacer.cs
@@ -14,135 +14,153 @@ using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Extensions;
 using WrathCombo.Services;
 
-namespace WrathCombo.Core
+namespace WrathCombo.Core;
+
+/// <summary> This class facilitates action+icon replacement. </summary>
+internal sealed class ActionReplacer : IDisposable
 {
-    /// <summary> This class facilitates action+icon replacement. </summary>
-    internal sealed class ActionReplacer : IDisposable
+    public readonly List<CustomCombo> CustomCombos;
+
+    private readonly Hook<IsActionReplaceableDelegate> isActionReplaceableHook;
+    public readonly Hook<GetActionDelegate> getActionHook;
+
+    private delegate ulong IsActionReplaceableDelegate(uint actionID);
+    public delegate uint GetActionDelegate(uint actionID);
+
+    private ulong IsActionReplaceableDetour(uint actionID) => 1;
+
+    private readonly Dictionary<uint, uint> lastActionInvokeFor = [];
+
+    /// <summary> Calls the original hook. </summary>
+    /// <param name="actionID"> Action ID. </param>
+    /// <returns> The result from the hook. </returns>
+    internal uint OriginalHook(uint actionID) => getActionHook.Original(actionID);
+
+    /// <summary> Initializes a new instance of the <see cref="ActionReplacer"/> class. </summary>
+    public ActionReplacer()
     {
-        public readonly List<CustomCombo> CustomCombos;
-        private readonly Hook<IsActionReplaceableDelegate> isActionReplaceableHook;
-        public readonly Hook<GetActionDelegate> getActionHook;
+        CustomCombos = Assembly.GetAssembly(typeof(CustomCombo))!.GetTypes()
+            .Where(t => !t.IsAbstract && t.BaseType == typeof(CustomCombo))
+            .Select(Activator.CreateInstance)
+            .Cast<CustomCombo>()
+            .OrderByDescending(x => x.Preset)
+            .ToList();
 
-        private IntPtr actionManager = IntPtr.Zero;
-        private readonly IntPtr module = IntPtr.Zero;
-        private Dictionary<uint, uint> lastActionInvokeFor = new Dictionary<uint, uint>();
+        getActionHook = Svc.Hook.HookFromAddress<GetActionDelegate>
+            (ActionManager.Addresses.GetAdjustedActionId.Value, GetAdjustedActionDetour);
+        isActionReplaceableHook = Svc.Hook.HookFromAddress<IsActionReplaceableDelegate>
+            (Service.Address.IsActionIdReplaceable, IsActionReplaceableDetour);
 
-        /// <summary> Initializes a new instance of the <see cref="ActionReplacer"/> class. </summary>
-        public ActionReplacer()
-        {
-            CustomCombos = Assembly.GetAssembly(typeof(CustomCombo))!.GetTypes()
-                .Where(t => !t.IsAbstract && t.BaseType == typeof(CustomCombo))
-                .Select(t => Activator.CreateInstance(t))
-                .Cast<CustomCombo>()
-                .OrderByDescending(x => x.Preset)
-                .ToList();
+        getActionHook.Enable();
+        isActionReplaceableHook.Enable();
+    }
 
-            getActionHook = Svc.Hook.HookFromAddress<GetActionDelegate>((nint)ActionManager.Addresses.GetAdjustedActionId.Value, GetAdjustedActionDetour);
-            isActionReplaceableHook = Svc.Hook.HookFromAddress<IsActionReplaceableDelegate>(Service.Address.IsActionIdReplaceable, IsActionReplaceableDetour);
+    /// <summary>
+    ///     Throttles access to <see cref="GetAdjustedAction(uint)"/>.
+    /// </summary>
+    /// <param name="actionID">The action a combo replaces.</param>
+    /// <returns>The action a combo returns.</returns>
+    private uint GetAdjustedActionDetour(uint actionID)
+    {
+        if (FilteredCombos is null)
+            UpdateFilteredCombos();
 
-            getActionHook.Enable();
-            isActionReplaceableHook.Enable();
-        }
-
-        private delegate ulong IsActionReplaceableDelegate(uint actionID);
-
-        public delegate uint GetActionDelegate(IntPtr actionManager, uint actionID);
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            getActionHook?.Disable();
-            getActionHook?.Dispose();
-            isActionReplaceableHook?.Disable();
-            isActionReplaceableHook?.Dispose();
-        }
-
-        /// <summary> Calls the original hook. </summary>
-        /// <param name="actionID"> Action ID. </param>
-        /// <returns> The result from the hook. </returns>
-        internal uint OriginalHook(uint actionID) => getActionHook.Original(actionManager, actionID);
-
-        public static IEnumerable<CustomCombo>? FilteredCombos;
-
-        public void UpdateFilteredCombos()
-        {
-            FilteredCombos = CustomCombos.Where(x => x.Preset.Attributes() is not null && x.Preset.Attributes().IsPvP == CustomComboFunctions.InPvP() && ((x.Preset.Attributes().RoleAttribute is not null && x.Preset.Attributes().RoleAttribute.PlayerIsRole()) || x.Preset.Attributes().CustomComboInfo.JobID == Player.JobId || x.Preset.Attributes().CustomComboInfo.JobID == CustomComboFunctions.JobIDs.ClassToJob(Player.JobId)));
-            Svc.Log.Debug($"Now running {FilteredCombos.Count()} combos\n{string.Join("\n", FilteredCombos.Select(x => x.Preset.Attributes().CustomComboInfo.Name))}");
-        }
-
-        private uint GetAdjustedActionDetour(IntPtr _, uint actionID)
-        {
-            if (FilteredCombos is null)
-                UpdateFilteredCombos();
-
-            // Only refresh every so often
-            if (!EzThrottler.Throttle("Actions" + actionID,
-                    Service.Configuration.Throttle))
-                return lastActionInvokeFor[actionID];
-
-            // Actually get the action
-            lastActionInvokeFor[actionID] = GetAdjustedAction(actionID);
+        // Only refresh every so often
+        if (!EzThrottler.Throttle("Actions" + actionID,
+                Service.Configuration.Throttle))
             return lastActionInvokeFor[actionID];
-        }
 
-        private unsafe uint GetAdjustedAction(uint actionID)
+        // Actually get the action
+        lastActionInvokeFor[actionID] = GetAdjustedAction(actionID);
+        return lastActionInvokeFor[actionID];
+    }
+
+    /// <summary>
+    ///     Replaces an action with the result from a combo.
+    /// </summary>
+    /// <param name="actionID">The action a combo replaces.</param>
+    /// <returns>The action a combo returns.</returns>
+    private unsafe uint GetAdjustedAction(uint actionID)
+    {
+        try
         {
-            try
+            if (Service.Configuration.PerformanceMode)
+                return OriginalHook(actionID);
+
+            if (Svc.ClientState.LocalPlayer == null)
+                return OriginalHook(actionID);
+
+            if (ClassLocked() ||
+                (DisabledJobsPVE.Any(x => x == Svc.ClientState.LocalPlayer.ClassJob.RowId) && !Svc.ClientState.IsPvP) ||
+                (DisabledJobsPVP.Any(x => x == Svc.ClientState.LocalPlayer.ClassJob.RowId) && Svc.ClientState.IsPvP))
+                return OriginalHook(actionID);
+
+            foreach (CustomCombo? combo in FilteredCombos)
             {
-                if (Service.Configuration.PerformanceMode)
-                    return OriginalHook(actionID);
-
-                if (Svc.ClientState.LocalPlayer == null)
-                    return OriginalHook(actionID);
-
-                if (ClassLocked() ||
-                    (DisabledJobsPVE.Any(x => x == Svc.ClientState.LocalPlayer.ClassJob.RowId) && !Svc.ClientState.IsPvP) ||
-                    (DisabledJobsPVP.Any(x => x == Svc.ClientState.LocalPlayer.ClassJob.RowId) && Svc.ClientState.IsPvP))
-                    return OriginalHook(actionID);
-
-                foreach (CustomCombo? combo in FilteredCombos)
+                if (combo.TryInvoke(actionID, out uint newActionID))
                 {
-                    if (combo.TryInvoke(actionID, out uint newActionID))
+                    if (Service.Configuration.BlockSpellOnMove && ActionManager.GetAdjustedCastTime(ActionType.Action, newActionID) > 0 && CustomComboFunctions.TimeMoving.Ticks > 0)
                     {
-                        if (Service.Configuration.BlockSpellOnMove && ActionManager.GetAdjustedCastTime(ActionType.Action, newActionID) > 0 && CustomComboFunctions.TimeMoving.Ticks > 0)
-                        {
-                            return All.SavageBlade;
-                        }
-                        return newActionID;
+                        return All.SavageBlade;
                     }
+                    return newActionID;
                 }
-
-                return OriginalHook(actionID);
             }
 
-            catch (Exception ex)
-            {
-                Svc.Log.Error(ex, "Preset error");
-                return OriginalHook(actionID);
-            }
+            return OriginalHook(actionID);
         }
 
-        // Class locking
-        public unsafe static bool ClassLocked()
+        catch (Exception ex)
         {
-            if (Svc.ClientState.LocalPlayer is null) return false;
-
-            if (Svc.ClientState.LocalPlayer.Level <= 35) return false;
-
-            if (Svc.ClientState.LocalPlayer.ClassJob.RowId is
-                (>= 8 and <= 25) or 27 or 28 or >= 30)
-                return false;
-
-            if (!UIState.Instance()->IsUnlockLinkUnlockedOrQuestCompleted(66049))
-                return false;
-
-            if ((Svc.ClientState.LocalPlayer.ClassJob.RowId is 1 or 2 or 3 or 4 or 5 or 6 or 7 or 26 or 29) &&
-                Svc.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.BoundByDuty] &&
-                Svc.ClientState.LocalPlayer.Level > 35) return true;
-
-            return false;
+            Svc.Log.Error(ex, "Preset error");
+            return OriginalHook(actionID);
         }
+    }
 
-        private ulong IsActionReplaceableDetour(uint actionID) => 1;
+    #region Restrict combos to current job
+
+    public static IEnumerable<CustomCombo>? FilteredCombos;
+
+    public void UpdateFilteredCombos()
+    {
+        FilteredCombos = CustomCombos.Where(x => x.Preset.Attributes() is not null && x.Preset.Attributes().IsPvP == CustomComboFunctions.InPvP() && ((x.Preset.Attributes().RoleAttribute is not null && x.Preset.Attributes().RoleAttribute.PlayerIsRole()) || x.Preset.Attributes().CustomComboInfo.JobID == Player.JobId || x.Preset.Attributes().CustomComboInfo.JobID == CustomComboFunctions.JobIDs.ClassToJob(Player.JobId)));
+        var filteredCombos = FilteredCombos as CustomCombo[] ?? FilteredCombos.ToArray();
+        Svc.Log.Debug($"Now running {filteredCombos.Count()} combos\n{string.Join("\n", filteredCombos.Select(x => x.Preset.Attributes().CustomComboInfo.Name))}");
+    }
+
+    #endregion
+
+    /// <summary>
+    ///     Checks if the player could be on a job instead of a class.
+    /// </summary>
+    /// <returns>
+    ///     <see langword="true"/> if the user could be on a job instead.
+    /// </returns>
+    public static unsafe bool ClassLocked()
+    {
+        if (Svc.ClientState.LocalPlayer is null) return false;
+
+        if (Svc.ClientState.LocalPlayer.Level <= 35) return false;
+
+        if (Svc.ClientState.LocalPlayer.ClassJob.RowId is
+            (>= 8 and <= 25) or 27 or 28 or >= 30)
+            return false;
+
+        if (!UIState.Instance()->IsUnlockLinkUnlockedOrQuestCompleted(66049))
+            return false;
+
+        if ((Svc.ClientState.LocalPlayer.ClassJob.RowId is 1 or 2 or 3 or 4 or 5 or 6 or 7 or 26 or 29) &&
+            Svc.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.BoundByDuty] &&
+            Svc.ClientState.LocalPlayer.Level > 35) return true;
+
+        return false;
+    }
+
+    public void Dispose()
+    {
+        getActionHook.Disable();
+        getActionHook.Dispose();
+        isActionReplaceableHook.Disable();
+        isActionReplaceableHook.Dispose();
     }
 }

--- a/WrathCombo/Core/ActionReplacer.cs
+++ b/WrathCombo/Core/ActionReplacer.cs
@@ -22,7 +22,7 @@ internal sealed class ActionReplacer : IDisposable
     public readonly List<CustomCombo> CustomCombos;
 
     /// <summary>
-    ///     Critical for the hook, do not remove or modify
+    ///     Critical for the hook, do not remove or modify.
     /// </summary>
     // ReSharper disable once FieldCanBeMadeReadOnly.Local
     private IntPtr _actionManager = IntPtr.Zero;
@@ -81,6 +81,12 @@ internal sealed class ActionReplacer : IDisposable
         if (FilteredCombos is null)
             UpdateFilteredCombos();
 
+        // Bail if not wanting to replace actions in this manner
+        if (Service.Configuration.PerformanceMode)
+            return OriginalHook(actionID);
+        if (Svc.ClientState.LocalPlayer == null)
+            return OriginalHook(actionID);
+
         // Only refresh every so often
         if (!EzThrottler.Throttle("Actions" + actionID,
                 Service.Configuration.Throttle))
@@ -101,12 +107,6 @@ internal sealed class ActionReplacer : IDisposable
     {
         try
         {
-            if (Service.Configuration.PerformanceMode)
-                return OriginalHook(actionID);
-
-            if (Svc.ClientState.LocalPlayer == null)
-                return OriginalHook(actionID);
-
             if (ClassLocked() ||
                 (DisabledJobsPVE.Any(x => x == Svc.ClientState.LocalPlayer.ClassJob.RowId) && !Svc.ClientState.IsPvP) ||
                 (DisabledJobsPVP.Any(x => x == Svc.ClientState.LocalPlayer.ClassJob.RowId) && Svc.ClientState.IsPvP))

--- a/WrathCombo/Core/PluginConfiguration.cs
+++ b/WrathCombo/Core/PluginConfiguration.cs
@@ -58,6 +58,8 @@ namespace WrathCombo.Core
 
         public bool PerformanceMode = false;
 
+        public int Throttle = 25;
+
         public double InterruptDelay  = 0.0f;
 
         public bool OpenToCurrentJob = false;

--- a/WrathCombo/Core/PluginConfiguration.cs
+++ b/WrathCombo/Core/PluginConfiguration.cs
@@ -58,7 +58,7 @@ namespace WrathCombo.Core
 
         public bool PerformanceMode = false;
 
-        public int Throttle = 25;
+        public int Throttle = 50;
 
         public double InterruptDelay  = 0.0f;
 

--- a/WrathCombo/CustomCombo/Functions/Action.cs
+++ b/WrathCombo/CustomCombo/Functions/Action.cs
@@ -17,12 +17,12 @@ namespace WrathCombo.CustomComboNS.Functions
         /// <summary> Calls the original hook. </summary>
         /// <param name="actionID"> Action ID. </param>
         /// <returns> The result from the hook. </returns>
-        public static uint OriginalHook(uint actionID) => Service.IconReplacer.OriginalHook(actionID);
+        public static uint OriginalHook(uint actionID) => Service.ActionReplacer.OriginalHook(actionID);
 
         /// <summary> Compare the original hook to the given action ID. </summary>
         /// <param name="actionID"> Action ID. </param>
         /// <returns> A value indicating whether the action would be modified. </returns>
-        public static bool IsOriginal(uint actionID) => Service.IconReplacer.OriginalHook(actionID) == actionID;
+        public static bool IsOriginal(uint actionID) => Service.ActionReplacer.OriginalHook(actionID) == actionID;
 
         /// <summary> Checks if the player is high enough level to use the passed Action ID. </summary>
         /// <param name="actionid"> ID of the action. </param>

--- a/WrathCombo/CustomCombo/WrathOpener.cs
+++ b/WrathCombo/CustomCombo/WrathOpener.cs
@@ -26,7 +26,7 @@ namespace WrathCombo.CustomComboNS
 
         private void UpdateOpener(Dalamud.Plugin.Services.IFramework framework)
         {
-            if (!Service.IconReplacer.getIconHook.IsEnabled)
+            if (!Service.ActionReplacer.getActionHook.IsEnabled)
             {
                 uint _ = 0;
                 FullOpener(ref _);

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -354,7 +354,7 @@ namespace WrathCombo.Data
             if (Service.Configuration.PerformanceMode)
             {
                 var result = actionId;
-                foreach (var combo in IconReplacer.FilteredCombos)
+                foreach (var combo in ActionReplacer.FilteredCombos)
                 {
                     if (combo.TryInvoke(actionId, out result))
                     {

--- a/WrathCombo/DebugFile.cs
+++ b/WrathCombo/DebugFile.cs
@@ -96,6 +96,8 @@ public static class DebugFile
 
             AddPlayerInfo();
 
+            AddSettingsInfo();
+
             AddAutoRotationInfo();
 
             AddFeatures(job);
@@ -183,6 +185,21 @@ public static class DebugFile
         AddLine($"Current Zone: {currentZone}");
         AddLine($"Current Party Size: {GetPartyMembers().Count}");
         AddLine("END PLAYER INFO");
+
+        AddLine();
+    }
+
+    private static void AddSettingsInfo()
+    {
+        AddLine("START SETTINGS INFO");
+        AddLine($"Throttle: {Service.Configuration.Throttle}ms");
+        AddLine($"Performance Mode: {(Service.Configuration.PerformanceMode ? "ON" : "OFF")}");
+        AddLine($"Block Spell on Move: {(Service.Configuration.BlockSpellOnMove ? "ON" : "OFF")}");
+        AddLine($"Movement Delay: {Service.Configuration.MovementLeeway}s");
+        AddLine($"Opener Timeout: {Service.Configuration.OpenerTimeout}s");
+        AddLine($"Melee Offset: {Service.Configuration.MeleeOffset}y");
+        AddLine($"Interrupt Delay: {Service.Configuration.InterruptDelay*100}%");
+        AddLine("END SETTINGS INFO");
 
         AddLine();
     }

--- a/WrathCombo/Services/Service.cs
+++ b/WrathCombo/Services/Service.cs
@@ -16,6 +16,6 @@ namespace WrathCombo.Services
         internal static PluginConfiguration Configuration { get; set; } = null!;
 
         /// <summary> Gets or sets the plugin icon replacer. </summary>
-        internal static IconReplacer IconReplacer { get; set; } = null!;
+        internal static ActionReplacer ActionReplacer { get; set; } = null!;
     }
 }

--- a/WrathCombo/Window/Tabs/PvEFeatures.cs
+++ b/WrathCombo/Window/Tabs/PvEFeatures.cs
@@ -23,7 +23,7 @@ namespace WrathCombo.Window.Tabs
         internal static new void Draw()
         {
             //#if !DEBUG
-            if (IconReplacer.ClassLocked())
+            if (ActionReplacer.ClassLocked())
             {
                 ImGui.TextWrapped("Equip your job stone to re-unlock features.");
                 return;

--- a/WrathCombo/Window/Tabs/Settings.cs
+++ b/WrathCombo/Window/Tabs/Settings.cs
@@ -1,4 +1,5 @@
-﻿using Dalamud.Interface.Components;
+﻿using System;
+using Dalamud.Interface.Components;
 using Dalamud.Interface.Utility.Raii;
 using ImGuiNET;
 using System.Numerics;
@@ -127,10 +128,7 @@ namespace WrathCombo.Window.Tabs
                 if (ImGui.InputInt("milliseconds    -    Action Updater Throttle",
                         ref throttle, 10))
                 {
-                    if (throttle < 0) throttle = 0;
-                    if (throttle > 1500) throttle = 1500;
-                    Service.Configuration.Throttle = throttle;
-
+                    Service.Configuration.Throttle = Math.Clamp(throttle, 0, 1500);
                     Service.Configuration.Save();
                 }
 

--- a/WrathCombo/Window/Tabs/Settings.cs
+++ b/WrathCombo/Window/Tabs/Settings.cs
@@ -120,6 +120,23 @@ namespace WrathCombo.Window.Tabs
                 ImGui.Dummy(new Vector2(20f));
                 ImGuiEx.TextUnderlined("Rotation Behavior Options");
 
+                #region Throttle
+
+                ImGui.PushItemWidth(110);
+                var throttle = Service.Configuration.Throttle;
+                if (ImGui.InputInt("milliseconds    -    Action Updater Throttle", ref throttle))
+                {
+                    if (throttle < 0) throttle = 0;
+                    if (throttle > 1500) throttle = 1500;
+                    Service.Configuration.Throttle = throttle;
+
+                    Service.Configuration.Save();
+                }
+
+                ImGuiComponents.HelpMarker("This is the restriction for how often combos will update the action on your hotbar.\nBy default this isn't really restricting the combos,\nso you always get an up-to-date action, dependent on your game's performance.\n\nHowever, if you have FPS issues, you can increase this value to make combos run less often.\nThis has the trade-off of making your combos less responsive, and perhaps even clipping your GCDs.\nIt is not recommended to increase this value over 500ms.");
+
+                #endregion
+
                 #region Performance Mode
 
                 if (ImGui.Checkbox("Performance Mode", ref Service.Configuration.PerformanceMode))

--- a/WrathCombo/Window/Tabs/Settings.cs
+++ b/WrathCombo/Window/Tabs/Settings.cs
@@ -132,7 +132,15 @@ namespace WrathCombo.Window.Tabs
                     Service.Configuration.Save();
                 }
 
-                ImGuiComponents.HelpMarker("This is the restriction for how often combos will update the action on your hotbar.\nBy default this isn't really restricting the combos,\nso you always get an up-to-date action, dependent on your game's performance.\n\nIf you have minor FPS issues, you can increase this value to make combos run less often.\nThis has the trade-off of making your combos less responsive, and perhaps even clipping your GCDs.\nAt large values, this may break your rotation entirely.\n\nA value of 200 can make a reasonable difference in your FPS.\nIt is not recommended to increase this value over 500ms.\nPerformance Mode below is vastly superior to values over 500ms.");
+                ImGuiComponents.HelpMarker(
+                    "This is the restriction for how often combos will update the action on your hotbar." +
+                    "\nBy default this isn't restricting the combos, so you always get an up-to-date action." +
+                    "\n\nIf you have minor FPS issues, you can increase this value to make combos run less often." +
+                    "\nThis makes your combos less responsive, and perhaps even clips GCDs." +
+                    "\nAt high values, this can break your rotation entirely." +
+                    "\nMore severe FPS issues should instead be handled with Performance Mode below." +
+                    "\n\n200ms can make a reasonable difference in your FPS." +
+                    "\nValues over 500ms are NOT recommended.");
 
                 #endregion
 

--- a/WrathCombo/Window/Tabs/Settings.cs
+++ b/WrathCombo/Window/Tabs/Settings.cs
@@ -128,7 +128,7 @@ namespace WrathCombo.Window.Tabs
                         ref throttle, 10))
                 {
                     if (throttle < 0) throttle = 0;
-                    if (throttle > 1000) throttle = 1000;
+                    if (throttle > 1500) throttle = 1500;
                     Service.Configuration.Throttle = throttle;
 
                     Service.Configuration.Save();

--- a/WrathCombo/Window/Tabs/Settings.cs
+++ b/WrathCombo/Window/Tabs/Settings.cs
@@ -122,18 +122,19 @@ namespace WrathCombo.Window.Tabs
 
                 #region Throttle
 
-                ImGui.PushItemWidth(110);
+                ImGui.PushItemWidth(125);
                 var throttle = Service.Configuration.Throttle;
-                if (ImGui.InputInt("milliseconds    -    Action Updater Throttle", ref throttle))
+                if (ImGui.InputInt("milliseconds    -    Action Updater Throttle",
+                        ref throttle, 10))
                 {
                     if (throttle < 0) throttle = 0;
-                    if (throttle > 1500) throttle = 1500;
+                    if (throttle > 1000) throttle = 1000;
                     Service.Configuration.Throttle = throttle;
 
                     Service.Configuration.Save();
                 }
 
-                ImGuiComponents.HelpMarker("This is the restriction for how often combos will update the action on your hotbar.\nBy default this isn't really restricting the combos,\nso you always get an up-to-date action, dependent on your game's performance.\n\nHowever, if you have FPS issues, you can increase this value to make combos run less often.\nThis has the trade-off of making your combos less responsive, and perhaps even clipping your GCDs.\nIt is not recommended to increase this value over 500ms.");
+                ImGuiComponents.HelpMarker("This is the restriction for how often combos will update the action on your hotbar.\nBy default this isn't really restricting the combos,\nso you always get an up-to-date action, dependent on your game's performance.\n\nHowever, if you have FPS issues, you can increase this value to make combos run less often.\nThis has the trade-off of making your combos less responsive, and perhaps even clipping your GCDs.\nAt large values, this may break your rotation entirely.\n\nA value of 200 can make a reasonable difference in your FPS.\nIt is not recommended to increase this value over 500ms.");
 
                 #endregion
 

--- a/WrathCombo/Window/Tabs/Settings.cs
+++ b/WrathCombo/Window/Tabs/Settings.cs
@@ -132,7 +132,7 @@ namespace WrathCombo.Window.Tabs
                     Service.Configuration.Save();
                 }
 
-                ImGuiComponents.HelpMarker("This is the restriction for how often combos will update the action on your hotbar.\nBy default this isn't really restricting the combos,\nso you always get an up-to-date action, dependent on your game's performance.\n\nHowever, if you have FPS issues, you can increase this value to make combos run less often.\nThis has the trade-off of making your combos less responsive, and perhaps even clipping your GCDs.\nAt large values, this may break your rotation entirely.\n\nA value of 200 can make a reasonable difference in your FPS.\nIt is not recommended to increase this value over 500ms.");
+                ImGuiComponents.HelpMarker("This is the restriction for how often combos will update the action on your hotbar.\nBy default this isn't really restricting the combos,\nso you always get an up-to-date action, dependent on your game's performance.\n\nIf you have minor FPS issues, you can increase this value to make combos run less often.\nThis has the trade-off of making your combos less responsive, and perhaps even clipping your GCDs.\nAt large values, this may break your rotation entirely.\n\nA value of 200 can make a reasonable difference in your FPS.\nIt is not recommended to increase this value over 500ms.\nPerformance Mode below is vastly superior to values over 500ms.");
 
                 #endregion
 

--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -107,7 +107,7 @@ public sealed partial class WrathCombo : IDalamudPlugin
             if (onJobChange)
             {
                 PvEFeatures.OpenToCurrentJob(true);
-                Service.IconReplacer.UpdateFilteredCombos();
+                Service.ActionReplacer.UpdateFilteredCombos();
                 WrathOpener.SelectOpener();
                 P.IPCSearch.UpdateActiveJobPresets();
             }
@@ -148,7 +148,7 @@ public sealed partial class WrathCombo : IDalamudPlugin
         PresetStorage.Init();
 
         Service.ComboCache = new CustomComboCache();
-        Service.IconReplacer = new IconReplacer();
+        Service.ActionReplacer = new ActionReplacer();
         ActionWatching.Enable();
         AST.InitCheckCards();
         IPC = Provider.InitAsync().Result;
@@ -382,7 +382,7 @@ public sealed partial class WrathCombo : IDalamudPlugin
         Svc.PluginInterface.UiBuilder.OpenConfigUi -= OnOpenConfigUi;
         Svc.PluginInterface.UiBuilder.Draw -= DrawUI;
 
-        Service.IconReplacer.Dispose();
+        Service.ActionReplacer.Dispose();
         Service.ComboCache.Dispose();
         ActionWatching.Dispose();
         AST.DisposeCheckCards();


### PR DESCRIPTION
- [X] Adds a new setting that throttles how often `GetIconDetour` runs\
      ![image](https://github.com/user-attachments/assets/1308cc64-a63f-43ee-886d-c13739a1e9b9)
      It is clamped to `0` - `1500`; values `0` and below all do the same thing, values over `1500` seem to break all weaves.
      A value of `200` - `500` seems to be the most beneficial.