### PR TITLE
[Core] `/wrath toggle <x>` improvements

### DIFF
--- a/WrathCombo/Commands.cs
+++ b/WrathCombo/Commands.cs
@@ -224,6 +224,13 @@ public partial class WrathCombo
             var usablePreset = (CustomComboPreset)preset!;
             method(usablePreset, false);
 
+            if (action == toggle)
+                action =
+                    Service.Configuration.EnabledActions
+                        .TryGetValue(usablePreset, out _)
+                        ? set
+                        : unset;
+
             var ctrlText = P.UIHelper.PresetControlled(usablePreset) is not null
                 ? " " + OptionControlledByIPC
                 : "";

--- a/WrathCombo/Commands.cs
+++ b/WrathCombo/Commands.cs
@@ -190,9 +190,17 @@ public partial class WrathCombo
         if (target != all)
         {
             var presetCanNumber = int.TryParse(target, out var targetNumber);
-            preset = presetCanNumber
-                ? (CustomComboPreset)targetNumber
-                : Enum.Parse<CustomComboPreset>(target, true);
+            try
+            {
+                preset = presetCanNumber
+                    ? (CustomComboPreset)targetNumber
+                    : Enum.Parse<CustomComboPreset>(target, true);
+            }
+            catch
+            {
+                DuoLog.Error($"Could not find preset '{target}'");
+                return;
+            }
         }
 
         // Give the correct method for the action

--- a/WrathCombo/Commands.cs
+++ b/WrathCombo/Commands.cs
@@ -236,7 +236,7 @@ public partial class WrathCombo
                 : "";
 
             DuoLog.Information(
-                $"{target} {(action == toggle ? "toggled" : action)} {ctrlText}");
+                $"{usablePreset.Attributes().CustomComboInfo.Name} {action} {ctrlText}");
         }
     }
 


### PR DESCRIPTION
- [X] Now tells you if the preset was flipped to be enabled, or not.
      (Instead of simply saying it was "toggled")
      Closes #388
- [X] Now gives an error if the preset cannot be found
- [X] Now Displays the actual Preset name instead of whatever was input.
      `/wrath toggle 5001` gives `[WrathCombo] Simple Mode - Single Target set`
      `/wrath toggle DRK_ST_Adv` gives `[WrathCombo] Advanced Mode - Single Target set`