### PR TITLE
[WHM & SGE] Regen and shield fixes

### DIFF
--- a/WrathCombo/Combos/PvE/SGE/SGE.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE.cs
@@ -367,12 +367,10 @@ internal partial class SGE : Healer
             }
 
             if (IsEnabled(CustomComboPreset.SGE_ST_Heal_EDiagnosis) && LevelChecked(Eukrasia) &&
-                GetTargetHPPercent(healTarget, Config.SGE_ST_Heal_IncludeShields) <=
-                Config.SGE_ST_Heal_EDiagnosisHP &&
-                (Config.SGE_ST_Heal_EDiagnosisOpts[0] ||
-                 HasStatusEffect(Buffs.EukrasianDiagnosis, healTarget, true) && //Ignore existing shield check
-                (!Config.SGE_ST_Heal_EDiagnosisOpts[1] ||
-                 HasStatusEffect(SCH.Buffs.Galvanize, healTarget, true)))) //Galvenize Check
+                GetTargetHPPercent(healTarget, Config.SGE_ST_Heal_IncludeShields) <= Config.SGE_ST_Heal_EDiagnosisHP &&
+                (Config.SGE_ST_Heal_EDiagnosisOpts[0] || // Ignore Any Shield check
+                !HasStatusEffect(Buffs.EukrasianDiagnosis, healTarget, true) && //Shield Check
+                (!Config.SGE_ST_Heal_EDiagnosisOpts[1] || !HasStatusEffect(SCH.Buffs.Galvanize, healTarget, true)))) //Galvanize Check
                 return Eukrasia;
 
             return actionID;

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -217,11 +217,10 @@ internal partial class WHM : Healer
 
             var regenReady = ActionReady(Regen) &&
                              !JustUsed(Regen, 4) &&
-                             GetStatusEffect(Buffs.Regen, healTarget)?
-                                 .RemainingTime <= Config.WHM_STHeals_RegenTimer &&
-                             GetTargetHPPercent(healTarget,
-                                 Config.WHM_STHeals_IncludeShields) >=
-                             Config.WHM_STHeals_RegenHP;
+                             GetStatusEffectRemainingTime(Buffs.Regen, healTarget) 
+                                <= Config.WHM_STHeals_RegenTimer && //Refresh Time Threshold
+                             GetTargetHPPercent(healTarget,Config.WHM_STHeals_IncludeShields) 
+                                >= Config.WHM_STHeals_RegenHP; // Regen use threshold for low health
 
             #endregion
 


### PR DESCRIPTION
The GetStatusEffect was not working and preventing any use of Regen. Rewrote it for GetStatusEffectRemainingTime, simplified yet functions as it should.

Added the missing !s to sage eukrasian diagnosis setup to make the shield checks function correctly again,. 

#501 