### PR TITLE
[AST] Card pooling options

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -188,9 +188,18 @@ public enum CustomComboPreset
         AST.JobID)]
     AST_DPS_AutoPlay = 1037,
 
+    [ParentCombo(AST_DPS_AutoPlay)]
+    [CustomComboInfo("Card Play Pooling Option", "Pools your dps cards for the Divination window",
+        AST.JobID)]
+    AST_DPS_CardPool = 1055,
+
     [ParentCombo(AST_ST_DPS)]
     [CustomComboInfo("Lord of Crowns Weave Option", "Adds Lord Of Crowns", AST.JobID)]
     AST_DPS_LazyLord = 1014,
+
+    [ParentCombo(AST_DPS_LazyLord)]
+    [CustomComboInfo("Lord of Crowns Pooling Option", "Holds Lord of Crowns for the Divination window", AST.JobID)]
+    AST_DPS_LordPool = 1056,
 
     [ParentCombo(AST_ST_DPS)]
     [CustomComboInfo("Oracle Option", "Adds Oracle after Divination", AST.JobID)]
@@ -232,9 +241,18 @@ public enum CustomComboPreset
         AST.JobID)]
     AST_AOE_AutoPlay = 1045,
 
+    [ParentCombo(AST_AOE_AutoPlay)]
+    [CustomComboInfo("Card Play Pooling Option", "Pools your dps cards for the Divination window",
+        AST.JobID)]
+    AST_AOE_CardPool = 1057,
+
     [ParentCombo(AST_AOE_DPS)]
     [CustomComboInfo("Lord of Crowns Weave Option", "Adds Lord Of Crowns", AST.JobID)]
     AST_AOE_LazyLord = 1046,
+
+    [ParentCombo(AST_AOE_LazyLord)]
+    [CustomComboInfo("Lord of Crowns Pooling Option", "Holds Lord of Crowns for the Divination window", AST.JobID)]
+    AST_AOE_LordPool = 1058,
 
     [ParentCombo(AST_AOE_DPS)]
     [CustomComboInfo("Oracle Option", "Adds Oracle after Divination", AST.JobID)]
