### PR TITLE
[BRD] Utilizing Helper file

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -778,7 +778,7 @@ public enum CustomComboPreset
     BRD_Adv_Buffs_Battlevoice = 3050,
 
     [ParentCombo(BRD_Adv_Buffs)]
-        [CustomComboInfo("Radiant Finale Option", "Adds Radiant Finale", BRD.JobID)]
+    [CustomComboInfo("Radiant Finale Option", "Adds Radiant Finale", BRD.JobID)]
     BRD_Adv_Buffs_RadiantFinale = 3051,
 
     [ParentCombo(BRD_Adv_Buffs)]
@@ -929,7 +929,7 @@ public enum CustomComboPreset
     BRD_IronJawsApex = 3024,
 
     [ReplaceSkill(BRD.IronJaws)]
-    [ConflictingCombos(BRD_IronJaws]
+    [ConflictingCombos(BRD_IronJaws)]
     [CustomComboInfo("Iron Jaws Alternate Feature",
         "Iron Jaws is replaced with Caustic Bite/Stormbite if one or both are not up.\nIron Jaws will only show up when debuffs are about to expire.",
         BRD.JobID)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -748,7 +748,6 @@ public enum CustomComboPreset
     BRD_ST_AdvMode = 3009,
 
     [ParentCombo(BRD_ST_AdvMode)]
-    [ConflictingCombos(BRD_IronJaws_Alternate, BRD_IronJaws, BRD_ST_oGCD)]
     [CustomComboInfo("Balance Opener (Level 100)", "Adds the Balance opener at level 100.", BRD.JobID)]
     BRD_ST_Adv_Balance_Standard = 3048,
 
@@ -919,7 +918,7 @@ public enum CustomComboPreset
     BRD_ApexST = 3034,
 
     [ReplaceSkill(BRD.IronJaws)]
-    [ConflictingCombos(BRD_IronJaws_Alternate, BRD_ST_Adv_Balance_Standard)]
+    [ConflictingCombos(BRD_IronJaws_Alternate)]
     [CustomComboInfo("Iron Jaws Feature",
         "Iron Jaws is replaced with Caustic Bite/Stormbite if one or both are not up.\nAlternates between the two if Iron Jaws isn't available.",
         BRD.JobID)]
@@ -930,7 +929,7 @@ public enum CustomComboPreset
     BRD_IronJawsApex = 3024,
 
     [ReplaceSkill(BRD.IronJaws)]
-    [ConflictingCombos(BRD_IronJaws, BRD_ST_Adv_Balance_Standard)]
+    [ConflictingCombos(BRD_IronJaws]
     [CustomComboInfo("Iron Jaws Alternate Feature",
         "Iron Jaws is replaced with Caustic Bite/Stormbite if one or both are not up.\nIron Jaws will only show up when debuffs are about to expire.",
         BRD.JobID)]
@@ -948,7 +947,6 @@ public enum CustomComboPreset
     BRD_Apex = 3005,
 
     [ReplaceSkill(BRD.Bloodletter)]
-    [ConflictingCombos(BRD_ST_Adv_Balance_Standard)]
     [CustomComboInfo("Single Target oGCD Feature", "All oGCD's on Bloodletter/Heartbreakshot", BRD.JobID)]
     BRD_ST_oGCD = 3006,
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -803,7 +803,7 @@ public enum CustomComboPreset
     BRD_ST_Adv_oGCD = 3038,
 
     [ParentCombo(BRD_ST_AdvMode)]
-    [CustomComboInfo("Pooling Option", "84+ Pools Bloodletter charges and Sidewinder to allow for optimum burst phases ", BRD.JobID)]
+    [CustomComboInfo("Pooling Option", "Pools Bloodletter charges and Sidewinder to allow for optimum burst phases ", BRD.JobID)]
     BRD_Adv_Pooling = 3023,
 
     [ParentCombo(BRD_ST_AdvMode)]
@@ -866,7 +866,7 @@ public enum CustomComboPreset
     BRD_AoE_Adv_oGCD = 3037,
 
     [ParentCombo(BRD_AoE_AdvMode)]
-    [CustomComboInfo("Pooling Option", "84+ Pools Rain of death charges to allow for optimum burst phases.", BRD.JobID)]
+    [CustomComboInfo("Pooling Option", "Pools Rain of death charges to allow for optimum burst phases.", BRD.JobID)]
     BRD_AoE_Pooling = 3040,
 
     [ParentCombo(BRD_AoE_AdvMode)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -803,8 +803,12 @@ public enum CustomComboPreset
     BRD_ST_Adv_oGCD = 3038,
 
     [ParentCombo(BRD_ST_AdvMode)]
-    [CustomComboInfo("Pooling Option", "84+ Pools Bloodletter charges to allow for optimum burst phases.", BRD.JobID)]
+    [CustomComboInfo("Pooling Option", "84+ Pools Bloodletter charges and Sidewinder to allow for optimum burst phases ", BRD.JobID)]
     BRD_Adv_Pooling = 3023,
+
+    [ParentCombo(BRD_ST_AdvMode)]
+    [CustomComboInfo("Apex Pooling Option", "Pools Apex arrow into buff window and when buffs are between 50-60 seconds on cd.", BRD.JobID)]
+    BRD_Adv_ApexPooling = 3057,
 
     [ParentCombo(BRD_ST_AdvMode)]
     [CustomComboInfo("Interrupt Option", "Uses interrupt during the rotation if applicable.", BRD.JobID)]
@@ -866,12 +870,16 @@ public enum CustomComboPreset
     BRD_AoE_Pooling = 3040,
 
     [ParentCombo(BRD_AoE_AdvMode)]
+    [CustomComboInfo("Apex Pooling Option", "Pools Apex arrow into buff window and when buffs are between 50-60 seconds on cd.", BRD.JobID)]
+    BRD_AoE_ApexPooling = 3058,
+
+    [ParentCombo(BRD_AoE_AdvMode)]
     [CustomComboInfo("Interrupt Option", "Uses interrupt during the rotation if applicable.", BRD.JobID)]
     BRD_AoE_Adv_Interrupt = 3043,
 
     [ParentCombo(BRD_AoE_AdvMode)]
     [CustomComboInfo("Apex Arrow Option", "Adds Apex Arrow and Blast shot", BRD.JobID)]
-    BRD_Aoe_ApexArrow = 3039,
+    BRD_AoE_ApexArrow = 3039,
 
     [ParentCombo(BRD_AoE_AdvMode)]
     [CustomComboInfo("AoE No Waste Option",
@@ -980,7 +988,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last value = 3048
+    // Last value = 3058
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -748,6 +748,7 @@ public enum CustomComboPreset
     BRD_ST_AdvMode = 3009,
 
     [ParentCombo(BRD_ST_AdvMode)]
+    [ConflictingCombos(BRD_IronJaws_Alternate)]
     [CustomComboInfo("Balance Opener (Level 100)", "Adds the Balance opener at level 100.", BRD.JobID)]
     BRD_ST_Adv_Balance_Standard = 3048,
 
@@ -929,7 +930,7 @@ public enum CustomComboPreset
     BRD_IronJawsApex = 3024,
 
     [ReplaceSkill(BRD.IronJaws)]
-    [ConflictingCombos(BRD_IronJaws)]
+    [ConflictingCombos(BRD_IronJaws, BRD_ST_Adv_Balance_Standard)]
     [CustomComboInfo("Iron Jaws Alternate Feature",
         "Iron Jaws is replaced with Caustic Bite/Stormbite if one or both are not up.\nIron Jaws will only show up when debuffs are about to expire.",
         BRD.JobID)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -766,7 +766,7 @@ public enum CustomComboPreset
     BRD_Adv_Song = 3011,
 
     [ParentCombo(BRD_ST_AdvMode)]
-    [CustomComboInfo("Buffs Option", "Adds buffs onto the Advanced Bard feature. \nBuffs have specific timing with each other intended to follow balance. \nDisabling only one can lead to unwanted results", BRD.JobID)]
+    [CustomComboInfo("Buffs Option", "Adds buffs onto the Advanced Bard feature. \nEnable all to follow balance buff windows \nDisabling any buff will follow simple priority", BRD.JobID)]
     BRD_Adv_Buffs = 3017,
 
     [ParentCombo(BRD_Adv_Buffs)]
@@ -841,7 +841,7 @@ public enum CustomComboPreset
     BRD_AoE_Adv_Songs = 3016,
 
     [ParentCombo(BRD_AoE_AdvMode)]
-    [CustomComboInfo("AoE Buffs Option", "Adds buffs onto the Advance AoE Bard feature.\nBuffs have specific timing with each other intended to follow balance. \nDisabling only one can lead to unwanted results", BRD.JobID)]
+    [CustomComboInfo("AoE Buffs Option", "Adds buffs onto the Advance AoE Bard feature.\nEnable all to follow balance buff windows \nDisabling any buff will follow simple priority", BRD.JobID)]
     BRD_AoE_Adv_Buffs = 3032,
 
     [ParentCombo(BRD_AoE_Adv_Buffs)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -748,7 +748,7 @@ public enum CustomComboPreset
     BRD_ST_AdvMode = 3009,
 
     [ParentCombo(BRD_ST_AdvMode)]
-    [ConflictingCombos(BRD_IronJaws_Alternate)]
+    [ConflictingCombos(BRD_IronJaws_Alternate, BRD_IronJaws, BRD_ST_oGCD)]
     [CustomComboInfo("Balance Opener (Level 100)", "Adds the Balance opener at level 100.", BRD.JobID)]
     BRD_ST_Adv_Balance_Standard = 3048,
 
@@ -919,7 +919,7 @@ public enum CustomComboPreset
     BRD_ApexST = 3034,
 
     [ReplaceSkill(BRD.IronJaws)]
-    [ConflictingCombos(BRD_IronJaws_Alternate)]
+    [ConflictingCombos(BRD_IronJaws_Alternate, BRD_ST_Adv_Balance_Standard)]
     [CustomComboInfo("Iron Jaws Feature",
         "Iron Jaws is replaced with Caustic Bite/Stormbite if one or both are not up.\nAlternates between the two if Iron Jaws isn't available.",
         BRD.JobID)]
@@ -948,6 +948,7 @@ public enum CustomComboPreset
     BRD_Apex = 3005,
 
     [ReplaceSkill(BRD.Bloodletter)]
+    [ConflictingCombos(BRD_ST_Adv_Balance_Standard)]
     [CustomComboInfo("Single Target oGCD Feature", "All oGCD's on Bloodletter/Heartbreakshot", BRD.JobID)]
     BRD_ST_oGCD = 3006,
 

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -381,35 +381,9 @@ internal partial class BRD : PhysRangedJob
                 if (Role.CanHeadGraze(CustomComboPreset.BRD_AoE_Adv_Interrupt) && CanWeaveDelayed)
                     return Role.HeadGraze;
 
-                // Rain of death Logic
-                if (CanBardWeave && IsEnabled(CustomComboPreset.BRD_AoE_Adv_oGCD))
-            
-                if (LevelChecked(RainOfDeath) && !WasLastAction(RainOfDeath) && EmpyrealCD > 1 || !LevelChecked(EmpyrealArrow))
-                {
-                    if (IsEnabled(CustomComboPreset.BRD_AoE_Pooling) && LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
-                    {
-                        //Stop pooling for buff window
-                        if (SongWanderer && ((HasEffect(Buffs.RagingStrikes) || RagingCD > 10) &&
-                            (HasEffect(Buffs.BattleVoice) || BattleVoiceCD > 10 ||
-                             !LevelChecked(BattleVoice)) &&
-                            (HasEffect(Buffs.RadiantFinale) || RadiantCD > 10 ||
-                             !LevelChecked(RadiantFinale)) &&
-                            RainOfDeathCharges > 0 || RainOfDeathCharges > 2))
-                            return OriginalHook(RainOfDeath);
-
-                        if (SongArmy && (RainOfDeathCharges == 3 || gauge.SongTimer / 1000 > 30 && RainOfDeathCharges > 0)) //Start pooling in Armys
-                            return OriginalHook(RainOfDeath);
-
-                        if (SongMage && RainOfDeathCharges > 0) // Dont poolin mages
-                            return OriginalHook(RainOfDeath);
-
-                        if (SongNone && RainOfDeathCharges == 3) //Pool when no song
-                            return OriginalHook(RainOfDeath);
-                    }
-
-                    else if (RainOfDeathCharges > 0) //Dont pool when not enabled
-                        return OriginalHook(RainOfDeath);
-                }
+                if (ActionReady(RainOfDeath) &&
+                    (IsEnabled(CustomComboPreset.BRD_AoE_Pooling) && UsePooledBloodRain() || !IsEnabled(CustomComboPreset.BRD_AoE_Pooling)))
+                    return OriginalHook(RainOfDeath);
 
                 if (!LevelChecked(RainOfDeath) && !(WasLastAction(Bloodletter) && BloodletterCharges > 0))
                     return OriginalHook(Bloodletter);
@@ -610,31 +584,9 @@ internal partial class BRD : PhysRangedJob
                 if (Role.CanHeadGraze(CustomComboPreset.BRD_Adv_Interrupt) && CanWeaveDelayed)
                     return Role.HeadGraze;
 
-                if (ActionReady(Bloodletter) && !(WasLastAction(Bloodletter) || WasLastAction(HeartbreakShot)) && EmpyrealCD > 1 || !LevelChecked(EmpyrealArrow))
-                {
-                    if (IsEnabled(CustomComboPreset.BRD_Adv_Pooling) &&
-                        LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
-                    {
-                        if (SongWanderer && ((HasEffect(Buffs.RagingStrikes) || RagingCD > 10) &&
-                            (HasEffect(Buffs.BattleVoice) || BattleVoiceCD > 10 ||
-                             !LevelChecked(BattleVoice)) &&
-                            (HasEffect(Buffs.RadiantFinale) || RadiantCD > 10 ||
-                             !LevelChecked(RadiantFinale)) &&
-                            BloodletterCharges > 0 || BloodletterCharges > 2))
-                            return OriginalHook(Bloodletter);
-
-                        if (SongArmy && (BloodletterCharges == 3 || gauge.SongTimer / 1000 > 30 && BloodletterCharges > 0)) // Start pooling in Army
-                            return OriginalHook(Bloodletter);
-
-                        if (SongMage && BloodletterCharges > 0) //Don't pool in Mages
-                            return OriginalHook(Bloodletter);
-
-                        if (SongNone && BloodletterCharges == 3) //Pool with no song
-                            return OriginalHook(Bloodletter);
-                    }
-                    else if (BloodletterCharges > 0)
-                        return OriginalHook(Bloodletter);
-                }
+                if (ActionReady(Bloodletter) &&
+                    (IsEnabled(CustomComboPreset.BRD_Adv_Pooling) && UsePooledBloodRain() || !IsEnabled(CustomComboPreset.BRD_Adv_Pooling)))
+                    return OriginalHook(Bloodletter);
             }
 
             #endregion
@@ -827,31 +779,8 @@ internal partial class BRD : PhysRangedJob
                 if (Role.CanHeadGraze(CustomComboPreset.BRD_AoE_SimpleMode) && CanWeaveDelayed)
                     return Role.HeadGraze;
 
-                // Pooling logic for rain of death basied on song
-                if (LevelChecked(RainOfDeath) && !WasLastAction(RainOfDeath) && (EmpyrealCD > 1 || !LevelChecked(EmpyrealArrow)))
-                {
-                    if (LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
-                    {
-                        if (SongWanderer && ((HasEffect(Buffs.RagingStrikes) || RagingCD > 10) &&
-                            (HasEffect(Buffs.BattleVoice) || BattleVoiceCD > 10 ||
-                             !LevelChecked(BattleVoice)) &&
-                            (HasEffect(Buffs.RadiantFinale) || RadiantCD > 10 ||
-                             !LevelChecked(RadiantFinale)) &&
-                            RainOfDeathCharges > 0 || RainOfDeathCharges > 2))
-                            return OriginalHook(RainOfDeath);
-
-                        if (SongArmy && (RainOfDeathCharges == 3 || gauge.SongTimer / 1000 > 30 && RainOfDeathCharges > 0))
-                            return OriginalHook(RainOfDeath);
-
-                        if (SongMage && RainOfDeathCharges > 0)
-                            return OriginalHook(RainOfDeath);
-
-                        if (SongNone && RainOfDeathCharges == 3)
-                            return OriginalHook(RainOfDeath);
-                    }
-                    else if (RainOfDeathCharges > 0)
-                        return OriginalHook(RainOfDeath);
-                }
+                if (ActionReady(RainOfDeath) && UsePooledBloodRain())
+                    return OriginalHook(RainOfDeath);
 
                 if (!LevelChecked(RainOfDeath) && !(WasLastAction(Bloodletter) && BloodletterCharges > 0))
                     return OriginalHook(Bloodletter);
@@ -1012,33 +941,8 @@ internal partial class BRD : PhysRangedJob
                 if (Role.CanHeadGraze(CustomComboPreset.BRD_ST_SimpleMode) && CanWeaveDelayed)
                     return Role.HeadGraze;
 
-                // Bloodletter pooling logic
-                if (ActionReady(Bloodletter) && !(WasLastAction(Bloodletter) || WasLastAction(HeartbreakShot)) && (EmpyrealCD > 1 || !LevelChecked(EmpyrealArrow)))
-                {
-                    if (LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
-                    {
-                        // Stop pooling in burst window
-                        if (SongWanderer && ((HasEffect(Buffs.RagingStrikes) || RagingCD > 10) &&
-                            (HasEffect(Buffs.BattleVoice) || BattleVoiceCD > 10 ||
-                             !LevelChecked(BattleVoice)) &&
-                            (HasEffect(Buffs.RadiantFinale) || RadiantCD > 10 ||
-                             !LevelChecked(RadiantFinale)) &&
-                            BloodletterCharges > 0 || BloodletterCharges > 2))
-                            return OriginalHook(Bloodletter);
-
-                        if (SongArmy && (BloodletterCharges == 3 || gauge.SongTimer / 1000 > 30 && BloodletterCharges > 0)) // Start pooling in army
-                            return OriginalHook(Bloodletter);
-
-                        if (SongMage && BloodletterCharges > 0) // Dont pool in mages
-                            return OriginalHook(Bloodletter);
-
-                        if (SongNone && BloodletterCharges == 3) // No song pooling
-                            return OriginalHook(Bloodletter);
-                    }
-
-                    else if (BloodletterCharges > 0)
-                        return OriginalHook(Bloodletter);
-                }
+                if (ActionReady(Bloodletter) && UsePooledBloodRain())
+                    return OriginalHook(Bloodletter);
 
                 if (Role.CanSecondWind(40))
                     return Role.SecondWind;

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -378,7 +378,7 @@ internal partial class BRD : PhysRangedJob
             if (HasEffect(Buffs.Barrage))
                 return OriginalHook(WideVolley);
 
-            if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore) && HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 18)
+            if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore) && HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16)
                 return OriginalHook(RadiantEncore);
 
             if (IsEnabled(CustomComboPreset.BRD_AoE_ApexArrow))
@@ -576,7 +576,7 @@ internal partial class BRD : PhysRangedJob
             if (HasEffect(Buffs.Barrage))
                 return OriginalHook(StraightShot);
 
-            if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore) && HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 17)
+            if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore) && HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16)
                 return OriginalHook(RadiantEncore);
 
             if (IsEnabled(CustomComboPreset.BRD_ST_ApexArrow))
@@ -728,7 +728,7 @@ internal partial class BRD : PhysRangedJob
             if (HasEffect(Buffs.ResonantArrowReady))
                 return ResonantArrow;
 
-            if (HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 18)
+            if (HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16)
                 return OriginalHook(RadiantEncore);
 
             if (HasEffect(Buffs.HawksEye))
@@ -878,7 +878,7 @@ internal partial class BRD : PhysRangedJob
             if (HasEffect(Buffs.ResonantArrowReady))
                 return ResonantArrow;
 
-            if (HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 18)
+            if (HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16)
                 return OriginalHook(RadiantEncore);
 
             if (HasEffect(Buffs.HawksEye))

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -55,19 +55,14 @@ internal partial class BRD : PhysRangedJob
             if (actionID is not IronJaws)
                 return actionID;
 
-            if (!LevelChecked(IronJaws))
-                return LevelChecked(Windbite) && BlueRemaining <= PurpleRemaining
-                    ? Windbite
-                    : VenomousBite;
+            if (UseIronJaws())
+                return IronJaws;
 
-            if (Blue is null && LevelChecked(Windbite))
+            if (ApplyBlueDot())
                 return OriginalHook(Windbite);
 
-            if (Purple is null && LevelChecked(VenomousBite))
+            if (ApplyPurpleDot())
                 return OriginalHook(VenomousBite);
-
-            if (PurpleRemaining < 4 || BlueRemaining < 4)
-                return IronJaws;
 
             // Apex Option
             if (IsEnabled(CustomComboPreset.BRD_IronJawsApex))
@@ -91,9 +86,7 @@ internal partial class BRD : PhysRangedJob
             if (actionID is not IronJaws)
                 return actionID;
 
-            if (LevelChecked(IronJaws) && (
-                Purple is not null && PurpleRemaining < 4 ||
-                Blue is not null && BlueRemaining < 4))
+            if (UseIronJaws())
                 return IronJaws;
 
             return LevelChecked(Windbite) && BlueRemaining <= PurpleRemaining ?
@@ -610,25 +603,16 @@ internal partial class BRD : PhysRangedJob
             {
                 if (IsEnabled(CustomComboPreset.BRD_Adv_DoT))
                 {
-                    if (Purple is not null && PurpleRemaining < 4)
-                        return CanIronJaws
-                            ? IronJaws
-                            : VenomousBite;
+                    if (UseIronJaws())
+                        return IronJaws;
 
-                    if (Blue is not null && BlueRemaining < 4)
-                        return CanIronJaws
-                            ? IronJaws
-                            : Windbite;
-
-                    if (Blue is null && LevelChecked(Windbite))
+                    if (ApplyBlueDot())
                         return OriginalHook(Windbite);
 
-                    if (Purple is null && LevelChecked(VenomousBite))
+                    if (ApplyPurpleDot())
                         return OriginalHook(VenomousBite);
 
-                    if (IsEnabled(CustomComboPreset.BRD_Adv_RagingJaws) && ActionReady(IronJaws) && HasEffect(Buffs.RagingStrikes) &&
-                        RagingStrikesDuration < ragingJawsRenewTime && // Raging Jaws Slider Check
-                        PurpleRemaining < 35 && BlueRemaining < 35) // Prevention of double refreshing dots
+                    if (IsEnabled(CustomComboPreset.BRD_Adv_RagingJaws) && RagingJawsRefresh() && RagingStrikesDuration < ragingJawsRenewTime)
                         return IronJaws;
                 }
             }
@@ -955,29 +939,18 @@ internal partial class BRD : PhysRangedJob
 
             #region Dot Management
 
-            // Iron jaws Dot refresh, or low level manaul dot refresh
-            if (Purple is not null && PurpleRemaining < 4)
-                return CanIronJaws
-                    ? IronJaws
-                    : VenomousBite;
+            if (UseIronJaws())
+                return IronJaws;
 
-            if (Blue is not null && BlueRemaining < 4)
-                return CanIronJaws
-                    ? IronJaws
-                    : Windbite;
-
-            // Dot application
-            if (Blue is null && LevelChecked(Windbite))
+            if (ApplyBlueDot())
                 return OriginalHook(Windbite);
 
-            if (Purple is null && LevelChecked(VenomousBite))
+            if (ApplyPurpleDot())
                 return OriginalHook(VenomousBite);
 
-            // Raging jaws dot snapshotting logic
-            if (ActionReady(IronJaws) && HasEffect(Buffs.RagingStrikes) &&
-                RagingStrikesDuration < 6 && // Raging Jaws 
-                PurpleRemaining < 35 && BlueRemaining < 35) // Prevention of double refreshing dots
+            if (RagingJawsRefresh() && RagingStrikesDuration < 6)
                 return IronJaws;
+
 
             #endregion
 
@@ -999,6 +972,7 @@ internal partial class BRD : PhysRangedJob
                 return OriginalHook(RadiantEncore);
 
             #endregion
+
             return actionID;
         }
     }

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -274,61 +274,24 @@ internal partial class BRD : PhysRangedJob
 
             #region Songs
 
-            if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Songs))
+            if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Songs) && isEnemyHealthHigh && InCombat() && (CanBardWeave || !BardHasTarget))
             {
-                // Limit optimisation to when you are high enough level to benefit from it.
-                if (LevelChecked(WanderersMinuet))
-                {
-                    if (CanBardWeave || !BardHasTarget)
-                    {
-                        if (SongNone && InCombat())
-                        {
-                            // Logic to determine first song
-                            if (ActionReady(WanderersMinuet) && !(JustUsed(MagesBallad) || JustUsed(ArmysPaeon)))
-                                return WanderersMinuet;
+                if (SongChangePitchPerfect())
+                    return PitchPerfect;
 
-                            if (ActionReady(MagesBallad) && !(JustUsed(WanderersMinuet) || JustUsed(ArmysPaeon)))
-                                return MagesBallad;
+                if (SongChangeEmpyreal())
+                    return EmpyrealArrow;
 
-                            if (ActionReady(ArmysPaeon) && !(JustUsed(MagesBallad) || JustUsed(WanderersMinuet)))
-                                return ArmysPaeon;
-                        }
+                if (WandererSong())
+                    return WanderersMinuet;
 
-                        if (SongWanderer)
-                        {
-                            if (SongTimerInSeconds <= 3 && gauge.Repertoire > 0 && BardHasTarget) // Spend any repertoire before switching to next song
-                                return OriginalHook(PitchPerfect);
+                if (MagesSong())
+                    return MagesBallad;
 
-                            if (SongTimerInSeconds <= 3 && ActionReady(MagesBallad)) // Move to Mage's Ballad if <= 3 seconds left on song
-                                return MagesBallad;
-                        }
+                if (ArmySong())
+                    return ArmysPaeon;
 
-                        // Move to Army's Paeon if < 3 seconds left on song
-                        // Special case for Empyreal Arrow: it must be cast before you change to it to avoid drift!
-                        if (SongMage && SongTimerInSeconds <= 3 && ActionReady(ArmysPaeon))
-                        {
-                            return ActionReady(EmpyrealArrow) && BardHasTarget
-                                ? EmpyrealArrow
-                                : ArmysPaeon;
-                        }
-                    }
-
-                    // Move to Wanderer's Minuet if <= 12 seconds left on song or WM off CD and have 4 repertoires of AP
-                    if (SongArmy && (CanWeaveDelayed || !BardHasTarget) &&
-                        (SongTimerInSeconds <= 12 || ActionReady(WanderersMinuet) && gauge.Repertoire == 4))
-                        return WanderersMinuet;
-                }
-
-                else if (SongTimerInSeconds <= 3 && CanWeaveDelayed)
-                {
-                    if (ActionReady(MagesBallad))
-                        return MagesBallad;
-
-                    if (ActionReady(ArmysPaeon))
-                        return ArmysPaeon;
-                }
             }
