### PR TITLE
[PVP] Fix Out-of-Range Purify issues

### DIFF
--- a/WrathCombo/Combos/PvP/ALL/ALL.cs
+++ b/WrathCombo/Combos/PvP/ALL/ALL.cs
@@ -1,6 +1,8 @@
-﻿using Dalamud.Game.ClientState.Objects.Types;
+﻿using System;
+using Dalamud.Game.ClientState.Objects.Types;
 using ECommons.GameHelpers;
 using System.Collections.Generic;
+using System.Linq;
 using WrathCombo.Combos.PvE;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
@@ -201,6 +203,18 @@ namespace WrathCombo.Combos.PvP
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PvP_QuickPurify;
 
+            public static (ushort debuff, string label)[] Statuses =
+            [
+                (Debuffs.Stun, "Stun"),
+                (Debuffs.DeepFreeze, "Deep Freeze"),
+                (Debuffs.HalfAsleep, "Half Asleep"),
+                (Debuffs.Sleep, "Sleep"),
+                (Debuffs.Bind, "Bind"),
+                (Debuffs.Heavy, "Heavy"),
+                (Debuffs.Silence, "Silence"),
+                (Debuffs.MiracleOfNature, "Miracle of Nature"),
+            ];
+
             protected override uint Invoke(uint actionID)
             {
                 if ((HasStatusEffect(Buffs.Guard) || JustUsed(Guard)) && IsEnabled(CustomComboPreset.PvP_MashCancel))
@@ -221,23 +235,22 @@ namespace WrathCombo.Combos.PvP
             {
                 bool[] selectedStatuses = Config.QuickPurifyStatuses;
 
-                if (HasStatusEffect(3180)) return false; //DRG LB buff
-                if (HasStatusEffect(4096)) return false; //VPR Snakesbane
-                if (HasStatusEffect(1420, anyOwner: true)) return false; //Rival Wings Mounted
-
+                // Bail if nothing is enabled
                 if (selectedStatuses.Length == 0) return false;
+                // Make sure new statuses are supported
+                Array.Resize(ref selectedStatuses, Statuses.Length);
+                // Bail if Purify is not available
                 if (GetCooldown(Purify).IsCooldown) return false;
-                if (HasStatusEffect(Debuffs.Stun, anyOwner: true) && selectedStatuses[0]) return true;
-                if (HasStatusEffect(Debuffs.DeepFreeze, anyOwner: true) && selectedStatuses[1]) return true;
-                if (HasStatusEffect(Debuffs.HalfAsleep, anyOwner: true) && selectedStatuses[2]) return true;
-                if (HasStatusEffect(Debuffs.Sleep, anyOwner: true) && selectedStatuses[3]) return true;
-                if (HasStatusEffect(Debuffs.Bind, anyOwner: true) && selectedStatuses[4]) return true;
-                if (HasStatusEffect(Debuffs.Heavy, anyOwner: true) && selectedStatuses[5]) return true;
-                if (HasStatusEffect(Debuffs.Silence, anyOwner: true) && selectedStatuses[6]) return true;
-                if (HasStatusEffect(Debuffs.MiracleOfNature, anyOwner: true) && selectedStatuses[7]) return true;
 
-                return false;
+                // Don't purify if under some buffs
+                if (HasStatusEffect(3180) || //DRG LB buff
+                    HasStatusEffect(4096) || //VPR Snake's Bane
+                    HasStatusEffect(1420, anyOwner: true)) //Rival Wings Mounted
+                    return false;
 
+                // Check if the status is present and one the user wants purified
+                return selectedStatuses.Where((t, i) =>
+                    t && HasStatusEffect(Statuses[i].debuff, anyOwner: true)).Any();
             }
         }
 

