### PR TITLE
[Core] Apply Stance and Dance Partner

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1244,6 +1244,27 @@ public enum CustomComboPreset
 
     #region Smaller Features
 
+    #region Dance Partner Features
+
+    /*
+    [ReplaceSkill(DNC.ClosedPosition, DNC.Ending)]
+    [CustomComboInfo("Dance Partner on Desirable Partner Feature",
+        "Replaces Closed Position (including in the combos above) with itself, but targeted to a party member, so you can cast it without having to pick anyone and without having to actually target anyone." +
+        "\nThis will check through your party members, and select the most desirable Partner based on The Balance's priority and stuff like Rez Sickness.", DNC.JobID)]
+    DNC_DesirablePartner = 4175,
+
+    [ParentCombo(DNC_DesirablePartner)]
+    [CustomComboInfo("Party-Target Overrides Selection Option", "If you are targeting a party member that is a valid target, they will be used instead of searching party members.\nTarget must be alive and in range.", DNC.JobID)]
+    DNC_Desirable_TargetOverride = 4176,
+
+    [ParentCombo(DNC_DesirablePartner)]
+    [CustomComboInfo("Custom Priority Option", "If your Partner priority differs from The Balance's recommendation for some reason, you can customize the priority here.\nNot generally recommended.", DNC.JobID)]
+    DNC_Desirable_CustomPriority = 4177,
+    */
+
+    #endregion
+    // Last value = 4177
+
     #region Dance Features
 
     [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]