-
             #endregion
 
             #region Buffs
@@ -415,8 +378,7 @@ internal partial class BRD : PhysRangedJob
             if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
                 return OriginalHook(WideVolley);
 
-            // Delay Encore enough for buff window
-            if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore) && HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 15)
+            if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore) && HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 18)
                 return OriginalHook(RadiantEncore);
 
             if (IsEnabled(CustomComboPreset.BRD_AoE_ApexArrow))
@@ -489,59 +451,23 @@ internal partial class BRD : PhysRangedJob
 
             #region Songs
 
-            if (IsEnabled(CustomComboPreset.BRD_Adv_Song) && isEnemyHealthHigh)
+            if (IsEnabled(CustomComboPreset.BRD_Adv_Song) && isEnemyHealthHigh && InCombat() && (CanBardWeave || !BardHasTarget))
             {
-                // Limit optimisation to when you are high enough level to benefit from it.
-                if (LevelChecked(WanderersMinuet))
-                {
-                    if (CanBardWeave || !BardHasTarget)
-                    {
-                        if (SongNone && InCombat())
-                        {
-                            // Logic to determine first song
-                            if (ActionReady(WanderersMinuet) && !(JustUsed(MagesBallad) || JustUsed(ArmysPaeon)))
-                                return WanderersMinuet;
+                if (SongChangePitchPerfect())
+                    return PitchPerfect;
 
-                            if (ActionReady(MagesBallad) && !(JustUsed(WanderersMinuet) || JustUsed(ArmysPaeon)))
-                                return MagesBallad;
+                if (SongChangeEmpyreal())
+                    return EmpyrealArrow;
 
-                            if (ActionReady(ArmysPaeon) && !(JustUsed(MagesBallad) || JustUsed(WanderersMinuet)))
-                                return ArmysPaeon;
-                        }
+                if (WandererSong())
+                    return WanderersMinuet;
 
-                        if (SongWanderer)
-                        {
-                            if (SongTimerInSeconds <= 3 && gauge.Repertoire > 0 && BardHasTarget) // Spend any repertoire before switching to next song
-                                return OriginalHook(PitchPerfect);
+                if (MagesSong())
+                    return MagesBallad;
 
-                            if (SongTimerInSeconds <= 3 && ActionReady(MagesBallad)) // Move to Mage's Ballad if <= 3 seconds left on song
-                                return MagesBallad;
-                        }
+                if (ArmySong())
+                    return ArmysPaeon;
 
-                        // Move to Army's Paeon if <= 3 seconds left on song
-                        // Special case for Empyreal Arrow: it must be cast before you change to it to avoid drift!
-                        if (SongMage && SongTimerInSeconds <= 3 && ActionReady(ArmysPaeon))
-                        {
-                            if (ActionReady(EmpyrealArrow) && BardHasTarget)
-                                return EmpyrealArrow;
-
-                            return ArmysPaeon;
-                        }
-                    }
-
-                    // Move to Wanderer's Minuet if <= 12 seconds left on song or WM off CD and have 4 repertoires of AP
-                    if (SongArmy && (CanWeaveDelayed || !BardHasTarget) && (SongTimerInSeconds <= 12 || ActionReady(WanderersMinuet) && gauge.Repertoire == 4))
-                        return WanderersMinuet;
-                }
-
-                else if (SongTimerInSeconds <= 3 && CanWeaveDelayed) // Before you get Wanderers, it just toggles the two songs.
-                {
-                    if (ActionReady(MagesBallad))
-                        return MagesBallad;
-
-                    if (ActionReady(ArmysPaeon))
-                        return ArmysPaeon;
-                }
             }
 
             #endregion
