### PR TITLE
[GNB] `Scuffed` options

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -2201,7 +2201,7 @@ public enum CustomComboPreset
     GNB_ST_Overcap = 7018,
 
     [ParentCombo(GNB_ST_Advanced)]
-    [CustomComboInfo("Scuffed Option", "Adds Solid Barrel into the rotation under scuffed conditions:\n- No Mercy is active\n- 1 cartridge\n- Last combo action was Brutal Shell\n- Gnashing Fang is still on cooldown", GNB.JobID)]
+    [CustomComboInfo("Scuffed Option", "Adds Solid Barrel into the rotation under scuffed conditions:\n- Level 90 or above\n- No Mercy is active\n- Only 1 cartridge available\n- Last combo action was Brutal Shell\n- Gnashing Fang combo is still not active", GNB.JobID)]
     GNB_ST_Scuffed = 7372,
 
     [ParentCombo(GNB_ST_Advanced)]
@@ -2455,7 +2455,7 @@ public enum CustomComboPreset
     GNB_GF_BurstStrike = 7309,
 
     [ParentCombo(GNB_GF_Features)]
-    [CustomComboInfo("Scuffed Option", "Adds Solid Barrel to Gnashing Fang under scuffed conditions:\n- 1 cartridge\n- No Mercy is active\n- Last combo action was Brutal Shell\n- Gnashing Fang is still on cooldown", GNB.JobID)]
+    [CustomComboInfo("Scuffed Option", "Adds Solid Barrel to Gnashing Fang under scuffed conditions:\n- Level 90 or above\n- No Mercy is active\n- Only 1 cartridge available\n- Last combo action was Brutal Shell\n- Gnashing Fang combo is still not active", GNB.JobID)]
     GNB_GF_Scuffed = 7371,
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -2201,6 +2201,10 @@ public enum CustomComboPreset
     GNB_ST_Overcap = 7018,
 
     [ParentCombo(GNB_ST_Advanced)]
+    [CustomComboInfo("Scuffed Option", "Adds Solid Barrel into the rotation under scuffed conditions:\n- No Mercy is active\n- 1 cartridge\n- Last combo action was Brutal Shell\n- Gnashing Fang is still on cooldown", GNB.JobID)]
+    GNB_ST_Scuffed = 7372,
+
+    [ParentCombo(GNB_ST_Advanced)]
     [CustomComboInfo("Lightning Shot Uptime Option", "Adds Lightning Shot to the main combo when you are out of range.",
         GNB.JobID)]
     GNB_ST_RangedUptime = 7004,
@@ -2449,6 +2453,10 @@ public enum CustomComboPreset
     [ParentCombo(GNB_GF_Features)]
     [CustomComboInfo("Burst Strike Option", "Adds Burst Strike on Gnashing Fang under No Mercy when appropriate.", GNB.JobID)]
     GNB_GF_BurstStrike = 7309,
+
+    [ParentCombo(GNB_GF_Features)]
+    [CustomComboInfo("Scuffed Option", "Adds Solid Barrel to Gnashing Fang under scuffed conditions:\n- 1 cartridge\n- No Mercy is active\n- Last combo action was Brutal Shell\n- Gnashing Fang is still on cooldown", GNB.JobID)]
+    GNB_GF_Scuffed = 7371,
     #endregion
 
     #region No Mercy

--- a/WrathCombo/Combos/PvE/GNB/GNB.cs
+++ b/WrathCombo/Combos/PvE/GNB/GNB.cs
@@ -195,7 +195,8 @@ internal partial class GNB : TankJob
                 return Hypervelocity;
             if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Cooldowns) && IsEnabled(CustomComboPreset.GNB_ST_Continuation) && ShouldUseContinuation())
                 return OriginalHook(Continuation);
-            if (LevelChecked(DoubleDown) && HasNM && GunStep == 0 && ComboAction is BrutalShell && Ammo == 1)
+            if (IsEnabled(CustomComboPreset.GNB_ST_Scuffed) &&
+                LevelChecked(DoubleDown) && HasNM && GunStep == 0 && ComboAction is BrutalShell && Ammo == 1)
                 return SolidBarrel;
             if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Cooldowns))
             {
@@ -489,7 +490,7 @@ internal partial class GNB : TankJob
                 return Hypervelocity;
             if (IsEnabled(CustomComboPreset.GNB_GF_Continuation) && ShouldUseContinuation())
                 return OriginalHook(Continuation);
-            if (LevelChecked(DoubleDown) && HasNM && GunStep == 0 && ComboAction is BrutalShell && Ammo == 1)
+            if (IsEnabled(CustomComboPreset.GNB_GF_Scuffed) && LevelChecked(DoubleDown) && HasNM && GunStep == 0 && ComboAction is BrutalShell && Ammo == 1)
                 return SolidBarrel;
             if (IsEnabled(CustomComboPreset.GNB_GF_Bloodfest) && ShouldUseBloodfest())
                 return Bloodfest;


### PR DESCRIPTION
Closes #419

- [x] Add an option select for this as per request, for both `Gnashing Fang Features` and `Advanced Mode - Single Target`
![image](https://github.com/user-attachments/assets/3f8e476e-d141-45b6-a6c7-772b20a0b347)
