### PR TITLE
[IPC] Various Fixes, including Freeze

### DIFF
--- a/WrathCombo/Services/IPC/Helper.cs
+++ b/WrathCombo/Services/IPC/Helper.cs
@@ -373,6 +373,7 @@ public partial class Helper(ref Leasing leasing)
             }
             catch (Exception e)
             {
+                data = "enabled";
                 Logging.Error(
                     "Failed to check IPC status. Assuming it is enabled.\n" +
                     e.Message

--- a/WrathCombo/Services/IPC/Helper.cs
+++ b/WrathCombo/Services/IPC/Helper.cs
@@ -128,9 +128,9 @@ public partial class Helper(ref Leasing leasing)
     /// </param>
     /// <param name="previousMatch">
     ///     The <see cref="ComboSimplicityLevelKeys">Simplicity Level</see> that
-    ///     was used in the last call of this method, to make sure that it uses
-    ///     the same level for both checking if enabled and enabled in Auto-Mode.
-    ///     <br />
+    ///     was used in the last set of calls of this method, to make sure that it
+    ///     uses the same level for both checking if enabled and enabled in
+    ///     Auto-Mode.<br />
     ///     Or <see langword="null" /> if it is the first call, so the level can be
     ///     set.
     /// </param>
@@ -140,13 +140,13 @@ public partial class Helper(ref Leasing leasing)
     /// </returns>
     /// <seealso cref="Provider.IsCurrentJobConfiguredOn" />
     /// <seealso cref="Provider.IsCurrentJobAutoModeOn" />
-    internal bool CheckCurrentJobModeIsEnabled
+    internal ComboSimplicityLevelKeys? CheckCurrentJobModeIsEnabled
             (ComboTargetTypeKeys mode,
             ComboStateKeys enabledStateToCheck,
-            ref ComboSimplicityLevelKeys? previousMatch)
+            ComboSimplicityLevelKeys? previousMatch = null)
     {
         if (CustomComboFunctions.LocalPlayer is null)
-            return false;
+            return null;
 
         // Convert current job/class to a job, if it is a class
         var currentJobRow = CustomComboFunctions.LocalPlayer.ClassJob;
@@ -159,7 +159,7 @@ public partial class Helper(ref Leasing leasing)
             out var comboStates);
 
         if (comboStates is null || comboStates.Count == 0)
-            return false;
+            return null;
 
         comboStates[mode]
             .TryGetValue(ComboSimplicityLevelKeys.Simple, out var simpleResults);
@@ -168,26 +168,22 @@ public partial class Helper(ref Leasing leasing)
         var advanced =
             comboStates[mode][ComboSimplicityLevelKeys.Advanced].First().Value;
 
-        // Save the simplicity level, so the same level can be checked for enabled
-        // and enabled in Auto-Mode
-        if (previousMatch is null)
-        {
-            if (simple is not null && simple[enabledStateToCheck])
-                previousMatch = ComboSimplicityLevelKeys.Simple;
-            else if (advanced[enabledStateToCheck])
-                previousMatch = ComboSimplicityLevelKeys.Advanced;
-        }
-
         // If the simplicity level is set, check that specifically instead of either
         if (previousMatch is not null)
         {
-            if (previousMatch == ComboSimplicityLevelKeys.Simple)
-                return simple is not null && simple[enabledStateToCheck];
-            return advanced[enabledStateToCheck];
+            if (previousMatch == ComboSimplicityLevelKeys.Simple &&
+                simple is not null && simple[enabledStateToCheck])
+                return ComboSimplicityLevelKeys.Simple;
+            return advanced[enabledStateToCheck]
+                ? ComboSimplicityLevelKeys.Advanced
+                : null;
         }
 
-        return simple is not null && simple[enabledStateToCheck] ||
-               advanced[enabledStateToCheck];
+        return simple is not null && simple[enabledStateToCheck]
+            ? ComboSimplicityLevelKeys.Simple
+            : advanced[enabledStateToCheck]
+                ? ComboSimplicityLevelKeys.Advanced
+                : null;
     }
 
     /// <summary>

