### PR TITLE
[DNC] Add range checks, anti-drift recommendation

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -954,6 +954,13 @@ public enum CustomComboPreset
 
     #region DANCER
 
+    [ReplaceSkill(DNC.StandardFinish2, DNC.TechnicalFinish4)]
+    [CustomComboInfo("Require Nearby Enemy for Finishes Feature",
+        "In all (non-Simple) Modes and Features below this will hold Standard Finish and Technical Finish until an enemy is within range of the abilities by replacing whatever button with Savage Blade." +
+        "\nWill show either Finish when the dance is about to expire." +
+        "\nThis behavior is recommended by The Balance but can introduce drift, so it may not be what is best for your group.", DNC.JobID)]
+    DNC_ST_BlockFinishes = 4000,
+
     #region Simple Mode
 
     [AutoAction(false, false)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -956,7 +956,7 @@ public enum CustomComboPreset
 
     [ReplaceSkill(DNC.StandardFinish2, DNC.TechnicalFinish4)]
     [CustomComboInfo("Require Nearby Enemy for Finishes Feature",
-        "In all (non-Simple) Modes and Features below this will hold Standard Finish and Technical Finish until an enemy is within range of the abilities by replacing whatever button with Savage Blade." +
+        "Will hold Standard Finish and Technical Finish until an enemy is within range of the abilities in all (non-Simple) Modes and Features below by replacing whatever button with Savage Blade." +
         "\nWill show either Finish when the dance is about to expire." +
         "\nThis behavior is recommended by The Balance but can introduce drift, so it may not be what is best for your group.", DNC.JobID)]
     DNC_ST_BlockFinishes = 4000,

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -360,7 +360,8 @@ internal partial class DNC
 
             // ST Tillana
             if (HasEffect(Buffs.FlourishingFinish) &&
-                IsEnabled(CustomComboPreset.DNC_ST_Adv_Tillana))
+                IsEnabled(CustomComboPreset.DNC_ST_Adv_Tillana) &&
+                EnemyIn15Yalms)
                 return Tillana;
 
             // ST Saber Dance
@@ -653,7 +654,8 @@ internal partial class DNC
                 return StarfallDance;
 
             // ST Tillana
-            if (HasEffect(Buffs.FlourishingFinish))
+            if (HasEffect(Buffs.FlourishingFinish) &&
+                EnemyIn15Yalms)
                 return Tillana;
 
             // ST combos and burst attacks

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -290,7 +290,8 @@ internal partial class DNC
                 if (IsEnabled(CustomComboPreset.DNC_ST_Adv_Improvisation) &&
                     ActionReady(Improvisation) &&
                     !HasEffect(Buffs.TechnicalFinish) &&
-                    InCombat())
+                    InCombat() &&
+                    EnemyIn8Yalms)
                     return Improvisation;
             }
 
@@ -315,7 +316,7 @@ internal partial class DNC
                 return LastDance;
 
             // ST Standard Step (Finishing Move)
-            if (needToStandardOrFinish && needToFinish)
+            if (needToStandardOrFinish && needToFinish && EnemyIn15Yalms)
                 return OriginalHook(FinishingMove);
 
             // ST Standard Step
@@ -616,7 +617,7 @@ internal partial class DNC
                 return LastDance;
 
             // ST Standard Step (Finishing Move)
-            if (needToStandardOrFinish && needToFinish)
+            if (needToStandardOrFinish && needToFinish && EnemyIn15Yalms)
                 return OriginalHook(FinishingMove);
 
             // ST Standard Step

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -149,14 +149,14 @@ internal partial class DNC
                 HasEffect(Buffs.StandardStep))
                 return Gauge.CompletedSteps < 2
                     ? Gauge.NextStep
-                    : StandardFinish2;
+                    : FinishOrHold(StandardFinish2);
 
             // ST Technical (Dance) Steps & Fill
             if ((IsEnabled(CustomComboPreset.DNC_ST_Adv_TS)) &&
                 HasEffect(Buffs.TechnicalStep))
                 return Gauge.CompletedSteps < 4
                     ? Gauge.NextStep
-                    : TechnicalFinish4;
+                    : FinishOrHold(TechnicalFinish4);
 
             #endregion
 
@@ -749,14 +749,14 @@ internal partial class DNC
                 HasEffect(Buffs.StandardStep))
                 return Gauge.CompletedSteps < 2
                     ? Gauge.NextStep
-                    : StandardFinish2;
+                    : FinishOrHold(StandardFinish2);
 
             // AoE Technical (Dance) Steps & Fill
             if (IsEnabled(CustomComboPreset.DNC_AoE_Adv_TS) &&
                 HasEffect(Buffs.TechnicalStep))
                 return Gauge.CompletedSteps < 4
                     ? Gauge.NextStep