@@ -647,7 +573,7 @@ internal partial class BRD : PhysRangedJob
             if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
                 return OriginalHook(StraightShot);
 
-            if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore) && HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 15)
+            if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore) && HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 18)
                 return OriginalHook(RadiantEncore);
 
             if (IsEnabled(CustomComboPreset.BRD_ST_ApexArrow))
@@ -693,54 +619,23 @@ internal partial class BRD : PhysRangedJob
             #region Songs
 
             // Limit optimisation to when you are high enough level to benefit from it.
-            if (LevelChecked(WanderersMinuet))
+            if (InCombat() && (CanBardWeave || !BardHasTarget))
             {
-                if (CanBardWeave || !BardHasTarget)
-                {
-                    if (SongNone && InCombat())
-                    {
-                        // Logic to determine first song
-                        if (ActionReady(WanderersMinuet) && !(JustUsed(MagesBallad) || JustUsed(ArmysPaeon)))
-                            return WanderersMinuet;
+                if (SongChangePitchPerfect())
+                    return PitchPerfect;
 
-                        if (ActionReady(MagesBallad) && !(JustUsed(WanderersMinuet) || JustUsed(ArmysPaeon)))
-                            return MagesBallad;
+                if (SongChangeEmpyreal())
+                    return EmpyrealArrow;
 
-                        if (ActionReady(ArmysPaeon) && !(JustUsed(MagesBallad) || JustUsed(WanderersMinuet)))
-                            return ArmysPaeon;
-                    }
-
-                    if (SongWanderer)
-                    {
-                        if (SongTimerInSeconds <= 3 && gauge.Repertoire > 0 && BardHasTarget) // Spend any repertoire before switching to next song
-                            return OriginalHook(PitchPerfect);
-
-                        if (SongTimerInSeconds <= 3 && ActionReady(MagesBallad)) // Move to Mage's Ballad if <= 3 seconds left on song
-                            return MagesBallad;
-                    }
-
-                    // Move to Army's Paeon if < 3 seconds left on song
-                    // Special case for Empyreal Arrow: it must be cast before you change to it to avoid drift!
-                    if (SongMage && SongTimerInSeconds <= 3 && ActionReady(ArmysPaeon))
-                    {
-                        return ActionReady(EmpyrealArrow) && BardHasTarget
-                            ? EmpyrealArrow
-                            : ArmysPaeon;
-                    }
-                }
-
-                // Move to Wanderer's Minuet if <= 12 seconds left on song or WM off CD and have 4 repertoires of AP
-                if (SongArmy && (CanWeaveDelayed || !BardHasTarget) && (SongTimerInSeconds <= 12 || gauge.Repertoire == 4) && ActionReady(WanderersMinuet))
+                if (WandererSong())
                     return WanderersMinuet;
-            }
 
-            else if (SongTimerInSeconds <= 3 && CanWeaveDelayed) // Not high enough for wanderers Minuet yet
-            {
-                if (ActionReady(MagesBallad))
+                if (MagesSong())
                     return MagesBallad;
 
-                if (ActionReady(ArmysPaeon))
+                if (ArmySong())
                     return ArmysPaeon;
+
             }
 
             #endregion
@@ -827,7 +722,7 @@ internal partial class BRD : PhysRangedJob
             if (HasEffect(Buffs.ResonantArrowReady))
                 return ResonantArrow;
 
-            if (HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 15)
+            if (HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 18)
                 return OriginalHook(RadiantEncore);
 
             #endregion
@@ -857,64 +752,23 @@ internal partial class BRD : PhysRangedJob
             #region Songs
 
             // Limit optimisation to when you are high enough level to benefit from it.
-            if (LevelChecked(WanderersMinuet))
+            if (InCombat() && (CanBardWeave || !BardHasTarget))
             {
-                // 43s of Wanderer's Minute, ~36s of Mage's Ballad, and ~43s of Army's Paeon
+                if (SongChangePitchPerfect())
+                    return PitchPerfect;
 
-                if (ActionReady(EmpyrealArrow) && JustUsed(WanderersMinuet))
+                if (SongChangeEmpyreal())
                     return EmpyrealArrow;
 
-                if (CanBardWeave || !BardHasTarget)
-                {
-                    if (SongNone && InCombat())
-                    {
-                        // Logic to determine first song
-                        if (ActionReady(WanderersMinuet) && !(JustUsed(MagesBallad) || JustUsed(ArmysPaeon)))
-                            return WanderersMinuet;
-
-                        if (ActionReady(MagesBallad) && !(JustUsed(WanderersMinuet) || JustUsed(ArmysPaeon)))
-                            return MagesBallad;
-
-                        if (ActionReady(ArmysPaeon) && !(JustUsed(MagesBallad) || JustUsed(WanderersMinuet)))
-                            return ArmysPaeon;
-                    }
-
-                    if (SongWanderer)
-                    {
-                        if (SongTimerInSeconds <= 3 && gauge.Repertoire > 0 && BardHasTarget) // Spend any repertoire before switching to next song
-                            return OriginalHook(PitchPerfect);
-
-                        if (SongTimerInSeconds <= 3 && ActionReady(MagesBallad)) // Move to Mage's Ballad if <= 3 seconds left on song
-                            return MagesBallad;
-                    }
-
-                    if (SongMage)
-                    {
-                        // Move to Army's Paeon if <= 3 seconds left on song
-                        if (SongTimerInSeconds <= 3 && ActionReady(ArmysPaeon))
-                        {
-                            // Special case for Empyreal Arrow: it must be cast before you change to it to avoid drift!
-                            if (ActionReady(EmpyrealArrow) && BardHasTarget)
-                                return EmpyrealArrow;
-
-                            return ArmysPaeon;
-                        }
-                    }
-                }
-
-                // Move to Wanderer's Minuet if <= 12 seconds left on song or WM off CD and have 4 repertoires of AP
-                if (SongArmy && (CanWeaveDelayed || !BardHasTarget) &&
-                    (SongTimerInSeconds <= 12 || ActionReady(WanderersMinuet) && gauge.Repertoire == 4))
+                if (WandererSong())
                     return WanderersMinuet;
-            }
 
-            else if (SongTimerInSeconds <= 3 && CanWeaveDelayed)
-            {
-                if (ActionReady(MagesBallad))
+                if (MagesSong())
                     return MagesBallad;
 
-                if (ActionReady(ArmysPaeon))
+                if (ArmySong())
                     return ArmysPaeon;
+
             }
 
             #endregion
@@ -1015,7 +869,7 @@ internal partial class BRD : PhysRangedJob
             if (HasEffect(Buffs.ResonantArrowReady))
                 return ResonantArrow;
 
-            if (HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 15)
+            if (HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 18)
                 return OriginalHook(RadiantEncore);
 
             #endregion

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -259,7 +259,7 @@ internal partial class BRD : PhysRangedJob
             bool battleVoiceEnabled = IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs_Battlevoice);
             bool barrageEnabled = IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs_Barrage);
             bool radiantEnabled = IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs_RadiantFinale);
-
+            bool allBuffsEnabled = radiantEnabled && battleVoiceEnabled && ragingEnabled && barrageEnabled;
             #endregion
 
             #region Variants
