### PR TITLE
[DNC] Resolve more feature conflicts, Various improvements

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1352,12 +1352,43 @@ public enum CustomComboPreset
 
     #region Dance Features
 
-    [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
-    [ConflictingCombos(DNC_StandardStep_LastDance, DNC_TechnicalStep_Devilment)]
-    [CustomComboInfo("Dance Step Combo Feature",
-        "Change Standard Step and Technical Step into each dance step, while dancing." +
+    //[ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
+    //[ConflictingCombos(DNC_StandardStep_LastDance, DNC_TechnicalStep_Devilment)]
+    //[CustomComboInfo("Dance Step Combo Feature",
+    //    "Change Standard Step and Technical Step into each dance step, while dancing." +
+    //    "\nWorks with Advanced Mode DNC.", DNC.JobID)]
+    //DNC_DanceStepCombo = 4110,
+
+    [CustomComboInfo("Dance Features", "Modifies default dance behaviors.", DNC.JobID)]
+    DNC_DanceFeatures = 4110,
+
+    [ParentCombo(DNC_DanceFeatures)]
+    [ReplaceSkill(DNC.StandardStep)]
+    [CustomComboInfo("Standard Step Combo Feature",
+        "Change Standard Step into each dance step, while dancing." +
         "\nWorks with Advanced Mode DNC.", DNC.JobID)]
-    DNC_DanceStepCombo = 4110,
+    DNC_StandardStepCombo = 4111,
+
+    [ParentCombo(DNC_DanceFeatures)]
+    [ReplaceSkill(DNC.TechnicalStep)]
+    [CustomComboInfo("Technical Step Combo Feature",
+        "Change Technical Step into each dance step, while dancing." +
+        "\nWorks with Advanced Mode DNC.", DNC.JobID)]
+    DNC_TechnicalStepCombo = 4112,
+
+    // StandardStep(or Finishing Move) --> Last Dance
+    [ParentCombo(DNC_StandardStepCombo)]
+    [ReplaceSkill(DNC.StandardStep, DNC.FinishingMove)]
+    [CustomComboInfo("Standard Step to Last Dance Feature",
+        "Change Standard Step or Finishing Move to Last Dance when available.", DNC.JobID)]
+    DNC_StandardStep_LastDance = 4155,
+
+    // Technical Step --> Devilment
+    [ParentCombo(DNC_TechnicalStepCombo)]
+    [ReplaceSkill(DNC.TechnicalStep)]
+    [CustomComboInfo("Technical Step to Devilment Feature", "Change Technical Step to Devilment as soon as possible.",
+        DNC.JobID)]
+    DNC_TechnicalStep_Devilment = 4160,
 
     [CustomComboInfo("Custom Dance Step Feature",
         "Change custom actions into dance steps while dancing." +
@@ -1416,20 +1447,6 @@ public enum CustomComboPreset
     [ReplaceSkill(DNC.Devilment)]
     [CustomComboInfo("Devilment to Starfall Feature", "Change Devilment into Starfall Dance after use.", DNC.JobID)]
     DNC_Starfall_Devilment = 4150,
-
-    // StandardStep(or Finishing Move) --> Last Dance
-    [ReplaceSkill(DNC.StandardStep, DNC.FinishingMove)]
-    [ConflictingCombos(DNC_DanceStepCombo)]
-    [CustomComboInfo("Standard Step to Last Dance Feature",
-        "Change Standard Step or Finishing Move to Last Dance when available.", DNC.JobID)]
-    DNC_StandardStep_LastDance = 4155,
-
-    // Technical Step --> Devilment
-    [ReplaceSkill(DNC.StandardStep, DNC.FinishingMove)]
-    [ConflictingCombos(DNC_DanceStepCombo)]
-    [CustomComboInfo("Technical Step to Devilment Feature", "Change Technical Step to Devilment as soon as possible.",
-        DNC.JobID)]
-    DNC_TechnicalStep_Devilment = 4160,
 
     // Bladeshower --> Bloodshower
     [ReplaceSkill(DNC.Bladeshower)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1071,6 +1071,10 @@ public enum CustomComboPreset
         "\n(REQUIRES a countdown)", DNC.JobID)]
     DNC_ST_BalanceOpener = 4011,
 
+    [ParentCombo(DNC_ST_BalanceOpener)]
+    [CustomComboInfo("Wait for Countdown Options", "When not in combat will change to Savage Blade to wait for a countdown to appear.\nMostly here to allow for targeting the boss before the exact countdown window your opener selection is waiting for.\nONLY designed to be something you turn on while doing back-to-back pulls of content, NOT suitable to leave on all the time.", DNC.JobID)]
+    DNC_ST_Opener_BlockEarly = 4031,
+
     [ParentCombo(DNC_ST_AdvancedMode)]
     [CustomComboInfo("Dance Partner Reminder Option", "Includes Closed Position when out of combat and no dance partner is found.", DNC.JobID)]
     DNC_ST_Adv_Partner = 4012,

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1352,53 +1352,43 @@ public enum CustomComboPreset
 
     #region Dance Features
 
-    //[ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
-    //[ConflictingCombos(DNC_StandardStep_LastDance, DNC_TechnicalStep_Devilment)]
-    //[CustomComboInfo("Dance Step Combo Feature",
-    //    "Change Standard Step and Technical Step into each dance step, while dancing." +
-    //    "\nWorks with Advanced Mode DNC.", DNC.JobID)]
-    //DNC_DanceStepCombo = 4110,
+    [CustomComboInfo("Custom Dance Step Feature",
+        "Change custom actions into dance steps while dancing." +
+        "\nLets you still dance with combos on, without using Step Combo Features above.", DNC.JobID)]
+    DNC_CustomDanceSteps = 4115,
 
-    [CustomComboInfo("Dance Features", "Modifies default dance behaviors.", DNC.JobID)]
-    DNC_DanceFeatures = 4110,
+    [ParentCombo(DNC_CustomDanceSteps)]
+    [CustomComboInfo("Override Smaller Features", "If enabled, will let you choose actions that are replaced by the smaller features listed below here, and they will return the Step that you have set them to when dancing.", DNC.JobID)]
+    DNC_CustomDanceSteps_Conflicts = 4116,
+
+    [CustomComboInfo("Dance Features", "Small Features for Standard and Technical Step", DNC.JobID)]
+    DNC_DanceFeatures = 4111,
 
     [ParentCombo(DNC_DanceFeatures)]
     [ReplaceSkill(DNC.StandardStep)]
     [CustomComboInfo("Standard Step Combo Feature",
-        "Change Standard Step into each dance step, while dancing." +
-        "\nWorks with Advanced Mode DNC.", DNC.JobID)]
-    DNC_StandardStepCombo = 4111,
-
-    [ParentCombo(DNC_DanceFeatures)]
-    [ReplaceSkill(DNC.TechnicalStep)]
-    [CustomComboInfo("Technical Step Combo Feature",
-        "Change Technical Step into each dance step, while dancing." +
-        "\nWorks with Advanced Mode DNC.", DNC.JobID)]
-    DNC_TechnicalStepCombo = 4112,
+        "Change Standard Step into each dance step, while dancing.", DNC.JobID)]
+    DNC_StandardStepCombo = 4110,
 
     // StandardStep(or Finishing Move) --> Last Dance
-    [ParentCombo(DNC_StandardStepCombo)]
+    [ParentCombo(DNC_DanceFeatures)]
     [ReplaceSkill(DNC.StandardStep, DNC.FinishingMove)]
     [CustomComboInfo("Standard Step to Last Dance Feature",
         "Change Standard Step or Finishing Move to Last Dance when available.", DNC.JobID)]
     DNC_StandardStep_LastDance = 4155,
 
+    [ParentCombo(DNC_DanceFeatures)]
+    [ReplaceSkill(DNC.TechnicalStep)]
+    [CustomComboInfo("Technical Step Combo Feature",
+        "Change Technical Step into each dance step, while dancing.", DNC.JobID)]
+    DNC_TechnicalStepCombo = 4112,
+
     // Technical Step --> Devilment
-    [ParentCombo(DNC_TechnicalStepCombo)]
+    [ParentCombo(DNC_DanceFeatures)]
     [ReplaceSkill(DNC.TechnicalStep)]
     [CustomComboInfo("Technical Step to Devilment Feature", "Change Technical Step to Devilment as soon as possible.",
         DNC.JobID)]
     DNC_TechnicalStep_Devilment = 4160,
-
-    [CustomComboInfo("Custom Dance Step Feature",
-        "Change custom actions into dance steps while dancing." +
-        "\nLets you still dance with combos on, without using Dance Step Combo Feature.", DNC.JobID)]
-    DNC_CustomDanceSteps = 4115,
-
-    [ParentCombo(DNC_CustomDanceSteps)]
-    [ReplaceSkill(DNC.Devilment)]
-    [CustomComboInfo("Override Smaller Features", "If enabled, will let you choose actions that are replaced by the smaller features listed below here, and they will return the Step that you have set them to when dancing.", DNC.JobID)]
-    DNC_CustomDanceSteps_Conflicts = 4116,
 
     #endregion
     // Last value = 4116
@@ -1462,7 +1452,7 @@ public enum CustomComboPreset
     // Last value = 4170
 
     #endregion
-    // Last value = 4170
+    // Last value = 4177
 
     #region Variant
 

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -182,7 +182,7 @@ internal partial class DNC : PhysicalRanged
             if (IsEnabled(CustomComboPreset.DNC_ST_Adv_Devilment) &&
                 CanWeave() &&
                 LevelChecked(Devilment) &&
-                GetCooldownRemainingTime(Devilment) < 0.05 &&
+                GetCooldownRemainingTime(Devilment) < GCD/2 &&
                 (HasStatusEffect(Buffs.TechnicalFinish) ||
                  WasLastAction(TechnicalFinish4) ||
                  !LevelChecked(TechnicalStep)))

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -1374,14 +1374,14 @@ internal partial class DNC : PhysicalRanged
 
     #region Dance Features
 
-    internal class DNC_DanceStepCombo : CustomCombo
+    internal class DNC_StandardStepCombo : CustomCombo
     {
         protected internal override CustomComboPreset Preset =>
-            CustomComboPreset.DNC_DanceStepCombo;
+            CustomComboPreset.DNC_StandardStepCombo;
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is not (StandardStep or TechnicalStep)) return actionID;
+            if (actionID is not StandardStep) return actionID;
 
             // Standard Step
             if (actionID is StandardStep && Gauge.IsDancing &&
@@ -1389,6 +1389,19 @@ internal partial class DNC : PhysicalRanged
                 return Gauge.CompletedSteps < 2
                     ? Gauge.NextStep
                     : FinishOrHold(StandardFinish2);
+
+            return actionID;
+        }
+    }
+
+    internal class DNC_TechnicalStepCombo : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset =>
+            CustomComboPreset.DNC_TechnicalStepCombo;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not TechnicalStep) return actionID;
 
             // Technical Step
             if (actionID is TechnicalStep && Gauge.IsDancing &&

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -1,5 +1,6 @@
 ﻿#region
 using WrathCombo.CustomComboNS;
+using WrathCombo.Data;
 
 // ReSharper disable UnusedType.Global
 // ReSharper disable ClassNeverInstantiated.Global
@@ -128,6 +129,12 @@ internal partial class DNC : PhysicalRanged
             #endregion
 
             #region Pre-pull
+
+            if (!InCombat() && ContentCheck.IsInConfiguredContent(
+                    Config.DNC_ST_OpenerDifficulty, ContentCheck.ListSet.BossOnly) &&
+                IsEnabled(CustomComboPreset.DNC_ST_BalanceOpener) &&
+                IsEnabled(CustomComboPreset.DNC_ST_Opener_BlockEarly))
+                return All.SavageBlade;
 
             if (!InCombat() && TargetIsHostile())
             {

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -1374,47 +1374,71 @@ internal partial class DNC : PhysicalRanged
 
     #region Dance Features
 
-    internal class DNC_StandardStepCombo : CustomCombo
+    internal class DNC_StandardDanceFeatures : CustomCombo
     {
         protected internal override CustomComboPreset Preset =>
-            CustomComboPreset.DNC_StandardStepCombo;
+            CustomComboPreset.DNC_DanceFeatures;
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is not StandardStep) return actionID;
+            if (actionID is not (StandardStep or FinishingMove)) return actionID;
 
-            // Standard Step
-            if (actionID is StandardStep && Gauge.IsDancing &&
+            // Standard Finish
+            if (IsEnabled(CustomComboPreset.DNC_StandardStepCombo) &&
+                actionID is StandardStep &&
+                Gauge.IsDancing &&
                 HasStatusEffect(Buffs.StandardStep))
                 return Gauge.CompletedSteps < 2
                     ? Gauge.NextStep
                     : FinishOrHold(StandardFinish2);
 
+            // Custom Steps
+            if (WantsCustomStepsOnSmallerFeatures)
+                if (GetCustomDanceStep(actionID, out var danceStep))
+                    return danceStep;
+
+            // StandardStep(or Finishing Move) --> Last Dance
+            if (IsEnabled(CustomComboPreset.DNC_StandardStep_LastDance) &&
+                HasStatusEffect(Buffs.LastDanceReady))
+                return LastDance;
+
             return actionID;
         }
     }
 
-    internal class DNC_TechnicalStepCombo : CustomCombo
+    internal class DNC_TechnicalDanceFeatures : CustomCombo
     {
         protected internal override CustomComboPreset Preset =>
-            CustomComboPreset.DNC_TechnicalStepCombo;
+            CustomComboPreset.DNC_DanceFeatures;
 
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not TechnicalStep) return actionID;
 
-            // Technical Step
-            if (actionID is TechnicalStep && Gauge.IsDancing &&
+            // Technical Finish
+            if (IsEnabled(CustomComboPreset.DNC_TechnicalStepCombo) &&
+                Gauge.IsDancing &&
                 HasStatusEffect(Buffs.TechnicalStep))
                 return Gauge.CompletedSteps < 4
                     ? Gauge.NextStep
                     : FinishOrHold(TechnicalFinish4);
 
+            // Custom Steps
+            if (WantsCustomStepsOnSmallerFeatures)
+                if (GetCustomDanceStep(actionID, out var danceStep))
+                    return danceStep;
+
+            // Technical Step --> Devilment
+            if (IsEnabled(CustomComboPreset.DNC_TechnicalStep_Devilment) &&
+                WasLastWeaponskill(TechnicalFinish4) &&
+                HasStatusEffect(Buffs.TechnicalFinish))
+                return Devilment;
+
             return actionID;
         }
     }
 
