### PR TITLE
[BRD] Radiant tweaks and missing option

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -878,6 +878,14 @@ public enum CustomComboPreset
     BRD_AoE_Adv_Interrupt = 3043,
 
     [ParentCombo(BRD_AoE_AdvMode)]
+    [CustomComboInfo("Encore Option", "Adds Radiant Encore to the Rotation after Finale.", BRD.JobID)]
+    BRD_AoE_BuffsEncore = 3062,
+
+    [ParentCombo(BRD_AoE_AdvMode)]
+    [CustomComboInfo("Resonant Option", "Adds Resonant Arrow to the Rotation after Barrage.", BRD.JobID)]
+    BRD_AoE_BuffsResonant = 3061,
+
+    [ParentCombo(BRD_AoE_AdvMode)]
     [CustomComboInfo("Apex Arrow Option", "Adds Apex Arrow and Blast shot", BRD.JobID)]
     BRD_AoE_ApexArrow = 3039,
 

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -346,14 +346,14 @@ internal partial class BRD : PhysicalRanged
                     (IsEnabled(CustomComboPreset.BRD_AoE_Pooling) && UsePooledSidewinder() || !IsEnabled(CustomComboPreset.BRD_AoE_Pooling)))
                     return Sidewinder;
             
-                if (Role.CanHeadGraze(CustomComboPreset.BRD_AoE_Adv_Interrupt) && CanWeaveDelayed)
+                if (Role.CanHeadGraze(CustomComboPreset.BRD_AoE_Adv_Interrupt) && UseInterrupt)
                     return Role.HeadGraze;
 
                 if (ActionReady(RainOfDeath) &&
                     (IsEnabled(CustomComboPreset.BRD_AoE_Pooling) && UsePooledBloodRain() || !IsEnabled(CustomComboPreset.BRD_AoE_Pooling)))
                     return OriginalHook(RainOfDeath);
 
-                if (!LevelChecked(RainOfDeath) && !(WasLastAction(Bloodletter) && BloodletterCharges > 0))
+                if (!LevelChecked(RainOfDeath) && !WasLastAction(Bloodletter) && BloodletterCharges > 0)
                     return OriginalHook(Bloodletter);
             }
 
@@ -527,7 +527,7 @@ internal partial class BRD : PhysicalRanged
                     (IsEnabled(CustomComboPreset.BRD_Adv_Pooling) && UsePooledSidewinder() || !IsEnabled(CustomComboPreset.BRD_Adv_Pooling)))
                     return Sidewinder;
 
-                if (Role.CanHeadGraze(CustomComboPreset.BRD_Adv_Interrupt) && CanWeaveDelayed)
+                if (Role.CanHeadGraze(CustomComboPreset.BRD_Adv_Interrupt) && UseInterrupt)
                     return Role.HeadGraze;
 
                 if (ActionReady(Bloodletter) &&
@@ -700,7 +700,7 @@ internal partial class BRD : PhysicalRanged
                 if (ActionReady(Sidewinder) && UsePooledSidewinder())
                     return Sidewinder;
 
-                if (Role.CanHeadGraze(CustomComboPreset.BRD_AoE_SimpleMode) && CanWeaveDelayed)
+                if (UseInterrupt)
                     return Role.HeadGraze;
 
                 if (ActionReady(RainOfDeath) && UsePooledBloodRain())
@@ -836,7 +836,7 @@ internal partial class BRD : PhysicalRanged
                 if (ActionReady(Sidewinder) && UsePooledSidewinder())
                     return Sidewinder;            
                
-                if (Role.CanHeadGraze(CustomComboPreset.BRD_ST_SimpleMode) && CanWeaveDelayed)
+                if (UseInterrupt)
                     return Role.HeadGraze;
 
                 if (ActionReady(Bloodletter) && UsePooledBloodRain())

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -397,7 +397,7 @@ internal partial class BRD : PhysicalRanged
                     return ResonantArrow;
             }
 
-            if (HasStatusEffect(Buffs.HawksEye))
+            if (HasStatusEffect(Buffs.HawksEye) && ActionReady(WideVolley))
                 return OriginalHook(WideVolley);
 
             #endregion
@@ -735,7 +735,7 @@ internal partial class BRD : PhysicalRanged
             if (HasStatusEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16 && HasStatusEffect(Buffs.RagingStrikes))
                 return OriginalHook(RadiantEncore);
 
