### PR TITLE
[AST] Add option to use balance priorities for card quick target

### DIFF
--- a/WrathCombo/Combos/PvE/AST/AST_Config.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Config.cs
@@ -52,8 +52,6 @@ internal partial class AST
         public static UserFloat
             AST_ST_DPS_CombustUptime_Threshold = new("AST_ST_DPS_CombustUptime_Threshold");
 
-        
-
         internal static void Draw(CustomComboPreset preset)
         {
             switch (preset)

--- a/WrathCombo/Combos/PvE/AST/AST_Config.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Config.cs
@@ -51,6 +51,8 @@ internal partial class AST
         public static UserFloat
             AST_ST_DPS_CombustUptime_Threshold = new("AST_ST_DPS_CombustUptime_Threshold");
 
+        
+
         internal static void Draw(CustomComboPreset preset)
         {
             switch (preset)

--- a/WrathCombo/Combos/PvE/AST/AST_Config.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Config.cs
@@ -32,6 +32,7 @@ internal partial class AST
 
         public static UserBool
             AST_QuickTarget_SkipDamageDown = new("AST_QuickTarget_SkipDamageDown"),
+            AST_QuickTarget_Prio = new("AST_QuickTarget_Prio"),
             AST_QuickTarget_SkipRezWeakness = new("AST_QuickTarget_SkipRezWeakness"),
             AST_ST_SimpleHeals_Adv = new("AST_ST_SimpleHeals_Adv"),
             AST_ST_SimpleHeals_UIMouseOver = new("AST_ST_SimpleHeals_UIMouseOver"),
@@ -197,6 +198,7 @@ internal partial class AST
                     ImGui.Spacing();
                     DrawAdditionalBoolChoice(AST_QuickTarget_SkipDamageDown, $"Skip targets with a {GetStatusName(62)} debuff", "");
                     DrawAdditionalBoolChoice(AST_QuickTarget_SkipRezWeakness, $"Skip targets with a {GetStatusName(43)} or {GetStatusName(44)} debuff", "");
+                    DrawAdditionalBoolChoice(AST_QuickTarget_Prio, $"Uses Fixed Card Priorities", "");
                     break;
 
                 case CustomComboPreset.AST_DPS_AutoDraw:

--- a/WrathCombo/Combos/PvE/AST/AST_Helper.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Helper.cs
@@ -230,24 +230,27 @@ internal partial class AST
             //Grok is a scary SOB
             if (PartyTargets.Count > 0)
             {
+                
                 //PartyTargets.Shuffle();
-
+                
                 PartyTargets.Sort((x, y) =>
 {
     Dictionary<byte, int> jobPriorities = new()
     {
-        { PCT.JobID, 1 },
-        { SAM.JobID, 2 },
-        { RPR.JobID, 3 },
-        { VPR.JobID, 4 },
+        { SAM.JobID, 1 },
+        { NIN.JobID, 2 },
+        { VPR.JobID, 3 },
+        { DRG.JobID, 4 },
         { MNK.JobID, 5 },
-        { NIN.JobID, 6 },
-        { DRG.JobID, 7 },
-        { BLM.JobID, 8 },
-        { RDM.JobID, 9 },
-        { SMN.JobID, 10 },
-        { MCH.JobID, 11 },
-        { BRD.JobID, 12 }
+        { DRK.JobID, 6 },
+        { RPR.JobID, 7 },
+        { PCT.JobID, 8 },
+        { SMN.JobID, 9 },
+        { MCH.JobID, 10 },
+        { BRD.JobID, 11 },
+        { RDM.JobID, 12 },
+{ DNC.JobID, 13 },
+{ BLM.JobID, 14 }
     };
 
     int GetPriority(IGameObject obj)
@@ -255,7 +258,8 @@ internal partial class AST
         if (obj is not IBattleChara chara)
             return int.MaxValue;
 
-        return jobPriorities.TryGetValue(chara.ClassJob.RowId, out int priority) ? priority : int.MaxValue;
+        return jobPriorities.TryGetValue((byte)chara.ClassJob.RowId, out int priority) ? priority : int.MaxValue;
+
     }
 
     return GetPriority(x).CompareTo(GetPriority(y));

--- a/WrathCombo/Combos/PvE/AST/AST_Helper.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Helper.cs
@@ -230,7 +230,36 @@ internal partial class AST
             //Grok is a scary SOB
             if (PartyTargets.Count > 0)
             {
-                PartyTargets.Shuffle();
+                //PartyTargets.Shuffle();
+
+                PartyTargets.Sort((x, y) =>
+{
+    Dictionary<byte, int> jobPriorities = new()
+    {
+        { PCT.JobID, 1 },
+        { SAM.JobID, 2 },
+        { RPR.JobID, 3 },
+        { VPR.JobID, 4 },
+        { MNK.JobID, 5 },
+        { NIN.JobID, 6 },
+        { DRG.JobID, 7 },
+        { BLM.JobID, 8 },
+        { RDM.JobID, 9 },
+        { SMN.JobID, 10 },
+        { MCH.JobID, 11 },
+        { BRD.JobID, 12 }
+    };
+
+    int GetPriority(IGameObject obj)
+    {
+        if (obj is not IBattleChara chara)
+            return int.MaxValue;
+
+        return jobPriorities.TryGetValue(chara.ClassJob.RowId, out int priority) ? priority : int.MaxValue;
+    }
+
+    return GetPriority(x).CompareTo(GetPriority(y));
+});
 
                 IGameObject? suitableDps = null;
                 IGameObject? unsuitableDps = null;

--- a/WrathCombo/Combos/PvE/AST/AST_Helper.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Helper.cs
@@ -230,40 +230,55 @@ internal partial class AST
             //Grok is a scary SOB
             if (PartyTargets.Count > 0)
             {
-                
-                //PartyTargets.Shuffle();
-                
-                PartyTargets.Sort((x, y) =>
-{
-    Dictionary<byte, int> jobPriorities = new()
-    {
-        { SAM.JobID, 1 },
-        { NIN.JobID, 2 },
-        { VPR.JobID, 3 },
-        { DRG.JobID, 4 },
-        { MNK.JobID, 5 },
-        { DRK.JobID, 6 },
-        { RPR.JobID, 7 },
-        { PCT.JobID, 8 },
-        { SMN.JobID, 9 },
-        { MCH.JobID, 10 },
-        { BRD.JobID, 11 },
-        { RDM.JobID, 12 },
-{ DNC.JobID, 13 },
-{ BLM.JobID, 14 }
-    };
 
-    int GetPriority(IGameObject obj)
-    {
-        if (obj is not IBattleChara chara)
-            return int.MaxValue;
+                //Start of AST Fixed Prio
 
-        return jobPriorities.TryGetValue((byte)chara.ClassJob.RowId, out int priority) ? priority : int.MaxValue;
+                if (Config.AST_QuickTarget_Prio)
+                {
+                    PartyTargets.Shuffle();
+                }
+                else
+                {
+                    
 
-    }
+                    PartyTargets.Sort((x, y) =>
+                    {
+                        Dictionary<byte, int> jobPriorities = new()
+                        {
+                        { SAM.JobID, 1 },
+                        { NIN.JobID, 2 },
+                        { VPR.JobID, 3 },
+                        { DRG.JobID, 4 },
+                        { MNK.JobID, 5 },
+                        { DRK.JobID, 6 },
+                        { RPR.JobID, 7 },
+                        { PCT.JobID, 8 },
+                        { SMN.JobID, 9 },
+                        { MCH.JobID, 10 },
+                        { BRD.JobID, 11 },
+                        { RDM.JobID, 12 },
+                        { DNC.JobID, 13 },
+                        { BLM.JobID, 14 }
+                        };
 
-    return GetPriority(x).CompareTo(GetPriority(y));
-});
+                        int GetPriority(IGameObject obj)
+                        {
+                            if (obj is not IBattleChara chara)
+                                return int.MaxValue;
+
+                            return jobPriorities.TryGetValue((byte)chara.ClassJob.RowId, out int priority) ? priority : int.MaxValue;
+
+                        }
+
+
+
+                        return GetPriority(x).CompareTo(GetPriority(y));
+                    });
+
+                }
+//End of AST Fixed prio
+
+
 
                 IGameObject? suitableDps = null;
                 IGameObject? unsuitableDps = null;

--- a/WrathCombo/Combos/PvE/AST/AST_Helper.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Helper.cs
@@ -235,12 +235,6 @@ internal partial class AST
 
                 if (Config.AST_QuickTarget_Prio)
                 {
-                    PartyTargets.Shuffle();
-                }
-                else
-                {
-                    
-
                     PartyTargets.Sort((x, y) =>
                     {
                         Dictionary<byte, int> jobPriorities = new()
@@ -266,15 +260,16 @@ internal partial class AST
                             if (obj is not IBattleChara chara)
                                 return int.MaxValue;
 
-                            return jobPriorities.TryGetValue((byte)chara.ClassJob.RowId, out int priority) ? priority : int.MaxValue;
+                            return jobPriorities.TryGetValue((byte)chara.ClassJob.RowId, out int priority) ? priority : 99;
 
                         }
 
-
-
                         return GetPriority(x).CompareTo(GetPriority(y));
                     });
-
+                }
+                else
+                {
+                    PartyTargets.Shuffle();
                 }
 //End of AST Fixed prio
 

--- a/WrathCombo/WrathCombo.csproj
+++ b/WrathCombo/WrathCombo.csproj
@@ -56,7 +56,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Content Include="..\res\plugin\wrathcombo.png" Link="images\wrathcombo.png" CopyToOutputDirectory="PreserveNewest" Visible="false"/>
+        <Content Include="..\res\plugin\wrathcombo.png" Link="images\wrathcombo.png" CopyToOutputDirectory="PreserveNewest" Visible="false" />
     </ItemGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -64,17 +64,20 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\.editorconfig" Link=".editorconfig"/>
+        <None Include="..\.editorconfig" Link=".editorconfig" />
     </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="DalamudPackager" Version="12.0.0" />
-        <PackageReference Include="ILRepack" Version="2.0.18"/>
+        <PackageReference Include="ILRepack" Version="2.0.41">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\ECommons\ECommons\ECommons.csproj"/>
-        <ProjectReference Include="..\PunishLib\PunishLib\PunishLib.csproj"/>
+        <ProjectReference Include="..\ECommons\ECommons\ECommons.csproj" />
+        <ProjectReference Include="..\PunishLib\PunishLib\PunishLib.csproj" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Add fixed priorities for cards and a combo box on the option to use them or keep the existing random selection
Priorities are based on the 2m windows