### PR TITLE
[IPC] Fix cache for Job-Ready check, minor readability improvements

### DIFF
--- a/WrathCombo/Services/IPC/Helper.cs
+++ b/WrathCombo/Services/IPC/Helper.cs
@@ -163,22 +163,22 @@ public partial class Helper(ref Leasing leasing)
         // Convert current job/class to a job, if it is a class
         var job = (Job)CustomComboFunctions.JobIDs.ClassToJob((uint)Player.Job);
 
+        // Get the user's settings for this job
         P.IPCSearch.CurrentJobComboStatesCategorized.TryGetValue(job,
             out var comboStates);
 
-        Logging.Log($"comboStates is null: {comboStates is null}, comboStates.Count is 0: {comboStates?.Count == 0}");
-
+        // Bail if there are no combos found for this job
         if (comboStates is null || comboStates.Count == 0)
             return null;
 
+        // Try to get the Simple Mode settings
         comboStates[mode]
             .TryGetValue(ComboSimplicityLevelKeys.Simple, out var simpleResults);
-
         var simpleHigher = simpleResults?.FirstOrDefault();
+        var simple = simpleHigher?.Value;
         #region Override the Values with any IPC-control
         CustomComboPreset? simpleComboPreset = simpleHigher is null ? null : (CustomComboPreset)
             Enum.Parse(typeof(CustomComboPreset), simpleHigher.Value.Key, true);
-        var simple = simpleHigher?.Value;
         if (simpleComboPreset is not null)
         {
             simple[ComboStateKeys.AutoMode] =
@@ -189,6 +189,7 @@ public partial class Helper(ref Leasing leasing)
         }
         #endregion
 
+        // Get the Advanced Mode settings
         var (advancedKey, advancedValue) = comboStates[mode][ComboSimplicityLevelKeys.Advanced].First();
         #region Override the Values with any IPC-control
         var advancedComboPreset = (CustomComboPreset)
@@ -210,6 +211,7 @@ public partial class Helper(ref Leasing leasing)
                 : null;
         }
 
+        // Check for either Simple or Advanced being ready
         return simple is not null && simple[enabledStateToCheck]
             ? ComboSimplicityLevelKeys.Simple
             : advancedValue[enabledStateToCheck]

--- a/WrathCombo/Services/IPC/Leasing.cs
+++ b/WrathCombo/Services/IPC/Leasing.cs
@@ -757,6 +757,7 @@ public partial class Leasing
         var now = DateTime.Now;
 
         // ReSharper disable once NotAccessedVariable
+        // ReSharper disable once RedundantAssignment
         var durationForBan = TimeSpan.FromMinutes(2);
 #if DEBUG
         durationForBan = TimeSpan.FromSeconds(15);

--- a/WrathCombo/Services/IPC/Leasing.cs
+++ b/WrathCombo/Services/IPC/Leasing.cs
@@ -14,6 +14,8 @@ using System.Text;
 using WrathCombo.Combos;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Extensions;
+using EZ = ECommons.Throttlers.EzThrottler;
+using TS = System.TimeSpan;
 using CancellationReasonEnum = WrathCombo.Services.IPC.CancellationReason;
 
 // ReSharper disable UseSymbolAlias
@@ -293,8 +295,6 @@ public partial class Leasing
         return _autoRotationStateUpdated;
     }
 
-    private DateTime _lastAutoRotationSetCheck = DateTime.MinValue;
-
     /// <summary>
     ///     Adds a registration for Auto-Rotation control to a lease.
     /// </summary>
@@ -310,12 +310,10 @@ public partial class Leasing
         if (registration.AutoRotationConfigsControlled.Count > 0 &&
             registration.AutoRotationControlled[0] == newState)
         {
-            if ((DateTime.Now - _lastAutoRotationSetCheck).TotalSeconds >= 15)
-            {
+            if (EZ.Throttle("ipcAutoRotSetLog", TS.FromSeconds(15)))
                 Logging.Log(
                     $"{registration.PluginName}: You are already controlling Auto-Rotation");
-                _lastAutoRotationSetCheck = DateTime.Now;
-            }
+
             return SetResult.Duplicate;
         }
 
@@ -354,8 +352,6 @@ public partial class Leasing
         return lease?.JobsControlled[resolvedJob];
     }
 
-    private DateTime _lasJobSetCheck = DateTime.MinValue;
-
     /// <summary>
     ///     Adds a registration for the current Job to a lease.
     /// </summary>
@@ -381,12 +377,10 @@ public partial class Leasing
 
         if (!registration.JobsControlled.TryAdd(job, true))
         {
-            if ((DateTime.Now - _lasJobSetCheck).TotalSeconds >= 15)
-            {
+            if (EZ.Throttle("ipcJobSetLog", TS.FromSeconds(15)))
                 Logging.Log(
                     $"{registration.PluginName}: You are already controlling the current job ({job})");
-                _lasJobSetCheck = DateTime.Now;
-            }
+
             return SetResult.Duplicate;
         }
 
@@ -761,10 +755,17 @@ public partial class Leasing
     private void CleanOutdatedBlacklistEntries()
     {
         var now = DateTime.Now;
+
+        // ReSharper disable once NotAccessedVariable
+        var durationForBan = TimeSpan.FromMinutes(2);
+#if DEBUG
+        durationForBan = TimeSpan.FromSeconds(15);
+#endif
+
         Dictionary<Guid, (string, byte[], DateTime)> blacklistCopy =
             new(_userRevokedTemporaryBlacklist);
         foreach (var (lease, (_, _, time)) in blacklistCopy)
-            if (now - time > TimeSpan.FromMinutes(2))
+            if (now - time > durationForBan)
                 _userRevokedTemporaryBlacklist.Remove(lease);
     }
 