@@ -333,25 +333,37 @@ internal partial class BRD : PhysRangedJob
 
             #region Buffs
 
-            if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs) && (!SongNone || !LevelChecked(MagesBallad)) && isEnemyHealthHigh)
+            if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs) && CanBardWeave && isEnemyHealthHigh)
             {
-                // Radiant First with late weave for tighter grouping
-                if (radiantEnabled && CanWeaveDelayed && ActionReady(RadiantFinale) && (RagingCD < 2.3 || !ragingEnabled) &&
-                    !HasEffect(Buffs.RadiantEncoreReady))
-                    return RadiantFinale;
+                if (allBuffsEnabled && !SongNone && LevelChecked(MagesBallad))
+                {
+                    if (UseRadiantBuff())
+                        return RadiantFinale;
 
-                // BV normal weave into the raging weave
-                if (battleVoiceEnabled && CanBardWeave && ActionReady(BattleVoice) && (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale) || !radiantEnabled))
-                    return BattleVoice;
+                    if (UseBattleVoiceBuff())
+                        return BattleVoice;
 
-                // Late weave Raging last, must have battle voice buff OR not be high enough level for Battlecoice
-                if (ragingEnabled && CanBardWeave && ActionReady(RagingStrikes) && (JustUsed(BattleVoice) || !LevelChecked(BattleVoice) || HasEffect(Buffs.BattleVoice) || !battleVoiceEnabled))
-                    return RagingStrikes;
+                    if (UseRagingStrikesBuff())
+                        return RagingStrikes;
 
-                // Barrage Logic to check for raging for low level reasons and it doesn't really need to check for the other buffs
-                if (barrageEnabled && CanBardWeave && ActionReady(Barrage) && (HasEffect(Buffs.RagingStrikes) || !ragingEnabled) &&
-                    !HasEffect(Buffs.ResonantArrowReady))
-                    return Barrage;
+                    if (UseBarrageBuff())
+                        return Barrage;
+                }
+
+                if (!allBuffsEnabled || !LevelChecked(MagesBallad))
+                {
+                    if (ActionReady(RadiantFinale) && radiantEnabled)
+                        return RadiantFinale;
+
+                    if (ActionReady(BattleVoice) && battleVoiceEnabled)
+                        return BattleVoice;
+
+                    if (ActionReady(RagingStrikes) && ragingEnabled)
+                        return RagingStrikes;
+
+                    if (ActionReady(Barrage) && barrageEnabled)
+                        return Barrage;
+                }
             }
 
             #endregion
@@ -444,6 +456,7 @@ internal partial class BRD : PhysRangedJob
             bool battleVoiceEnabled = IsEnabled(CustomComboPreset.BRD_Adv_Buffs_Battlevoice);
             bool barrageEnabled = IsEnabled(CustomComboPreset.BRD_Adv_Buffs_Barrage);
             bool radiantEnabled = IsEnabled(CustomComboPreset.BRD_Adv_Buffs_RadiantFinale);
+            bool allBuffsEnabled = radiantEnabled && battleVoiceEnabled && ragingEnabled && barrageEnabled;
             #endregion
 
             #region Variants
@@ -535,28 +548,38 @@ internal partial class BRD : PhysRangedJob
 
             #region Buffs
 
-            if (IsEnabled(CustomComboPreset.BRD_Adv_Buffs) &&
-                (!SongNone || !LevelChecked(MagesBallad)) && isEnemyHealthHigh)
+            if (IsEnabled(CustomComboPreset.BRD_Adv_Buffs) && CanBardWeave && isEnemyHealthHigh)
             {
-                // Radiant First with late weave for tighter grouping
-                if (radiantEnabled && CanWeaveDelayed && ActionReady(RadiantFinale) && (RagingCD < 2.3 || !ragingEnabled) &&
-                    !HasEffect(Buffs.RadiantEncoreReady))
-                    return RadiantFinale;
+                if (allBuffsEnabled && !SongNone && LevelChecked(MagesBallad))
+                {                    
+                    if (UseRadiantBuff())
+                        return RadiantFinale;
 
-                // BV normal weave into the raging weave
-                if (battleVoiceEnabled && CanBardWeave && ActionReady(BattleVoice) && (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale) || !radiantEnabled))
-                    return BattleVoice;
+                    if (UseBattleVoiceBuff())
+                        return BattleVoice;
+                                        
+                    if (UseRagingStrikesBuff())
+                        return RagingStrikes;
 
-                // Late weave Raging last, must have battle voice buff OR not be high enough level for Battlecoice
-                if (ragingEnabled && CanBardWeave && ActionReady(RagingStrikes) && (JustUsed(BattleVoice) || !LevelChecked(BattleVoice) || HasEffect(Buffs.BattleVoice) || !battleVoiceEnabled))
-                    return RagingStrikes;
+                    if (UseBarrageBuff())
+                        return Barrage;
+                }
 
-                // Barrage Logic to check for raging for low level reasons and it doesn't really need to check for the other buffs
-                if (barrageEnabled && CanBardWeave && ActionReady(Barrage) && (HasEffect(Buffs.RagingStrikes) || !ragingEnabled) &&
-                    !HasEffect(Buffs.ResonantArrowReady))
-                    return Barrage;
+                if (!allBuffsEnabled || !LevelChecked(MagesBallad))
+                {
+                    if (ActionReady(RadiantFinale) && radiantEnabled)
+                        return RadiantFinale;
+
+                    if (ActionReady(BattleVoice) && battleVoiceEnabled)
+                        return BattleVoice;
+
+                    if (ActionReady(RagingStrikes) && ragingEnabled)
+                        return RagingStrikes;
+
+                    if (ActionReady(Barrage) && barrageEnabled)
+                        return Barrage;
+                }
             }
-
             #endregion
 
             #region OGCD
@@ -724,25 +747,37 @@ internal partial class BRD : PhysRangedJob
 
             #region Buffs
 
-            if (!SongNone || !LevelChecked(MagesBallad))
+            if (CanBardWeave)
             {
-                // Radiant First with late weave for tighter grouping
-                if (CanWeaveDelayed && ActionReady(RadiantFinale) && RagingCD < 2.3 &&
-                    !HasEffect(Buffs.RadiantEncoreReady))
-                    return RadiantFinale;
+                if (!SongNone && LevelChecked(MagesBallad))
+                {
+                    if (UseRadiantBuff())
+                        return RadiantFinale;
 
-                // BV normal weave into the raging weave
-                if (CanBardWeave && ActionReady(BattleVoice) && (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale)))
-                    return BattleVoice;
+                    if (UseBattleVoiceBuff())
+                        return BattleVoice;
 
-                // Late weave Raging last, must have battle voice buff OR not be high enough level for Battlecoice
-                if (CanBardWeave && ActionReady(RagingStrikes) && (JustUsed(BattleVoice) || !LevelChecked(BattleVoice) || HasEffect(Buffs.BattleVoice)))
-                    return RagingStrikes;
+                    if (UseRagingStrikesBuff())
+                        return RagingStrikes;
 
-                // Barrage Logic to check for raging for low level reasons and it doesn't really need to check for the other buffs
-                if (CanBardWeave && ActionReady(Barrage) && HasEffect(Buffs.RagingStrikes) &&
-                    !HasEffect(Buffs.ResonantArrowReady))
-                    return Barrage;
+                    if (UseBarrageBuff())
+                        return Barrage;
+                }
+
+                if (!LevelChecked(MagesBallad))
+                {
+                    if (ActionReady(RadiantFinale))
+                        return RadiantFinale;
+
+                    if (ActionReady(BattleVoice))
+                        return BattleVoice;
+
+                    if (ActionReady(RagingStrikes))
+                        return RagingStrikes;
+
+                    if (ActionReady(Barrage))
+                        return Barrage;
+                }
             }
 
             #endregion
@@ -886,25 +921,37 @@ internal partial class BRD : PhysRangedJob
 
             #region Buffs
 
-            if (!SongNone || !LevelChecked(MagesBallad))
+            if (CanBardWeave)
             {
-                // Radiant First with late weave for tighter grouping
-                if (CanWeaveDelayed && ActionReady(RadiantFinale) && RagingCD < 2.3 &&
-                    !HasEffect(Buffs.RadiantEncoreReady))
-                    return RadiantFinale;
+                if (!SongNone && LevelChecked(MagesBallad))
+                {
+                    if (UseRadiantBuff())
+                        return RadiantFinale;
 
-                // BV normal weave into the raging weave
-                if (CanBardWeave && ActionReady(BattleVoice) && (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale)))
-                    return BattleVoice;
+                    if (UseBattleVoiceBuff())
+                        return BattleVoice;
 
-                // Late weave Raging last, must have battle voice buff OR not be high enough level for Battlecoice
-                if (CanBardWeave && ActionReady(RagingStrikes) && (JustUsed(BattleVoice) || !LevelChecked(BattleVoice) || HasEffect(Buffs.BattleVoice)))
-                    return RagingStrikes;
+                    if (UseRagingStrikesBuff())
+                        return RagingStrikes;
 
-                // Barrage Logic to check for raging for low level reasons and it doesn't really need to check for the other buffs
-                if (CanBardWeave && ActionReady(Barrage) && HasEffect(Buffs.RagingStrikes) &&
-                    !HasEffect(Buffs.ResonantArrowReady))
-                    return Barrage;
+                    if (UseBarrageBuff())
+                        return Barrage;
+                }
+
+                if (!LevelChecked(MagesBallad))
+                {
+                    if (ActionReady(RadiantFinale))
+                        return RadiantFinale;
+
+                    if (ActionReady(BattleVoice))
+                        return BattleVoice;
+
+                    if (ActionReady(RagingStrikes))
+                        return RagingStrikes;
+
+                    if (ActionReady(Barrage))
+                        return Barrage;
+                }
             }
 
             #endregion

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -1,7 +1,4 @@
 using Dalamud.Game.ClientState.JobGauge.Enums;
