### PR TITLE
[Core] New setting: always open Wrath to the PvE Features tab

### DIFF
--- a/WrathCombo/Commands.cs
+++ b/WrathCombo/Commands.cs
@@ -10,6 +10,7 @@ using Lumina.Excel.Sheets;
 using WrathCombo.Combos;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS.Functions;
+using WrathCombo.Data;
 using WrathCombo.Extensions;
 using WrathCombo.Services;
 using WrathCombo.Window;
@@ -584,8 +585,13 @@ public partial class WrathCombo
             ConfigWindow.IsOpen = forceOpen.Value;
 
         // Handle option to always open to the PvE tab
-        if (ConfigWindow.IsOpen && Service.Configuration.OpenToPvE)
-            ConfigWindow.OpenWindow = OpenWindow.PvE;
+        var openingToPvP =
+            ContentCheck.IsInPVPContent() && Service.Configuration.OpenToPvP;
+        if (ConfigWindow.IsOpen)
+            if (openingToPvP)
+                ConfigWindow.OpenWindow = OpenWindow.PvP;
+            else if (Service.Configuration.OpenToPvE)
+                ConfigWindow.OpenWindow = OpenWindow.PvE;
 
         // Open to specific tab
         if (tab is not null)
@@ -598,7 +604,7 @@ public partial class WrathCombo
         if (argument[0].Length <= 0)
         {
             // Handle the "Open to current job" setting
-            if (ConfigWindow.IsOpen)
+            if (ConfigWindow.IsOpen && !openingToPvP)
                 PvEFeatures.OpenToCurrentJob(false);
 
             // Skip trying to process arguments

--- a/WrathCombo/Commands.cs
+++ b/WrathCombo/Commands.cs
@@ -579,13 +579,13 @@ public partial class WrathCombo
         // Toggle the window state
         ConfigWindow.IsOpen = !ConfigWindow.IsOpen;
 
-        // Handle option to always open to the PvE tab
-        if (ConfigWindow.IsOpen && Service.Configuration.OpenToPvE)
-            ConfigWindow.OpenWindow = OpenWindow.PvE;
-
         // Force open (UI buttons)
         if (forceOpen is not null)
             ConfigWindow.IsOpen = forceOpen.Value;
+
+        // Handle option to always open to the PvE tab
+        if (ConfigWindow.IsOpen && Service.Configuration.OpenToPvE)
+            ConfigWindow.OpenWindow = OpenWindow.PvE;
 
         // Open to specific tab
         if (tab is not null)

--- a/WrathCombo/Commands.cs
+++ b/WrathCombo/Commands.cs
@@ -579,6 +579,13 @@ public partial class WrathCombo
         // Toggle the window state
         ConfigWindow.IsOpen = !ConfigWindow.IsOpen;
 
+        // Handle option to always open to the PvE tab
+        if (ConfigWindow.IsOpen && Service.Configuration.OpenToPvE)
+        {
+            ConfigWindow.OpenWindow = OpenWindow.PvE;
+            return;
+        }
+
         // Force open (UI buttons)
         if (forceOpen is not null)
             ConfigWindow.IsOpen = forceOpen.Value;

--- a/WrathCombo/Commands.cs
+++ b/WrathCombo/Commands.cs
@@ -581,10 +581,7 @@ public partial class WrathCombo
 
         // Handle option to always open to the PvE tab
         if (ConfigWindow.IsOpen && Service.Configuration.OpenToPvE)
-        {
             ConfigWindow.OpenWindow = OpenWindow.PvE;
-            return;
-        }
 
         // Force open (UI buttons)
         if (forceOpen is not null)

--- a/WrathCombo/Core/PluginConfiguration.cs
+++ b/WrathCombo/Core/PluginConfiguration.cs
@@ -68,6 +68,8 @@ namespace WrathCombo.Core
 
         public bool OpenToPvE = false;
 
+        public bool OpenToPvP = false;
+
         public bool OpenToCurrentJob = false;
 
         public bool OpenToCurrentJobOnSwitch = false;

--- a/WrathCombo/Core/PluginConfiguration.cs
+++ b/WrathCombo/Core/PluginConfiguration.cs
@@ -51,6 +51,7 @@ namespace WrathCombo.Core
         public double MeleeOffset { get; set; } = 0;
 
         public bool BlockSpellOnMove = false;
+
         public Vector4 TargetHighlightColor { get; set; } = new() { W = 1, X = 0.5f, Y = 0.5f, Z = 0.5f };
 
         public bool OutputOpenerLogs;
@@ -64,6 +65,8 @@ namespace WrathCombo.Core
         public int Throttle = 50;
 
         public double InterruptDelay  = 0.0f;
+
+        public bool OpenToPvE = false;
 
         public bool OpenToCurrentJob = false;
 

--- a/WrathCombo/Data/ContentCheck.cs
+++ b/WrathCombo/Data/ContentCheck.cs
@@ -102,6 +102,7 @@ public class ContentCheck
         }
     }
 
+    /// <seealso cref="IsInConfiguredContent(UserBoolArray, ListSet)"/>
     internal static bool IsInConfiguredContent
         (UserInt configuredContent, ListSet configListSet)
     {
@@ -120,6 +121,17 @@ public class ContentCheck
 
         return false;
     }