--- a/WrathCombo/Services/IPC/Provider.cs
+++ b/WrathCombo/Services/IPC/Provider.cs
@@ -368,6 +368,7 @@ public partial class Provider : IDisposable
     public bool IsCurrentJobAutoRotationReady()
     {
         if (File.GetLastWriteTime(P.IPCSearch.ConfigFilePath) <= _lastJobReadyCheck &&
+            (Leasing.CombosUpdated ?? DateTime.MinValue) <= _lastJobReadyCheck &&
             (DateTime.Now - _lastJobReadyCheck).TotalSeconds <= 45)
             return _lastJobReady;
 

--- a/WrathCombo/Services/IPC/Search.cs
+++ b/WrathCombo/Services/IPC/Search.cs
@@ -13,6 +13,8 @@ using WrathCombo.Core;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Extensions;
 using WrathCombo.Window.Tabs;
+using EZ = ECommons.Throttlers.EzThrottler;
+using TS = System.TimeSpan;
 
 #endregion
 
@@ -250,7 +252,6 @@ public class Search(Leasing leasing)
         get
         {
             return field ??= PresetStorage.AllPresets!
-                .Cast<CustomComboPreset>()
                 .Select(preset => new
                 {
                     ID = preset,
@@ -305,8 +306,7 @@ public class Search(Leasing leasing)
             else
             {
                 if (field != null &&
-                    DateTime.Now.AddSeconds(-1) <=
-                    _lastCacheUpdateForPresetStates &&
+                    !EZ.Throttle("ipcPresetStateCheck", TS.FromSeconds(1)) &&
                     presetsUpdated <= _lastCacheUpdateForPresetStates)
                     return field;
             }
@@ -342,7 +342,7 @@ public class Search(Leasing leasing)
         ActiveJobPresets = Window.Functions.Presets.GetJobAutorots.Count;
     }
 
-    internal int ActiveJobPresets = 0;
+    internal int ActiveJobPresets;
 
     #endregion
 
@@ -385,12 +385,6 @@ public class Search(Leasing leasing)
                         combo => PresetStates[combo]
                     )
             );
-
-    /// <summary>
-    ///     When <see cref="CurrentJobComboStatesCategorized" /> was last built.
-    /// </summary>
-    private DateTime _lastCacheUpdateForComboStatesByJobCategorized =
-        DateTime.MinValue;
 
     /// <summary>
     ///     The states of each combo, but heavily categorized.

--- a/WrathCombo/Services/IPC/UIHelper.cs
+++ b/WrathCombo/Services/IPC/UIHelper.cs
@@ -284,7 +284,8 @@ public class UIHelper(Leasing leasing)
         uint? forJob = null,
         CustomComboPreset? forPreset = null,
         string? forAutoRotationConfig = null,
-        bool showX = true)
+        bool showX = true,
+        bool shortDisplay = false)
     {
         (string controllers, object state)? controlled = null;
         var revokeID = "RevokeControl";
@@ -339,7 +340,10 @@ public class UIHelper(Leasing leasing)
 
         ImGui.PushStyleColor(ImGuiCol.ButtonHovered, _backgroundColor);
         ImGui.PushStyleColor(ImGuiCol.ButtonActive, _backgroundColor);
-        ImGui.SmallButton($"Controlled by: {controlled.Value.controllers}");
+        var buttonText = shortDisplay
+            ? "Controlled"
+            : "Controlled by: " + controlled.Value.controllers;
+        ImGui.SmallButton(buttonText);
         ImGui.PopStyleColor(2);
 
         if (showX)
@@ -614,8 +618,10 @@ public class UIHelper(Leasing leasing)
     public bool ShowIPCControlledIndicatorIfNeeded() =>
         ShowIPCControlledIndicator(forAutoRotation: true);
 
-    public bool ShowIPCControlledIndicatorIfNeeded(uint job, bool showX = true) =>
-        ShowIPCControlledIndicator(forJob: job, showX: showX);
+    public bool ShowIPCControlledIndicatorIfNeeded
+        (uint job, bool showX = true, bool shortDisplay = false) =>
+        ShowIPCControlledIndicator
+            (forJob: job, showX: showX, shortDisplay: shortDisplay);
 
     public bool ShowIPCControlledIndicatorIfNeeded(CustomComboPreset preset) =>
         ShowIPCControlledIndicator(forPreset: preset);

--- a/WrathCombo/Window/Tabs/PvEFeatures.cs
+++ b/WrathCombo/Window/Tabs/PvEFeatures.cs
@@ -79,7 +79,7 @@ namespace WrathCombo.Window.Tabs
                                 {
                                     ImGui.SameLine();
                                     P.UIHelper
-                                        .ShowIPCControlledIndicatorIfNeeded(id, false);
+                                        .ShowIPCControlledIndicatorIfNeeded(id, false, ColCount > 1);
                                 }
                             }
 


### PR DESCRIPTION
- [X] Fixes cache for `IsCurrentJobAutoRotationReady`
- [X] Updates time-gated variables to use `EzThrottler`

> [!IMPORTANT]
> Relies on ECommons bump to include NightmareXIV/ECommons#104 and NightmareXIV/ECommons@b89f56c