### PR TITLE
[Core] Handle specific-Tab cmds better, add `pve` and `pvp`, add `combo` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ To enable this:
 
 | **Chat command**                       | **Function**                                                                                                                                                                   |
 |:---------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `/wrath`                               | Opens the main plugin window, where you can enable/disable features, access settings and more.                                                                                 |
+| `/wrath`                               | Toggles the main plugin window, where you can enable/disable features, access settings and more.                                                                               |
+| `/wrath pve`                           | Opens the main plugin window, to the PvE tab.                                                                                                                                  |
+| `/wrath pvp`                           | Opens the main plugin window, to the PvP tab.                                                                                                                                  |
 | `/wrath settings`                      | Opens the main plugin window, to the Settings tab.                                                                                                                             |
 | `/wrath autosettings`                  | Opens the main plugin window, to the Auto-Rotation tab.                                                                                                                        |
 | `/wrath <X>`                           | Opens the main plugin window, to a specific job's PvE features.<br>Replace `<X>` with the jobs abbreviation.                                                                   |

--- a/WrathCombo/Commands.cs
+++ b/WrathCombo/Commands.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using ECommons;
 using ECommons.DalamudServices;
 using ECommons.GameFunctions;
-using ECommons.GameHelpers;
 using ECommons.Logging;
 using Lumina.Excel.Sheets;
 using WrathCombo.Combos;
@@ -26,7 +25,7 @@ public partial class WrathCombo
     private const string OldCommand = "/scombo";
 
     /// <summary>
-    ///     Registers the base commands for the plugin.<br/>
+    ///     Registers the base commands for the plugin.<br />
     ///     Also displays the biggest commands in Dalamud.
     /// </summary>
     private void RegisterCommands()
@@ -43,14 +42,14 @@ public partial class WrathCombo
     ///     Handles the command input, and calls the appropriate method.
     /// </summary>
     /// <param name="command">
-    ///     Irrelevant, as we handle all commands the same.<br/>
+    ///     Irrelevant, as we handle all commands the same.<br />
     ///     Required for the command handler.
     /// </param>
     /// <param name="arguments">
-    ///     The arguments provided with the command.<br/>
-    ///     Generally treated as:<br/>
+    ///     The arguments provided with the command.<br />
+    ///     Generally treated as:<br />
     ///     The first argument is the command to execute, and the second is the
-    ///     argument for the command.<br/>
+    ///     argument for the command.<br />
     ///     If the command is not recognized, the
     ///     <see cref="HandleOpenCommand">Open Command</see> is assumed, to handle
     ///     opening to a specific job.
@@ -83,6 +82,27 @@ public partial class WrathCombo
             case "debug":
                 HandleDebugCommands(argumentParts); break;
 
+            case "settings":
+            case "config": // unlisted
+                HandleOpenCommand(tab: OpenWindow.Settings, forceOpen: true); break;
+
+            case "autosettings":
+            case "autorotationsettings": // unlisted
+            case "autoconfig": // unlisted
+            case "autorotationconfig": // unlisted
+                HandleOpenCommand(tab: OpenWindow.AutoRotation, forceOpen: true);
+                break;
+
+            case "pve":
+                HandleOpenCommand(tab: OpenWindow.PvE, forceOpen: true); break;
+
+            case "pvp":
+                HandleOpenCommand(tab: OpenWindow.PvP, forceOpen: true); break;
+
+            case "dbg": // unlisted
+            case "debugtab": // unlisted
+                HandleOpenCommand(tab: OpenWindow.Debug, forceOpen: true); break;
+
             default:
                 HandleOpenCommand(argumentParts); break;
         }
@@ -94,10 +114,10 @@ public partial class WrathCombo
     ///     Handles the set command, which toggles, sets, or unsets presets.
     /// </summary>
     /// <value>
-    ///     <c>&lt;blank&gt;</c> - list valid arguments<br/>
-    ///     <c>toggle</c> - toggle preset, requires another argument<br/>
-    ///     <c>set</c> - enable preset, requires another argument<br/>
-    ///     <c>unset</c> - disable preset, requires another argument<br/>
+    ///     <c>&lt;blank&gt;</c> - list valid arguments<br />
+    ///     <c>toggle</c> - toggle preset, requires another argument<br />
+    ///     <c>set</c> - enable preset, requires another argument<br />
+    ///     <c>unset</c> - disable preset, requires another argument<br />
     ///     <c>unsetall</c> - disable all presets
     /// </value>
     /// <param name="argument">