--- a/WrathCombo/Combos/PvP/ALL/ALL.cs
+++ b/WrathCombo/Combos/PvP/ALL/ALL.cs
@@ -207,8 +207,8 @@ namespace WrathCombo.Combos.PvP
             [
                 (Debuffs.Stun, "Stun"),
                 (Debuffs.DeepFreeze, "Deep Freeze"),
-                (Debuffs.HalfAsleep, "Half Asleep"),
-                (Debuffs.Sleep, "Sleep"),
+                (Debuffs.HalfAsleep, "Half Asleep"), // todo: remove, reset cfg
+                (Debuffs.Sleep, "Sleep"), // todo: remove, reset cfg
                 (Debuffs.Bind, "Bind"),
                 (Debuffs.Heavy, "Heavy"),
                 (Debuffs.Silence, "Silence"),

--- a/WrathCombo/Window/Functions/UserConfig.cs
+++ b/WrathCombo/Window/Functions/UserConfig.cs
@@ -1,20 +1,16 @@
-﻿using Dalamud.Game.ClientState.Objects.SubKinds;
-using Dalamud.Interface;
+﻿using Dalamud.Interface;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Utility;
-using ECommons.DalamudServices;
 using ECommons.ImGuiMethods;
 using ImGuiNET;
 using System;
 using System.Numerics;
-using WrathCombo.Combos;
 using WrathCombo.Combos.PvP;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
 using WrathCombo.Services;
-
 
 namespace WrathCombo.Window.Functions
 {
@@ -565,84 +561,31 @@ namespace WrathCombo.Window.Functions
             ImGui.Unindent();
         }
 
+        /// <seealso cref="PvPCommon.QuickPurify.Statuses">
+        ///     PvP Purifiable Statuses List
+        /// </seealso>
+        /// <seealso cref="PvPCommon.Config.QuickPurifyStatuses">
+        ///     User-Selected List of Status to Purify
+        /// </seealso>
         public static void DrawPvPStatusMultiChoice(string config)
         {
             bool[]? values = PluginConfiguration.GetCustomBoolArrayValue(config);
-
-            ImGui.Columns(4, $"{config}", false);
-
-            Array.Resize(ref values, 8);
+            Array.Resize(ref values, PvPCommon.QuickPurify.Statuses.Length);
 
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.ParsedPink);
+            ImGui.Columns(4, $"{config}", false);
 
-            if (ImGui.Checkbox($"Stun###{config}0", ref values[0]))
+            for (var i = 0; i < PvPCommon.QuickPurify.Statuses.Length; i++)
             {
-                DebugFile.AddLog($"Set Config {config} to {string.Join(", ", values)}");
-                PluginConfiguration.SetCustomBoolArrayValue(config, values);
-                Service.Configuration.Save();
-            }
+                var status = PvPCommon.QuickPurify.Statuses[i];
+                if (ImGui.Checkbox($"{status.label}###{config}{i}", ref values[i]))
+                {
+                    DebugFile.AddLog($"Set Config {config} to {string.Join(", ", values)}");
+                    PluginConfiguration.SetCustomBoolArrayValue(config, values);
+                    Service.Configuration.Save();
+                }
 
-            ImGui.NextColumn();
-
-            if (ImGui.Checkbox($"Deep Freeze###{config}1", ref values[1]))
-            {
-                DebugFile.AddLog($"Set Config {config} to {string.Join(", ", values)}");
-                PluginConfiguration.SetCustomBoolArrayValue(config, values);
-                Service.Configuration.Save();
-            }
-
-            ImGui.NextColumn();
-
-            if (ImGui.Checkbox($"Half Asleep###{config}2", ref values[2]))
-            {
-                DebugFile.AddLog($"Set Config {config} to {string.Join(", ", values)}");
-                PluginConfiguration.SetCustomBoolArrayValue(config, values);
-                Service.Configuration.Save();
-            }
-
-            ImGui.NextColumn();
-
-            if (ImGui.Checkbox($"Sleep###{config}3", ref values[3]))
-            {
-                DebugFile.AddLog($"Set Config {config} to {string.Join(", ", values)}");
-                PluginConfiguration.SetCustomBoolArrayValue(config, values);
-                Service.Configuration.Save();
-            }
-
-            ImGui.NextColumn();
-
-            if (ImGui.Checkbox($"Bind###{config}4", ref values[4]))
-            {
-                DebugFile.AddLog($"Set Config {config} to {string.Join(", ", values)}");
-                PluginConfiguration.SetCustomBoolArrayValue(config, values);
-                Service.Configuration.Save();
-            }
-
-            ImGui.NextColumn();
-
-            if (ImGui.Checkbox($"Heavy###{config}5", ref values[5]))
-            {
-                DebugFile.AddLog($"Set Config {config} to {string.Join(", ", values)}");
-                PluginConfiguration.SetCustomBoolArrayValue(config, values);
-                Service.Configuration.Save();
-            }
-
-            ImGui.NextColumn();
-
-            if (ImGui.Checkbox($"Silence###{config}6", ref values[6]))
-            {
-                DebugFile.AddLog($"Set Config {config} to {string.Join(", ", values)}");
-                PluginConfiguration.SetCustomBoolArrayValue(config, values);
-                Service.Configuration.Save();
-            }
-
-            ImGui.NextColumn();
-
-            if (ImGui.Checkbox($"Miracle of Nature###{config}7", ref values[7]))
-            {
-                DebugFile.AddLog($"Set Config {config} to {string.Join(", ", values)}");
-                PluginConfiguration.SetCustomBoolArrayValue(config, values);
-                Service.Configuration.Save();
+                ImGui.NextColumn();
             }
 
             ImGui.Columns(1);


### PR DESCRIPTION
- [X] Quick-Purify Statuses are now completely based off of a master list,\
      no possibility for out-of-range errors anymore.
  - [X] Quick-Purify Statuses UI and Logic are no longer hard-coded, instead just looping over that master list.