--- a/WrathCombo/Combos/PvE/ALL/ALL.cs
+++ b/WrathCombo/Combos/PvE/ALL/ALL.cs
@@ -96,7 +96,6 @@ internal class All
     public static class Buffs
     {
         public const ushort
-            Weakness = 43,
             WellFed = 48,
             Medicated = 49,
             Bloodbath = 84,
@@ -113,6 +112,8 @@ internal class All
     public static class Debuffs
     {
         public const ushort
+            Weakness = 43,
+            BrinkOfDeath = 44,
 
             //Tank
             Reprisal = 1193, //applied by Reprisal to target

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -1,5 +1,9 @@
 ﻿#region
 
+using System;
+using Dalamud.Game.ClientState.Objects.Types;
+using ECommons.Logging;
+using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using WrathCombo.Combos.PvE.Content;
 using WrathCombo.CustomComboNS;
 
@@ -33,7 +37,8 @@ internal partial class DNC
             var targetHpThresholdStandard = Config.DNC_ST_Adv_SSBurstPercent;
             var targetHpThresholdTechnical = Config.DNC_ST_Adv_TSBurstPercent;
             var tillanaDriftProtectionActive =
-                Config.DNC_ST_ADV_TillanaUse == (int)Config.TillanaDriftProtection.Favor;
+                Config.DNC_ST_ADV_TillanaUse ==
+                (int)Config.TillanaDriftProtection.Favor;
 
             // Thresholds to wait for TS/SS to come off CD
             var longAlignmentThreshold = 0.6f;
@@ -72,7 +77,7 @@ internal partial class DNC
                 HasEffect(Buffs.FinishingMoveReady) &&
                 !HasEffect(Buffs.LastDanceReady) &&
                 ((GetCooldownRemainingTime(StandardStep) < longAlignmentThreshold &&
-                  HasEffect(Buffs.TechnicalFinish)) ||// Aggressive anti-drift
+                  HasEffect(Buffs.TechnicalFinish)) || // Aggressive anti-drift
                  (!HasEffect(Buffs.TechnicalFinish) && // Anti-Drift outside of Tech
                   GetCooldownRemainingTime(StandardStep) <
                   shortAlignmentThreshold));
@@ -333,8 +338,10 @@ internal partial class DNC
                 LevelChecked(DanceOfTheDawn) &&
                 (GetCooldownRemainingTime(TechnicalStep) > 5 ||
                  IsOffCooldown(TechnicalStep)) && // Tech is up
-                (Gauge.Esprit >= Config.DNC_ST_Adv_SaberThreshold || // >esprit threshold use
-                 (HasEffect(Buffs.TechnicalFinish) && // will overcap with Tillana if not used
+                (Gauge.Esprit >=
+                 Config.DNC_ST_Adv_SaberThreshold || // >esprit threshold use
+                 (HasEffect(Buffs
+                      .TechnicalFinish) && // will overcap with Tillana if not used
                   !tillanaDriftProtectionActive && Gauge.Esprit >= 50) ||
                  (GetBuffRemainingTime(Buffs.DanceOfTheDawnReady) < 5 &&
                   Gauge.Esprit >= 50))) // emergency use
@@ -432,7 +439,7 @@ internal partial class DNC
                 HasEffect(Buffs.FinishingMoveReady) &&
                 !HasEffect(Buffs.LastDanceReady) &&
                 ((GetCooldownRemainingTime(StandardStep) < longAlignmentThreshold &&
-                  HasEffect(Buffs.TechnicalFinish)) ||// Aggressive anti-drift
+                  HasEffect(Buffs.TechnicalFinish)) || // Aggressive anti-drift
                  (!HasEffect(Buffs.TechnicalFinish) && // Anti-Drift outside of Tech
                   GetCooldownRemainingTime(StandardStep) <
                   shortAlignmentThreshold));
@@ -591,7 +598,7 @@ internal partial class DNC
 
                 // ST Panic Heals
 
-               if (ActionReady(All.SecondWind) &&
+                if (ActionReady(All.SecondWind) &&
                     PlayerHealthPercentageHp() < 40)
                     return All.SecondWind;
             }
@@ -633,8 +640,10 @@ internal partial class DNC
                 LevelChecked(DanceOfTheDawn) &&
                 (GetCooldownRemainingTime(TechnicalStep) > 5 ||
                  IsOffCooldown(TechnicalStep)) && // Tech is up
-                (Gauge.Esprit >= Config.DNC_ST_Adv_SaberThreshold || // >esprit threshold use
-                 (HasEffect(Buffs.TechnicalFinish) && // will overcap with Tillana if not used
+                (Gauge.Esprit >=
+                 Config.DNC_ST_Adv_SaberThreshold || // >esprit threshold use
+                 (HasEffect(Buffs
+                      .TechnicalFinish) && // will overcap with Tillana if not used
                   Gauge.Esprit >= 50) ||
                  (GetBuffRemainingTime(Buffs.DanceOfTheDawnReady) < 5 &&
                   Gauge.Esprit >= 50))) // emergency use
@@ -1326,6 +1335,59 @@ internal partial class DNC
 
     #region Smaller Features
 
+    #region Dance Partner Features
+
+    /*internal class DNC_DesirablePartner : CustomCombo
+    {
+        private static DateTime _lastPartnerCheckTime = DateTime.MinValue;
+
+        protected internal override CustomComboPreset Preset =>
+            CustomComboPreset.DNC_DesirablePartner;
+
+        private static bool CurrentPartnerNonOptimal =>
+            DesirableDancePartner is not null &&
+            DesirableDancePartner.GameObjectId != CurrentDancePartner;
+
+        private static IGameObject? DesirableDancePartner
+        {
+            get
+            {
+                if ((DateTime.Now - _lastPartnerCheckTime).TotalSeconds <= 3)
+                    return field;
+
+                _lastPartnerCheckTime = DateTime.Now;
+                field = TryGetDancePartner(out var partner, true)
+                    ? partner
+                    : null;
+
+                return field;
+            }
+        }
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not (ClosedPosition or Ending)) return actionID;
+
+            var currentTarget = LocalPlayer.TargetObject;
+            var noCurrentPartner = !HasEffect(Buffs.ClosedPosition);
+
+            if (noCurrentPartner || CurrentPartnerNonOptimal)
+                if (DesirableDancePartner.GameObjectId == currentTarget.GameObjectId)
+                    return Ending;
+                else
+                {
+                    SetTarget(DesirableDancePartner);
+                    TM.DelayNext(250);
+                    TM.Enqueue(() => SetTarget(currentTarget));
+                    return ClosedPosition;
+                }
+
+            return actionID;
+        }
+    }*/
+
+    #endregion
+
     #region Dance Features
 
     internal class DNC_DanceStepCombo : CustomCombo
@@ -1481,7 +1543,8 @@ internal partial class DNC
         protected internal override CustomComboPreset Preset =>
             CustomComboPreset.DNC_TechnicalStep_Devilment;
 
-        protected override uint Invoke(uint actionID) {
+        protected override uint Invoke(uint actionID)
+        {
             if (actionID is not TechnicalStep) return actionID;
 
             if (WantsCustomStepsOnSmallerFeatures)

--- a/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
@@ -181,11 +181,11 @@ internal partial class DNC
 
         #endregion
 
-        bool TryGetBestPartner(out IGameObject? bestPartner, int step = 0)
+        bool TryGetBestPartner(out IGameObject? newBestPartner, int step = 0)
         {
             #region Variable Setup
 
-            bestPartner = null;
+            newBestPartner = null;
             var restrictions = PartnerPriority.RestrictionSteps[step];
             var filter = party;
             const int melee = (int)PartnerPriority.Role.Melee;
@@ -211,7 +211,7 @@ internal partial class DNC
 
             if (filter.Count == 0 &&
                 step < PartnerPriority.RestrictionSteps.Length - 1)
-                return TryGetBestPartner(out bestPartner, step + 1);
+                return TryGetBestPartner(out newBestPartner, step + 1);
             if (filter.Count == 0 && step == 6)
                 return false;
 
@@ -231,7 +231,7 @@ internal partial class DNC
                         : int.MaxValue)
                 .ToList();
 
-            bestPartner = filter.First();
+            newBestPartner = filter.First();
             return true;
         }
     }

--- a/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
@@ -4,6 +4,7 @@ using Dalamud.Game.ClientState.JobGauge.Types;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Dalamud.Game.ClientState.Objects.Types;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Services;
@@ -98,6 +99,28 @@ internal partial class DNC
                     : Options.DNC_AoE_AdvancedMode)
             ).ToString()
         )!.Values.Last();
