### PR TITLE
[UI] Minor fixes

### DIFF
--- a/WrathCombo/Commands.cs
+++ b/WrathCombo/Commands.cs
@@ -575,10 +575,15 @@ public partial class WrathCombo
             return;
         }
 
-        // Open to current job setting
-        PvEFeatures.OpenToCurrentJob(false);
+        // If no arguments provided
+        if (argument[0].Length <= 0)
+        {
+            // Handle the "Open to current job" setting
+            PvEFeatures.OpenToCurrentJob(false);
 
-        if (argument[0].Length <= 0) return;
+            // Skip trying to process arguments
+            return;
+        }
 
         // Open to specified job
         var jobName = argument[0].ToUpperInvariant();

--- a/WrathCombo/Commands.cs
+++ b/WrathCombo/Commands.cs
@@ -579,7 +579,8 @@ public partial class WrathCombo
         if (argument[0].Length <= 0)
         {
             // Handle the "Open to current job" setting
-            PvEFeatures.OpenToCurrentJob(false);
+            if (ConfigWindow.IsOpen)
+                PvEFeatures.OpenToCurrentJob(false);
 
             // Skip trying to process arguments
             return;

--- a/WrathCombo/Window/Tabs/PvEFeatures.cs
+++ b/WrathCombo/Window/Tabs/PvEFeatures.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Dalamud.Interface.Textures.TextureWraps;
-using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using ECommons.ExcelServices;
 using ECommons.GameHelpers;
@@ -11,10 +10,10 @@ using System.Numerics;
 using ECommons.Logging;
 using WrathCombo.Combos.PvE;
 using WrathCombo.Core;
-using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Services;
 using WrathCombo.Window.Functions;
 using WrathCombo.Window.MessagesNS;
+using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions.JobIDs;
 
 namespace WrathCombo.Window.Tabs
 {
@@ -251,13 +250,9 @@ namespace WrathCombo.Window.Tabs
                 return;
             }
 
-            var job = (Job)CustomComboFunctions.JobIDs.ClassToJob((uint)Player.Job);
-
-            OpenJob = groupedPresets
-                .FirstOrDefault(x =>
-                    x.Value.Any(y => y.Info.JobShorthand == job.ToString()))
-                .Key;
-
+            var job = JobIDToName(ClassToJob((uint)Player.Job));
+            if (groupedPresets.TryGetValue(job, out var foundJob))
+                OpenJob = foundJob.First().Info.JobName;
         }
     }
 }

--- a/WrathCombo/Window/Tabs/PvEFeatures.cs
+++ b/WrathCombo/Window/Tabs/PvEFeatures.cs
@@ -247,8 +247,7 @@ namespace WrathCombo.Window.Tabs
 
             if (Player.Job.IsDol())
             {
-                OpenJob = groupedPresets
-                    .FirstOrDefault(x => x.Value.Any(y => y.Info.JobID == DOL.JobID)).Key;
+                OpenJob = JobIDToName(DOL.JobID);
                 return;
             }
 

--- a/WrathCombo/Window/Tabs/PvEFeatures.cs
+++ b/WrathCombo/Window/Tabs/PvEFeatures.cs
@@ -11,6 +11,7 @@ using System.Numerics;
 using ECommons.Logging;
 using WrathCombo.Combos.PvE;
 using WrathCombo.Core;
+using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Services;
 using WrathCombo.Window.Functions;
 using WrathCombo.Window.MessagesNS;
@@ -251,9 +252,11 @@ namespace WrathCombo.Window.Tabs
                 return;
             }
 
+            var job = (Job)CustomComboFunctions.JobIDs.ClassToJob((uint)Player.Job);
+
             OpenJob = groupedPresets
                 .FirstOrDefault(x =>
-                    x.Value.Any(y => y.Info.JobShorthand == Player.Job.ToString()))
+                    x.Value.Any(y => y.Info.JobShorthand == job.ToString()))
                 .Key;
 
         }

--- a/WrathCombo/Window/Tabs/Settings.cs
+++ b/WrathCombo/Window/Tabs/Settings.cs
@@ -177,7 +177,7 @@ namespace WrathCombo.Window.Tabs
                     "\n\nIf you have minor FPS issues, you can increase this value to make combos run less often." +
                     "\nThis makes your combos less responsive, and perhaps even clips GCDs." +
                     "\nAt high values, this can break your rotation entirely." +
-                    "\nMore severe FPS issues should instead be handled with Performance Mode below." +
+                    "\nMore severe FPS issues should instead be handled with Performance Mode option above." +
                     "\n\n200ms can make a reasonable difference in your FPS." +
                     "\nValues over 500ms are NOT recommended.");
 

--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -197,6 +197,9 @@ public sealed partial class WrathCombo : IDalamudPlugin
 
 #if DEBUG
         ConfigWindow.IsOpen = true;
+
+        if (Service.Configuration.OpenToCurrentJob && Player.Available)
+            HandleOpenCommand([Player.Job.ToString()], forceOpen:true);
 #endif
     }
 

--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -199,7 +199,7 @@ public sealed partial class WrathCombo : IDalamudPlugin
         ConfigWindow.IsOpen = true;
 
         if (Service.Configuration.OpenToCurrentJob && Player.Available)
-            HandleOpenCommand([Player.Job.ToString()], forceOpen:true);
+            HandleOpenCommand([""], forceOpen:true);
 #endif
     }
 


### PR DESCRIPTION
- [X] Fixed hover text referencing another option, for an option that was moved.
- [X] In debug builds: If `OpenToCurrentJob` is enabled, open the plugin on load to the current job. (if available)
- [X] Fixed classes opening to nonexistent PvE sections