### PR TITLE
[DRK] Improve Dark Arts usage

### DIFF
--- a/WrathCombo/Combos/PvE/DRK/DRK_Config.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Config.cs
@@ -117,6 +117,10 @@ internal partial class DRK
                         DRK_ST_ManaSpenderPoolingDifficulty,
                         DRK_ST_ManaSpenderPoolingDifficultyListSet
                     );
+                    UserConfig.DrawSliderInt(0, 45, DRK_ST_BurstSoonThreshold,
+                        "Seconds before Burst to start saving Mana and Dark Arts (0 = Don't save)",
+                        itemWidth: little,
+                        sliderIncrement: SliderIncrements.Fives);
 
                     break;
 
@@ -646,6 +650,19 @@ internal partial class DRK
         /// <seealso cref="CustomComboPreset.DRK_ST_Sp_Edge" />
         public static readonly UserInt DRK_ST_ManaSpenderPooling =
             new("DRK_ST_ManaSpenderPooling", 3000);
+
+        /// <summary>
+        ///     Number of seconds before burst that high mana will be allowed within,
+        ///     and attempts to save Dark Arts will start working in.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 30<br />
+        ///     <b>Range</b>: 0 - 45 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Fives" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.DRK_ST_Sp_Edge" />
+        public static readonly UserInt DRK_ST_BurstSoonThreshold =
+            new("DRK_ST_BurstSoonThreshold", 30);
 
         /// <summary>
         ///     Difficulty of Mana Spender Pooling for Single Target.

--- a/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
@@ -942,6 +942,20 @@ internal partial class DRK
 
             #endregion
 
+            #region Mana Dark Arts Drop Prevention
+
+            if ((flags.HasFlag(Combo.Simple) ||
+                 ((flags.HasFlag(Combo.ST) &&
+                   IsEnabled(Preset.DRK_ST_Sp_DarkArts)) ||
+                  flags.HasFlag(Combo.AoE) && IsEnabled(Preset.DRK_AoE_Sp_Flood))) &&
+                Gauge.HasDarkArts && HasOwnTBN)
+                if (flags.HasFlag(Combo.ST) && LevelChecked(EdgeOfDarkness))
+                    return (action = OriginalHook(EdgeOfDarkness)) != 0;
+                else
+                    return (action = OriginalHook(FloodOfDarkness)) != 0;
+
+            #endregion
+
             // Bail if we're trying to save Dark Arts for burst
             if (Gauge.HasDarkArts && evenBurstSoon) return false;
 
@@ -951,22 +965,6 @@ internal partial class DRK
                  ((flags.HasFlag(Combo.ST) && IsEnabled(Preset.DRK_ST_Sp_Edge)) ||
                   flags.HasFlag(Combo.AoE) && IsEnabled(Preset.DRK_AoE_Sp_Flood))) &&
                 !evenBurstSoon)
-                if (flags.HasFlag(Combo.ST) && LevelChecked(EdgeOfDarkness))
-                    return (action = OriginalHook(EdgeOfDarkness)) != 0;
-                else
-                    return (action = OriginalHook(FloodOfDarkness)) != 0;
-
-            #endregion
-
-            #region Mana Dark Arts Drop Prevention
-
-            if ((flags.HasFlag(Combo.Simple) ||
-                 ((flags.HasFlag(Combo.ST) &&
-                   IsEnabled(Preset.DRK_ST_Sp_DarkArts)) ||
-                  flags.HasFlag(Combo.AoE) && IsEnabled(Preset.DRK_AoE_Sp_Flood))) &&
-                Gauge.HasDarkArts &&
-                (bursting ||
-                 (!evenBurstSoon && HasOwnTBN)))
                 if (flags.HasFlag(Combo.ST) && LevelChecked(EdgeOfDarkness))
                     return (action = OriginalHook(EdgeOfDarkness)) != 0;
                 else

--- a/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
@@ -877,7 +877,7 @@ internal partial class DRK
                     ? manaPooling ? (int)Config.DRK_ST_ManaSpenderPooling : 0
                     : (int)Config.DRK_AoE_ManaSpenderPooling
                 : 0;
-            var hasEnoughMana = mana >= (manaPool + 3000);
+            var hasEnoughMana = mana >= (manaPool + 3000) || Gauge.HasDarkArts;
             var manaEvenBurstSoon =
                 GetCooldownRemainingTime(LivingShadow) is > 0 and < 30;
             var manaBursting =

--- a/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
@@ -891,7 +891,41 @@ internal partial class DRK
 
             #endregion
 
