### PR TITLE
[MCH] fix AoE

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -2968,10 +2968,6 @@ public enum CustomComboPreset
     MCH_AoE_Adv_Hypercharge = 8303,
 
     [ParentCombo(MCH_AoE_AdvancedMode)]
-    [CustomComboInfo("Blazing Shot Option", "Use Blazing shot instead of Crossbow at lvl 92+", MCH.JobID)]
-    MCH_AoE_Adv_BlazingShot = 8312,
-
-    [ParentCombo(MCH_AoE_AdvancedMode)]
     [CustomComboInfo("Rook Autoturret/Automaton Queen Option", "Adds Rook Autoturret or Automaton Queen to the rotation.", MCH.JobID)]
     MCH_AoE_Adv_Queen = 8304,
 

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -430,7 +430,7 @@ internal partial class MCH : PhysicalRanged
                 if (ActionReady(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady))
                     return Chainsaw;
 
-                if (ActionReady(AirAnchor))
+                if (LevelChecked(AirAnchor) && IsOffCooldown(AirAnchor))
                     return AirAnchor;
             }
 
@@ -586,7 +586,7 @@ internal partial class MCH : PhysicalRanged
 
                 if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_AirAnchor) &&
                     reassembledAirAnchorAoE &&
-                    ActionReady(AirAnchor))
+                    LevelChecked(AirAnchor) && IsOffCooldown(AirAnchor))
                     return AirAnchor;
 
                 if (reassembledScattergunAoE)

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -434,11 +434,13 @@ internal partial class MCH : PhysicalRanged
                     return AirAnchor;
             }
 
-            if (LevelChecked(AutoCrossbow) && IsOverheated && !LevelChecked(CheckMate))
-                return AutoCrossbow;
-
-            if (IsOverheated && LevelChecked(CheckMate))
-                return BlazingShot;
+            if (ActionReady(BlazingShot) && IsOverheated)
+                return HasBattleTarget() &&
+                       (!LevelChecked(CheckMate) ||
+                        LevelChecked(CheckMate) &&
+                        NumberOfEnemiesInRange(AutoCrossbow, CurrentTarget) >= 5)
+                    ? AutoCrossbow
+                    : BlazingShot;
 
             return actionID;
         }
@@ -528,8 +530,7 @@ internal partial class MCH : PhysicalRanged
                         return Reassemble;
 
                     //gauss and ricochet outside HC
-                    if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_GaussRicochet) &&
-                        MCH_AoE_Hypercharge)
+                    if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_GaussRicochet))
                     {
                         if (ActionReady(GaussRound) &&
                             !JustUsed(OriginalHook(GaussRound), 2.5f))
@@ -540,13 +541,14 @@ internal partial class MCH : PhysicalRanged
                             return OriginalHook(Ricochet);
                     }
 
-                    if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_SecondWind) && Role.CanSecondWind(MCH_AoE_SecondWindThreshold))
+                    if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_SecondWind) &&
+                        Role.CanSecondWind(MCH_AoE_SecondWindThreshold))
                         return Role.SecondWind;
                 }
 
                 //AutoCrossbow, Gauss, Rico
                 if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_GaussRicochet) &&
-                    !MCH_AoE_Hypercharge &&
+                    IsOverheated &&
                     (JustUsed(OriginalHook(AutoCrossbow), 1f) ||
                      JustUsed(OriginalHook(Heatblast), 1f)) && HasNotWeaved)
                 {
@@ -593,13 +595,13 @@ internal partial class MCH : PhysicalRanged
                     return OriginalHook(Scattergun);
             }
 
-            if (LevelChecked(AutoCrossbow) && IsOverheated &&
-                (!LevelChecked(CheckMate) || IsNotEnabled(CustomComboPreset.MCH_AoE_Adv_BlazingShot)))
-                return AutoCrossbow;
-
-            if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_BlazingShot) &&
-                IsOverheated && LevelChecked(CheckMate))
-                return BlazingShot;
+            if (ActionReady(BlazingShot) && IsOverheated)
+                return HasBattleTarget() &&
+                       (!LevelChecked(CheckMate) ||
+                        LevelChecked(CheckMate) &&
+                        NumberOfEnemiesInRange(AutoCrossbow, CurrentTarget) >= 5)
+                    ? AutoCrossbow
+                    : BlazingShot;
 
             return actionID;
         }

--- a/WrathCombo/Combos/PvE/MCH/MCH_Config.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Config.cs
@@ -30,9 +30,6 @@ internal partial class MCH
             MCH_ST_Reassembled = new("MCH_ST_Reassembled"),
             MCH_AoE_Reassembled = new("MCH_AoE_Reassembled");
 
-        public static UserBool
-            MCH_AoE_Hypercharge = new("MCH_AoE_Hypercharge");
-
         internal static void Draw(CustomComboPreset preset)
         {
             switch (preset)
@@ -155,12 +152,6 @@ internal partial class MCH
                 case CustomComboPreset.MCH_AoE_Adv_Queen:
                     DrawSliderInt(50, 100, MCH_AoE_TurretUsage,
                         "Battery threshold", sliderIncrement: 5);
-
-                    break;
-
-                case CustomComboPreset.MCH_AoE_Adv_GaussRicochet:
-                    DrawAdditionalBoolChoice(MCH_AoE_Hypercharge,
-                        $"Use Outwith {Hypercharge.ActionName()}", "");
 
                     break;
 


### PR DESCRIPTION
- Fixes `Air Anchor` from going off in AoE pre 76
- Auto check blazing shot/crossbow usage.
- Fix gauss/rico usage in AoE
