### PR TITLE
[WHM] Aoe Glare fix

### DIFF
--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -299,7 +299,7 @@ internal partial class WHM : HealerJob
             if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_Assize) && ActionReady(Assize))
                 return Assize;
 
-            if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_PresenceOfMind) && presenceOfMindReady)
+            if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_PresenceOfMind) && presenceOfMindReady && !HasEffect(Buffs.SacredSight))
                 return PresenceOfMind;
 
             if (Variant.CanRampart(CustomComboPreset.WHM_DPS_Variant_Rampart))


### PR DESCRIPTION
Reported in Discord: Pom happens but stays stuck on pom instead of letting g4 happen. 

Pom changes into glare 4 on its own by se
Was coded without original hook bc of this, but action ready for pomready throws a true because of sacred sight buffs for glare 4. 

Added a no buff check. Aoe works as planned now. 