-    internal class DNC_DanceComboReplacer : CustomCombo
+    internal class DNC_CustomDanceSteps : CustomCombo
     {
         protected internal override CustomComboPreset Preset =>
             CustomComboPreset.DNC_CustomDanceSteps;
@@ -1510,47 +1534,6 @@ internal partial class DNC : PhysicalRanged
 
             if (HasStatusEffect(Buffs.FlourishingStarfall))
                 return StarfallDance;
-
-            return actionID;
-        }
-    }
-
-    internal class DNC_StandardStep_LastDance : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset =>
-            CustomComboPreset.DNC_StandardStep_LastDance;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not (StandardStep or FinishingMove)) return actionID;
-
-            if (WantsCustomStepsOnSmallerFeatures)
-                if (GetCustomDanceStep(actionID, out var danceStep))
-                    return danceStep;
-
-            if (HasStatusEffect(Buffs.LastDanceReady))
-                return LastDance;
-
-            return actionID;
-        }
-    }
-
-    internal class DNC_TechnicalStep_Devilment : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset =>
-            CustomComboPreset.DNC_TechnicalStep_Devilment;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not TechnicalStep) return actionID;
-
-            if (WantsCustomStepsOnSmallerFeatures)
-                if (GetCustomDanceStep(actionID, out var danceStep))
-                    return danceStep;
-
-            if (WasLastWeaponskill(TechnicalFinish4) &&
-                HasStatusEffect(Buffs.TechnicalFinish))
-                return Devilment;
 
             return actionID;
         }