-                    : TechnicalFinish4;
+                    : FinishOrHold(TechnicalFinish4);
 
             #endregion
 
@@ -1345,14 +1345,14 @@ internal partial class DNC
                 HasEffect(Buffs.StandardStep))
                 return Gauge.CompletedSteps < 2
                     ? Gauge.NextStep
-                    : StandardFinish2;
+                    : FinishOrHold(StandardFinish2);
 
             // Technical Step
             if (actionID is TechnicalStep && Gauge.IsDancing &&
                 HasEffect(Buffs.TechnicalStep))
                 return Gauge.CompletedSteps < 4
                     ? Gauge.NextStep
-                    : TechnicalFinish4;
+                    : FinishOrHold(TechnicalFinish4);
 
             return actionID;
         }

--- a/WrathCombo/Combos/PvE/DNC/DNC_Config.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Config.cs
@@ -33,17 +33,36 @@ internal partial class DNC
             ImGui.Dummy(new Vector2(1f, 12f));
             ImGui.Indent(40f);
             ImGui.Text("Anti-Drift Options:     (hover each for more info)");
+
+            #region Show a colored display of the user's current detected GCD
+
+            var color = GCDValue switch
+            {
+                GCDRange.Perfect => ImGuiColors.HealerGreen,
+                GCDRange.NotGood => ImGuiColors.DalamudYellow,
+                _ => ImGuiColors.DalamudRed,
+            };
+            ImGui.SameLine();
+            ImGui.Text("GCD: " );
+            ImGui.SameLine();
+            ImGui.TextColored(color, $"{GCD:0.00}");
             ImGui.Unindent(40f);
             ImGui.NewLine();
 
+            #endregion
+
+            var t = ImGui.GetCursorPos();
+            const string texTrip = "Forced Triple Weave";
             UserConfig.DrawRadioButton(
-                DNC_ST_ADV_AntiDrift, "Forced Triple Weave",
+                DNC_ST_ADV_AntiDrift, texTrip,
                 "Forces a triple weave of Flourish and Fan Dance 3 + 4 during non-opener burst windows." +
                 "\nFixes SS/FM drift where you use a gcd when SS/FM is on a 0.5sec CD." +
                 "\nRecommended anti-drift option.",
                 outputValue: (int) AntiDrift.TripleWeave, descriptionAsTooltip: true);
+            var h = ImGui.GetCursorPos();
+            const string texHold = "Hold before Standard Step";
             UserConfig.DrawRadioButton(
-                DNC_ST_ADV_AntiDrift, "Hold before Standard Step",
+                DNC_ST_ADV_AntiDrift, texHold,
                 "Will hold GCDs for Standard Step if it is going to come off cooldown before your next GCD." +
                 "\nThis WILL give you down-time." +
                 "\nONLY recommended if you have extra skill speed, but can be used as an anti-drift option.",
@@ -59,6 +78,32 @@ internal partial class DNC
                 "Will not use any anti-drift options." +
                 "\nThis WILL cause drift. NOT recommended.",
                 outputValue: (int) AntiDrift.None, descriptionAsTooltip: true);
+
+            #region Show recommended setting, based on GCD
+
+            // Save the current cursor position
+            var pos = ImGui.GetCursorPos();
+
+            // Determine which recommendation text to show
+            const string rec = "(Recommended)";
+            var recTriple = GCDValue is GCDRange.Perfect ? rec : "";
+            var recHold = GCDValue is not GCDRange.Perfect ? rec : "";
+
+            // Set the position of (any) Triple-Weave recommendation text
+            var texSize = ImGui.CalcTextSize(texHold);
+            ImGui.SetCursorPos(
+                t with { X = t.X + texSize.X + 110f.Scale(), Y = t.Y - texSize.Y - 2f.Scale() });
+            ImGui.TextColored(ImGuiColors.DalamudGrey, recTriple);
+
+            // Set the position of (any) Hold recommendation text
+            ImGui.SetCursorPos(
+                h with { X = h.X + texSize.X + 110f.Scale(), Y = h.Y - 2f.Scale() });
+            ImGui.TextColored(ImGuiColors.DalamudGrey, recHold);
+
+            // Reset to where the cursor was
+            ImGui.SetCursorPos(pos);
+
+            #endregion
         }
 
         internal static void Draw(CustomComboPreset preset)

--- a/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
@@ -1,9 +1,9 @@
 ﻿#region
 
-using Dalamud.Game.ClientState.JobGauge.Types;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Dalamud.Game.ClientState.JobGauge.Types;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Services;
@@ -24,43 +24,8 @@ namespace WrathCombo.Combos.PvE;
 // ReSharper disable CheckNamespace
 // ReSharper disable MemberCanBePrivate.Global
 // ReSharper disable MemberHidesStaticFromOuterClass