@@ -209,15 +229,15 @@ public partial class WrathCombo
     ///     Handles the list command, which lists all available presets.
     /// </summary>
     /// <value>
-    ///     <c>&lt;blank&gt;</c> - list valid arguments<br/>
-    ///     <c>set</c> - enabled presets<br/>
-    ///     <c>enabled</c> - enabled presets<br/>
-    ///     <c>unset</c> - disabled presets<br/>
-    ///     <c>disabled</c> - disabled presets (unlisted command)<br/>
+    ///     <c>&lt;blank&gt;</c> - list valid arguments<br />
+    ///     <c>set</c> - enabled presets<br />
+    ///     <c>enabled</c> - enabled presets<br />
+    ///     <c>unset</c> - disabled presets<br />
+    ///     <c>disabled</c> - disabled presets (unlisted command)<br />
     ///     <c>all</c> - all presets
     /// </value>
     /// <param name="argument">
-    ///     The filter to apply to the list.<br/>
+    ///     The filter to apply to the list.<br />
     ///     If no argument is provided, all presets are listed.
     /// </param>
     private void HandleListCommands(string[] argument)
@@ -229,7 +249,9 @@ public partial class WrathCombo
             case "enabled":
             case "set":
                 foreach (var preset in Enum.GetValues<CustomComboPreset>()
-                             .Where(preset => IPC.GetComboState(preset.ToString())!.First().Value))
+                             .Where(preset =>
+                                 IPC.GetComboState(preset.ToString())!.First()
+                                     .Value))
                 {
                     var controlled =
                         P.UIHelper.PresetControlled(preset) is not null;
@@ -242,7 +264,9 @@ public partial class WrathCombo
             case "disabled":
             case "unset":
                 foreach (var preset in Enum.GetValues<CustomComboPreset>()
-                             .Where(preset => !IPC.GetComboState(preset.ToString())!.First().Value))
+                             .Where(preset =>
+                                 !IPC.GetComboState(preset.ToString())!.First()
+                                     .Value))
                 {
                     var controlled =
                         P.UIHelper.PresetControlled(preset) is not null;
@@ -273,13 +297,13 @@ public partial class WrathCombo
     ///     Handles the combo command, the replacing of actions.
     /// </summary>
     /// <value>
-    ///     <c>&lt;blank&gt;</c> - toggle<br/>
-    ///     <c>on</c> - enable<br/>
-    ///     <c>off</c> - disable<br/>
+    ///     <c>&lt;blank&gt;</c> - toggle<br />
+    ///     <c>on</c> - enable<br />
+    ///     <c>off</c> - disable<br />
     ///     <c>toggle</c> - toggle
     /// </value>
     /// <param name="argument">
-    ///     The way to change the combo setting.<br/>
+    ///     The way to change the combo setting.<br />
     ///     If no argument is provided, the setting is toggled.
     /// </param>
     private void HandleComboCommands(string[] argument)
@@ -322,13 +346,13 @@ public partial class WrathCombo
     ///     Handles the auto command, which calls <see cref="ToggleAutoRotation" />.
     /// </summary>
     /// <value>
-    ///     <c>&lt;blank&gt;</c> - toggle<br/>
-    ///     <c>on</c> - enable<br/>
-    ///     <c>off</c> - disable<br/>
+    ///     <c>&lt;blank&gt;</c> - toggle<br />
+    ///     <c>on</c> - enable<br />
+    ///     <c>off</c> - disable<br />
     ///     <c>toggle</c> - toggle
     /// </value>
     /// <param name="argument">
-    ///     The way to change the auto-rotation setting.<br/>
+    ///     The way to change the auto-rotation setting.<br />
     ///     If no argument is provided, the setting is toggled.
     /// </param>
     private void HandleAutoCommands(string[] argument)
@@ -369,7 +393,7 @@ public partial class WrathCombo
     ///     Handles the ignore command.
     /// </summary>
     /// <value>
-    ///     <c>&lt;blank&gt;</c> - add target<br/>
+    ///     <c>&lt;blank&gt;</c> - add target<br />
     /// </value>
     /// <remarks>
     ///     Requires a target to be selected, and the target to be hostile.
@@ -411,12 +435,12 @@ public partial class WrathCombo
     ///     <see cref="DebugFile.MakeDebugFile" />.
     /// </summary>
     /// <value>
-    ///     <c>&lt;blank&gt;</c> - current job<br/>
-    ///     <c>&lt;job abbr&gt;</c> - that job<br/>
-    ///     <c>all</c> - all jobs<br/>
+    ///     <c>&lt;blank&gt;</c> - current job<br />
+    ///     <c>&lt;job abbr&gt;</c> - that job<br />
+    ///     <c>all</c> - all jobs<br />
     /// </value>
     /// <param name="argument">
-    ///     The job abbreviation to provide the debug file for (or "all").<br/>
+    ///     The job abbreviation to provide the debug file for (or "all").<br />
     ///     If no argument is provided, the current job is used.
     /// </param>
     private void HandleDebugCommands(string[] argument)
@@ -487,46 +511,48 @@ public partial class WrathCombo
     ///     Handles the opening of the window, as well as the opening command.
     /// </summary>
     /// <value>
-    ///     <c>&lt;blank&gt;</c> - toggle window<br/>
+    ///     <c>&lt;blank&gt;</c> - toggle window<br />
     ///     <c>&lt;job abbr&gt;</c> - open window, to that job
     /// </value>
     /// <param name="argument">
     ///     Only should be provided if coming from
-    ///     <see cref="OnCommand">OnCommand</see>.<br/>
+    ///     <see cref="OnCommand">OnCommand</see>.<br />
     ///     Job Abbreviation to open to (the PvE tab for).
     /// </param>
     /// <param name="tab">
     ///     Only should be provided if coming from <see cref="OnOpenMainUi" /> or
-    ///     <see cref="OnOpenConfigUi" />.<br/>
+    ///     <see cref="OnOpenConfigUi" />, or the tab commands in
+    ///     <see cref="OnCommand">OnCommand</see>.<br />
     ///     The tab of the UI window to open to.
     /// </param>
     /// <param name="forceOpen">
     ///     Only should be provided if coming from <see cref="OnOpenMainUi" /> or
-    ///     <see cref="OnOpenConfigUi" />.<br/>
+    ///     <see cref="OnOpenConfigUi" />, or the tab commands in
+    ///     <see cref="OnCommand">OnCommand</see>.<br />
     ///     If provided: the state the window should be forced to.
     /// </param>
     /// <remarks>
-    ///    The order of operations is as follows:
+    ///     The order of operations is as follows:
     ///     <list type="number">
-    ///        <item>Toggle the window state</item>
-    ///        <item>
+    ///         <item>Toggle the window state</item>
+    ///         <item>
     ///             Force window state (UI buttons)
     ///             (if <paramref name="forceOpen" />)
     ///         </item>
-    ///        <item>
+    ///         <item>
     ///             Open to specific tab
     ///             (if <paramref name="tab" />)
     ///             (returns early)
     ///         </item>
-    ///        <item>
+    ///         <item>
     ///             Open to current job setting
     ///             (if <see cref="PluginConfiguration.OpenToCurrentJob" />)
     ///         </item>
-    ///        <item>
+    ///         <item>
     ///             Open to specified job
     ///             (if specified in <paramref name="argument" />, from
     ///             <see cref="OnCommand">OnCommand</see>)
-    ///        </item>
+    ///         </item>
     ///     </list>
     /// </remarks>
     private void HandleOpenCommand
@@ -553,40 +579,6 @@ public partial class WrathCombo
 
         if (argument[0].Length <= 0) return;
 
-        // Open to specified tab
-        switch (argument[0])
-        {
-            case "settings":
-            case "config":
-                ConfigWindow.OpenWindow = OpenWindow.Settings;
-                ConfigWindow.IsOpen = true;
-                return;
-
-            case "autosettings":
-            case "autorotationsettings":
-            case "autoconfig":
-            case "autorotationconfig":
-                ConfigWindow.OpenWindow = OpenWindow.AutoRotation;
-                ConfigWindow.IsOpen = true;
-                return;
-
-            case "pve":
-                ConfigWindow.OpenWindow = OpenWindow.PvE;
-                ConfigWindow.IsOpen = true;
-                return;
-
-            case "pvp":
-                ConfigWindow.OpenWindow = OpenWindow.PvP;
-                ConfigWindow.IsOpen = true;
-                return;
-
-            case "dbg":
-            case "debugtab":
-                ConfigWindow.OpenWindow = OpenWindow.Debug;
-                ConfigWindow.IsOpen = true;
-                return;
-        }
-
         // Open to specified job
         var jobName = argument[0].ToUpperInvariant();
         jobName = ConfigWindow.groupedPresets
@@ -597,6 +589,7 @@ public partial class WrathCombo
             DuoLog.Error($"{argument[0]} is not a correct job abbreviation.");
             return;
         }
