### PR TITLE
[Core] Function Updates

### DIFF
--- a/WrathCombo/CustomCombo/CustomCombo.cs
+++ b/WrathCombo/CustomCombo/CustomCombo.cs
@@ -47,13 +47,8 @@ namespace WrathCombo.CustomComboNS
             if (!IsEnabled(Preset))
                 return false;
 
-            //Cache the LocalPlayer for the Combo
-            LocalPlayer = Player.Object;
-            if (LocalPlayer is null) return false; //Safeguard. LocalPlayer shouldn't be null at this point anyways.
+            if (Player.Object is null) return false; //Safeguard. LocalPlayer shouldn't be null at this point anyways.
             if (Player.IsDead) return false; //Don't do combos while dead
-
-            //Cache the CurrentTarget for the Combo
-            CurrentTarget = Svc.Targets.Target;
 
             uint classJobID = LocalPlayer!.ClassJob.RowId;
 

--- a/WrathCombo/CustomCombo/CustomCombo.cs
+++ b/WrathCombo/CustomCombo/CustomCombo.cs
@@ -1,6 +1,7 @@
 ﻿using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Utility;
 using ECommons.DalamudServices;
+using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using WrathCombo.Attributes;
 using WrathCombo.Combos;
@@ -45,6 +46,14 @@ namespace WrathCombo.CustomComboNS
 
             if (!IsEnabled(Preset))
                 return false;
+
+            //Cache the LocalPlayer for the Combo
+            LocalPlayer = Player.Object;
+            if (LocalPlayer is null) return false; //Safeguard. LocalPlayer shouldn't be null at this point anyways.
+            if (Player.IsDead) return false; //Don't do combos while dead
+
+            //Cache the CurrentTarget for the Combo
+            CurrentTarget = Svc.Targets.Target;
 
             uint classJobID = LocalPlayer!.ClassJob.RowId;
 

--- a/WrathCombo/CustomCombo/Functions/Action.cs
+++ b/WrathCombo/CustomCombo/Functions/Action.cs
@@ -84,9 +84,9 @@ namespace WrathCombo.CustomComboNS.Functions
         /// <returns></returns>
         public static int GetTraitLevel(uint id) => ActionWatching.GetTraitLevel(id);
 
-        /// <summary> Checks if the player can use an action based on level required and off cooldown / has charges. </summary>
-        /// <param name="id"> The ID of the action. </param>
-        /// <returns> Testing indicates non-charge actions have a max. charge of 1, and it's zero during cooldown. </returns>
+        /// <summary> Checks if the player can use an action based on level required and whether it has charges / is off cooldown. </summary>
+        /// <param name="id"> ID of the action. </param>
+        /// <returns> Non-charge actions have a charge value of 1 when off cooldown; otherwise 0. </returns>
         public static unsafe bool ActionReady(uint id)
         {
             uint hookedId = OriginalHook(id);
@@ -94,7 +94,7 @@ namespace WrathCombo.CustomComboNS.Functions
             // Check 1: Cooldown (Non-Abilities)
             bool isOffCooldown = GetCooldownRemainingTime(hookedId) <= RemainingGCD + 0.5f && ActionWatching.GetAttackType(hookedId) != ActionWatching.ActionAttackType.Ability;
 
-            // Check 2: Charges (Abilities)
+            // Check 2: Charges
             bool hasChargesLeft = HasCharges(hookedId);
 
             // Check 3: Usable Flags
@@ -103,6 +103,9 @@ namespace WrathCombo.CustomComboNS.Functions
             return (isOffCooldown || hasChargesLeft) && isUsable;
         }
 