+
+    /// <summary>
+    ///     Check if the current area is PvP content.
+    /// </summary>
+    /// <returns>
+    ///     Whether the current area is the pier or instanced PvP content.
+    /// </returns>
+    public static bool IsInPVPContent() =>
+        (Content.ContentType is ContentType.OverWorld &&
+         Content.TerritoryName == "Wolves' Den Pier") ||
+        Content.ContentType is ContentType.PVP;
 
     #region Halved Content Lists
 

--- a/WrathCombo/Window/Tabs/Settings.cs
+++ b/WrathCombo/Window/Tabs/Settings.cs
@@ -115,6 +115,20 @@ namespace WrathCombo.Window.Tabs
 
                 #endregion
 
+                #region Open to PvP
+
+                if (ImGui.Checkbox("Open Wrath to the PvP Features tab in PvP areas", ref
+                        Service.Configuration.OpenToPvP))
+                    Service.Configuration.Save();
+
+                ImGuiComponents.HelpMarker("Same as above, when you open Wrath with `/wrath`, it will open to the PvP Features tab, instead of the last tab you were on, when in a PvP area." +
+                                           "\nSimilar to using the `/wrath pvp` command to open Wrath.");
+
+                ImGui.SameLine();
+                ImGui.TextColored(ImGuiColors.DalamudGrey, $"(Will override the option above)");
+
+                #endregion
+
                 #region Open to Current Job
 
                 if (ImGui.Checkbox("Open PvE Features UI to Current Job on Opening", ref Service.Configuration.OpenToCurrentJob))

--- a/WrathCombo/Window/Tabs/Settings.cs
+++ b/WrathCombo/Window/Tabs/Settings.cs
@@ -53,20 +53,6 @@ namespace WrathCombo.Window.Tabs
 
                 #endregion
 
-                #region Open to Current Job
-
-                if (ImGui.Checkbox("Open PvE Features UI to Current Job on Opening", ref Service.Configuration.OpenToCurrentJob))
-                    Service.Configuration.Save();
-
-                ImGuiComponents.HelpMarker("When you open Wrath's UI, it will automatically open to the job you are currently playing.");
-
-                if (ImGui.Checkbox("Open PvE Features UI to Current Job on Switching Jobs", ref Service.Configuration.OpenToCurrentJobOnSwitch))
-                    Service.Configuration.Save();
-
-                ImGuiComponents.HelpMarker("When you switch jobs, it will automatically open to the job you are currently playing.");
-
-                #endregion
-
                 #region Shorten DTR bar text
 
                 bool shortDTRText = Service.Configuration.ShortDTRText;
@@ -116,6 +102,37 @@ namespace WrathCombo.Window.Tabs
 
                 #endregion
 
+                ImGuiEx.Spacing(new Vector2(0, 10));
+
+                #region Open to PvE
+
+                if (ImGui.Checkbox("Open Wrath to the PvE Features tab", ref
+                        Service.Configuration.OpenToPvE))
+                    Service.Configuration.Save();
+
+                ImGuiComponents.HelpMarker("When you open Wrath with `/wrath`, it will open to the PvE Features tab, instead of the last tab you were on." +
+                                           "\nSame as always using the `/wrath pve` command to open Wrath.");
+
+                #endregion
+
+                #region Open to Current Job
+
+                if (ImGui.Checkbox("Open PvE Features UI to Current Job on Opening", ref Service.Configuration.OpenToCurrentJob))
+                    Service.Configuration.Save();
+
+                ImGuiComponents.HelpMarker("When you open Wrath's UI, if your last tab was PvE, it will automatically open to the job you are currently playing.");
+
+                #endregion
+
+                #region Open to Current Job on Switching
+
+                if (ImGui.Checkbox("Open PvE Features UI to Current Job on Switching Jobs", ref Service.Configuration.OpenToCurrentJobOnSwitch))
+                    Service.Configuration.Save();
+
+                ImGuiComponents.HelpMarker("When you switch jobs, it will automatically switch the PvE Features tab to the job you are currently playing.");
+
+                #endregion
+
                 #endregion
 
                 #region Rotation Behavior Options
@@ -147,7 +164,7 @@ namespace WrathCombo.Window.Tabs
                 if (ImGui.Checkbox("Action Replacing", ref Service.Configuration.ActionChanging))
                     Service.Configuration.Save();
 
-                ImGuiComponents.HelpMarker("Controls whether Actions will be Intercepted Replaced with combos from the plugin.\nIf disabled, your manual presses of abilities will no longer be affected by your Wrath settings.\n\nAuto-Rotation will work regardless of the setting.\n\nControlled by /wrath combo");
+                ImGuiComponents.HelpMarker("Controls whether Actions will be Intercepted Replaced with combos from the plugin.\nIf disabled, your manual presses of abilities will no longer be affected by your Wrath settings.\n\nAuto-Rotation will work regardless of the setting.\n\nControlled by the `/wrath combo` command.");
 
                 #endregion
 


### PR DESCRIPTION
- [X] Adds a new setting to allow `/wrath` command to always open to the PvE tab instead of the last tab.\
      (can still be overridden, like with `/wrath pvp` or `/wrath settings`)

Closes #492 