--- a/WrathCombo/Combos/PvE/DNC/DNC_Config.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Config.cs
@@ -5,9 +5,9 @@ using ECommons.ImGuiMethods;
 using ImGuiNET;
 using System.Linq;
 using System.Numerics;
-using WrathCombo.Combos.PvP;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
+using WrathCombo.Extensions;
 using WrathCombo.Services;
 using WrathCombo.Window.Functions;
 
@@ -199,7 +199,15 @@ internal partial class DNC
                         (int)Openers.SevenSecondTech, descriptionAsTooltip: true);
 
                     ImGui.Indent();
-                    UserConfig.DrawBossOnlyChoice(DNC_ST_OpenerDifficulty);
+                    ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudGrey);
+                    ImGui.TextWrapped(
+                        "Opener options:");
+                    ImGui.PopStyleColor();
+
+                    UserConfig.DrawAdditionalBoolChoice(DNC_ST_OpenerOption_Peloton,
+                        $"Include {Peloton.ActionName()}", "");
+
+                    UserConfig.DrawBossOnlyChoice(DNC_ST_OpenerDifficulty, "Select what kind of content to use this opener in:");
                     ImGui.Unindent();
 
                     break;
@@ -458,6 +466,17 @@ internal partial class DNC
         /// <seealso cref="CustomComboPreset.DNC_ST_BalanceOpener" />
         public static readonly UserInt DNC_ST_OpenerSelection =
             new("DNC_ST_OpenerSelection", (int) Openers.FifteenSecond);