-            #region Mana Burst
+            #region Mana Overcap
+
+            if ((flags.HasFlag(Combo.Simple) ||
+                 ((flags.HasFlag(Combo.ST) &&
+                   IsEnabled(Preset.DRK_ST_Sp_ManaOvercap)) ||
+                  flags.HasFlag(Combo.AoE) &&
+                  IsEnabled(Preset.DRK_AoE_Sp_ManaOvercap))) &&
+                mana >= 8500 &&
+                !manaEvenBurstSoon)
+                if (flags.HasFlag(Combo.ST) && LevelChecked(EdgeOfDarkness))
+                    return (action = OriginalHook(EdgeOfDarkness)) != 0;
+                else
+                    return (action = OriginalHook(FloodOfDarkness)) != 0;
+
+            #endregion
+
+            #region Darkside Maintenance
+
+            if ((flags.HasFlag(Combo.Simple) ||
+                 ((flags.HasFlag(Combo.ST) &&
+                   IsEnabled(Preset.DRK_ST_Sp_EdgeDarkside)) ||
+                  flags.HasFlag(Combo.AoE) &&
+                  IsEnabled(Preset.DRK_AoE_Sp_Flood))) &&
+                manaDarksideDropping)
+                if (flags.HasFlag(Combo.ST) && LevelChecked(EdgeOfDarkness))
+                    return (action = OriginalHook(EdgeOfDarkness)) != 0;
+                else
+                    return (action = OriginalHook(FloodOfDarkness)) != 0;
+
+            #endregion
+
+            // Bail if it is too early into the fight
+            if (CombatEngageDuration().TotalSeconds <= 10) return false;
+
+            #region Burst Phase Spending
 
             if ((flags.HasFlag(Combo.Simple) ||
                  ((flags.HasFlag(Combo.ST) && IsEnabled(Preset.DRK_ST_Sp_Edge)) ||
@@ -920,24 +954,6 @@ internal partial class DRK
 
             #endregion
 
-            #region Mana Darkside Maintenance
-
-            if ((flags.HasFlag(Combo.Simple) ||
-                 ((flags.HasFlag(Combo.ST) &&
-                   IsEnabled(Preset.DRK_ST_Sp_EdgeDarkside)) ||
-                  flags.HasFlag(Combo.AoE) &&
-                  IsEnabled(Preset.DRK_AoE_Sp_Flood))) &&
-                manaDarksideDropping)
-                if (flags.HasFlag(Combo.ST) && LevelChecked(EdgeOfDarkness))
-                    return (action = OriginalHook(EdgeOfDarkness)) != 0;
-                else
-                    return (action = OriginalHook(FloodOfDarkness)) != 0;
-
-            #endregion
-
-            // Bail if it is too early into the fight
-            if (CombatEngageDuration().TotalSeconds <= 10) return false;
-
             #region Mana Dark Arts Drop Prevention
 
             if ((flags.HasFlag(Combo.Simple) ||
@@ -947,22 +963,6 @@ internal partial class DRK
                 Gauge.HasDarkArts &&
                 (manaBursting ||
                  (!manaEvenBurstSoon && HasOwnTBN)))
-                if (flags.HasFlag(Combo.ST) && LevelChecked(EdgeOfDarkness))
-                    return (action = OriginalHook(EdgeOfDarkness)) != 0;
-                else
-                    return (action = OriginalHook(FloodOfDarkness)) != 0;
-
-            #endregion
-
-            #region Mana Overcap
-
-            if ((flags.HasFlag(Combo.Simple) ||
-                 ((flags.HasFlag(Combo.ST) &&
-                   IsEnabled(Preset.DRK_ST_Sp_ManaOvercap)) ||
-                  flags.HasFlag(Combo.AoE) &&
-                  IsEnabled(Preset.DRK_AoE_Sp_ManaOvercap))) &&
-                mana >= 8500 &&
-                !manaEvenBurstSoon)
                 if (flags.HasFlag(Combo.ST) && LevelChecked(EdgeOfDarkness))
                     return (action = OriginalHook(EdgeOfDarkness)) != 0;
                 else

--- a/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
@@ -878,13 +878,17 @@ internal partial class DRK
                     : (int)Config.DRK_AoE_ManaSpenderPooling
                 : 0;
             var hasEnoughMana = mana >= (manaPool + 3000) || Gauge.HasDarkArts;
-            var manaEvenBurstSoon =
-                GetCooldownRemainingTime(LivingShadow) is > 0 and < 30;
-            var manaBursting =
+            var secondsBeforeBurst =
+                flags.HasFlag(Combo.Adv) && flags.HasFlag(Combo.ST)
+                    ? Config.DRK_ST_BurstSoonThreshold
+                    : 30;
+            var evenBurstSoon =
+                IsOnCooldown(LivingShadow) &&
+                GetCooldownRemainingTime(LivingShadow) < secondsBeforeBurst;
+            var bursting =
                 GetCooldownRemainingTime(LivingShadow) >= 100 ||
                 GetCooldownRemainingTime(Delirium) >= 50;
-            var manaDarksideDropping =
-                Gauge.DarksideTimeRemaining / 1000 < 10;
+            var darksideDropping = Gauge.DarksideTimeRemaining / 1000 < 10;
 
             // Bail if we don't have enough mana
             if (!hasEnoughMana) return false;
@@ -899,7 +903,7 @@ internal partial class DRK
                   flags.HasFlag(Combo.AoE) &&
                   IsEnabled(Preset.DRK_AoE_Sp_ManaOvercap))) &&
                 mana >= 8500 &&
-                !manaEvenBurstSoon)
+                !evenBurstSoon)
                 if (flags.HasFlag(Combo.ST) && LevelChecked(EdgeOfDarkness))
                     return (action = OriginalHook(EdgeOfDarkness)) != 0;
                 else
