### PR TITLE
[Core] Removed legacy IsEnabled(uint). ActionReady handles it now.

### DIFF
--- a/WrathCombo/Combos/PvE/Content/Variant.cs
+++ b/WrathCombo/Combos/PvE/Content/Variant.cs
@@ -52,24 +52,22 @@ internal static class VariantActions
     }
 
     internal static bool CanRampart(CustomComboPreset preset, WeaveTypes weave = WeaveTypes.None) =>
-        IsEnabled(preset) && IsEnabled(VariantRampart) && ActionReady(VariantRampart) &&
+        IsEnabled(preset) && ActionReady(VariantRampart) &&
         CheckWeave(weave);
 
     internal static bool CanSpiritDart(CustomComboPreset preset) =>
-        IsEnabled(preset) && IsEnabled(VariantSpiritDart) && ActionReady(VariantSpiritDart) &&
+        IsEnabled(preset) && ActionReady(VariantSpiritDart) &&
         HasBattleTarget() && GetDebuffRemainingTime(Debuffs.SustainedDamage) <= 3;
 
     internal static bool CanCure(CustomComboPreset preset, int healthpercent) =>
-        IsEnabled(preset) && IsEnabled(VariantCure) && ActionReady(VariantCure) &&
+        IsEnabled(preset) && ActionReady(VariantCure) &&
         PlayerHealthPercentageHp() <= healthpercent;
 
     internal static bool CanRaise(CustomComboPreset preset) =>
-        IsEnabled(preset) && IsEnabled(VariantRaise) &&
-        ActionReady(VariantRaise) && HasEffect(MagicRole.Buffs.Swiftcast);
+        IsEnabled(preset) && ActionReady(VariantRaise) && HasEffect(MagicRole.Buffs.Swiftcast);
 
     internal static bool CanUltimatum(CustomComboPreset preset, WeaveTypes weave = WeaveTypes.None) => 
-        IsEnabled(preset) && IsEnabled(VariantUltimatum) &&
-        ActionReady(VariantUltimatum) && CanCircleAoe(5) > 0 && CheckWeave(weave);
+        IsEnabled(preset) && ActionReady(VariantUltimatum) && CanCircleAoe(5) > 0 && CheckWeave(weave);
 
 }
 

--- a/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
@@ -141,7 +141,6 @@ internal partial class DRK
 
             if ((flags.HasFlag(Combo.Simple) ||
                  (flags.HasFlag(Combo.Adv) && IsEnabled(Preset.DRK_Var_Cure))) &&
-                IsEnabled(Variant.Cure) &&
                 ActionReady(Variant.Cure) &&
                 PlayerHealthPercentageHp() <= GetOptionValue(Config.DRK_VariantCure))
                 return (action = Variant.Cure) != 0;
@@ -155,7 +154,6 @@ internal partial class DRK
 
             if ((flags.HasFlag(Combo.Simple) ||
                  (flags.HasFlag(Combo.Adv) && IsEnabled(Preset.DRK_Var_Ulti))) &&
-                IsEnabled(Variant.Ultimatum) &&
                 ActionReady(Variant.Ultimatum))
                 return (action = Variant.Ultimatum) != 0;
 
@@ -167,7 +165,6 @@ internal partial class DRK
                 FindTargetEffect(VariantActions.Debuffs.SustainedDamage);
             if ((flags.HasFlag(Combo.Simple) ||
                  (flags.HasFlag(Combo.Adv) && IsEnabled(Preset.DRK_Var_Dart))) &&
-                IsEnabled(Variant.SpiritDart) &&
                 ActionReady(Variant.SpiritDart) &&
                 DoTStatus?.RemainingTime <= 3)
                 return (action = Variant.SpiritDart) != 0;
@@ -1147,7 +1144,7 @@ internal partial class DRK
     /// </value>
     /// <remarks>
     ///     Each logic check is already combined with checking if the preset
-    ///     <see cref="IsEnabled(uint)">is enabled</see>
+    ///     <see cref="IsEnabled">is enabled</see>
     ///     and if the action is <see cref="ActionReady(uint)">ready</see> and
     ///     <see cref="LevelChecked(uint)">level-checked</see>.<br />
     ///     Do not add any of these checks to <c>Logic</c>.

--- a/WrathCombo/Combos/PvE/RDM/RDM.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM.cs
@@ -10,7 +10,7 @@ internal partial class RDM : CasterJob
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_Variant_Cure2;
 
         protected override uint Invoke(uint actionID) =>
-            actionID is Vercure && IsEnabled(Variant.Cure)
+            actionID is Vercure && Variant.CanCure(Preset,100)
             ? Variant.Cure
             : actionID;
     }

--- a/WrathCombo/CustomCombo/Functions/Cooldown.cs
+++ b/WrathCombo/CustomCombo/Functions/Cooldown.cs
@@ -90,11 +90,6 @@ namespace WrathCombo.CustomComboNS.Functions
         /// <returns> Number of charges. </returns>
         public static ushort GetMaxCharges(uint actionID) => GetCooldown(actionID).MaxCharges;
 
-        /// <summary> Get if an action is enabled.</summary>
-        /// <param name="actionID"> Action ID to check</param>
-        /// <returns> If the action is currently enabled.</returns>
-        public static unsafe bool IsEnabled(uint actionID) => ActionManager.Instance()->GetActionStatus(ActionType.Action, actionID) == 0;
-
         private static uint Action1 => DutyActionManager.GetDutyActionId(0);
         private static uint Action2 => DutyActionManager.GetDutyActionId(1);
 


### PR DESCRIPTION
@zbee If you don't mind, can you take a quick gander at DRK_Helper, and let me know if you want me to remove IsEnabled, or if you want to do something different.