--- a/WrathCombo/Services/IPC/Leasing.cs
+++ b/WrathCombo/Services/IPC/Leasing.cs
@@ -310,7 +310,7 @@ public partial class Leasing
         if (registration.AutoRotationConfigsControlled.Count > 0 &&
             registration.AutoRotationControlled[0] == newState)
         {
-            if ((DateTime.Now - _lastAutoRotationSetCheck).TotalSeconds >= 30)
+            if ((DateTime.Now - _lastAutoRotationSetCheck).TotalSeconds >= 15)
             {
                 Logging.Log(
                     $"{registration.PluginName}: You are already controlling Auto-Rotation");
@@ -358,6 +358,8 @@ public partial class Leasing
         return lease?.JobsControlled[resolvedJob];
     }
 
+    private DateTime _lasJobSetCheck = DateTime.MinValue;
+
     /// <summary>
     ///     Adds a registration for the current Job to a lease.
     /// </summary>
@@ -391,8 +393,12 @@ public partial class Leasing
 
         if (!registration.JobsControlled.TryAdd(currentJob, true))
         {
-            Logging.Log(
-                $"{registration.PluginName}: You are already controlling the current job ({job})");
+            if ((DateTime.Now - _lasJobSetCheck).TotalSeconds >= 15)
+            {
+                Logging.Log(
+                    $"{registration.PluginName}: You are already controlling the current job ({job})");
+                _lasJobSetCheck = DateTime.Now;
+            }
             return SetResult.Duplicate;
         }
 

--- a/WrathCombo/Services/IPC/Leasing.cs
+++ b/WrathCombo/Services/IPC/Leasing.cs
@@ -293,6 +293,8 @@ public partial class Leasing
         return _autoRotationStateUpdated;
     }
 
+    private DateTime _lastAutoRotationSetCheck = DateTime.MinValue;
+
     /// <summary>
     ///     Adds a registration for Auto-Rotation control to a lease.
     /// </summary>
@@ -308,8 +310,12 @@ public partial class Leasing
         if (registration.AutoRotationConfigsControlled.Count > 0 &&
             registration.AutoRotationControlled[0] == newState)
         {
-            Logging.Log(
-                $"{registration.PluginName}: You are already controlling Auto-Rotation");
+            if ((DateTime.Now - _lastAutoRotationSetCheck).TotalSeconds >= 30)
+            {
+                Logging.Log(
+                    $"{registration.PluginName}: You are already controlling Auto-Rotation");
+                _lastAutoRotationSetCheck = DateTime.Now;
+            }
             return SetResult.Duplicate;
         }
 

--- a/WrathCombo/Services/IPC/Provider.cs
+++ b/WrathCombo/Services/IPC/Provider.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using WrathCombo.Combos;
 
 // ReSharper disable UnusedMethodReturnValue.Global
@@ -287,6 +288,11 @@ public partial class Provider : IDisposable
     }
 
     /// <summary>
+    ///     The last time the current job was reported as not ready.
+    /// </summary>
+    private DateTime _lastJobReadyLog = DateTime.MinValue;
+
+    /// <summary>
     ///     Checks if the current job has a Single and Multi-Target combo configured
     ///     that are enabled in Auto-Mode.
     /// </summary>
@@ -298,11 +304,27 @@ public partial class Provider : IDisposable
     [EzIPC]
     public bool IsCurrentJobAutoRotationReady()
     {
-        // Check if job has a Single and Multi-Target combo configured on and
-        // enabled in Auto-Mode
-        return
-            IsCurrentJobConfiguredOn().All(x => x.Value) &&
-            IsCurrentJobAutoModeOn().All(x => x.Value);
+        // Check if the current job has a Single and Multi-Target combo configured on
+        var jobOn = IsCurrentJobConfiguredOn();
+        // Check if the current job has those same combos configured on in Auto-Mode
+        var jobAutoOn = InternalIsCurrentJobAutoModeOn(jobOn);
+
+        // Check that all combos are configured and enabled in Auto-Mode
+        var allGood = jobOn.All(x => x.Value is not null) &&
+               jobAutoOn.All(x => x.Value is not null);
+
+        // Log if not ready
+        if (!allGood && (DateTime.Now - _lastJobReadyLog).TotalSeconds > 15)
+        {
+            Logging.Warn(
+                $"Current job is not fully ready for Auto-Rotation.\n" +
+                $"jobOn: {JsonConvert.SerializeObject(jobOn)}\n" +
+                $"jobAutoOn: {JsonConvert.SerializeObject(jobAutoOn)}"
+            );
+            _lastJobReadyLog = DateTime.Now;
+        }
+
+        return allGood;
     }
 
     /// <summary>
