### PR TITLE
[Core] Add a couple Debug commands to help people with wine

### DIFF
--- a/WrathCombo/Commands.cs
+++ b/WrathCombo/Commands.cs
@@ -468,6 +468,23 @@ public partial class WrathCombo
             // Handle an entered job abbreviation
             if (argument.Length > 1)
             {
+                if (argument[1] == "path")
+                {
+                    DuoLog.Information(
+                        $"WrathDebug.txt should have been created at:\n" +
+                        $"{DebugFile.GetDebugFilePath()}");
+                    return;
+                }
+
+                if (argument[1] == "string")
+                {
+                    GenericHelpers.Copy(
+                        "```\n" + DebugFile.GetDebugCode() + "\n```");
+                    DuoLog.Information(
+                        "Debug string copied to clipboard. Paste this where requested.");
+                    return;
+                }
+
                 if (argument[1].Length != 3)
                 {
                     DuoLog.Error("Invalid job abbreviation");

--- a/WrathCombo/DebugFile.cs
+++ b/WrathCombo/DebugFile.cs
@@ -56,7 +56,13 @@ public static class DebugFile
     /// <summary>
     /// List of many things the user has done in the current session (Toggles, config changes etc.)
     /// </summary>
-    internal static List<string> DebugLog = new();
+    internal static List<string> DebugLog = [];
+
+    /// Get the path to the debug file.
+    public static string GetDebugFilePath() {
+        var separator = DesktopPath?.Contains('\\') == true ? "\\" : "/";
+        return $"{DesktopPath}{separator}WrathDebug.txt";
+    }
 
     /// <summary>
     ///     Makes a debug file on the desktop.
@@ -90,7 +96,7 @@ public static class DebugFile
         }
 
         using (_file = new StreamWriter(
-                   $"{DesktopPath}/WrathDebug.txt", append: false))
+                   GetDebugFilePath(), append: false))
         {
             AddLine("START DEBUG LOG");
             AddLine();
@@ -125,7 +131,8 @@ public static class DebugFile
             DuoLog.Information(
                 "WrathDebug.txt created on your desktop, for " +
                 (job is null ? "all jobs" : job.Value.Abbreviation.ToString()) +
-                ". Upload this file where requested.");
+                ". Upload this file where requested." +
+                "If you're unsure of where the file was created, use /wrath debug path");
         }
     }
 
@@ -489,12 +496,17 @@ public static class DebugFile
         AddLine("END REDUNDANT IDS");
     }
 
+    public static string GetDebugCode()
+    {
+        var bytes = Encoding.UTF8.GetBytes(
+            JsonConvert.SerializeObject(Service.Configuration));
+        return Convert.ToBase64String(bytes);
+    }
+
     private static void AddDebugCode()
     {
         AddLine("START DEBUG CODE");
-        var b64 = Encoding.UTF8
-            .GetBytes(JsonConvert.SerializeObject(Service.Configuration));
-        AddLine(Convert.ToBase64String(b64));
+        AddLine(GetDebugCode());
         AddLine("END DEBUG CODE");
     }
 

--- a/WrathCombo/DebugFile.cs
+++ b/WrathCombo/DebugFile.cs
@@ -95,8 +95,7 @@ public static class DebugFile
             job = Svc.ClientState.LocalPlayer.ClassJob.Value;
         }
 
-        using (_file = new StreamWriter(
-                   GetDebugFilePath(), append: false))
+        using (_file = new StreamWriter(GetDebugFilePath(), append: false))
         {
             AddLine("START DEBUG LOG");
             AddLine();

--- a/WrathCombo/DebugFile.cs
+++ b/WrathCombo/DebugFile.cs
@@ -496,6 +496,7 @@ public static class DebugFile
         AddLine("END REDUNDANT IDS");
     }
 
+    /// Get the debug code by itself.
     public static string GetDebugCode()
     {
         var bytes = Encoding.UTF8.GetBytes(

--- a/WrathCombo/DebugFile.cs
+++ b/WrathCombo/DebugFile.cs
@@ -130,7 +130,7 @@ public static class DebugFile
             DuoLog.Information(
                 "WrathDebug.txt created on your desktop, for " +
                 (job is null ? "all jobs" : job.Value.Abbreviation.ToString()) +
-                ". Upload this file where requested." +
+                ". Upload this file where requested.\n" +
                 "If you're unsure of where the file was created, use /wrath debug path");
         }
     }

--- a/WrathCombo/Window/Tabs/Settings.cs
+++ b/WrathCombo/Window/Tabs/Settings.cs
@@ -291,7 +291,7 @@ namespace WrathCombo.Window.Tabs
                     if (Player.Available)
                         DebugFile.MakeDebugFile();
                     else
-                        DebugFile.MakeDebugFile(allJobs:true);
+                        DebugFile.MakeDebugFile(allJobs: true);
                 }
 
                 ImGuiComponents.HelpMarker("Will generate a debug file on your desktop.\nUseful to give developers to help troubleshoot issues.\nThe same as using the following command: /wrath debug");


### PR DESCRIPTION
- [X] Adds `/wrath debug path`, an undocumented command (that is suggested to users when they create a debug file) that prints the path the file was put at.
- [X] Adds `/wrath debug string`, an undocumented command that copies the debug code to the clipboard, ready to be pasted into discord, for us to workaround any issues with file creation.