+
+        /// <summary>
+        ///     Whether to include Peloton in the opener.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: <see langword="true"/><br />
+        ///     <b>Options</b>: <see langword="true"/> or <see langword="false"/>
+        /// </value>
+        /// <seealso cref="CustomComboPreset.DNC_ST_BalanceOpener" />
+        public static readonly UserBool DNC_ST_OpenerOption_Peloton =
+            new("DNC_ST_OpenerOption_Peloton", true);
 
         /// <summary>
         ///     Esprit threshold for Single Target.

--- a/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
@@ -524,7 +524,7 @@ internal partial class DNC
         } =
         [
             ([4], () => 7),
-            ([5], () => 5),
+            ([5], () => (!Config.DNC_ST_OpenerOption_Peloton ? 12 : 5)),
         ];
 
         public override List<(int[], uint, Func<bool>)> SubstitutionSteps
@@ -544,6 +544,15 @@ internal partial class DNC
             ([21, 22, 23], LastDance, () => HasStatusEffect(Buffs.LastDanceReady)),
             ([21, 22, 23], Fountainfall, () =>
                 HasStatusEffect(Buffs.SilkenFlow) || HasStatusEffect(Buffs.FlourishingFlow)),
+        ];
+
+        public override List<(int[] Steps, Func<bool> Condition)> SkipSteps
+        {
+            get;
+            set;
+        } =
+        [
+            ([4], () => !Config.DNC_ST_OpenerOption_Peloton),
         ];
 
         internal override UserData? ContentCheckConfig =>