@@ -375,22 +397,19 @@ public partial class Provider : IDisposable
     /// <seealso cref="Helper.CheckCurrentJobModeIsEnabled" />
     [EzIPC]
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
-    public Dictionary<ComboTargetTypeKeys, bool> IsCurrentJobConfiguredOn()
+    public Dictionary<ComboTargetTypeKeys, ComboSimplicityLevelKeys?> IsCurrentJobConfiguredOn()
     {
-        ComboSimplicityLevelKeys? previousMatch = null;
-        return new Dictionary<ComboTargetTypeKeys, bool>
+        return new Dictionary<ComboTargetTypeKeys, ComboSimplicityLevelKeys?>
         {
             {
                 ComboTargetTypeKeys.SingleTarget,
                 Helper.CheckCurrentJobModeIsEnabled(
-                    ComboTargetTypeKeys.SingleTarget, ComboStateKeys.Enabled,
-                    ref previousMatch)
+                    ComboTargetTypeKeys.SingleTarget, ComboStateKeys.Enabled)
             },
             {
                 ComboTargetTypeKeys.MultiTarget,
                 Helper.CheckCurrentJobModeIsEnabled(
-                    ComboTargetTypeKeys.MultiTarget, ComboStateKeys.Enabled,
-                    ref previousMatch)
+                    ComboTargetTypeKeys.MultiTarget, ComboStateKeys.Enabled)
             },
         };
     }
@@ -400,29 +419,59 @@ public partial class Provider : IDisposable
     ///     combo enabled in Auto-Mode.
     /// </summary>
     /// <returns>
-    ///     <see cref="ComboTargetTypeKeys.SingleTarget" /> - a <c>bool</c> indicating if
-    ///     a Single-Target combo is enabled in Auto-Mode.<br />
-    ///     <see cref="ComboTargetTypeKeys.MultiTarget" /> - a <c>bool</c> indicating if
-    ///     a Multi-Target combo is enabled in Auto-Mode.
+    ///     <see cref="ComboTargetTypeKeys.SingleTarget" /> - a
+    ///     <see cref="ComboSimplicityLevelKeys">SimplicityLevel?</see> indicating
+    ///     what mode, if any, is enabled for Auto-Mode for Single-Target.<br />
+    ///     <see cref="ComboTargetTypeKeys.MultiTarget" /> - a
+    ///     <see cref="ComboSimplicityLevelKeys">SimplicityLevel?</see> indicating
+    ///     what mode, if any, is enabled for Auto-Mode for Multi-Target.<br />
     /// </returns>
     [EzIPC]
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
-    public Dictionary<ComboTargetTypeKeys, bool> IsCurrentJobAutoModeOn()
+    public Dictionary<ComboTargetTypeKeys, ComboSimplicityLevelKeys?>
+        IsCurrentJobAutoModeOn()
     {
-        ComboSimplicityLevelKeys? previousMatch = null;
-        return new Dictionary<ComboTargetTypeKeys, bool>
+        return new Dictionary<ComboTargetTypeKeys, ComboSimplicityLevelKeys?>
+        {
+            {
+                ComboTargetTypeKeys.SingleTarget,
+                Helper.CheckCurrentJobModeIsEnabled(
+                    ComboTargetTypeKeys.SingleTarget, ComboStateKeys.AutoMode)
+            },
+            {
+                ComboTargetTypeKeys.MultiTarget,
+                Helper.CheckCurrentJobModeIsEnabled(
+                    ComboTargetTypeKeys.MultiTarget, ComboStateKeys.AutoMode)
+            },
+        };
+    }
+
+    /// <summary>
+    ///     Same as <see cref="IsCurrentJobAutoModeOn" />, but with a parameter
+    ///     to make sure that Auto-Mode is enabled for the same enabled combos.
+    /// </summary>
+    /// <param name="previousMatches">
+    ///     The result of <see cref="IsCurrentJobConfiguredOn" />.
+    /// </param>
+    /// <returns></returns>
+    /// <seealso cref="IsCurrentJobAutoModeOn"/>
+    private Dictionary<ComboTargetTypeKeys, ComboSimplicityLevelKeys?>
+        InternalIsCurrentJobAutoModeOn
+        (Dictionary<ComboTargetTypeKeys, ComboSimplicityLevelKeys?> previousMatches)
+    {
+        return new Dictionary<ComboTargetTypeKeys, ComboSimplicityLevelKeys?>
         {
             {
                 ComboTargetTypeKeys.SingleTarget,
                 Helper.CheckCurrentJobModeIsEnabled(
                     ComboTargetTypeKeys.SingleTarget, ComboStateKeys.AutoMode,
-                    ref previousMatch)
+                    previousMatches[ComboTargetTypeKeys.SingleTarget])
             },
             {
                 ComboTargetTypeKeys.MultiTarget,
                 Helper.CheckCurrentJobModeIsEnabled(
                     ComboTargetTypeKeys.MultiTarget, ComboStateKeys.AutoMode,
-                    ref previousMatch)
+                    previousMatches[ComboTargetTypeKeys.MultiTarget])
             },
         };
     }