+
+    #region Dance Partner
+
+    internal static ulong? DesiredDancePartner =>
+        TryGetDancePartner(out var partner) ? partner.GameObjectId : null;
+
+    private static bool TryGetDancePartner(out IGameObject? partner)
+    {
+        partner = null;
+
+        if (!IsEnabled(Options.DNC_ST_Adv_Partner))
+            return false;
+
+        if (!HasEffect(Buffs.ClosedPosition))
+            return false;
+
+        partner = GetPartyMembers();
+
+        return partner != null;
+    }
+
+    #endregion
 
     #region Custom Dance Step Logic
 

--- a/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
@@ -7,7 +7,6 @@ using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.Types;
 using ECommons.DalamudServices;
 using ECommons.GameHelpers;
-using Dalamud.Game.ClientState.JobGauge.Types;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Extensions;
@@ -28,17 +27,6 @@ namespace WrathCombo.Combos.PvE;
 // ReSharper disable MemberHidesStaticFromOuterClass
 internal partial class DNC
 {
-    /// <summary>
-    ///     Dancer Gauge data, just consolidated.
-    /// </summary>
-    private static DNCGauge Gauge => GetJobGauge<DNCGauge>();
-
-    /// <summary>
-    ///     DNC's GCD, truncated to two decimal places.
-    /// </summary>
-    private static double GCD =>
-        Math.Floor(GetCooldown(Cascade).CooldownTotal * 100) / 100;
-
     /// <summary>
     ///     Dancer Gauge data, just consolidated.
     /// </summary>
@@ -139,8 +127,8 @@ internal partial class DNC
     /// </param>
     /// <returns>
     ///     The Finisher to use, or if
-    ///     <see cref="CustomComboPreset.DNC_ST_BlockFinishes"/> is enabled and
-    ///     there is no enemy in range: <see cref="All.SavageBlade"/>.
+    ///     <see cref="CustomComboPreset.DNC_ST_BlockFinishes" /> is enabled and
+    ///     there is no enemy in range: <see cref="All.SavageBlade" />.
     /// </returns>
     private static uint FinishOrHold(uint desiredFinish)
     {

--- a/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
@@ -1,18 +1,18 @@
 ﻿#region
 
-using Dalamud.Game.ClientState.JobGauge.Types;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.Types;
+using ECommons.DalamudServices;
+using ECommons.GameHelpers;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
+using WrathCombo.Extensions;
 using WrathCombo.Services;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 using Options = WrathCombo.Combos.CustomComboPreset;
-
-// ReSharper disable ClassNeverInstantiated.Global
-// ReSharper disable CheckNamespace
 
 #endregion
 
@@ -29,40 +29,6 @@ namespace WrathCombo.Combos.PvE;
 internal partial class DNC
 {
     /// <summary>
-    ///     Logic to pick different openers.
-    /// </summary>
-    /// <returns>The chosen Opener.</returns>
-    internal static WrathOpener Opener()
-    {
-        if (Config.DNC_ST_OpenerSelection ==
-            (int) Config.Openers.FifteenSecond &&
-            Opener15S.LevelChecked)
-            return Opener15S;
-
-        if (Config.DNC_ST_OpenerSelection ==
-            (int) Config.Openers.SevenSecond &&
-            Opener07S.LevelChecked)
-            return Opener07S;
-
-        if (Config.DNC_ST_OpenerSelection ==
-            (int) Config.Openers.ThirtySecondTech &&
-            Opener30STech.LevelChecked)
-            return Opener30STech;
-
-        if (Config.DNC_ST_OpenerSelection ==
-            (int) Config.Openers.SevenPlusSecondTech &&
-            Opener07PlusSTech.LevelChecked)
-            return Opener07PlusSTech;
-
-        if (Config.DNC_ST_OpenerSelection ==
-            (int) Config.Openers.SevenSecondTech &&
-            Opener07STech.LevelChecked)
-            return Opener07STech;
-
-        return WrathOpener.Dummy;
-    }
-
-    /// <summary>
     ///     Dancer Gauge data, just consolidated.
     /// </summary>
     private static DNCGauge Gauge => GetJobGauge<DNCGauge>();
@@ -72,6 +38,40 @@ internal partial class DNC
     /// </summary>
     private static double GCD =>
         Math.Floor(GetCooldown(Cascade).CooldownTotal * 100) / 100;
+
+    /// <summary>
+    ///     Logic to pick different openers.
+    /// </summary>
+    /// <returns>The chosen Opener.</returns>
+    internal static WrathOpener Opener()
+    {
+        if (Config.DNC_ST_OpenerSelection ==
+            (int)Config.Openers.FifteenSecond &&
+            Opener15S.LevelChecked)
+            return Opener15S;
+
+        if (Config.DNC_ST_OpenerSelection ==
+            (int)Config.Openers.SevenSecond &&
+            Opener07S.LevelChecked)
+            return Opener07S;
+
+        if (Config.DNC_ST_OpenerSelection ==
+            (int)Config.Openers.ThirtySecondTech &&
+            Opener30STech.LevelChecked)
+            return Opener30STech;
+
+        if (Config.DNC_ST_OpenerSelection ==
+            (int)Config.Openers.SevenPlusSecondTech &&
+            Opener07PlusSTech.LevelChecked)
+            return Opener07PlusSTech;
+
+        if (Config.DNC_ST_OpenerSelection ==
+            (int)Config.Openers.SevenSecondTech &&
+            Opener07STech.LevelChecked)
+            return Opener07STech;
+
+        return WrathOpener.Dummy;
+    }
 
     /// <summary>
     ///     Check if the rotation is in Auto-Rotation.
@@ -102,23 +102,232 @@ internal partial class DNC
 
     #region Dance Partner
 
+    internal static ulong? CurrentDancePartner =>
+        GetPartyMembers()
+            .Where(HasMyPartner)
+            .Select(x => (ulong?)x.GameObjectId)
+            .FirstOrDefault();
+
     internal static ulong? DesiredDancePartner =>
         TryGetDancePartner(out var partner) ? partner.GameObjectId : null;
 
-    private static bool TryGetDancePartner(out IGameObject? partner)
+    private static bool TryGetDancePartner
+        (out IGameObject? partner, bool? callingFromFeature = null)
     {
         partner = null;
+        var playerID = LocalPlayer.GameObjectId;
+        var party = GetPartyMembers()
+            .Where(member => member.GameObjectId != playerID)
+            .Where(member => !member.BattleChara.IsDead)
+            .Where(member => IsInRange(member.BattleChara, 30))
+            .Where(member => !HasAnyPartner(member) || HasMyPartner(member))
+            .Select(member => member.BattleChara)
+            .ToList();
 
-        if (!IsEnabled(Options.DNC_ST_Adv_Partner))
+        // Bails
+        if (!Player.Available)
+            return false;
+        if (party.Count <= 1 && !HasCompanionPresent())
             return false;
 
-        if (!HasEffect(Buffs.ClosedPosition))
-            return false;
+        // Check if we have a target overriding any searching
+        /*
+         if (callingFromFeature is true &&
+            IsEnabled(Options.DNC_Desirable_TargetOverride) &&
+            LocalPlayer.TargetObject is IBattleChara &&
+            !LocalPlayer.TargetObject.IsDead &&
+            party.Any(x =>
+                x.GameObjectId == LocalPlayer.TargetObject.GameObjectId) &&
+            IsInRange(LocalPlayer.TargetObject, 30))
+        {
+            partner = LocalPlayer.TargetObject;
+            return true;
+        }*/
 
-        partner = GetPartyMembers();
+        // Search for a partner
+        if (TryGetBestPartner(out var bestPartner))
+        {
+            partner = bestPartner;
+            return true;
+        }
 
-        return partner != null;
+        // Fallback to companion
+        if (HasCompanionPresent())
+        {
+            partner = Svc.Buddies.CompanionBuddy.GameObject;
+            return true;
+        }
+
+        // Fallback to first party slot that isn't the player
+        if (party.Count > 1)
+        {
+            partner = party.First();
+            return true;
+        }
+
+        return false;
+
+        #region Sickness-checking shortcut methods
+
+        bool SicknessFree(IGameObject target)
+        {
+            return !TargetHasRezWeakness(target);
+        }
+
+        bool BrinkFree(IGameObject target)
+        {
+            return !TargetHasRezWeakness(target, false);
+        }
+
+        #endregion
+
+        bool TryGetBestPartner(out IGameObject? bestPartner, int step = 0)
+        {
+            #region Variable Setup
+
+            bestPartner = null;
+            var restrictions = PartnerPriority.RestrictionSteps[step];
+            var filter = party;
+            const int melee = (int)PartnerPriority.Role.Melee;
+            const int ranged = (int)PartnerPriority.Role.Ranged;
+
+            #endregion
+
+            if (restrictions.HasFlag(PartnerPriority.Restrictions.MustBeMelee))
+                filter = filter
+                    .Where(x => x.ClassJob.RowId.Role() is melee).ToList();
+
+            if (restrictions.HasFlag(PartnerPriority.Restrictions.MustBeDPS))
+                filter = filter
+                    .Where(x => x.ClassJob.RowId.Role() is melee or ranged)
+                    .ToList();
+
+            if (restrictions.HasFlag(PartnerPriority.Restrictions
+                    .MustBeSicknessFree))
+                filter = filter.Where(SicknessFree).ToList();
+
+            if (restrictions.HasFlag(PartnerPriority.Restrictions.MustBeBrinkFree))
+                filter = filter.Where(BrinkFree).ToList();
+
+            if (filter.Count == 0 &&
+                step < PartnerPriority.RestrictionSteps.Length - 1)
+                return TryGetBestPartner(out bestPartner, step + 1);
+            if (filter.Count == 0 && step == 6)
+                return false;
+
+            filter = filter
+                .OrderBy(x =>
+                    PartnerPriority.RolePrio.GetValueOrDefault(
+                        x.ClassJob.RowId.Role(), int.MaxValue))
+                .ThenBy(x =>
+                    Player.Level >= 90
+                        ? PartnerPriority.Job090Prio.GetValueOrDefault(
+                            x.ClassJob.RowId, int.MaxValue)
+                        : int.MaxValue)
+                .ThenBy(x =>
+                    Player.Level >= 100
+                        ? PartnerPriority.Job100Prio.GetValueOrDefault(
+                            x.ClassJob.RowId, int.MaxValue)
+                        : int.MaxValue)
+                .ToList();
+
+            bestPartner = filter.First();
+            return true;
+        }
     }
+
+    private static bool HasAnyPartner(WrathPartyMember target) =>
+        FindEffect(Buffs.Partner, target.BattleChara, null)
+            is not null;
+
+    private static bool HasMyPartner(WrathPartyMember target) =>
+        FindEffect(Buffs.Partner, target.BattleChara, LocalPlayer?.GameObjectId)
+            is not null;
+
+    #region Partner Priority Static Data
+
+    private static class PartnerPriority
+    {
+        internal static readonly Dictionary<int, int> RolePrio = new()
+        {
+            { (int)Role.Melee, 1 },
+            { (int)Role.Ranged, 1 },
+            { (int)Role.Tank, 2 },
+            { (int)Role.Healer, 3 },
+        };
+
+        internal static readonly Dictionary<uint, int> Job100Prio = new()
+        {
+            { PCT.JobID, 1 },
+            { SAM.JobID, 1 },
+            { RPR.JobID, 2 },
+            { VPR.JobID, 2 },
+            { MNK.JobID, 2 },
+            { NIN.JobID, 2 },
+            { DRG.JobID, 3 },
+            { BLM.JobID, 3 },
+            { RDM.JobID, 4 },
+            { SMN.JobID, 5 },
+            { MCH.JobID, 6 },
+            { BRD.JobID, 7 },
+            { JobID, 8 },
+        };
+
+        internal static readonly Dictionary<uint, int> Job090Prio = new()
+        {
+            { PCT.JobID, 0 },
+            { SAM.JobID, 1 },
+            { NIN.JobID, 2 },
+            { MNK.JobID, 3 },
+            { RPR.JobID, 4 },
+            { BLM.JobID, 5 },
+            { DRG.JobID, 6 },
+            { VPR.JobID, 7 },
+            { SMN.JobID, 8 },
+            { RDM.JobID, 9 },
+            { MCH.JobID, 10 },
+            { BRD.JobID, 11 },
+            { JobID, 12 },
+        };
+
+        internal static readonly Restrictions[] RestrictionSteps =
+        [
+            // Sickness-free DPS
+            Restrictions.MustBeMelee | Restrictions.MustBeSicknessFree,
+            Restrictions.MustBeDPS | Restrictions.MustBeSicknessFree,
+            // Sick DPS
+            Restrictions.MustBeMelee | Restrictions.MustBeBrinkFree,
+            Restrictions.MustBeDPS | Restrictions.MustBeBrinkFree,
+            // Sickness-free
+            Restrictions.MustBeSicknessFree,
+            // Sick
+            Restrictions.MustBeBrinkFree,
+            // :(
+            Restrictions.ScrapeTheBottom,
+        ];
+
+        internal enum Role
+        {
+            Tank = 1,
+            Melee = 2,
+
+            /// Casters and Phys Ranged
+            Ranged = 3,
+            Healer = 4,
+        }
+
+        [Flags]
+        internal enum Restrictions
+        {
+            MustBeMelee = 1 << 0, // 1
+            MustBeDPS = 1 << 1, // 2
+            MustBeSicknessFree = 1 << 2, // 4
+            MustBeBrinkFree = 1 << 3, // 8
+            ScrapeTheBottom = 1 << 4, // 16
+        }
+    }
+
+    #endregion
 
     #endregion
 
@@ -145,8 +354,8 @@ internal partial class DNC
     /// </summary>
     /// <param name="action">The action ID to check.</param>
     /// <param name="updatedAction">
-    ///     The matching dance step the action was assigned to.<br/>
-    ///     Will be Savage Blade if used and was not a custom dance step.<br/>
+    ///     The matching dance step the action was assigned to.<br />
+    ///     Will be Savage Blade if used and was not a custom dance step.<br />
     ///     Do not use this value if the return is <c>false</c>.
     /// </param>
     /// <returns>If the action was assigned as a custom dance step.</returns>
@@ -187,7 +396,6 @@ internal partial class DNC
     internal class FifteenSecondOpener : WrathOpener
     {
         public override int MinOpenerLevel => 100;
-
         public override int MaxOpenerLevel => 109;
 
         public override List<uint> OpenerActions { get; set; } =
@@ -279,7 +487,6 @@ internal partial class DNC
     internal class SevenSecondOpener : WrathOpener
     {
         public override int MinOpenerLevel => 100;
-
         public override int MaxOpenerLevel => 109;
 
         public override List<uint> OpenerActions { get; set; } =
@@ -375,7 +582,6 @@ internal partial class DNC
     internal class ThirtySecondTechOpener : WrathOpener
     {
         public override int MinOpenerLevel => 100;
-
         public override int MaxOpenerLevel => 109;
 
         public override List<uint> OpenerActions { get; set; } =
@@ -467,7 +673,6 @@ internal partial class DNC
     internal class SevenPlusSecondTechOpener : WrathOpener
     {
         public override int MinOpenerLevel => 100;
-
         public override int MaxOpenerLevel => 109;
 
         public override List<uint> OpenerActions { get; set; } =
@@ -550,7 +755,6 @@ internal partial class DNC
     internal class SevenSecondTechOpener : WrathOpener
     {
         public override int MinOpenerLevel => 100;
-
         public override int MaxOpenerLevel => 109;
 
         public override List<uint> OpenerActions { get; set; } =
@@ -678,6 +882,7 @@ internal partial class DNC
         Peloton = 7557,
         SaberDance = 16005,
         ClosedPosition = 16006,
+        Ending = 18073,
         EnAvant = 16010,
         Devilment = 16011,
         ShieldSamba = 16012,
@@ -716,6 +921,7 @@ internal partial class DNC
             // Other
             Peloton = 1199,
             ClosedPosition = 1823,
+            Partner = 1824,
             ShieldSamba = 1826,
             LastDanceReady = 3867,
             FinishingMoveReady = 3868,

--- a/WrathCombo/Combos/PvE/PLD/PLD_Helper.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD_Helper.cs
@@ -24,6 +24,7 @@ internal partial class PLD
         Bulwark = 22,
         CircleOfScorn = 23,
         ShieldLob = 24,
+        IronWill = 28,
         SpiritsWithin = 29,
         HallowedGround = 30,
         GoringBlade = 3538,

--- a/WrathCombo/CustomCombo/Functions/Status.cs
+++ b/WrathCombo/CustomCombo/Functions/Status.cs
@@ -4,6 +4,7 @@ using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using System.Collections.Generic;
 using System.Linq;
+using WrathCombo.Combos.PvE;
 using WrathCombo.Data;
 using WrathCombo.Services;
 using Status = Dalamud.Game.ClientState.Statuses.Status;
@@ -171,16 +172,16 @@ namespace WrathCombo.CustomComboNS.Functions
             return false;
         }
 
-        public static bool TargetHasRezWeakness(IGameObject? target)
+        public static bool TargetHasRezWeakness(IGameObject? target, bool checkForWeakness = true)
         {
-            foreach (var status in ActionWatching.GetStatusesByName(GetStatusName(43)))
-            {
+            if (checkForWeakness)
+                foreach (var status in ActionWatching.GetStatusesByName(
+                             GetStatusName(All.Debuffs.Weakness)))
+                    if (FindEffectOnMember((ushort)status, target) is not null) return true;
+
+            foreach (var status in ActionWatching.GetStatusesByName(
+                         GetStatusName(All.Debuffs.BrinkOfDeath)))
                 if (FindEffectOnMember((ushort)status, target) is not null) return true;
-            }
-            foreach (var status in ActionWatching.GetStatusesByName(GetStatusName(44)))
-            {
-                if (FindEffectOnMember((ushort)status, target) is not null) return true;
-            }
 
             return false;
         }

--- a/WrathCombo/Extensions/UIntExtensions.cs
+++ b/WrathCombo/Extensions/UIntExtensions.cs
@@ -10,6 +10,8 @@ namespace WrathCombo.Extensions
         internal static bool TraitLevelChecked(this uint value) => CustomComboFunctions.TraitLevelChecked(value);
 
         internal static string ActionName(this uint value) => ActionWatching.GetActionName(value);
+
+        internal static int Role(this uint value) => CustomComboFunctions.JobIDs.JobIDToRole(value);
     }
 
     internal static class UShortExtensions

--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -40,7 +40,7 @@ namespace WrathCombo;
 public sealed partial class WrathCombo : IDalamudPlugin
 {
     internal static TaskManager? TM;
-    private readonly ConfigWindow ConfigWindow;
+    internal readonly ConfigWindow ConfigWindow;
     private readonly SettingChangeWindow SettingChangeWindow;
     private readonly TargetHelper TargetHelper;
     internal static WrathCombo? P;


### PR DESCRIPTION
- [X] Adds new Territory Change code that runs if IPC-Controlled when loading into an area
  - [X] If a tank or DNC:
    - [X] Will try to cast the correct Tank Stance, or apply Dance Partner
    - [X] Will retry up to 10 times, with delays between
- [X] Adds DNC logic for Dance Partner selection
- [X] Adds basis for DNC Feature to make `Closed Position` cast onto the correct partner
      (Does not add this option, as it wouldn't work for a couple of reasons. Relies on `RetargetedActions`)

> [!NOTE]
> This includes #373.