@@ -914,7 +918,7 @@ internal partial class DRK
                    IsEnabled(Preset.DRK_ST_Sp_EdgeDarkside)) ||
                   flags.HasFlag(Combo.AoE) &&
                   IsEnabled(Preset.DRK_AoE_Sp_Flood))) &&
-                manaDarksideDropping)
+                darksideDropping)
                 if (flags.HasFlag(Combo.ST) && LevelChecked(EdgeOfDarkness))
                     return (action = OriginalHook(EdgeOfDarkness)) != 0;
                 else
@@ -930,7 +934,7 @@ internal partial class DRK
             if ((flags.HasFlag(Combo.Simple) ||
                  ((flags.HasFlag(Combo.ST) && IsEnabled(Preset.DRK_ST_Sp_Edge)) ||
                   flags.HasFlag(Combo.AoE) && IsEnabled(Preset.DRK_AoE_Sp_Flood))) &&
-                manaBursting)
+                bursting)
                 if (flags.HasFlag(Combo.ST) && LevelChecked(EdgeOfDarkness))
                     return (action = OriginalHook(EdgeOfDarkness)) != 0;
                 else
@@ -939,14 +943,14 @@ internal partial class DRK
             #endregion
 
             // Bail if we're trying to save Dark Arts for burst
-            if (Gauge.HasDarkArts && manaEvenBurstSoon) return false;
+            if (Gauge.HasDarkArts && evenBurstSoon) return false;
 
             #region Mana Spend to Limit
 
             if ((flags.HasFlag(Combo.Simple) ||
                  ((flags.HasFlag(Combo.ST) && IsEnabled(Preset.DRK_ST_Sp_Edge)) ||
                   flags.HasFlag(Combo.AoE) && IsEnabled(Preset.DRK_AoE_Sp_Flood))) &&
-                !manaEvenBurstSoon)
+                !evenBurstSoon)
                 if (flags.HasFlag(Combo.ST) && LevelChecked(EdgeOfDarkness))
                     return (action = OriginalHook(EdgeOfDarkness)) != 0;
                 else
@@ -961,8 +965,8 @@ internal partial class DRK
                    IsEnabled(Preset.DRK_ST_Sp_DarkArts)) ||
                   flags.HasFlag(Combo.AoE) && IsEnabled(Preset.DRK_AoE_Sp_Flood))) &&
                 Gauge.HasDarkArts &&
-                (manaBursting ||
-                 (!manaEvenBurstSoon && HasOwnTBN)))
+                (bursting ||
+                 (!evenBurstSoon && HasOwnTBN)))
                 if (flags.HasFlag(Combo.ST) && LevelChecked(EdgeOfDarkness))
                     return (action = OriginalHook(EdgeOfDarkness)) != 0;
                 else


### PR DESCRIPTION
- [X] Allow Dark Arts to be used in odd-minute bursts
- [X] Allow Dark Arts Drop Prevention to run near Burst phases
- [X] Re-ordered some Edge usages to allow for some more Dark Arts spending
- [X] Added a slider to control when saving of Dark Arts and mana should begin before burst