--- a/WrathCombo/Services/IPC/Provider.cs
+++ b/WrathCombo/Services/IPC/Provider.cs
@@ -6,6 +6,7 @@ using ECommons.GameHelpers;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -293,6 +294,16 @@ public partial class Provider : IDisposable
     private DateTime _lastJobReadyLog = DateTime.MinValue;
 
     /// <summary>
+    ///     The last time there was a full check for the current job's readiness.
+    /// </summary>
+    private DateTime _lastJobReadyCheck = DateTime.MinValue;
+
+    /// <summary>
+    ///     The state of the last <see cref="IsCurrentJobAutoRotationReady" /> check.
+    /// </summary>
+    private bool _lastJobReady;
+
+    /// <summary>
     ///     Checks if the current job has a Single and Multi-Target combo configured
     ///     that are enabled in Auto-Mode.
     /// </summary>
@@ -304,6 +315,10 @@ public partial class Provider : IDisposable
     [EzIPC]
     public bool IsCurrentJobAutoRotationReady()
     {
+        if (File.GetLastWriteTime(P.IPCSearch.ConfigFilePath) <= _lastJobReadyCheck &&
+            (DateTime.Now - _lastJobReadyCheck).TotalSeconds <= 45)
+            return _lastJobReady;
+
         // Check if the current job has a Single and Multi-Target combo configured on
         var jobOn = IsCurrentJobConfiguredOn();
         // Check if the current job has those same combos configured on in Auto-Mode
@@ -324,6 +339,8 @@ public partial class Provider : IDisposable
             _lastJobReadyLog = DateTime.Now;
         }
 
+        _lastJobReadyCheck = DateTime.Now;
+        _lastJobReady = allGood;
         return allGood;
     }
 

--- a/WrathCombo/Services/IPC/Search.cs
+++ b/WrathCombo/Services/IPC/Search.cs
@@ -195,7 +195,7 @@ public class Search(Leasing leasing)
     /// <summary>
     ///     The path to the configuration file for Wrath Combo.
     /// </summary>
-    private string ConfigFilePath
+    internal string ConfigFilePath
     {
         get
         {


### PR DESCRIPTION
- [X] Prevents log spam from setting Auto-Rotation's state
- [X] Prevents `GetOppositeModeCombo` from working with Features, giving false Disables
- [X] Fixes issue with suspending all leases when HTTP request times out
- [X] Rework `IsCurrentJobAutoRotationReady`, and its children, to be more resilient and heavily cached.
      Now also won't cross wires between enabled/enabled in auto-mode for simple vs advanced.
      This is the fix for the freeze some folks were getting.