+
         ConfigWindow.IsOpen = true;
         PvEFeatures.OpenJob = jobName;
     }

--- a/WrathCombo/Commands.cs
+++ b/WrathCombo/Commands.cs
@@ -310,36 +310,37 @@ public partial class WrathCombo
     {
         if (argument.Length < 2)
         {
-            if (Service.ActionReplacer.getActionHook.IsEnabled)
-                Service.ActionReplacer.getActionHook.Disable();
-            else
-                Service.ActionReplacer.getActionHook.Enable();
+            Service.Configuration.SetActionChanging(
+                !Service.Configuration.ActionChanging);
+            DuoLog.Information(
+                "Action Replacing set to "
+                + (Service.Configuration.ActionChanging ? "ON" : "OFF"));
             return;
         }
 
         switch (argument[1])
         {
             case "on":
-                if (!Service.ActionReplacer.getActionHook.IsEnabled)
-                    Service.ActionReplacer.getActionHook.Enable();
+                Service.Configuration.SetActionChanging(true);
                 break;
 
             case "off":
-                if (Service.ActionReplacer.getActionHook.IsEnabled)
-                    Service.ActionReplacer.getActionHook.Disable();
+                Service.Configuration.SetActionChanging(false);
                 break;
 
             case "toggle":
-                if (Service.ActionReplacer.getActionHook.IsEnabled)
-                    Service.ActionReplacer.getActionHook.Disable();
-                else
-                    Service.ActionReplacer.getActionHook.Enable();
+                Service.Configuration.SetActionChanging(
+                    !Service.Configuration.ActionChanging);
                 break;
 
             default:
                 DuoLog.Error("Available combo options: on, off, toggle");
-                break;
+                return;
         }
+
+        DuoLog.Information(
+            "Action Replacing set to "
+            + (Service.Configuration.ActionChanging ? "ON" : "OFF"));
     }
 
     /// <summary>