+        /// <summary> Checks if all passed actions are ready to be used. </summary>
+        /// <param name="ids"> IDs of the actions. </param>
+        /// <returns></returns>
         public static bool ActionsReady(uint[] ids)
         {
             foreach (var id in ids)
@@ -114,7 +117,7 @@ namespace WrathCombo.CustomComboNS.Functions
         /// <summary> Checks if the last action performed was the passed ID. </summary>
         /// <param name="id"> ID of the action. </param>
         /// <returns></returns>
-        public static bool WasLastAction(uint id) => ActionWatching.CombatActions.Count > 0 ? ActionWatching.CombatActions.LastOrDefault() == id : false;
+        public static bool WasLastAction(uint id) => ActionWatching.CombatActions.Count > 0 && ActionWatching.CombatActions.LastOrDefault() == id;
 
         /// <summary> Returns how many times in a row the last action was used. </summary>
         /// <returns></returns>

--- a/WrathCombo/CustomCombo/Functions/Action.cs
+++ b/WrathCombo/CustomCombo/Functions/Action.cs
@@ -84,23 +84,23 @@ namespace WrathCombo.CustomComboNS.Functions
         /// <returns></returns>
         public static int GetTraitLevel(uint id) => ActionWatching.GetTraitLevel(id);
 
-        /// <summary> Checks if the player can use an action based on level required and whether it has charges / is off cooldown. </summary>
+        /// <summary> Checks if the player can use an action based on the level required and whether it has charges / is off cooldown. </summary>
         /// <param name="id"> ID of the action. </param>
-        /// <returns> Non-charge actions have a charge value of 1 when off cooldown; otherwise 0. </returns>
+        /// <returns> Non-charge actions have a charge value of 1 when off cooldown; otherwise they have a value of 0. </returns>
         public static unsafe bool ActionReady(uint id)
         {
             uint hookedId = OriginalHook(id);
 
-            // Check 1: Cooldown (Non-Abilities)
-            bool isOffCooldown = GetCooldownRemainingTime(hookedId) <= RemainingGCD + 0.5f && ActionWatching.GetAttackType(hookedId) != ActionWatching.ActionAttackType.Ability;
-
-            // Check 2: Charges
+            // Check 1: Charges
             bool hasChargesLeft = HasCharges(hookedId);
+
+            // Check 2: Cooldown (Non-Abilities)
+            bool isOffCooldown = ActionWatching.GetAttackType(hookedId) != ActionWatching.ActionAttackType.Ability && GetCooldownRemainingTime(hookedId) <= RemainingGCD + 0.5f;
 
             // Check 3: Usable Flags
             bool isUsable = ActionManager.Instance()->GetActionStatus(ActionType.Action, hookedId, checkRecastActive: false, checkCastingActive: false) is 0 or 582 or 580;
 
-            return (isOffCooldown || hasChargesLeft) && isUsable;
+            return isUsable && (hasChargesLeft || isOffCooldown);
         }
 
         /// <summary> Checks if all passed actions are ready to be used. </summary>

--- a/WrathCombo/CustomCombo/Functions/PlayerCharacter.cs
+++ b/WrathCombo/CustomCombo/Functions/PlayerCharacter.cs
@@ -18,7 +18,7 @@ namespace WrathCombo.CustomComboNS.Functions
     internal abstract partial class CustomComboFunctions
     {
         /// <summary> Gets the player or null. Set on each combo invoke</summary>
-        public static IPlayerCharacter? LocalPlayer = Svc.ClientState.LocalPlayer;
+        public static IPlayerCharacter? LocalPlayer => Svc.ClientState.LocalPlayer;
 
         /// <summary> Find if the player has a certain condition. </summary>
         /// <param name="flag"> Condition flag. </param>

--- a/WrathCombo/CustomCombo/Functions/PlayerCharacter.cs
+++ b/WrathCombo/CustomCombo/Functions/PlayerCharacter.cs
@@ -18,7 +18,7 @@ namespace WrathCombo.CustomComboNS.Functions
     internal abstract partial class CustomComboFunctions
     {
         /// <summary> Gets the player or null. Set on each combo invoke</summary>
-        public static IPlayerCharacter? LocalPlayer;
+        public static IPlayerCharacter? LocalPlayer = Svc.ClientState.LocalPlayer;
 
         /// <summary> Find if the player has a certain condition. </summary>
         /// <param name="flag"> Condition flag. </param>

--- a/WrathCombo/CustomCombo/Functions/PlayerCharacter.cs
+++ b/WrathCombo/CustomCombo/Functions/PlayerCharacter.cs
@@ -17,7 +17,7 @@ namespace WrathCombo.CustomComboNS.Functions
 {
     internal abstract partial class CustomComboFunctions
     {
-        /// <summary> Gets the player or null. Set on each combo invoke</summary>
+        /// <summary> Gets the player or null. </summary>
         public static IPlayerCharacter? LocalPlayer => Svc.ClientState.LocalPlayer;
 
         /// <summary> Find if the player has a certain condition. </summary>

--- a/WrathCombo/CustomCombo/Functions/PlayerCharacter.cs
+++ b/WrathCombo/CustomCombo/Functions/PlayerCharacter.cs
@@ -17,8 +17,8 @@ namespace WrathCombo.CustomComboNS.Functions
 {
     internal abstract partial class CustomComboFunctions
     {
-        /// <summary> Gets the player or null. </summary>
-        public static IPlayerCharacter? LocalPlayer => Svc.ClientState.LocalPlayer;
+        /// <summary> Gets the player or null. Set on each combo invoke</summary>
+        public static IPlayerCharacter? LocalPlayer;
 
         /// <summary> Find if the player has a certain condition. </summary>
         /// <param name="flag"> Condition flag. </param>

--- a/WrathCombo/CustomCombo/Functions/Target.cs
+++ b/WrathCombo/CustomCombo/Functions/Target.cs
@@ -342,36 +342,44 @@ namespace WrathCombo.CustomComboNS.Functions
             P8
         }
 
-        /// <summary> Gets the player's position relative to the target. </summary>
-        /// <returns> 1: Right Flank. <br/> 2: Rear. <br/> 3: Left Flank. <br/> 4: Front. </returns>
-        public static int AngleToTarget()
+        public enum AttackAngle
         {
-            if (LocalPlayer is not { } player || CurrentTarget is not IBattleChara target || target.ObjectKind != ObjectKind.BattleNpc) return 0;
+            Front,
+            Flank,
+            Rear,
+            Unknown
+        }
+
+        /// <summary> Gets the player's position relative to the target. </summary>
+        /// <returns> Front, Flank, Rear or Unknown as AttackAngle type. </returns>
+        public static AttackAngle AngleToTarget()
+        {
+            if (LocalPlayer is not { } player || CurrentTarget is not IBattleChara target || target.ObjectKind != ObjectKind.BattleNpc) return AttackAngle.Unknown;
 
             float angle = PositionalMath.AngleXZ(target.Position, player.Position) - target.Rotation;
             float regionDegrees = PositionalMath.ToDegrees(angle) + (angle < 0f ? 360f : 0f);
 
             return regionDegrees switch
             {
-                >= 315f or <= 45f       => 4, // Front (0° ± 45°)
-                >= 45f and <= 135f      => 1, // Right Flank (90° ± 45°)
-                >= 135f and <= 225f     => 2, // Rear (180° ± 45°)
-                >= 225f and <= 315f     => 3, // Left Flank (270° ± 45°)
-                _                       => 0  // Fallback
+                >= 315f or <= 45f       => AttackAngle.Front,   // 0° ± 45°
+                >= 45f and <= 135f      => AttackAngle.Flank,   // 90° ± 45°
+                >= 135f and <= 225f     => AttackAngle.Rear,    // 180° ± 45°
+                >= 225f and <= 315f     => AttackAngle.Flank,   // 270° ± 45°
+                _                       => AttackAngle.Unknown
             };
         }
 
         /// <summary> Is player on target's rear. </summary>
         /// <returns> True or false. </returns>
-        public static bool OnTargetsRear() => AngleToTarget() is 2;
+        public static bool OnTargetsRear() => AngleToTarget() is AttackAngle.Rear;
 
         /// <summary> Is player on target's flank. </summary>
         /// <returns> True or false. </returns>
-        public static bool OnTargetsFlank() => AngleToTarget() is 1 or 3;
+        public static bool OnTargetsFlank() => AngleToTarget() is AttackAngle.Flank;
 
         /// <summary> Is player on target's front. </summary>
         /// <returns> True or false. </returns>
-        public static bool OnTargetsFront() => AngleToTarget() is 4;
+        public static bool OnTargetsFront() => AngleToTarget() is AttackAngle.Front;
 
         /// <summary> Performs positional calculations. Based on the excellent Resonant plugin. </summary>
         internal static class PositionalMath

--- a/WrathCombo/CustomCombo/Functions/Target.cs
+++ b/WrathCombo/CustomCombo/Functions/Target.cs
@@ -604,8 +604,7 @@ namespace WrathCombo.CustomComboNS.Functions
 
         internal static unsafe bool IsQuestMob(IGameObject target) => target.Struct()->NamePlateIconId is 71204 or 71144 or 71224 or 71344;
 
-        private static bool IsBoss(IGameObject? target) =>
-            target != null && Svc.Data.GetExcelSheet<BNpcBase>().HasRow(target.DataId) && Svc.Data.GetExcelSheet<BNpcBase>().GetRow(target.DataId).Rank is 2 or 6;
+        private static bool IsBoss(IGameObject? target) => target is not null && Svc.Data.GetExcelSheet<BNpcBase>().TryGetRow(target.DataId, out var dataRow) && dataRow.Rank is 2 or 6;
 
         internal static bool TargetIsBoss() => IsBoss(LocalPlayer.TargetObject);
 

--- a/WrathCombo/CustomCombo/Functions/Target.cs
+++ b/WrathCombo/CustomCombo/Functions/Target.cs
@@ -24,8 +24,6 @@ namespace WrathCombo.CustomComboNS.Functions
 {
     internal abstract partial class CustomComboFunctions
     {
-        private static readonly Dictionary<uint, bool> NPCPositionals = new();
-
         /// <summary> Gets the current target or null. </summary>
         public static IGameObject? CurrentTarget => Svc.Targets.Target;
 
@@ -243,14 +241,10 @@ namespace WrathCombo.CustomComboNS.Functions
 
         public static bool TargetNeedsPositionals()
         {
-            if (!HasBattleTarget()) return false;
-            if (HasStatusEffect(3808, CurrentTarget, true)) return false; // Directional Disregard Effect (Patch 7.01)
-            if (!NPCPositionals.ContainsKey(CurrentTarget.DataId))
-            {
-                if (Svc.Data.GetExcelSheet<BNpcBase>().TryGetFirst(x => x.RowId == CurrentTarget.DataId, out var bnpc))
-                    NPCPositionals[CurrentTarget.DataId] = bnpc.IsOmnidirectional;
-            }
-            return !NPCPositionals[CurrentTarget.DataId];
+            if (CurrentTarget is not IBattleChara target || HasStatusEffect(3808, target, true))
+                return false;
+
+            return Svc.Data.GetExcelSheet<BNpcBase>().TryGetRow(target.DataId, out var dataRow) && !dataRow.IsOmnidirectional;
         }
 
         /// <summary> Attempts to target the given party member </summary>

--- a/WrathCombo/Window/Tabs/Debug.cs
+++ b/WrathCombo/Window/Tabs/Debug.cs
@@ -325,10 +325,7 @@ namespace WrathCombo.Window.Tabs
                 CustomStyleText("Hitbox Radius:", target?.HitboxRadius);
                 CustomStyleText("In Melee Range:", InMeleeRange());
                 CustomStyleText("Requires Postionals:", TargetNeedsPositionals());
-                CustomStyleText("Relative Position:",
-                    AngleToTarget() is 2 ? "Rear" :
-                    (AngleToTarget() is 1 or 3) ? "Flank" :
-                    AngleToTarget() is 4 ? "Front" : "");
+                CustomStyleText("Relative Position:", AngleToTarget().ToString());
                 CustomStyleText("Health:",
                     $"{EnemyHealthCurrentHp():N0} / {EnemyHealthMaxHp():N0} ({Math.Round(GetTargetHPPercent(), 2)}%)");
                 CustomStyleText("Shield:",


### PR DESCRIPTION
## 1. Update: ActionReady()
- Cached `OriginalHook(id)` value to reduce amount of function calls  `(4 → 1)`.
- Fixed `GetAttackType(id)` being passed instead of `GetAttackType(OriginalHook(id))`.

```
public static unsafe bool ActionReady(uint id)
{
	uint hookedId = OriginalHook(id);

	return ((GetCooldownRemainingTime(hookedId) <= RemainingGCD + 0.5f && ActionWatching.GetAttackType(hookedId) != ActionWatching.ActionAttackType.Ability) ||
		HasCharges(hookedId)) && ActionManager.Instance()->GetActionStatus(ActionType.Action, hookedId, checkRecastActive: false, checkCastingActive: false) is 0 or 582 or 580;
}
```

## 2. Update: JustUsed() & JustUsedOn()
- Replaced two `ContainsKey` lookups with one `TryGetValue` lookup.
- Refactored division into multiplication; added `(long)` cast to match time type.

```
public static bool JustUsed(uint actionID, float variance = 3f)
{
	if (!ActionWatching.ActionTimestamps.TryGetValue(actionID, out long timestamp))
		return false;

	return (Environment.TickCount64 - timestamp) <= (long)(variance * 1000f);
}
```

## 3. Refactor: AngleToTarget()
- Refactored branching `if` structure into `switch`; added references to avoid repeated getter calls.
- Now centralizes all calculations for `OnTargetsRear()`, `OnTargetsFlank()` and `OnTargetsFront()`.

```
public enum AttackAngle
{
    Front,
    Flank,
    Rear,
    Unknown
}

public static AttackAngle AngleToTarget()
{
    if (LocalPlayer is not { } player || CurrentTarget is not IBattleChara target || target.ObjectKind != ObjectKind.BattleNpc) return AttackAngle.Unknown;

    float angle = PositionalMath.AngleXZ(target.Position, player.Position) - target.Rotation;
    float regionDegrees = PositionalMath.ToDegrees(angle) + (angle < 0f ? 360f : 0f);

    return regionDegrees switch
    {
        >= 315f or <= 45f       => AttackAngle.Front,   // 0° ± 45°
        >= 45f and <= 135f      => AttackAngle.Flank,   // 90° ± 45°
        >= 135f and <= 225f     => AttackAngle.Rear,    // 180° ± 45°
        >= 225f and <= 315f     => AttackAngle.Flank,   // 270° ± 45°
        _                       => AttackAngle.Unknown
    };
}

public static bool OnTargetsRear() => AngleToTarget() is AttackAngle.Rear;

public static bool OnTargetsFlank() => AngleToTarget() is AttackAngle.Flank;

public static bool OnTargetsFront() => AngleToTarget() is AttackAngle.Front;
```

## 4. Update: PositionalMath Library
- Conversion values using PI are now calculated at compile-time into constants.
- All math is now handled in `float` instead of cross-casting `float` ↔ `double`.

```
internal static class PositionalMath
{
	public const float DegreesToRadians = MathF.PI / 180f;
	public const float RadiansToDegrees = 180f / MathF.PI;

	public static float ToRadians(float degrees) => degrees * DegreesToRadians;

	public static float ToDegrees(float radians) => radians * RadiansToDegrees;

	public static float AngleXZ(Vector3 a, Vector3 b) => MathF.Atan2(b.X - a.X, b.Z - a.Z);
}
```

## 5. Update: PlayerHealthPercentageHp()
- Uses `LocalPlayer` reference to reduce amount of property getter calls `(3 → 1)`.
- Multiplication moved to `CurrentHp`; higher precision and implicit promotion to `float`.

```
public static float PlayerHealthPercentageHp() =>
    LocalPlayer is { } player ? player.CurrentHp * 100f / player.MaxHp : 0f;
```

## 6. Update: IsBoss()
- Replaced `HasRow` and `GetRow` with `TryGetRow`.
- Now performs the same task with one sheet lookup.

```
private static bool IsBoss(IGameObject? target) => target is not null &&
    Svc.Data.GetExcelSheet<BNpcBase>().TryGetRow(target.DataId, out var dataRow) && dataRow.Rank is 2 or 6;
```

## 7. Update: TargetNeedsPositionals()
- **Massive** (~40x) performance increase by replacing LINQ `TryGetFirst` with Lumina `TryGetRow`.
- Uses `CurrentTarget` reference to reduce amount of property getter calls `(3 → 1)`.
- Old `NPCPositionals` dictionary used for caching can be safely discarded.

```
public static bool TargetNeedsPositionals()
{
    if (CurrentTarget is not IBattleChara target || HasStatusEffect(3808, target, true))
        return false;

    return Svc.Data.GetExcelSheet<BNpcBase>().TryGetRow(target.DataId, out var dataRow) &&
        !dataRow.IsOmnidirectional;
}
```