@@ -615,7 +624,7 @@ internal partial class DNC
         } =
         [
             ([4], () => 2),
-            ([5], () => 2),
+            ([5], () => (!Config.DNC_ST_OpenerOption_Peloton ? 4 : 2)),
         ];
 
         public override List<(int[], uint, Func<bool>)> SubstitutionSteps
@@ -635,6 +644,15 @@ internal partial class DNC
             ([20, 21, 23], LastDance, () => HasStatusEffect(Buffs.LastDanceReady)),
             ([20, 21, 23], Fountainfall, () =>
                 HasStatusEffect(Buffs.SilkenFlow) || HasStatusEffect(Buffs.FlourishingFlow)),
+        ];
+
+        public override List<(int[] Steps, Func<bool> Condition)> SkipSteps
+        {
+            get;
+            set;
+        } =
+        [
+            ([4], () => !Config.DNC_ST_OpenerOption_Peloton),
         ];
 
         internal override UserData? ContentCheckConfig =>
@@ -710,7 +728,7 @@ internal partial class DNC
         } =
         [
             ([5], () => 1),
-            ([6], () => 6),
+            ([6], () => (!Config.DNC_ST_OpenerOption_Peloton ? 7 : 6)),
         ];
 
         public override List<(int[], uint, Func<bool>)> SubstitutionSteps
@@ -730,6 +748,15 @@ internal partial class DNC
             ([21, 22, 23], LastDance, () => HasStatusEffect(Buffs.LastDanceReady)),
             ([21, 22, 23], Fountainfall, () =>
                 HasStatusEffect(Buffs.SilkenFlow) || HasStatusEffect(Buffs.FlourishingFlow)),
+        ];
+
+        public override List<(int[] Steps, Func<bool> Condition)> SkipSteps
+        {
+            get;
+            set;
+        } =
+        [
+            ([5], () => !Config.DNC_ST_OpenerOption_Peloton),
         ];
 
         internal override UserData? ContentCheckConfig =>
@@ -897,6 +924,15 @@ internal partial class DNC
             ([16, 17, 18], LastDance, () => HasStatusEffect(Buffs.LastDanceReady)),
             ([16, 17, 18], Fountainfall, () =>
                 HasStatusEffect(Buffs.SilkenFlow) || HasStatusEffect(Buffs.FlourishingFlow)),
+        ];
+
+        public override List<(int[] Steps, Func<bool> Condition)> SkipSteps
+        {
+            get;
+            set;
+        } =
+        [
+            ([6], () => !Config.DNC_ST_OpenerOption_Peloton),
         ];
 
         internal override UserData? ContentCheckConfig =>

--- a/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
@@ -413,7 +413,7 @@ internal partial class DNC
     /// <summary>
     ///     Saved custom dance steps.
     /// </summary>
-    /// <seealso cref="DNC_DanceComboReplacer.Invoke">DanceComboReplacer</seealso>
+    /// <seealso cref="DNC_CustomDanceSteps.Invoke">CustomDanceSteps</seealso>
     private static uint[] CustomDanceStepActions =>
         Service.Configuration.DancerDanceCompatActionIDs;
 


### PR DESCRIPTION
- [X] Flatten and Deconflict Dance features, thank you @tylenwells
- [X] Addressed issues with `Devilment` drift
- [X] Added option to block combo out of combat, until opener is ready (only suitable for boss spam, i.e. EXs and Savage)
- [X] Added option to skip `Peloton` in Balance Openers