### PR TITLE
[DRK] Minor Improvements

### DIFF
--- a/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
@@ -889,6 +889,11 @@ internal partial class DRK
 
             #endregion
 
+            // Bail if it is right before burst
+            if (GetCooldownRemainingTime(LivingShadow) <
+                Math.Min(6, secondsBeforeBurst))
+                return false;
+
             #region Mana Overcap
 
             if ((flags.HasFlag(Combo.Simple) ||

--- a/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
@@ -481,8 +481,6 @@ internal partial class DRK
     {
         public bool TryGetAction(Combo flags, ref uint action)
         {
-            if (JustUsedMitigation) return false;
-
             // Bail if we're trying to Invuln or actively Invulnerable
             if (HasStatusEffect(Buffs.LivingDead) ||
                 HasStatusEffect(Buffs.WalkingDead) ||
@@ -537,6 +535,8 @@ internal partial class DRK
 
             // Bail if we can't weave any other mitigations
             if (!CanWeave) return false;
+            // Bail if we just used mitigation
+            if (JustUsedMitigation) return false;
 
             #region TBN
 


### PR DESCRIPTION
- [X] Prevents use of any mana abilities right before burst
- [X] Allowed `Living Dead` to be used even if mitigation just was
      This may not sound ideal on the surface, but consider that Oblation could prevent Living Dead