--- a/WrathCombo/Commands.cs
+++ b/WrathCombo/Commands.cs
@@ -559,6 +559,7 @@ public partial class WrathCombo
             case "settings":
             case "config":
                 ConfigWindow.OpenWindow = OpenWindow.Settings;
+                ConfigWindow.IsOpen = true;
                 return;
 
             case "autosettings":
@@ -566,6 +567,18 @@ public partial class WrathCombo
             case "autoconfig":
             case "autorotationconfig":
                 ConfigWindow.OpenWindow = OpenWindow.AutoRotation;
+                ConfigWindow.IsOpen = true;
+                return;
+
+            case "pvp":
+                ConfigWindow.OpenWindow = OpenWindow.PvP;
+                ConfigWindow.IsOpen = true;
+                return;
+
+            case "dbg":
+            case "debugtab":
+                ConfigWindow.OpenWindow = OpenWindow.Debug;
+                ConfigWindow.IsOpen = true;
                 return;
         }
 

--- a/WrathCombo/Commands.cs
+++ b/WrathCombo/Commands.cs
@@ -570,6 +570,11 @@ public partial class WrathCombo
                 ConfigWindow.IsOpen = true;
                 return;
 
+            case "pve":
+                ConfigWindow.OpenWindow = OpenWindow.PvE;
+                ConfigWindow.IsOpen = true;
+                return;
+
             case "pvp":
                 ConfigWindow.OpenWindow = OpenWindow.PvP;
                 ConfigWindow.IsOpen = true;

--- a/WrathCombo/Core/PluginConfiguration.cs
+++ b/WrathCombo/Core/PluginConfiguration.cs
@@ -69,18 +69,23 @@ namespace WrathCombo.Core
 
         public bool ActionChanging = true;
 
+        private DateTime _lastActionChangeCheck = DateTime.MinValue;
+
         internal void SetActionChanging(bool? newValue = null)
         {
-            if (newValue is not null)
+            if ((DateTime.Now - _lastActionChangeCheck).TotalSeconds < 3) return;
+
+            if (newValue is not null && newValue != ActionChanging)
+            {
                 ActionChanging = newValue.Value;
+                Save();
+            }
 
             // Checks if action replacing is not in line with the setting
             if (ActionChanging && !Service.ActionReplacer.getActionHook.IsEnabled)
                 Service.ActionReplacer.getActionHook.Enable();
             if (!ActionChanging && Service.ActionReplacer.getActionHook.IsEnabled)
                 Service.ActionReplacer.getActionHook.Disable();
-
-            Save();
         }
 
         #endregion

