### PR TITLE
[PCT] Add option to prioritize instant casts when `Inspiration` and `Hyperphantasia` are active

### DIFF
--- a/WrathCombo/Combos/PvE/PCT/PCT_Config.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT_Config.cs
@@ -26,10 +26,13 @@ internal partial class PCT
             PCT_Balance_Content = new("PCT_Balance_Content", 1);
 
         public static UserBool
+            WhiteHyperphantasiaOption = new("WhiteHyperphantasiaOption"),
+            BlackHyperphantasiaOption = new("BlackHyperphantasiaOption"),
             CombinedMotifsMog = new("CombinedMotifsMog"),
             CombinedMotifsMadeen = new("CombinedMotifsMadeen"),
             CombinedMotifsWeapon = new("CombinedMotifsWeapon"),
             CombinedMotifsLandscape = new("CombinedMotifsLandscape");
+
 
         internal static void Draw(CustomComboPreset preset)
         {
@@ -70,6 +73,17 @@ internal partial class PCT
                     UserConfig.DrawAdditionalBoolChoice(CombinedMotifsLandscape, $"{StarPrism.ActionName()} Feature",
                         $"Add {StarPrism.ActionName()} when under the effect of {Buffs.Starstruck.StatusName()}.");
                     break;
+
+                case CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HolyInWhite:
+                    UserConfig.DrawAdditionalBoolChoice(WhiteHyperphantasiaOption, "Hyperphantasia Priority Option",
+                        $"Prioritizes {HolyInWhite.ActionName()} if {Buffs.Inspiration.StatusName()} and {Buffs.Hyperphantasia.StatusName()} are active.");
+                    break;
+
+                case CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_CometinBlack:
+                    UserConfig.DrawAdditionalBoolChoice(BlackHyperphantasiaOption, "Hyperphantasia Priority Option",
+                        $"Prioritizes {CometinBlack.ActionName()} if {Buffs.Inspiration.StatusName()} and {Buffs.Hyperphantasia.StatusName()} are active.");
+                    break;
+
 
                 case CustomComboPreset.PCT_ST_AdvancedMode_LucidDreaming:
                     UserConfig.DrawSliderInt(0, 10000, PCT_ST_AdvancedMode_LucidOption,


### PR DESCRIPTION
Previously, there were situations where if we had to move outside our Ley Lines during `Starry Muse` windows it would force-use `Hammer Combo` over `Comet In Black` and `Holy In White` regardless of conditions, which would cause `Rainbow Bright` to not generate sometimes due to moving outside of buff or not being able to spend `Hyperphantasia` stacks quickly enough. 

This PR adds an option to both casts to prioritize using them immediately when inside Ley Lines over `Hammer Combo` while moving.

![image](https://github.com/user-attachments/assets/571c38f4-f103-41fd-bae4-7ca597fb26c5) <br/>
![image](https://github.com/user-attachments/assets/66306572-2f4d-43ef-b0c4-445c5dcd27a9)