-            if (HasStatusEffect(Buffs.HawksEye))
+            if (HasStatusEffect(Buffs.HawksEye) && ActionReady(WideVolley))
                 return OriginalHook(WideVolley);
 
             #endregion

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -378,7 +378,8 @@ internal partial class BRD : PhysicalRanged
             if (HasStatusEffect(Buffs.Barrage))
                 return OriginalHook(WideVolley);
 
-            if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore) && HasStatusEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16)
+            if (IsEnabled(CustomComboPreset.BRD_AoE_BuffsEncore) && HasStatusEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16 &&
+               (HasStatusEffect(Buffs.RagingStrikes) || !ragingEnabled))
                 return OriginalHook(RadiantEncore);
 
             if (IsEnabled(CustomComboPreset.BRD_AoE_ApexArrow))
@@ -390,7 +391,7 @@ internal partial class BRD : PhysicalRanged
                     return ApexArrow;
             }
 
-            if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsResonant))
+            if (IsEnabled(CustomComboPreset.BRD_AoE_BuffsResonant))
             {
                 if (HasStatusEffect(Buffs.ResonantArrowReady))
                     return ResonantArrow;
@@ -578,7 +579,8 @@ internal partial class BRD : PhysicalRanged
             if (HasStatusEffect(Buffs.Barrage))
                 return OriginalHook(StraightShot);
 
-            if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore) && HasStatusEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16)
+            if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore) && HasStatusEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16 && 
+               (HasStatusEffect(Buffs.RagingStrikes) || !ragingEnabled))
                 return OriginalHook(RadiantEncore);
 
             if (IsEnabled(CustomComboPreset.BRD_ST_ApexArrow))
@@ -730,7 +732,7 @@ internal partial class BRD : PhysicalRanged
             if (HasStatusEffect(Buffs.ResonantArrowReady))
                 return ResonantArrow;
 
-            if (HasStatusEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16)
+            if (HasStatusEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16 && HasStatusEffect(Buffs.RagingStrikes))
                 return OriginalHook(RadiantEncore);
 
             if (HasStatusEffect(Buffs.HawksEye))
@@ -880,7 +882,7 @@ internal partial class BRD : PhysicalRanged
             if (HasStatusEffect(Buffs.ResonantArrowReady))
                 return ResonantArrow;
 
-            if (HasStatusEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16)
+            if (HasStatusEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16 && HasStatusEffect(Buffs.RagingStrikes))
                 return OriginalHook(RadiantEncore);
 
             if (HasStatusEffect(Buffs.HawksEye))

--- a/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
@@ -134,7 +134,7 @@ internal partial class BRD
         //Raging jaws option dot refresh for snapshot
         internal static bool RagingJawsRefresh()
         {
-            if (HasStatusEffect(Buffs.RagingStrikes) && PurpleRemaining < 35 && BlueRemaining < 35)
+            if (ActionReady(IronJaws) && HasStatusEffect(Buffs.RagingStrikes) && PurpleRemaining < 35 && BlueRemaining < 35)
                 return true;
             return false;
         }

--- a/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
@@ -37,6 +37,7 @@ internal partial class BRD
     internal static bool CanWeaveDelayed => CanDelayedWeave() && !ActionWatching.HasDoubleWeaved();
     internal static bool CanIronJaws => LevelChecked(IronJaws);
     internal static bool BuffTime => GetCooldownRemainingTime(RagingStrikes) < 2.7;
+    internal static bool UseInterrupt => CanWeaveDelayed && ActionReady(Role.HeadGraze);
     internal static bool BuffWindow => HasStatusEffect(Buffs.RagingStrikes) && 
                                        (HasStatusEffect(Buffs.BattleVoice) || !LevelChecked(BattleVoice)) &&
                                        (HasStatusEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale));


### PR DESCRIPTION
- [x] Add raging strike requirement to radiant encore as extra layer to prevent it firing early. cant replicate but someone logged it. 
- [x] New checkboxes!! Added AoE options for resonant arrow and radiant encore as they were using the single target CCP for some reason
- [x] Fix raging jaws missing level check of IJ
- [x] Added missing level check for wide volley with hawks eye.
- [x] set up interrupt in helper with an actual action ready. discord reported it was firing before learning it with the new role action stuff. No way for me to test of confirm but actionready wont hurt. 