@@ -357,7 +375,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last value = 1054
+    // Last value = 1058
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/AST/AST.cs
+++ b/WrathCombo/Combos/PvE/AST/AST.cs
@@ -61,7 +61,7 @@ internal partial class AST : Healer
             if (InCombat())
             {
                 //Variant stuff
-                if (Variant.CanSpiritDart(CustomComboPreset.AST_Variant_Rampart))
+                if (Variant.CanRampart(CustomComboPreset.AST_Variant_Rampart))
                     return Variant.Rampart;
 
                 if (Variant.CanSpiritDart(CustomComboPreset.AST_Variant_SpiritDart) && HasBattleTarget())

--- a/WrathCombo/Combos/PvE/AST/AST.cs
+++ b/WrathCombo/Combos/PvE/AST/AST.cs
@@ -38,6 +38,8 @@ internal partial class AST : Healer
             bool alternateMode = Config.AST_DPS_AltMode > 0; //(0 or 1 radio values)
             bool actionFound = !alternateMode && MaleficList.Contains(actionID) ||
                                alternateMode && CombustList.ContainsKey(actionID);
+            bool cardPooling = IsEnabled(CustomComboPreset.AST_DPS_CardPool);
+            bool lordPooling = IsEnabled(CustomComboPreset.AST_DPS_LordPool);
 
             if (!actionFound)
                 return actionID;
@@ -60,6 +62,9 @@ internal partial class AST : Healer
             {
                 //Variant stuff
                 if (Variant.CanSpiritDart(CustomComboPreset.AST_Variant_Rampart))
+                    return Variant.Rampart;
+
+                if (Variant.CanSpiritDart(CustomComboPreset.AST_Variant_SpiritDart) && HasBattleTarget())
                     return Variant.SpiritDart;
 
                 if (IsEnabled(CustomComboPreset.AST_DPS_LightSpeed) &&
@@ -73,12 +78,25 @@ internal partial class AST : Healer
                     Role.CanLucidDream(Config.AST_LucidDreaming))
                     return Role.LucidDreaming;
 
-                //Play Card
+                //Play Card with pooling option
                 if (IsEnabled(CustomComboPreset.AST_DPS_AutoPlay) &&
                     ActionReady(Play1) &&
                     Gauge.DrawnCards[0] is not CardType.None &&
-                    CanSpellWeave())
+                    CanSpellWeave() &&
+                    (cardPooling && HasStatusEffect(Buffs.Divination, anyOwner: true) ||
+                    !cardPooling ||
+                    !LevelChecked(Divination)))
                     return OriginalHook(Play1);
+
+                //Minor Arcana / Lord of Crowns
+                if (ActionReady(OriginalHook(MinorArcana)) &&
+                    IsEnabled(CustomComboPreset.AST_DPS_LazyLord) &&
+                    Gauge.DrawnCrownCard is CardType.Lord &&
+                    HasBattleTarget() && CanDelayedWeave() &&
+                    (lordPooling && HasStatusEffect(Buffs.Divination, anyOwner: true) ||
+                    !lordPooling ||
+                    !LevelChecked(Divination)))
+                    return OriginalHook(MinorArcana);
 
                 //Card Draw
                 if (IsEnabled(CustomComboPreset.AST_DPS_AutoDraw) &&
@@ -108,13 +126,6 @@ internal partial class AST : Healer
                     CanSpellWeave())
                     return Oracle;
 
-                //Minor Arcana / Lord of Crowns
-                if (ActionReady(OriginalHook(MinorArcana)) &&
-                    IsEnabled(CustomComboPreset.AST_DPS_LazyLord) &&
-                    Gauge.DrawnCrownCard is CardType.Lord &&
-                    HasBattleTarget() && CanDelayedWeave())
-                    return OriginalHook(MinorArcana);
-
                 if (HasBattleTarget())
                 {
                     //Combust
@@ -122,10 +133,7 @@ internal partial class AST : Healer
                         !GravityList.Contains(actionID) &&
                         LevelChecked(Combust) &&
                         CombustList.TryGetValue(OriginalHook(Combust), out ushort dotDebuffID))
-                    {
-                        if (Variant.CanSpiritDart(CustomComboPreset.AST_Variant_SpiritDart))
-                            return Variant.SpiritDart;
-
+                    {   
                         float refreshTimer = Config.AST_ST_DPS_CombustUptime_Threshold;
                         int hpThreshold = Config.AST_ST_DPS_CombustSubOption == 1 || !InBossEncounter() ? Config.AST_DPS_CombustOption : 0;
                         if (GetStatusEffectRemainingTime(dotDebuffID, CurrentTarget) <= refreshTimer &&
@@ -147,6 +155,9 @@ internal partial class AST : Healer
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AST_AOE_DPS;
         protected override uint Invoke(uint actionID)
         {
+            bool cardPooling = IsEnabled(CustomComboPreset.AST_AOE_CardPool);
+            bool lordPooling = IsEnabled(CustomComboPreset.AST_AOE_LordPool);
+
             if (!GravityList.Contains(actionID))
                 return actionID;
 
@@ -168,12 +179,24 @@ internal partial class AST : Healer
                 Role.CanLucidDream(Config.AST_LucidDreaming))
                 return Role.LucidDreaming;
 
-            //Play Card
+            //Play Card with Pooling
             if (IsEnabled(CustomComboPreset.AST_AOE_AutoPlay) &&
                 ActionReady(Play1) &&
                 Gauge.DrawnCards[0] is not CardType.None &&
-                CanSpellWeave())
+                CanSpellWeave() &&
+                (cardPooling && HasStatusEffect(Buffs.Divination, anyOwner: true) ||
+                !cardPooling ||
+                !LevelChecked(Divination)))
                 return OriginalHook(Play1);
+
+            //Minor Arcana / Lord of Crowns
+            if (ActionReady(OriginalHook(MinorArcana)) &&
+                IsEnabled(CustomComboPreset.AST_AOE_LazyLord) && Gauge.DrawnCrownCard is CardType.Lord &&
+                HasBattleTarget() && CanDelayedWeave() &&
+                (lordPooling && HasStatusEffect(Buffs.Divination, anyOwner: true) ||
+                !lordPooling ||
+                !LevelChecked(Divination)))
+                return OriginalHook(MinorArcana);
 
             //Card Draw
             if (IsEnabled(CustomComboPreset.AST_AOE_AutoDraw) &&
@@ -202,12 +225,6 @@ internal partial class AST : Healer
                 CanSpellWeave())
                 return Oracle;
 
-            //Minor Arcana / Lord of Crowns
-            if (ActionReady(OriginalHook(MinorArcana)) &&
-                IsEnabled(CustomComboPreset.AST_AOE_LazyLord) && Gauge.DrawnCrownCard is CardType.Lord &&
-                HasBattleTarget() &&
-                CanDelayedWeave())
-                return OriginalHook(MinorArcana);
             return actionID;
         }
     }


### PR DESCRIPTION
Pooling option and small variant fix I saw was needed. 
#176 and discord request.

- [x] Added card pooling option for single target rotation into divination window
- [x] Added card pooling option for aoe rotation into divination window
- [x] Added lord pooling option for single target rotation into divination window
- [x] Added lord pooling option for aoe rotation into divination window
- [x] fixed single target variant rampart calling use of spirit dart
- [x] moved single target spirit dart up with rampart and outside of requiring combust being enabled