-
 internal partial class DNC
 {
-    /// <summary>
-    ///     Logic to pick different openers.
-    /// </summary>
-    /// <returns>The chosen Opener.</returns>
-    internal static WrathOpener Opener()
-    {
-        if (Config.DNC_ST_OpenerSelection ==
-            (int) Config.Openers.FifteenSecond &&
-            Opener15S.LevelChecked)
-            return Opener15S;
-
-        if (Config.DNC_ST_OpenerSelection ==
-            (int) Config.Openers.SevenSecond &&
-            Opener07S.LevelChecked)
-            return Opener07S;
-
-        if (Config.DNC_ST_OpenerSelection ==
-            (int) Config.Openers.ThirtySecondTech &&
-            Opener30STech.LevelChecked)
-            return Opener30STech;
-
-        if (Config.DNC_ST_OpenerSelection ==
-            (int) Config.Openers.SevenPlusSecondTech &&
-            Opener07PlusSTech.LevelChecked)
-            return Opener07PlusSTech;
-
-        if (Config.DNC_ST_OpenerSelection ==
-            (int) Config.Openers.SevenSecondTech &&
-            Opener07STech.LevelChecked)
-            return Opener07STech;
-
-        return WrathOpener.Dummy;
-    }
-
     /// <summary>
     ///     Dancer Gauge data, just consolidated.
     /// </summary>
@@ -71,6 +36,58 @@ internal partial class DNC
     /// </summary>
     private static double GCD =>
         Math.Floor(GetCooldown(Cascade).CooldownTotal * 100) / 100;
+
+    /// <summary>
+    ///     Checks if any enemy is within 15 yalms.
+    /// </summary>
+    /// <remarks>
+    ///     This is used for <see cref="StandardFinish2"/>,
+    ///     <see cref="TechnicalFinish4"/>, <see cref="FinishingMove"/>,
+    ///     and <see cref="Tillana"/>.
+    /// </remarks>
+    private static bool EnemyIn15Yalms => CanCircleAoe(15, true) > 0;
+
+    /// <summary>
+    ///    Checks if any enemy is within 8 yalms.
+    /// </summary>
+    /// <remarks>
+    ///     This is used for <see cref="Improvisation"/>.
+    /// </remarks>
+    private static bool EnemyIn8Yalms => CanCircleAoe(8, true) > 0;
+
+    /// <summary>
+    ///     Logic to pick different openers.
+    /// </summary>
+    /// <returns>The chosen Opener.</returns>
+    internal static WrathOpener Opener()
+    {
+        if (Config.DNC_ST_OpenerSelection ==
+            (int)Config.Openers.FifteenSecond &&
+            Opener15S.LevelChecked)
+            return Opener15S;
+
+        if (Config.DNC_ST_OpenerSelection ==
+            (int)Config.Openers.SevenSecond &&
+            Opener07S.LevelChecked)
+            return Opener07S;
+
+        if (Config.DNC_ST_OpenerSelection ==
+            (int)Config.Openers.ThirtySecondTech &&
+            Opener30STech.LevelChecked)
+            return Opener30STech;
+
+        if (Config.DNC_ST_OpenerSelection ==
+            (int)Config.Openers.SevenPlusSecondTech &&
+            Opener07PlusSTech.LevelChecked)
+            return Opener07PlusSTech;
+
+        if (Config.DNC_ST_OpenerSelection ==
+            (int)Config.Openers.SevenSecondTech &&
+            Opener07STech.LevelChecked)
+            return Opener07STech;
+
+        return WrathOpener.Dummy;
+    }
 
     /// <summary>
     ///     Check if the rotation is in Auto-Rotation.
@@ -122,8 +139,8 @@ internal partial class DNC
     /// </summary>
     /// <param name="action">The action ID to check.</param>
     /// <param name="updatedAction">
-    ///     The matching dance step the action was assigned to.<br/>
-    ///     Will be Savage Blade if used and was not a custom dance step.<br/>
+    ///     The matching dance step the action was assigned to.<br />
+    ///     Will be Savage Blade if used and was not a custom dance step.<br />
     ///     Do not use this value if the return is <c>false</c>.
     /// </param>
     /// <returns>If the action was assigned as a custom dance step.</returns>
@@ -164,7 +181,6 @@ internal partial class DNC
     internal class FifteenSecondOpener : WrathOpener
     {
         public override int MinOpenerLevel => 100;
-
         public override int MaxOpenerLevel => 109;
 
         public override List<uint> OpenerActions { get; set; } =
@@ -256,7 +272,6 @@ internal partial class DNC
     internal class SevenSecondOpener : WrathOpener
     {
         public override int MinOpenerLevel => 100;
-
         public override int MaxOpenerLevel => 109;
 
         public override List<uint> OpenerActions { get; set; } =
@@ -352,7 +367,6 @@ internal partial class DNC
     internal class ThirtySecondTechOpener : WrathOpener
     {
         public override int MinOpenerLevel => 100;
-
         public override int MaxOpenerLevel => 109;
 
         public override List<uint> OpenerActions { get; set; } =
@@ -444,7 +458,6 @@ internal partial class DNC
     internal class SevenPlusSecondTechOpener : WrathOpener
     {
         public override int MinOpenerLevel => 100;
-
         public override int MaxOpenerLevel => 109;
 
         public override List<uint> OpenerActions { get; set; } =
@@ -527,7 +540,6 @@ internal partial class DNC
     internal class SevenSecondTechOpener : WrathOpener
     {
         public override int MinOpenerLevel => 100;
-
         public override int MaxOpenerLevel => 109;
 
         public override List<uint> OpenerActions { get; set; } =

--- a/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
@@ -151,6 +151,25 @@ internal partial class DNC
         return desiredFinish;
     }
 
+    #region GCD Evaluation
+
+    private static GCDRange GCDValue =>
+        GCD switch
+        {
+            2.50 => GCDRange.Perfect,
+            2.49 => GCDRange.NotGood,
+            _ => GCDRange.Bad,
+        };
+
+    private enum GCDRange
+    {
+        Perfect,
+        NotGood,
+        Bad,
+    }
+
+    #endregion
+
     #region Custom Dance Step Logic
 
     /// <summary>

--- a/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
@@ -41,17 +41,17 @@ internal partial class DNC
     ///     Checks if any enemy is within 15 yalms.
     /// </summary>
     /// <remarks>
-    ///     This is used for <see cref="StandardFinish2"/>,
-    ///     <see cref="TechnicalFinish4"/>, <see cref="FinishingMove"/>,
-    ///     and <see cref="Tillana"/>.
+    ///     This is used for <see cref="StandardFinish2" />,
+    ///     <see cref="TechnicalFinish4" />, <see cref="FinishingMove" />,
+    ///     and <see cref="Tillana" />.
     /// </remarks>
     private static bool EnemyIn15Yalms => CanCircleAoe(15, true) > 0;
 
     /// <summary>
-    ///    Checks if any enemy is within 8 yalms.
+    ///     Checks if any enemy is within 8 yalms.
     /// </summary>
     /// <remarks>
-    ///     This is used for <see cref="Improvisation"/>.
+    ///     This is used for <see cref="Improvisation" />.
     /// </remarks>
     private static bool EnemyIn8Yalms => CanCircleAoe(8, true) > 0;
 
@@ -115,6 +115,41 @@ internal partial class DNC
                     : Options.DNC_AoE_AdvancedMode)
             ).ToString()
         )!.Values.Last();
+
+    /// <summary>
+    ///     Hold or Return a dance's Finisher based on user options and enemy ranges.
+    /// </summary>
+    /// <param name="desiredFinish">
+    ///     Which Finisher should be returned.<br />
+    ///     Expects <see cref="StandardFinish2" /> or
+    ///     <see cref="TechnicalFinish4" />.
+    /// </param>
+    /// <returns>
+    ///     The Finisher to use, or if
+    ///     <see cref="CustomComboPreset.DNC_ST_BlockFinishes"/> is enabled and
+    ///     there is no enemy in range: <see cref="All.SavageBlade"/>.
+    /// </returns>
+    private static uint FinishOrHold(uint desiredFinish)
+    {
+        // If the option to hold is not enabled
+        if (IsNotEnabled(Options.DNC_ST_BlockFinishes))
+            return desiredFinish;
+
+        // Return the Finish if the dance is about to expire
+        if (desiredFinish is StandardFinish2 &&
+            GetBuffRemainingTime(Buffs.StandardStep) < GCD * 1.5)
+            return desiredFinish;
+        if (desiredFinish is TechnicalFinish4 &&
+            GetBuffRemainingTime(Buffs.TechnicalStep) < GCD * 1.5)
+            return desiredFinish;
+
+        // If there is no enemy in range, hold the finish
+        if (!EnemyIn15Yalms)
+            return All.SavageBlade;
+
+        // If there is an enemy in range, or as a fallback, return the desired finish
+        return desiredFinish;
+    }
 
     #region Custom Dance Step Logic
 


### PR DESCRIPTION
Add range checks to:
- [X] ST Improvisation
- [X] ST Finishing Move
- [X] ST Tillana
- [X] Standard Finish (not Simple Mode)
- [X] Technical Finish (not Simple Mode)

![image](https://github.com/user-attachments/assets/9c097165-a1cb-419c-b4e2-27978e344577)

Adds new anti-drift recommendation feature:
![Untitled](https://github.com/user-attachments/assets/fa017e48-dc78-4813-ab90-7d7bd949e4ed)