--- a/WrathCombo/Core/PluginConfiguration.cs
+++ b/WrathCombo/Core/PluginConfiguration.cs
@@ -9,6 +9,7 @@ using ECommons.Logging;
 using WrathCombo.AutoRotation;
 using WrathCombo.Combos;
 using WrathCombo.Extensions;
+using WrathCombo.Services;
 using WrathCombo.Window;
 using WrathCombo.Window.Tabs;
 
@@ -65,6 +66,22 @@ namespace WrathCombo.Core
         public bool OpenToCurrentJob = false;
 
         public bool OpenToCurrentJobOnSwitch = false;
+
+        public bool ActionChanging = true;
+
+        internal void SetActionChanging(bool? newValue = null)
+        {
+            if (newValue is not null)
+                ActionChanging = newValue.Value;
+
+            // Checks if action replacing is not in line with the setting
+            if (ActionChanging && !Service.ActionReplacer.getActionHook.IsEnabled)
+                Service.ActionReplacer.getActionHook.Enable();
+            if (!ActionChanging && Service.ActionReplacer.getActionHook.IsEnabled)
+                Service.ActionReplacer.getActionHook.Disable();
+
+            Save();
+        }
 
         #endregion
 

--- a/WrathCombo/Window/Tabs/PvEFeatures.cs
+++ b/WrathCombo/Window/Tabs/PvEFeatures.cs
@@ -231,6 +231,9 @@ namespace WrathCombo.Window.Tabs
                 (onJobChange || !Service.Configuration.OpenToCurrentJob ||
                  !Player.Available)) return;
 
+            if (onJobChange && !P.ConfigWindow.IsOpen)
+                return;
+
             if (Player.Job.IsDoh())
                 return;
 

--- a/WrathCombo/Window/Tabs/Settings.cs
+++ b/WrathCombo/Window/Tabs/Settings.cs
@@ -142,6 +142,15 @@ namespace WrathCombo.Window.Tabs
 
                 #endregion
 
+                #region Action Changing
+
+                if (ImGui.Checkbox("Action Replacing", ref Service.Configuration.ActionChanging))
+                    Service.Configuration.Save();
+
+                ImGuiComponents.HelpMarker("Controls whether Actions will be Intercepted Replaced with combos from the plugin.\nIf disabled, your manual presses of abilities will no longer be affected by your Wrath settings.\n\nAuto-Rotation will work regardless of the setting.\n\nControlled by /wrath combo");
+
+                #endregion
+
                 #region Throttle
 
                 var len = ImGui.CalcTextSize("milliseconds").X;

--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -37,7 +37,7 @@ namespace WrathCombo;
 public sealed partial class WrathCombo : IDalamudPlugin
 {
     private static TaskManager? TM;
-    private readonly ConfigWindow ConfigWindow;
+    internal readonly ConfigWindow ConfigWindow;
     private readonly SettingChangeWindow SettingChangeWindow;
     private readonly TargetHelper TargetHelper;
     internal static WrathCombo? P;

--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -263,6 +263,8 @@ public sealed partial class WrathCombo : IDalamudPlugin
         AutoRotationController.Run();
         PluginConfiguration.ProcessSaveQueue();
 
+        Service.Configuration.SetActionChanging();
+
         // Skip the IPC checking if hidden
         if (DtrBarEntry.UserHidden) return;
 


### PR DESCRIPTION
- [X] Move specific-Tab commands to be with the other commands.
      This simplifies the logic for each specific-Tab command, and prevents master commands from overwriting them.
- [X] Add `/wrath pve`
- [X] Add `/wrath pvp`
- [X] Add `/wrath dbg` and `/wrath debugtab` (both unlisted)
      (so you can always open the debug tab, not just on dev builds)
- [X] Make `OpenToCurrentJobOnSwitch` only function if the window is currently open.
      Without this, it was effectively just `OpenToCurrentJob`, but it didn't work immediately.
- [X] Add full Setting for `/wrath combo`
  - [X] Added feedback to the `/wrath combo` command