-using Dalamud.Game.ClientState.JobGauge.Types;
-using Dalamud.Game.ClientState.Statuses;
-using System;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Data;
@@ -10,12 +7,6 @@ namespace WrathCombo.Combos.PvE;
 
 internal partial class BRD : PhysRangedJob
 {
-    #region Song status
-    internal static bool SongIsNotNone(Song value) => value != Song.None;
-    internal static bool SongIsNone(Song value) => value == Song.None;
-    internal static bool SongIsWandererMinuet(Song value) => value == Song.Wanderer;
-    #endregion
-
     #region Smaller features
     internal class BRD_StraightShotUpgrade : CustomCombo
     {
@@ -29,13 +20,7 @@ internal partial class BRD : PhysRangedJob
             if (IsEnabled(CustomComboPreset.BRD_DoTMaintainance))
             {
                 if (InCombat())
-                {
-                    bool canIronJaws = LevelChecked(IronJaws);
-                    Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
-                    Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
-                    float purpleRemaining = purple?.RemainingTime ?? 0;
-                    float blueRemaining = blue?.RemainingTime ?? 0;
-
+                {                    
                     if (purple is not null && purpleRemaining < 4)
                         return canIronJaws ? IronJaws : VenomousBite;
                     if (blue is not null && blueRemaining < 4)
@@ -45,8 +30,6 @@ internal partial class BRD : PhysRangedJob
 
             if (IsEnabled(CustomComboPreset.BRD_ApexST))
             {
-                BRDGauge? gauge = GetJobGauge<BRDGauge>();
-
                 if (gauge.SoulVoice == 100)
                     return ApexArrow;
                 if (HasEffect(Buffs.BlastArrowReady))
@@ -69,11 +52,6 @@ internal partial class BRD : PhysRangedJob
             if (actionID is not IronJaws)
                 return actionID;
 
-            Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
-            Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
-            float purpleRemaining = purple?.RemainingTime ?? 0;
-            float blueRemaining = blue?.RemainingTime ?? 0;
-
             // Before Iron Jaws: Alternate between DoTs
             if (!LevelChecked(IronJaws))
                 return LevelChecked(Windbite) && blueRemaining <= purpleRemaining ? Windbite : VenomousBite;
@@ -93,8 +71,6 @@ internal partial class BRD : PhysRangedJob
             // Apex Option
             if (IsEnabled(CustomComboPreset.BRD_IronJawsApex))
             {
-                BRDGauge? gauge = GetJobGauge<BRDGauge>();
-
                 if (LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady))
                     return BlastArrow;
                 if (gauge.SoulVoice == 100)
@@ -112,11 +88,6 @@ internal partial class BRD : PhysRangedJob
         {
             if (actionID is not IronJaws)
                 return actionID;
-
-            Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
-            Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
-            float purpleRemaining = purple?.RemainingTime ?? 0;
-            float blueRemaining = blue?.RemainingTime ?? 0;
 
             // Iron Jaws only if it is applicable
             if (LevelChecked(IronJaws) && (
@@ -139,10 +110,6 @@ internal partial class BRD : PhysRangedJob
         {
             if (actionID is not RainOfDeath)
                 return actionID;
-
-            BRDGauge? gauge = GetJobGauge<BRDGauge>();
-            bool songArmy = gauge.Song == Song.Army;
-            bool songWanderer = gauge.Song == Song.Wanderer;
 
             if (IsEnabled(CustomComboPreset.BRD_AoE_oGCD_Songs) && (gauge.SongTimer < 1 || songArmy))
             {
@@ -175,10 +142,6 @@ internal partial class BRD : PhysRangedJob
         {
             if (actionID is not (Bloodletter or HeartbreakShot))
                 return actionID;
-
-            BRDGauge? gauge = GetJobGauge<BRDGauge>();
-            bool songArmy = gauge.Song == Song.Army;
-            bool songWanderer = gauge.Song == Song.Wanderer;
 
             if (IsEnabled(CustomComboPreset.BRD_ST_oGCD_Songs) && (gauge.SongTimer < 1 || songArmy))
             {
@@ -214,8 +177,6 @@ internal partial class BRD : PhysRangedJob
 
             if (IsEnabled(CustomComboPreset.BRD_Apex))
             {
-                BRDGauge? gauge = GetJobGauge<BRDGauge>();
-
                 if (gauge.SoulVoice == 100)
                     return ApexArrow;
                 if (HasEffect(Buffs.BlastArrowReady))
@@ -258,10 +219,6 @@ internal partial class BRD : PhysRangedJob
             if (actionID is not WanderersMinuet)
                 return actionID;
 
-            // Doesn't display the lowest cooldown song if they have been used out of order and are all on cooldown.
-            BRDGauge? gauge = GetJobGauge<BRDGauge>();
-            int songTimerInSeconds = gauge.SongTimer / 1000;
-
             if (ActionReady(WanderersMinuet) || (gauge.Song == Song.Wanderer && songTimerInSeconds > 11))
                 return WanderersMinuet;
 
@@ -286,21 +243,16 @@ internal partial class BRD : PhysRangedJob
             if (actionID is not (Ladonsbite or QuickNock))
                 return actionID;
 
-            BRDGauge? gauge = GetJobGauge<BRDGauge>();
-            bool canWeave = CanWeave() && !ActionWatching.HasDoubleWeaved();
-            bool canWeaveDelayed = CanDelayedWeave(0.9) && !ActionWatching.HasDoubleWeaved();
-            int songTimerInSeconds = gauge.SongTimer / 1000;
-            bool songNone = gauge.Song == Song.None;
-            bool songWanderer = gauge.Song == Song.Wanderer;
-            bool songMage = gauge.Song == Song.Mage;
-            bool songArmy = gauge.Song == Song.Army;
+            #region Variables
+
             int targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_AoENoWasteHPPercentage);
             bool isEnemyHealthHigh = !IsEnabled(CustomComboPreset.BRD_AoE_Adv_NoWaste) || GetTargetHPPercent() > targetHPThreshold;
-            bool hasTarget = HasBattleTarget();
             bool ragingEnabled = IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs_Raging);
             bool battleVoiceEnabled = IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs_Battlevoice);
             bool barrageEnabled = IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs_Barrage);
             bool radiantEnabled = IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs_RadiantFinale);
+
+            #endregion
 
             #region Variants
 
@@ -315,7 +267,6 @@ internal partial class BRD : PhysRangedJob
             #region Songs
             if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Songs))
             {
-
                 // Limit optimisation to when you are high enough level to benefit from it.
                 if (LevelChecked(WanderersMinuet))
                 {
@@ -342,7 +293,6 @@ internal partial class BRD : PhysRangedJob
 
                         if (songMage)
                         {
-
                             // Move to Army's Paeon if < 3 seconds left on song
                             if (songTimerInSeconds <= 3 && ActionReady(ArmysPaeon))
                             {
@@ -375,12 +325,9 @@ internal partial class BRD : PhysRangedJob
 
             if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs) && (!songNone || !LevelChecked(MagesBallad)) && isEnemyHealthHigh)
             {
-                float ragingCD = GetCooldownRemainingTime(RagingStrikes);
-
                // Radiant First with late weave for tighter grouping
                 if (radiantEnabled && canWeaveDelayed && ActionReady(RadiantFinale) && (ragingCD < 2.3 || !ragingEnabled) &&
-                !HasEffect(Buffs.RadiantEncoreReady) &&
-                (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet)))
+                !HasEffect(Buffs.RadiantEncoreReady))
                     return RadiantFinale;
 
                 // BV normal weave into the raging weave
@@ -404,13 +351,12 @@ internal partial class BRD : PhysRangedJob
 
             if (canWeave && IsEnabled(CustomComboPreset.BRD_AoE_Adv_oGCD))
             {
-
                 if (ActionReady(EmpyrealArrow))
                     return EmpyrealArrow;
 
                 // Pitch perfect logic. Uses when full, or at 2 stacks before Empy arrow to prevent overcap
                 if (LevelChecked(PitchPerfect) && songWanderer &&
-                    (gauge.Repertoire == 3 || (LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && GetCooldownRemainingTime(EmpyrealArrow) < 2)))
+                    (gauge.Repertoire == 3 || (LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && empyrealCD < 2)))
                     return OriginalHook(PitchPerfect);
 
                 // Sidewinder Logic to stay in the buff window on 2 min, but on cd with the 1 min
@@ -418,9 +364,9 @@ internal partial class BRD : PhysRangedJob
                 {
                     if (songWanderer)
                     {
-                        if ((HasEffect(Buffs.RagingStrikes) || GetCooldownRemainingTime(RagingStrikes) > 10) &&
-                            (HasEffect(Buffs.BattleVoice) || GetCooldownRemainingTime(BattleVoice) > 10) &&
-                            (HasEffect(Buffs.RadiantFinale) || GetCooldownRemainingTime(RadiantFinale) > 10 ||
+                        if ((HasEffect(Buffs.RagingStrikes) || ragingCD > 10) &&
+                            (HasEffect(Buffs.BattleVoice) || battleVoiceCD > 10) &&
+                            (HasEffect(Buffs.RadiantFinale) || radiantCD > 10 ||
                              !LevelChecked(RadiantFinale)))
                             return Sidewinder;
                     }
@@ -436,19 +382,16 @@ internal partial class BRD : PhysRangedJob
             // Rain of death Logic
             if (canWeave && IsEnabled(CustomComboPreset.BRD_AoE_Adv_oGCD))
             {
-                if (LevelChecked(RainOfDeath) && !WasLastAction(RainOfDeath) && (GetCooldownRemainingTime(EmpyrealArrow) > 1 || !LevelChecked(EmpyrealArrow)))
+                if (LevelChecked(RainOfDeath) && !WasLastAction(RainOfDeath) && empyrealCD > 1 || !LevelChecked(EmpyrealArrow))
                 {
-
-                    uint rainOfDeathCharges = LevelChecked(RainOfDeath) ? GetRemainingCharges(RainOfDeath) : 0;
-
                     if (IsEnabled(CustomComboPreset.BRD_AoE_Pooling) && LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
                     {
                         if (songWanderer) //Stop pooling for buff window
                         {
-                            if (((HasEffect(Buffs.RagingStrikes) || GetCooldownRemainingTime(RagingStrikes) > 10) &&
-                                 (HasEffect(Buffs.BattleVoice) || GetCooldownRemainingTime(BattleVoice) > 10 ||
+                            if (((HasEffect(Buffs.RagingStrikes) || ragingCD > 10) &&
+                                 (HasEffect(Buffs.BattleVoice) || battleVoiceCD > 10 ||
                                   !LevelChecked(BattleVoice)) &&
-                                 (HasEffect(Buffs.RadiantFinale) || GetCooldownRemainingTime(RadiantFinale) > 10 ||
+                                 (HasEffect(Buffs.RadiantFinale) || radiantCD > 10 ||
                                   !LevelChecked(RadiantFinale)) &&
                                  rainOfDeathCharges > 0) || rainOfDeathCharges > 2)
                                 return OriginalHook(RainOfDeath);
@@ -464,7 +407,7 @@ internal partial class BRD : PhysRangedJob
                     else if (rainOfDeathCharges > 0) //Dont pool when not enabled
                         return OriginalHook(RainOfDeath);
                 }
-                if (!LevelChecked(RainOfDeath) && !(WasLastAction(Bloodletter) && GetRemainingCharges(Bloodletter) > 0))
+                if (!LevelChecked(RainOfDeath) && !(WasLastAction(Bloodletter) && bloodletterCharges > 0))
                     return OriginalHook(Bloodletter);
             }
 
@@ -530,27 +473,14 @@ internal partial class BRD : PhysRangedJob
     internal class BRD_ST_AdvMode : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_ST_AdvMode;
-        internal static bool usedStraightShotReady = false;
-        internal static bool usedPitchPerfect = false;
-        internal delegate bool DotRecast(int value);
-
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not (HeavyShot or BurstShot))
                 return actionID;
 
-            BRDGauge? gauge = GetJobGauge<BRDGauge>();
-            bool canWeave = CanWeave() && !ActionWatching.HasDoubleWeaved();
-            bool canWeaveDelayed = CanDelayedWeave(0.9) && !ActionWatching.HasDoubleWeaved();
-            bool songNone = gauge.Song == Song.None;
-            bool songWanderer = gauge.Song == Song.Wanderer;
-            bool songMage = gauge.Song == Song.Mage;
-            bool songArmy = gauge.Song == Song.Army;
-            int songTimerInSeconds = gauge.SongTimer / 1000;
             int targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_NoWasteHPPercentage);
-            bool isEnemyHealthHigh = !IsEnabled(CustomComboPreset.BRD_Adv_NoWaste) || GetTargetHPPercent() > targetHPThreshold;
-            bool hasTarget = HasBattleTarget();
-            bool buffTime = GetCooldownRemainingTime(RagingStrikes) < 2.7;
+            int ragingJawsRenewTime = PluginConfiguration.GetCustomIntValue(Config.BRD_RagingJawsRenewTime);
+            bool isEnemyHealthHigh = !IsEnabled(CustomComboPreset.BRD_Adv_NoWaste) || GetTargetHPPercent() > targetHPThreshold;            
             bool ragingEnabled = IsEnabled(CustomComboPreset.BRD_Adv_Buffs_Raging);
             bool battleVoiceEnabled = IsEnabled(CustomComboPreset.BRD_Adv_Buffs_Battlevoice);
             bool barrageEnabled = IsEnabled(CustomComboPreset.BRD_Adv_Buffs_Barrage);
@@ -571,7 +501,7 @@ internal partial class BRD : PhysRangedJob
             {
                 if (ActionWatching.GetAttackType(Opener().CurrentOpenerAction) != ActionWatching.ActionAttackType.Ability && canWeave)
                 {
-                    if (HasEffect(Buffs.RagingStrikes) && (gauge.Repertoire == 3 || (gauge.Repertoire == 2 && GetCooldownRemainingTime(EmpyrealArrow) < 2)))
+                    if (HasEffect(Buffs.RagingStrikes) && (gauge.Repertoire == 3 || (gauge.Repertoire == 2 && empyrealCD < 2)))
                         return OriginalHook(PitchPerfect);
 
                     if (ActionReady(HeartbreakShot) && HasEffect(Buffs.RagingStrikes))
@@ -648,12 +578,10 @@ internal partial class BRD : PhysRangedJob
 
             if (IsEnabled(CustomComboPreset.BRD_Adv_Buffs) && (!songNone || !LevelChecked(MagesBallad)) && isEnemyHealthHigh)
             {
-                float ragingCD = GetCooldownRemainingTime(RagingStrikes);
 
                 // Radiant First with late weave for tighter grouping
                 if (radiantEnabled && canWeaveDelayed && ActionReady(RadiantFinale) && (ragingCD < 2.3 || !ragingEnabled) &&
-                !HasEffect(Buffs.RadiantEncoreReady) &&
-                (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet)))
+                !HasEffect(Buffs.RadiantEncoreReady))
                     return RadiantFinale;
 
                 // BV normal weave into the raging weave
@@ -680,7 +608,7 @@ internal partial class BRD : PhysRangedJob
             {
                 // Pitch Perfect logic to use when full or when Empyreal arrow might overcap it.
                 if (LevelChecked(PitchPerfect) && songWanderer &&
-                    (gauge.Repertoire == 3 || (LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && GetCooldownRemainingTime(EmpyrealArrow) < 2)))
+                    (gauge.Repertoire == 3 || (LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && empyrealCD < 2)))
                     return OriginalHook(PitchPerfect);
 
                 if (ActionReady(EmpyrealArrow))
@@ -693,9 +621,9 @@ internal partial class BRD : PhysRangedJob
                     {
                         if (songWanderer)
                         {
-                            if ((HasEffect(Buffs.RagingStrikes) || GetCooldownRemainingTime(RagingStrikes) > 10) &&
-                                (HasEffect(Buffs.BattleVoice) || GetCooldownRemainingTime(BattleVoice) > 10) &&
-                                (HasEffect(Buffs.RadiantFinale) || GetCooldownRemainingTime(RadiantFinale) > 10 ||
+                            if ((HasEffect(Buffs.RagingStrikes) || ragingCD > 10) &&
+                                (HasEffect(Buffs.BattleVoice) || battleVoiceCD > 10) &&
+                                (HasEffect(Buffs.RadiantFinale) || radiantCD > 10 ||
                                  !LevelChecked(RadiantFinale)))
                                 return Sidewinder;
                         }
@@ -713,18 +641,16 @@ internal partial class BRD : PhysRangedJob
             // Bloodletter pooling logic. Will Pool as buffs are coming up.
             if (canWeave && IsEnabled(CustomComboPreset.BRD_ST_Adv_oGCD))
             {
-                if (ActionReady(Bloodletter) && !(WasLastAction(Bloodletter) || WasLastAction(HeartbreakShot)) && (GetCooldownRemainingTime(EmpyrealArrow) > 1 || !LevelChecked(EmpyrealArrow)))
+                if (ActionReady(Bloodletter) && !(WasLastAction(Bloodletter) || WasLastAction(HeartbreakShot)) && empyrealCD > 1 || !LevelChecked(EmpyrealArrow))
                 {
-                    uint bloodletterCharges = GetRemainingCharges(Bloodletter);
-
                     if (IsEnabled(CustomComboPreset.BRD_Adv_Pooling) && LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
                     {
                         if (songWanderer) // Pool until buffs go out in wanderers
                         {
-                            if (((HasEffect(Buffs.RagingStrikes) || GetCooldownRemainingTime(RagingStrikes) > 10) &&
-                                 (HasEffect(Buffs.BattleVoice) || GetCooldownRemainingTime(BattleVoice) > 10 ||
+                            if (((HasEffect(Buffs.RagingStrikes) || ragingCD > 10) &&
+                                 (HasEffect(Buffs.BattleVoice) || battleVoiceCD > 10 ||
                                   !LevelChecked(BattleVoice)) &&
-                                 (HasEffect(Buffs.RadiantFinale) || GetCooldownRemainingTime(RadiantFinale) > 10 ||
+                                 (HasEffect(Buffs.RadiantFinale) || radiantCD > 10 ||
                                   !LevelChecked(RadiantFinale)) &&
                                  bloodletterCharges > 0) || bloodletterCharges > 2)
                                 return OriginalHook(Bloodletter);
@@ -761,14 +687,6 @@ internal partial class BRD : PhysRangedJob
 
             if (isEnemyHealthHigh)
             {
-                bool canIronJaws = LevelChecked(IronJaws);
-                Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
-                Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
-                float purpleRemaining = purple?.RemainingTime ?? 0;
-                float blueRemaining = blue?.RemainingTime ?? 0;
-                float ragingStrikesDuration = GetBuffRemainingTime(Buffs.RagingStrikes);
-                int ragingJawsRenewTime = PluginConfiguration.GetCustomIntValue(Config.BRD_RagingJawsRenewTime);
-
                 if (IsEnabled(CustomComboPreset.BRD_Adv_DoT))
                 {
                     if (purple is not null && purpleRemaining < 4)
@@ -834,27 +752,11 @@ internal partial class BRD : PhysRangedJob
     #region Simple Modes
     internal class BRD_AoE_SimpleMode : CustomCombo
     {
-        internal static bool inOpener = false;
-        internal static bool openerFinished = false;
-
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_AoE_SimpleMode;
-
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not (Ladonsbite or QuickNock))
                 return actionID;
-
-            BRDGauge? gauge = GetJobGauge<BRDGauge>();
-            bool canWeave = CanWeave() && !ActionWatching.HasDoubleWeaved();
-            bool canWeaveDelayed = CanDelayedWeave(0.9) && !ActionWatching.HasDoubleWeaved();
-            int songTimerInSeconds = gauge.SongTimer / 1000;
-            bool songNone = gauge.Song == Song.None;
-            bool songWanderer = gauge.Song == Song.Wanderer;
-            bool songMage = gauge.Song == Song.Mage;
-            bool songArmy = gauge.Song == Song.Army;
-            int targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_AoENoWasteHPPercentage);
-            bool isEnemyHealthHigh = GetTargetHPPercent() > 5;
-            bool hasTarget = HasBattleTarget();
 
             #region Variants
 
@@ -925,14 +827,11 @@ internal partial class BRD : PhysRangedJob
 
             #region Buffs
 
-            if ((!songNone || !LevelChecked(MagesBallad)) && isEnemyHealthHigh)
+            if (!songNone || !LevelChecked(MagesBallad)) 
             {
-                float ragingCD = GetCooldownRemainingTime(RagingStrikes);
-
                 // Radiant First with late weave for tighter grouping
                 if (canWeaveDelayed && ActionReady(RadiantFinale) && ragingCD < 2.3 &&
-                !HasEffect(Buffs.RadiantEncoreReady) &&
-                (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet)))
+                !HasEffect(Buffs.RadiantEncoreReady))
                     return RadiantFinale;
 
                 // BV normal weave into the raging weave
@@ -947,7 +846,6 @@ internal partial class BRD : PhysRangedJob
                 if (canWeave && ActionReady(Barrage) && HasEffect(Buffs.RagingStrikes) &&
                     !HasEffect(Buffs.ResonantArrowReady))
                     return Barrage;
-
             }
 
             #endregion
@@ -956,11 +854,6 @@ internal partial class BRD : PhysRangedJob
 
             if (canWeave)
             {
-                float battleVoiceCD = GetCooldownRemainingTime(BattleVoice);
-                float empyrealCD = GetCooldownRemainingTime(EmpyrealArrow);
-                float ragingCD = GetCooldownRemainingTime(RagingStrikes);
-                float radiantCD = GetCooldownRemainingTime(RadiantFinale);
-
                 if (ActionReady(EmpyrealArrow))
                     return EmpyrealArrow;
 
@@ -991,9 +884,7 @@ internal partial class BRD : PhysRangedJob
 
                 // Pooling logic for rain of death basied on song
                 if (LevelChecked(RainOfDeath) && !WasLastAction(RainOfDeath) && (empyrealCD > 1 || !LevelChecked(EmpyrealArrow)))
-                {
-                    uint rainOfDeathCharges = LevelChecked(RainOfDeath) ? GetRemainingCharges(RainOfDeath) : 0;
-
+                {                   
                     if (LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
                     {
                         if (songWanderer)
@@ -1018,7 +909,7 @@ internal partial class BRD : PhysRangedJob
                         return OriginalHook(RainOfDeath);
                 }
 
-                if (!LevelChecked(RainOfDeath) && !(WasLastAction(Bloodletter) && GetRemainingCharges(Bloodletter) > 0))
+                if (!LevelChecked(RainOfDeath) && !(WasLastAction(Bloodletter) && bloodletterCharges > 0))
                     return OriginalHook(Bloodletter);
 
                 // Self care section for healing and debuff removal
@@ -1056,25 +947,10 @@ internal partial class BRD : PhysRangedJob
     internal class BRD_ST_SimpleMode : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_ST_SimpleMode;
-        internal static bool usedStraightShotReady = false;
-        internal static bool usedPitchPerfect = false;
-        internal delegate bool DotRecast(int value);
-
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not (HeavyShot or BurstShot))
                 return actionID;
-
-            BRDGauge? gauge = GetJobGauge<BRDGauge>();
-            bool canWeave = CanWeave() && !ActionWatching.HasDoubleWeaved();
-            bool canWeaveDelayed = CanDelayedWeave(0.9) && !ActionWatching.HasDoubleWeaved();
-            bool songNone = gauge.Song == Song.None;
-            bool songWanderer = gauge.Song == Song.Wanderer;
-            bool songMage = gauge.Song == Song.Mage;
-            bool songArmy = gauge.Song == Song.Army;
-            bool isEnemyHealthHigh = GetTargetHPPercent() > 1;
-            int songTimerInSeconds = gauge.SongTimer / 1000;
-            bool hasTarget = HasBattleTarget();
 
             #region Variants
             if (Variant.CanCure(CustomComboPreset.BRD_Variant_Cure, 50))
@@ -1148,14 +1024,11 @@ internal partial class BRD : PhysRangedJob
 
             #region Buffs
 
-            if ((!songNone || !LevelChecked(MagesBallad)) && isEnemyHealthHigh)
+            if (!songNone || !LevelChecked(MagesBallad))
             {
-                float ragingCD = GetCooldownRemainingTime(RagingStrikes);
-
                 // Radiant First with late weave for tighter grouping
                 if (canWeaveDelayed && ActionReady(RadiantFinale) && ragingCD < 2.3 &&
-                !HasEffect(Buffs.RadiantEncoreReady) &&
-                (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet)))
+                !HasEffect(Buffs.RadiantEncoreReady))
                     return RadiantFinale;
 
                 // BV normal weave into the raging weave
@@ -1179,11 +1052,6 @@ internal partial class BRD : PhysRangedJob
 
             if (canWeave)
             {
-                float battleVoiceCD = GetCooldownRemainingTime(BattleVoice);
-                float empyrealCD = GetCooldownRemainingTime(EmpyrealArrow);
-                float ragingCD = GetCooldownRemainingTime(RagingStrikes);
-                float radiantCD = GetCooldownRemainingTime(RadiantFinale);
-
                 // Empyreal Arrow first to minimize drift
                 if (ActionReady(EmpyrealArrow))
                     return EmpyrealArrow;
@@ -1215,8 +1083,6 @@ internal partial class BRD : PhysRangedJob
                 // Bloodletter pooling logic
                 if (ActionReady(Bloodletter) && !(WasLastAction(Bloodletter) || WasLastAction(HeartbreakShot)) && (empyrealCD > 1 || !LevelChecked(EmpyrealArrow)))
                 {
-                    uint bloodletterCharges = GetRemainingCharges(Bloodletter);
-
                     if (LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
                     {
                         if (songWanderer) // Stop pooling in burst window
@@ -1253,36 +1119,26 @@ internal partial class BRD : PhysRangedJob
 
             #region Dot Management
 
-            if (isEnemyHealthHigh)
+            // Iron jaws Dot refresh, or low level manaul dot refresh
+            if (purple is not null && purpleRemaining < 4)
+                return canIronJaws ? IronJaws : VenomousBite;
+            if (blue is not null && blueRemaining < 4)
+                return canIronJaws ? IronJaws : Windbite;
+
+            // Dot application
+            if (blue is null && LevelChecked(Windbite))
+                return OriginalHook(Windbite);
+            if (purple is null && LevelChecked(VenomousBite))
+                return OriginalHook(VenomousBite);
+
+            // Raging jaws dot snapshotting logic
+            if (ActionReady(IronJaws) && HasEffect(Buffs.RagingStrikes) &&
+            ragingStrikesDuration < 6 && // Raging Jaws 
+            purpleRemaining < 35 && blueRemaining < 35)    // Prevention of double refreshing dots
             {
-                bool canIronJaws = LevelChecked(IronJaws);
-                Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
-                Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
-                float purpleRemaining = purple?.RemainingTime ?? 0;
-                float blueRemaining = blue?.RemainingTime ?? 0;
-                float ragingStrikesDuration = GetBuffRemainingTime(Buffs.RagingStrikes);
-                int ragingJawsRenewTime = 6;
-
-                // Iron jaws Dot refresh, or low level manaul dot refresh
-                if (purple is not null && purpleRemaining < 4)
-                    return canIronJaws ? IronJaws : VenomousBite;
-                if (blue is not null && blueRemaining < 4)
-                    return canIronJaws ? IronJaws : Windbite;
-
-                // Dot application
-                if (blue is null && LevelChecked(Windbite))
-                    return OriginalHook(Windbite);
-                if (purple is null && LevelChecked(VenomousBite))
-                    return OriginalHook(VenomousBite);
-
-                // Raging jaws dot snapshotting logic
-                if (ActionReady(IronJaws) && HasEffect(Buffs.RagingStrikes) &&
-                ragingStrikesDuration < ragingJawsRenewTime && // Raging Jaws 
-                purpleRemaining < 35 && blueRemaining < 35)    // Prevention of double refreshing dots
-                {
-                    return IronJaws;
-                }
+                return IronJaws;
             }
+            
             #endregion
 
             #region GCDS

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -375,7 +375,7 @@ internal partial class BRD : PhysRangedJob
 
             #region GCDS
 
-            if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
+            if (HasEffect(Buffs.Barrage))
                 return OriginalHook(WideVolley);
 
             if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore) && HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 18)
@@ -395,6 +395,9 @@ internal partial class BRD : PhysRangedJob
                 if (HasEffect(Buffs.ResonantArrowReady))
                     return ResonantArrow;
             }
+
+            if (HasEffect(Buffs.HawksEye))
+                return OriginalHook(WideVolley);
 
             #endregion
 
@@ -451,7 +454,7 @@ internal partial class BRD : PhysRangedJob
 
             #region Songs
 
-            if (IsEnabled(CustomComboPreset.BRD_Adv_Song) && isEnemyHealthHigh && InCombat() && (CanBardWeave || !BardHasTarget))
+            if (IsEnabled(CustomComboPreset.BRD_Adv_Song) && isEnemyHealthHigh && InCombat())
             {
                 if (SongChangePitchPerfect())
                     return PitchPerfect;
@@ -570,10 +573,10 @@ internal partial class BRD : PhysRangedJob
 
             #region GCDS
 
-            if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
+            if (HasEffect(Buffs.Barrage))
                 return OriginalHook(StraightShot);
 
-            if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore) && HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 18)
+            if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore) && HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 17)
                 return OriginalHook(RadiantEncore);
 
             if (IsEnabled(CustomComboPreset.BRD_ST_ApexArrow))
@@ -587,6 +590,9 @@ internal partial class BRD : PhysRangedJob
 
             if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsResonant) && HasEffect(Buffs.ResonantArrowReady))
                 return ResonantArrow;
+
+            if (HasEffect(Buffs.HawksEye))
+                return OriginalHook(StraightShot);
 
             #endregion
 
@@ -710,7 +716,7 @@ internal partial class BRD : PhysRangedJob
 
             #region GCDS
 
-            if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
+            if (HasEffect(Buffs.Barrage))
                 return OriginalHook(WideVolley);
 
             if (HasEffect(Buffs.BlastArrowReady))
@@ -724,6 +730,9 @@ internal partial class BRD : PhysRangedJob
 
             if (HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 18)
                 return OriginalHook(RadiantEncore);
+
+            if (HasEffect(Buffs.HawksEye))
+                return OriginalHook(WideVolley);
 
             #endregion
 
@@ -857,7 +866,7 @@ internal partial class BRD : PhysRangedJob
 
             #region GCDS
 
-            if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
+            if (HasEffect(Buffs.Barrage))
                 return OriginalHook(StraightShot);
 
             if (HasEffect(Buffs.BlastArrowReady))
@@ -871,6 +880,9 @@ internal partial class BRD : PhysRangedJob
 
             if (HasEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 18)
                 return OriginalHook(RadiantEncore);
+
+            if (HasEffect(Buffs.HawksEye))
+                return OriginalHook(StraightShot);
 
             #endregion
 

--- a/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
@@ -3,6 +3,7 @@
 using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Statuses;
+using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -174,7 +175,70 @@ internal partial class BRD
                 return true;
             return false;
         }
-            #endregion
+    #endregion
+
+        #region Songs
+
+    internal static bool WandererSong()
+    {
+        if (ActionReady(WanderersMinuet))
+        {
+            if (SongNone)
+               return true;
+                
+            if (SongArmy && (CanWeaveDelayed || !BardHasTarget) && (SongTimerInSeconds <= 12 || gauge.Repertoire == 4))
+                return true;
+        }
+        return false;
+    }
+    internal static bool MagesSong()
+    {
+        if (ActionReady(MagesBallad))
+        {
+            if (SongNone && !ActionReady(WanderersMinuet))
+                return true;
+
+            if (SongWanderer && SongTimerInSeconds <= 3)
+                return true;
+
+            if (!LevelChecked(WanderersMinuet) && SongTimerInSeconds <= 3 && CanWeaveDelayed)
+                return true;
+        }
+        return false;
+    }
+
+    internal static bool ArmySong()
+    {
+        if (ActionReady(ArmysPaeon))
+        {
+            if (SongNone && !ActionReady(MagesBallad) && !ActionReady(WanderersMinuet))
+                return true;
+
+            if (SongMage && SongTimerInSeconds <= 3)
+                return true;
+
+            if (!LevelChecked(WanderersMinuet) && SongTimerInSeconds <= 3 && CanWeaveDelayed && !ActionReady(MagesBallad))
+                return true;
+        }
+        return false;
+    }
+
+    internal static bool SongChangeEmpyreal()
+    {
+        if (SongMage && SongTimerInSeconds <= 3 && ActionReady(ArmysPaeon) && ActionReady(EmpyrealArrow) && BardHasTarget)
+            return true;
+        
+        return false;
+    }
+
+    internal static bool SongChangePitchPerfect()
+    {
+        if (SongWanderer && SongTimerInSeconds <= 3 && gauge.Repertoire > 0 && BardHasTarget)
+            return true;
+
+        return false;
+    }
+    #endregion
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
@@ -1,11 +1,19 @@
-﻿using System;
+﻿#region Dependencies
+using System;
 using System.Collections.Generic;
+using Dalamud.Game.ClientState.JobGauge.Enums;
+using Dalamud.Game.ClientState.JobGauge.Types;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
+using WrathCombo.Data;
+using Dalamud.Game.ClientState.Statuses;
+using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
+
+#endregion
 
 namespace WrathCombo.Combos.PvE;
 
-internal partial class BRD
+internal partial class BRD : PhysRangedJob
 {
     #region ID's
 
@@ -80,6 +88,39 @@ internal partial class BRD
     }
 
     #endregion
+
+    #region Variables
+
+    internal static BRDGauge? gauge = GetJobGauge<BRDGauge>();
+    internal static int songTimerInSeconds = gauge.SongTimer / 1000;
+    internal static bool songNone = gauge.Song == Song.None;
+    internal static bool songWanderer = gauge.Song == Song.Wanderer;
+    internal static bool songMage = gauge.Song == Song.Mage;
+    internal static bool songArmy = gauge.Song == Song.Army;
+
+    internal static Status? purple = FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
+    internal static Status? blue = FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
+    internal static float purpleRemaining = purple?.RemainingTime ?? 0;
+    internal static float blueRemaining = blue?.RemainingTime ?? 0;
+
+    internal static bool hasTarget = HasBattleTarget();
+    internal static bool canWeave = CanWeave() && !ActionWatching.HasDoubleWeaved();
+    internal static bool canWeaveDelayed = CanDelayedWeave(0.9) && !ActionWatching.HasDoubleWeaved();
+    internal static bool canIronJaws = LevelChecked(IronJaws);
+    internal static bool buffTime = GetCooldownRemainingTime(RagingStrikes) < 2.7;
+
+    internal static float ragingCD = GetCooldownRemainingTime(RagingStrikes);
+    internal static float battleVoiceCD = GetCooldownRemainingTime(BattleVoice);
+    internal static float empyrealCD = GetCooldownRemainingTime(EmpyrealArrow);
+    internal static float radiantCD = GetCooldownRemainingTime(RadiantFinale);
+    internal static float ragingStrikesDuration = GetBuffRemainingTime(Buffs.RagingStrikes);
+
+    internal static uint rainOfDeathCharges = LevelChecked(RainOfDeath) ? GetRemainingCharges(RainOfDeath) : 0;
+    internal static uint bloodletterCharges = GetRemainingCharges(Bloodletter);
+
+    #endregion
+
+    #region Openers
 
     public static BRDStandard Opener1 = new();
     public static BRDAdjusted Opener2 = new();
@@ -290,5 +331,6 @@ internal partial class BRD
             return true;
         }
     }
+    #endregion
 }
 

--- a/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
@@ -83,7 +83,7 @@ internal partial class BRD
         //Sidewinder Logic
         internal static bool UsePooledSidewinder()
         {
-            if (BuffWindow && RagingStrikesDuration < 18 || RagingCD >= 10)
+            if (BuffWindow && RagingStrikesDuration < 18 || RagingCD > 30)
                     return true;
             
            return false;
@@ -92,7 +92,7 @@ internal partial class BRD
         //Bloodletter & Rain of Death Logic
         internal static bool UsePooledBloodRain()
         {
-            if ((!JustUsed(OriginalHook(Bloodletter)) || !JustUsed(OriginalHook(RainOfDeath))) && 
+            if ((!WasLastAbility(Bloodletter) || !WasLastAbility(RainOfDeath) || !WasLastAbility(HeartbreakShot)) && 
                (EmpyrealCD > 2 || !LevelChecked(EmpyrealArrow)))
             {
                 if (BloodletterCharges == 3 && TraitLevelChecked(Traits.EnhancedBloodletter) || 

--- a/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
@@ -58,84 +58,123 @@ internal partial class BRD
 
     #region Functions
 
-        
-
-    // Pooled Apex Logic
-    internal static bool UsePooledApex()
-    {
-        if (gauge.SoulVoice >= 80)
+        #region Pooling
+        // Pooled Apex Logic
+        internal static bool UsePooledApex()
         {
-            if (BuffWindow && RagingStrikesDuration < 18 || RagingCD >= 50 && RagingCD <= 62)
-                return true;
+            if (gauge.SoulVoice >= 80)
+            {
+                if (BuffWindow && RagingStrikesDuration < 18 || RagingCD >= 50 && RagingCD <= 62)
+                    return true;
+            }
+            return false;
         }
-        return false;
-    }
-
-    // Pitch Perfect Logic
-    internal static bool PitchPerfected()
-    {
-       if (LevelChecked(PitchPerfect) && SongWanderer &&
-            (gauge.Repertoire == 3 || LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && EmpyrealCD < 2))
-            return true;
-        
-       return false;
-    }
-
-    //Sidewinder Logic
-    internal static bool UsePooledSidewinder()
-    {
-        if (BuffWindow && RagingStrikesDuration < 18 || RagingCD >= 10)
-                return true;
-            
-       return false;
-    }
-
-    //Bloodletter & Rain of Death Logic
-    internal static bool UsePooledBloodRain()
-    {
-        if ((!JustUsed(OriginalHook(Bloodletter)) || !JustUsed(OriginalHook(RainOfDeath))) && 
-           (EmpyrealCD > 1 || !LevelChecked(EmpyrealArrow)))
-        {
-            if (BloodletterCharges == 3 && TraitLevelChecked(Traits.EnhancedBloodletter) || 
-                BloodletterCharges == 2 && !TraitLevelChecked(Traits.EnhancedBloodletter) ||
-                BloodletterCharges > 0 && (BuffWindow || RagingCD > 30))
-                return true; 
-        }
-        return false;
-    }
     
-    //Iron Jaws dot refreshing
-    internal static bool UseIronJaws()
-    {
-        if (ActionReady(IronJaws) && Purple is not null && Blue is not null &&
-                (PurpleRemaining < 4 || BlueRemaining < 4))
-            return true;
-        return false;
-    }
 
-    //Blue dot application and low level refresh
-    internal static bool ApplyBlueDot()
-    {
-        if (ActionReady(Windbite) && (Blue is null || !CanIronJaws && BlueRemaining < 4))
-            return true;
-        return false;
-    }
+        // Pitch Perfect Logic
+        internal static bool PitchPerfected()
+        {
+           if (LevelChecked(PitchPerfect) && SongWanderer &&
+                (gauge.Repertoire == 3 || LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && EmpyrealCD < 2))
+                return true;
+        
+           return false;
+        }
 
-    //Purple dot application and low level refresh
-    internal static bool ApplyPurpleDot()
-    {
-        if (ActionReady(VenomousBite) && (Purple is null || !CanIronJaws && PurpleRemaining < 4))
-            return true;
-        return false;
-    }
+        //Sidewinder Logic
+        internal static bool UsePooledSidewinder()
+        {
+            if (BuffWindow && RagingStrikesDuration < 18 || RagingCD >= 10)
+                    return true;
+            
+           return false;
+        }
 
-    //Raging jaws option dot refresh for snapshot
-    internal static bool RagingJawsRefresh()
-    {
-        if (HasEffect(Buffs.RagingStrikes) && PurpleRemaining < 35 && BlueRemaining < 35)
-            return true;
-        return false;
-    }
+        //Bloodletter & Rain of Death Logic
+        internal static bool UsePooledBloodRain()
+        {
+            if ((!JustUsed(OriginalHook(Bloodletter)) || !JustUsed(OriginalHook(RainOfDeath))) && 
+               (EmpyrealCD > 1 || !LevelChecked(EmpyrealArrow)))
+            {
+                if (BloodletterCharges == 3 && TraitLevelChecked(Traits.EnhancedBloodletter) || 
+                    BloodletterCharges == 2 && !TraitLevelChecked(Traits.EnhancedBloodletter) ||
+                    BloodletterCharges > 0 && (BuffWindow || RagingCD > 30))
+                    return true; 
+            }
+            return false;
+        }
+        #endregion
+
+        #region Dot Management
+
+        //Iron Jaws dot refreshing
+        internal static bool UseIronJaws()
+        {
+            if (ActionReady(IronJaws) && Purple is not null && Blue is not null &&
+                    (PurpleRemaining < 4 || BlueRemaining < 4))
+                return true;
+            return false;
+        }
+
+        //Blue dot application and low level refresh
+        internal static bool ApplyBlueDot()
+        {
+            if (ActionReady(Windbite) && (Blue is null || !CanIronJaws && BlueRemaining < 4))
+                return true;
+            return false;
+        }
+
+        //Purple dot application and low level refresh
+        internal static bool ApplyPurpleDot()
+        {
+            if (ActionReady(VenomousBite) && (Purple is null || !CanIronJaws && PurpleRemaining < 4))
+                return true;
+            return false;
+        }
+
+        //Raging jaws option dot refresh for snapshot
+        internal static bool RagingJawsRefresh()
+        {
+            if (HasEffect(Buffs.RagingStrikes) && PurpleRemaining < 35 && BlueRemaining < 35)
+                return true;
+            return false;
+        }
+        #endregion
+
+        #region Buff Timing
+        //RadiantFinale Buff
+        internal static bool UseRadiantBuff()
+        {
+            if (ActionReady(RadiantFinale) && RagingCD < 2.3 && CanWeaveDelayed && !HasEffect(Buffs.RadiantEncoreReady))
+                return true;
+            return false;
+        } 
+
+        //BattleVoice Buff
+        internal static bool UseBattleVoiceBuff()
+        {
+            if (ActionReady(BattleVoice) && (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale)))
+                return true;
+            return false;
+        }
+    
+        //RagingStrikes Buff
+        internal static bool UseRagingStrikesBuff()
+        {
+            if (ActionReady(RagingStrikes) && (JustUsed(BattleVoice) || !LevelChecked(BattleVoice) || HasEffect(Buffs.BattleVoice)))
+                return true;
+            return false;
+
+        } 
+
+        //Barrage Buff
+        internal static bool UseBarrageBuff()
+        {
+            if (ActionReady(Barrage) && HasEffect(Buffs.RagingStrikes) && !HasEffect(Buffs.ResonantArrowReady))
+                return true;
+            return false;
+        }
+            #endregion
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
@@ -16,34 +16,74 @@ namespace WrathCombo.Combos.PvE;
 
 internal partial class BRD
 {
-     #region Variables
+    #region Variables
 
+    // Gauge Stuff
     internal static BRDGauge? gauge = GetJobGauge<BRDGauge>();
     internal static int SongTimerInSeconds => gauge.SongTimer / 1000;
     internal static bool SongNone => gauge.Song == Song.None;
     internal static bool SongWanderer => gauge.Song == Song.Wanderer;
     internal static bool SongMage => gauge.Song == Song.Mage;
     internal static bool SongArmy => gauge.Song == Song.Army;
-
+    //Dot Management
     internal static Status? Purple => FindTargetEffect(Debuffs.CausticBite) ?? FindTargetEffect(Debuffs.VenomousBite);
     internal static Status? Blue => FindTargetEffect(Debuffs.Stormbite) ?? FindTargetEffect(Debuffs.Windbite);
     internal static float PurpleRemaining => Purple?.RemainingTime ?? 0;
     internal static float BlueRemaining => Blue?.RemainingTime ?? 0;
 
+    //Useful Bools
     internal static bool BardHasTarget => HasBattleTarget();
     internal static bool CanBardWeave => CanWeave() && !ActionWatching.HasDoubleWeaved();
     internal static bool CanWeaveDelayed => CanDelayedWeave(0.9) && !ActionWatching.HasDoubleWeaved();
     internal static bool CanIronJaws => LevelChecked(IronJaws);
     internal static bool BuffTime => GetCooldownRemainingTime(RagingStrikes) < 2.7;
+    internal static bool BuffWindow => HasEffect(Buffs.RagingStrikes) && HasEffect(Buffs.BattleVoice) && (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale));
 
+    //Buff Tracking
     internal static float RagingCD => GetCooldownRemainingTime(RagingStrikes);
     internal static float BattleVoiceCD => GetCooldownRemainingTime(BattleVoice);
     internal static float EmpyrealCD => GetCooldownRemainingTime(EmpyrealArrow);
     internal static float RadiantCD => GetCooldownRemainingTime(RadiantFinale);
     internal static float RagingStrikesDuration => GetBuffRemainingTime(Buffs.RagingStrikes);
+    internal static float RadiantFinaleDuration => GetBuffRemainingTime(Buffs.RadiantFinale);
 
+    // Charge Tracking
     internal static uint RainOfDeathCharges => LevelChecked(RainOfDeath) ? GetRemainingCharges(RainOfDeath) : 0;
     internal static uint BloodletterCharges => GetRemainingCharges(Bloodletter);
+
+    #endregion
+
+    #region Functions
+
+    // Pooled Apex Logic
+    internal static bool UsePooledApex()
+    {
+        if (gauge.SoulVoice >= 80)
+        {
+            if (BuffWindow && RagingStrikesDuration < 18 || RagingCD >= 50 && RagingCD <= 58)
+                return true;
+        }
+        return false;
+    }
+
+    // Pitch Perfect Logic
+    internal static bool PitchPerfected()
+    {
+       if (LevelChecked(PitchPerfect) && SongWanderer &&
+            (gauge.Repertoire == 3 || LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && EmpyrealCD < 2))
+            return true;
+        
+       return false;
+    }
+
+    //Sidewinder
+    internal static bool UsePooledSidewinder()
+    {
+        if (BuffWindow && RagingStrikesDuration < 18 || RagingCD >= 10)
+                return true;
+            
+       return false;
+    }
 
     #endregion
 
@@ -183,7 +223,8 @@ internal partial class BRD
             IsOffCooldown(BattleVoice) &&
             IsOffCooldown(RadiantFinale) &&
             IsOffCooldown(RagingStrikes) &&
-            IsOffCooldown(Barrage);
+            IsOffCooldown(Barrage) &&
+            IsOffCooldown(Sidewinder);
     }
 
     internal class BRDAdjusted : WrathOpener
@@ -232,7 +273,8 @@ internal partial class BRD
             IsOffCooldown(BattleVoice) &&
             IsOffCooldown(RadiantFinale) &&
             IsOffCooldown(RagingStrikes) &&
-            IsOffCooldown(Barrage);
+            IsOffCooldown(Barrage) &&
+            IsOffCooldown(Sidewinder);
     }
 
     internal class BRDComfy : WrathOpener
@@ -276,7 +318,8 @@ internal partial class BRD
             IsOffCooldown(BattleVoice) &&
             IsOffCooldown(RadiantFinale) &&
             IsOffCooldown(RagingStrikes) &&
-            IsOffCooldown(Barrage);
+            IsOffCooldown(Barrage) &&
+            IsOffCooldown(Sidewinder);
     }
 
     #endregion

--- a/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
@@ -37,7 +37,9 @@ internal partial class BRD
     internal static bool CanWeaveDelayed => CanDelayedWeave(0.9) && !ActionWatching.HasDoubleWeaved();
     internal static bool CanIronJaws => LevelChecked(IronJaws);
     internal static bool BuffTime => GetCooldownRemainingTime(RagingStrikes) < 2.7;
-    internal static bool BuffWindow => HasEffect(Buffs.RagingStrikes) && HasEffect(Buffs.BattleVoice) && (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale));
+    internal static bool BuffWindow => HasEffect(Buffs.RagingStrikes) && 
+                                       (HasEffect(Buffs.BattleVoice) || !LevelChecked(BattleVoice)) &&
+                                       (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale));
 
     //Buff Tracking
     internal static float RagingCD => GetCooldownRemainingTime(RagingStrikes);
@@ -76,13 +78,27 @@ internal partial class BRD
        return false;
     }
 
-    //Sidewinder
+    //Sidewinder Logic
     internal static bool UsePooledSidewinder()
     {
         if (BuffWindow && RagingStrikesDuration < 18 || RagingCD >= 10)
                 return true;
             
        return false;
+    }
+
+    //Bloodletter & Rain of Death Logic
+    internal static bool UsePooledBloodRain()
+    {
+        if ((!JustUsed(OriginalHook(Bloodletter)) || !JustUsed(OriginalHook(RainOfDeath))) && 
+           (EmpyrealCD > 1 || !LevelChecked(EmpyrealArrow)))
+        {
+            if (BloodletterCharges == 3 && TraitLevelChecked(Traits.EnhancedBloodletter) || 
+                BloodletterCharges == 2 && !TraitLevelChecked(Traits.EnhancedBloodletter) ||
+                BloodletterCharges > 0 && (BuffWindow || RagingCD > 30))
+                return true; 
+        }
+        return false;
     }
 
     #endregion

--- a/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
@@ -5,6 +5,7 @@ using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Statuses;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
@@ -57,12 +58,14 @@ internal partial class BRD
 
     #region Functions
 
+        
+
     // Pooled Apex Logic
     internal static bool UsePooledApex()
     {
         if (gauge.SoulVoice >= 80)
         {
-            if (BuffWindow && RagingStrikesDuration < 18 || RagingCD >= 50 && RagingCD <= 58)
+            if (BuffWindow && RagingStrikesDuration < 18 || RagingCD >= 50 && RagingCD <= 62)
                 return true;
         }
         return false;
@@ -98,6 +101,39 @@ internal partial class BRD
                 BloodletterCharges > 0 && (BuffWindow || RagingCD > 30))
                 return true; 
         }
+        return false;
+    }
+    
+    //Iron Jaws dot refreshing
+    internal static bool UseIronJaws()
+    {
+        if (ActionReady(IronJaws) && Purple is not null && Blue is not null &&
+                (PurpleRemaining < 4 || BlueRemaining < 4))
+            return true;
+        return false;
+    }
+
+    //Blue dot application and low level refresh
+    internal static bool ApplyBlueDot()
+    {
+        if (ActionReady(Windbite) && (Blue is null || !CanIronJaws && BlueRemaining < 4))
+            return true;
+        return false;
+    }
+
+    //Purple dot application and low level refresh
+    internal static bool ApplyPurpleDot()
+    {
+        if (ActionReady(VenomousBite) && (Purple is null || !CanIronJaws && PurpleRemaining < 4))
+            return true;
+        return false;
+    }
+
+    //Raging jaws option dot refresh for snapshot
+    internal static bool RagingJawsRefresh()
+    {
+        if (HasEffect(Buffs.RagingStrikes) && PurpleRemaining < 35 && BlueRemaining < 35)
+            return true;
         return false;
     }
 

--- a/WrathCombo/WrathCombo.csproj
+++ b/WrathCombo/WrathCombo.csproj
@@ -4,7 +4,7 @@
     <PropertyGroup>
         <Authors>Team Wrath</Authors>
         <Company>-</Company>
-        <Version>1.0.0.14</Version>
+        <Version>1.0.1.0</Version>
         <!-- This is the version that will be used when pushing to the repo.-->
         <Description>XIVCombo for very lazy players</Description>
         <Copyright>Copyleft attick 2021 thanks attick UwU</Copyright>


### PR DESCRIPTION
Patch Notes
Reworked Bard logic. Pooling now tied to buff cooldowns and not song status so it is possible to hold buffs without breaking the rotation. 
Added option, Apex Arrow pooling. It always pooled before how it is optional in case a fight has really bad timings. 

- [x] Move variables to the helper file to slim down repetitive definitions in BRD.CS
- [x] Get frustrated and get Kage to show me where I was dumb. He did some clean up, fixed expression to work from helper. and taught me functions
- [x] Apex arrow pooling converted to function, uses buffs instead of song now so people can hold buffs
- [x] Sidewinder pooling converted to function, uses buffs instead of song now so people can hold buffs
- [x] Bloodletter pooling converted to function, uses buffs instead of song now so people can hold buffs
- [x] Rain of death pooling converted to function, uses buffs instead of song now so people can hold buffs
- [x] Pitch Perfect converted to function
- [x] Dot management converted to function
- [x] Buffs converted to function
- [x] Songs converted to function
- [x] Put the fun in function
- [x] Final tweaks complete to address drift created new logic. Should perform as well if not better than before now. 