### PR TITLE
[GNB/WAR] some big boy cleanup

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6366,9 +6366,7 @@ SMN.JobID)]
     WAR_Mit_Reprisal = 18049,
 
     [ParentCombo(WAR_Mit_OneButton)]
-    [CustomComboInfo("Thrill Of Battle First Option",
-        "Adds Thrill Of Battle to the one-button mitigation." +
-        "\nNOTE: even if disabled, will still try to use Thrill Of Battle as the lowest priority.", WAR.JobID)]
+    [CustomComboInfo("Thrill Of Battle First Option", "Adds Thrill Of Battle to the one-button mitigation.\nNOTE: even if disabled, will still try to use Thrill Of Battle as the lowest priority.", WAR.JobID)]
     WAR_Mit_ThrillOfBattle = 18050,
 
     [ParentCombo(WAR_Mit_OneButton)]
@@ -6435,15 +6433,9 @@ SMN.JobID)]
     [CustomComboInfo("Ultimatum Option", "Use Variant Ultimatum on cooldown.", WAR.JobID)]
     WAR_Variant_Ultimatum = 18030,
 
-    [ReplaceSkill(WAR.ThrillOfBattle)]
-    [ConflictingCombos(WAR_Mit_OneButton)]
-    [CustomComboInfo("Equilibrium Feature", "Replaces Thrill Of Battle with Equilibrium when used.", WAR.JobID)]
+    [ReplaceSkill(WAR.Equilibrium)]
+    [CustomComboInfo("Thrill of Battle to Equilibirum Feature", "Replaces Equilibirum with Thrill of Battle when ready.", WAR.JobID)]
     WAR_ThrillEquilibrium = 18055,
-
-    [ParentCombo(WAR_ThrillEquilibrium)]
-    [CustomComboInfo("Buffed Equilibrium Only", "Replaces Thrill Of Battle with Equilibrium only when under its buff.",
-        WAR.JobID)]
-    WAR_ThrillEquilibrium_BuffOnly = 18056,
 
     [ReplaceSkill(WAR.NascentFlash)]
     [CustomComboInfo("Nascent Flash Feature", "Replace Nascent Flash with Raw intuition when level synced below 76.", WAR.JobID)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -2215,106 +2215,82 @@ public enum CustomComboPreset
     #region GUNBREAKER
     
     #region Simple Mode
-
     [AutoAction(false, false)]
     [ConflictingCombos(GNB_ST_Advanced)]
     [ReplaceSkill(GNB.KeenEdge)]
-    [CustomComboInfo("Simple Mode - Single Target",
-        "Replaces Keen Edge with a full one-button single target rotation.\nThis is the ideal option for newcomers to the job.",
-        GNB.JobID)]
+    [CustomComboInfo("Simple Mode - Single Target", "Replaces Keen Edge with a full one-button single target rotation.\nThis is the ideal option for newcomers to the job.", GNB.JobID)]
     GNB_ST_Simple = 7001,
 
     [AutoAction(true, false)]
     [ConflictingCombos(GNB_AoE_Advanced)]
     [ReplaceSkill(GNB.DemonSlice)]
-    [CustomComboInfo("Simple Mode - AoE",
-        "Replaces Demon Slice with a full one-button AoE rotation.\nThis is the ideal option for newcomers to the job.",
-        GNB.JobID)]
+    [CustomComboInfo("Simple Mode - AoE", "Replaces Demon Slice with a full one-button AoE rotation.\nThis is the ideal option for newcomers to the job.", GNB.JobID)]
     GNB_AoE_Simple = 7002,
-
     #endregion
 
     #region Advanced ST
-
     [AutoAction(false, false)]
     [ConflictingCombos(GNB_ST_Simple)]
     [ReplaceSkill(GNB.KeenEdge)]
-    [CustomComboInfo("Advanced Mode - Single Target",
-        "Replaces Keen Edge with a full one-button single target rotation.\nThese features are ideal if you want to customize the rotation.",
-        GNB.JobID)]
+    [CustomComboInfo("Advanced Mode - Single Target", "Replaces Keen Edge with a full one-button single target rotation.\nThese features are ideal if you want to customize the rotation.", GNB.JobID)]
     GNB_ST_Advanced = 7003,
 
     [ParentCombo(GNB_ST_Advanced)]
     [CustomComboInfo("Balance Openers", "Add openers into the rotation based on Skill Speed and current Level, starting at Lv90.", GNB.JobID)]
-    GNB_ST_Advanced_Opener = 7006,
-
-    [ParentCombo(GNB_ST_Advanced)]
-    [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", GNB.JobID)]
-    GNB_ST_Interrupt = 7084,
-
-    #region Cooldowns
-
-    [ParentCombo(GNB_ST_Advanced)]
-    [CustomComboInfo("Cooldowns Option", "Adds various cooldowns into the rotation.", GNB.JobID)]
-    GNB_ST_Advanced_Cooldowns = 7007,
+    GNB_ST_Opener = 7006,
 
     [ConflictingCombos(GNB_NM_Features)]
-    [ParentCombo(GNB_ST_Advanced_Cooldowns)]
+    [ParentCombo(GNB_ST_Advanced)]
     [CustomComboInfo("No Mercy Option", "Adds No Mercy into the rotation when appropriate.", GNB.JobID)]
     GNB_ST_NoMercy = 7008,
 
-    [ParentCombo(GNB_ST_Advanced_Cooldowns)]
-    [CustomComboInfo("Sonic Break Option", "Adds Sonic Break into the rotation when appropriate.", GNB.JobID)]
-    GNB_ST_SonicBreak = 7012,
-
-    [ParentCombo(GNB_ST_Advanced_Cooldowns)]
+    [ParentCombo(GNB_ST_Advanced)]
     [CustomComboInfo("Zone Option", "Adds Danger / Blasting Zone into the rotation when available.", GNB.JobID)]
     GNB_ST_Zone = 7009,
 
-    [ParentCombo(GNB_ST_Advanced_Cooldowns)]
-    [CustomComboInfo("Bow Shock Option", "Adds Bow Shock into the rotation when appropriate.", GNB.JobID)]
-    GNB_ST_BowShock = 7010,
-
-    [ParentCombo(GNB_ST_Advanced_Cooldowns)]
-    [CustomComboInfo("Bloodfest Option", "Adds Bloodfest into the rotation when appropriate.", GNB.JobID)]
-    GNB_ST_Bloodfest = 7011,
-
-    [ParentCombo(GNB_ST_Advanced_Cooldowns)]
-    [CustomComboInfo("Gnashing Fang Option", "Adds Gnashing Fang combo into the rotation.", GNB.JobID)]
-    GNB_ST_GnashingFang = 7016,
-
-    [ParentCombo(GNB_ST_GnashingFang)]
-    [CustomComboInfo("Continuation Option",
-        "Adds Continuation & Hypervelocity into the rotation.\n'Gnashing Fang' option must be enabled or started manually.",
-        GNB.JobID)]
-    GNB_ST_Continuation = 7005,
-
-    [ParentCombo(GNB_ST_Advanced_Cooldowns)]
-    [CustomComboInfo("Double Down Option", "Adds Double Down into the rotation when appropriate.", GNB.JobID)]
-    GNB_ST_DoubleDown = 7017,
-
-    [ParentCombo(GNB_ST_Advanced_Cooldowns)]
-    [CustomComboInfo("Reign Combo Option", "Adds Reign/Noble/Lionheart into the rotation when appropriate.", GNB.JobID)]
-    GNB_ST_Reign = 7014,
-
-    [ParentCombo(GNB_ST_Advanced_Cooldowns)]
+    [ParentCombo(GNB_ST_Advanced)]
     [CustomComboInfo("Burst Strike Option", "Adds Burst Strike into the rotation when appropriate.", GNB.JobID)]
     GNB_ST_BurstStrike = 7015,
 
     [ParentCombo(GNB_ST_Advanced)]
-    [CustomComboInfo("Ammo Overcap Option",
-        "Adds Burst Strike into the rotation if you have max cartridges & your last combo action was Brutal Shell.",
-        GNB.JobID)]
-    GNB_ST_Overcap = 7018,
+    [CustomComboInfo("Sonic Break Option", "Adds Sonic Break into the rotation when appropriate.", GNB.JobID)]
+    GNB_ST_SonicBreak = 7012,
+
+    [ParentCombo(GNB_ST_Advanced)]
+    [CustomComboInfo("Gnashing Fang Option", "Adds Gnashing Fang combo into the rotation.", GNB.JobID)]
+    GNB_ST_GnashingFang = 7016,
+
+    [ParentCombo(GNB_ST_Advanced)]
+    [CustomComboInfo("Bow Shock Option", "Adds Bow Shock into the rotation when appropriate.", GNB.JobID)]
+    GNB_ST_BowShock = 7010,
+
+    [ParentCombo(GNB_ST_Advanced)]
+    [CustomComboInfo("Continuation Option", "Adds Continuation & Hypervelocity into the rotation when appropriate.", GNB.JobID)]
+    GNB_ST_Continuation = 7005,
+
+    [ParentCombo(GNB_ST_Advanced)]
+    [CustomComboInfo("Bloodfest Option", "Adds Bloodfest into the rotation when appropriate.", GNB.JobID)]
+    GNB_ST_Bloodfest = 7011,
+
+    [ParentCombo(GNB_ST_Advanced)]
+    [CustomComboInfo("Double Down Option", "Adds Double Down into the rotation when appropriate.", GNB.JobID)]
+    GNB_ST_DoubleDown = 7017,
+
+    [ParentCombo(GNB_ST_Advanced)]
+    [CustomComboInfo("Reign Combo Option", "Adds Reign/Noble/Lionheart into the rotation when appropriate.", GNB.JobID)]
+    GNB_ST_Reign = 7014,
 
     [ParentCombo(GNB_ST_Advanced)]
     [CustomComboInfo("Scuffed Option", "Adds Solid Barrel into the rotation under scuffed conditions:\n- Level 90 or above\n- No Mercy is active\n- Only 1 cartridge available\n- Last combo action was Brutal Shell\n- Gnashing Fang combo is still not active", GNB.JobID)]
     GNB_ST_Scuffed = 7372,
 
     [ParentCombo(GNB_ST_Advanced)]
-    [CustomComboInfo("Lightning Shot Uptime Option", "Adds Lightning Shot to the main combo when you are out of range.",
-        GNB.JobID)]
+    [CustomComboInfo("Lightning Shot Uptime Option", "Adds Lightning Shot to the main combo when you are out of range.", GNB.JobID)]
     GNB_ST_RangedUptime = 7004,
+
+    [ParentCombo(GNB_ST_Advanced)]
+    [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", GNB.JobID)]
+    GNB_ST_Interrupt = 7084,
 
     #region Mitigations
 
@@ -2347,10 +2323,6 @@ public enum CustomComboPreset
     GNB_ST_Superbolide = 7022,
 
     [ParentCombo(GNB_ST_Mitigation)]
-    [CustomComboInfo("Aurora Protection Feature", "Locks out Aurora if Aurora's effect is on the target by replacing it with Savage Blade.", GNB.JobID)]
-    GNB_AuroraProtection = 7023,
-
-    [ParentCombo(GNB_ST_Mitigation)]
     [CustomComboInfo("Reprisal Option", "Adds Reprisal into the rotation based on Health percentage remaining.", GNB.JobID)]
     GNB_ST_Reprisal = 7027,
 
@@ -2362,25 +2334,12 @@ public enum CustomComboPreset
 
     #endregion
 
-    #endregion
-
     #region Advanced AoE
-
     [AutoAction(true, false)]
     [ConflictingCombos(GNB_AoE_Simple)]
     [ReplaceSkill(GNB.DemonSlice)]
-    [CustomComboInfo("Advanced Mode - AoE",
-        "Replaces Demon Slice with a full one-button AoE rotation.\nThese features are ideal if you want to customize the rotation.",
-        GNB.JobID)]
+    [CustomComboInfo("Advanced Mode - AoE", "Replaces Demon Slice with a full one-button AoE rotation.\nThese features are ideal if you want to customize the rotation.", GNB.JobID)]
     GNB_AoE_Advanced = 7200,
-
-    [ParentCombo(GNB_AoE_Advanced)]
-    [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", GNB.JobID)]
-    GNB_AoE_Interrupt = 7222,
-
-    [ParentCombo(GNB_AoE_Advanced)]
-    [CustomComboInfo("Interrupt with Stun Option", "Adds Low Blow to the rotation when your target is casting, interruptible or not.", GNB.JobID)]
-    GNB_AoE_Stun = 7223,
 
     [ConflictingCombos(GNB_NM_Features)]
     [ParentCombo(GNB_AoE_Advanced)]
@@ -2388,8 +2347,7 @@ public enum CustomComboPreset
     GNB_AoE_NoMercy = 7201,
 
     [ParentCombo(GNB_AoE_Advanced)]
-    [CustomComboInfo("Danger/Blasting Zone Option", "Adds Danger/Blasting Zone into the AoE rotation when appropriate.",
-        GNB.JobID)]
+    [CustomComboInfo("Danger/Blasting Zone Option", "Adds Danger/Blasting Zone into the AoE rotation when appropriate.", GNB.JobID)]
     GNB_AoE_Zone = 7202,
 
     [ParentCombo(GNB_AoE_Advanced)]
@@ -2409,30 +2367,20 @@ public enum CustomComboPreset
     GNB_AoE_DoubleDown = 7206,
 
     [ParentCombo(GNB_AoE_Advanced)]
-    [CustomComboInfo("Reign Combo Option", "Adds Reign/Noble/LionHeart into the AoE rotation when appropriate.",
-        GNB.JobID)]
+    [CustomComboInfo("Reign Combo Option", "Adds Reign/Noble/LionHeart into the AoE rotation when appropriate.", GNB.JobID)]
     GNB_AoE_Reign = 7207,
 
     [ParentCombo(GNB_AoE_Advanced)]
     [CustomComboInfo("Fated Circle Option", "Adds Fated Circle into the AoE rotation when appropriate.", GNB.JobID)]
     GNB_AoE_FatedCircle = 7208,
 
-    [ParentCombo(GNB_AoE_FatedCircle)]
-    [CustomComboInfo("Ammo Overcap Option",
-        "Adds Fated Circle into the AoE rotation when overcapping cartridges is imminent.",
-        GNB.JobID)]
-    GNB_AoE_Overcap = 7209,
+    [ParentCombo(GNB_AoE_Advanced)]
+    [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", GNB.JobID)]
+    GNB_AoE_Interrupt = 7222,
 
-    [ParentCombo(GNB_AoE_FatedCircle)]
-    [CustomComboInfo("Burst Strike Option",
-        "Adds Burst Strike into the AoE rotation if you do not have Fated Circle unlocked yet.", GNB.JobID)]
-    GNB_AoE_noFatedCircle = 7212,
-
-    [ParentCombo(GNB_AoE_noFatedCircle)]
-    [CustomComboInfo("Ammo Overcap Burst Strike Option",
-        "Adds Burst Strike into the AoE rotation when overcapping cartridges is imminent.",
-        GNB.JobID)]
-    GNB_AoE_BSOvercap = 7211,
+    [ParentCombo(GNB_AoE_Advanced)]
+    [CustomComboInfo("Interrupt with Stun Option", "Adds Low Blow to the rotation when your target is casting, interruptible or not.", GNB.JobID)]
+    GNB_AoE_Stun = 7223,
 
     #region Mitigations
 
@@ -2473,14 +2421,6 @@ public enum CustomComboPreset
     GNB_AoE_ArmsLength = 7221,
 
     #endregion
-
-    #endregion
-
-    #region Basic combo
-
-    [ReplaceSkill(GNB.SolidBarrel)]
-    [CustomComboInfo("Basic Combo", "Replace Solid Barrel with its combo chain.", GNB.JobID)]
-    GNB_ST_BasicCombo = 7100,
 
     #endregion
 
@@ -2528,14 +2468,20 @@ public enum CustomComboPreset
     GNB_Mit_Nebula = 7083,
     #endregion
 
+    #region Misc
+
+    #region Basic combo
+
+    [ReplaceSkill(GNB.SolidBarrel)]
+    [CustomComboInfo("Basic Combo", "Replace Solid Barrel with its combo chain.", GNB.JobID)]
+    GNB_ST_BasicCombo = 7100,
+
+    #endregion
+
     #region Gnashing Fang
     [ReplaceSkill(GNB.GnashingFang)]
     [CustomComboInfo("Gnashing Fang Features", "Collection of Gnashing Fang related features.\n Enable all for this to be an all-in-one Single Target Burst button.", GNB.JobID)]
     GNB_GF_Features = 7300,
-
-    [ParentCombo(GNB_GF_Features)]
-    [CustomComboInfo("Continuation Option", "Adds Continuation to Gnashing Fang when available.", GNB.JobID)]
-    GNB_GF_Continuation = 7301,
 
     [ParentCombo(GNB_GF_Features)]
     [CustomComboInfo("No Mercy Option", "Adds No Mercy to Gnashing Fang when available.", GNB.JobID)]
@@ -2546,32 +2492,32 @@ public enum CustomComboPreset
     GNB_GF_Zone = 7303,
 
     [ParentCombo(GNB_GF_Features)]
-    [CustomComboInfo("Bow Shock Option", "Adds Bow Shock to Gnashing Fang when available.", GNB.JobID)]
-    GNB_GF_BowShock = 7304,
-
-    [ParentCombo(GNB_GF_Features)]
-    [CustomComboInfo("Bloodfest Option", "Adds Bloodfest to Gnashing Fang when available.", GNB.JobID)]
-    GNB_GF_Bloodfest = 7305,
+    [CustomComboInfo("Burst Strike Option", "Adds Burst Strike on Gnashing Fang under No Mercy when appropriate.", GNB.JobID)]
+    GNB_GF_BurstStrike = 7309,
 
     [ParentCombo(GNB_GF_Features)]
     [CustomComboInfo("Sonic Break Option", "Adds Sonic Break on Gnashing Fang under No Mercy when appropriate.", GNB.JobID)]
     GNB_GF_SonicBreak = 7306,
 
     [ParentCombo(GNB_GF_Features)]
+    [CustomComboInfo("Bow Shock Option", "Adds Bow Shock to Gnashing Fang when available.", GNB.JobID)]
+    GNB_GF_BowShock = 7304,
+
+    [ParentCombo(GNB_GF_Features)]
+    [CustomComboInfo("Continuation Option", "Adds Continuation to Gnashing Fang when available.", GNB.JobID)]
+    GNB_GF_Continuation = 7301,
+
+    [ParentCombo(GNB_GF_Features)]
+    [CustomComboInfo("Bloodfest Option", "Adds Bloodfest to Gnashing Fang when available.", GNB.JobID)]
+    GNB_GF_Bloodfest = 7305,
+
+    [ParentCombo(GNB_GF_Features)]
     [CustomComboInfo("Double Down Option", "Adds Double Down to Gnashing Fang under No Mercy when appropriate.", GNB.JobID)]
     GNB_GF_DoubleDown = 7307,
 
     [ParentCombo(GNB_GF_Features)]
-    [CustomComboInfo("Reign combo Option", "Adds Reign combo on Gnashing Fang under No Mercy when appropriate.", GNB.JobID)]
+    [CustomComboInfo("Reign Combo Option", "Adds Reign combo on Gnashing Fang under No Mercy when appropriate.", GNB.JobID)]
     GNB_GF_Reign = 7308,
-
-    [ParentCombo(GNB_GF_Features)]
-    [CustomComboInfo("Burst Strike Option", "Adds Burst Strike on Gnashing Fang under No Mercy when appropriate.", GNB.JobID)]
-    GNB_GF_BurstStrike = 7309,
-
-    [ParentCombo(GNB_GF_Features)]
-    [CustomComboInfo("Scuffed Option", "Adds Solid Barrel to Gnashing Fang under scuffed conditions:\n- Level 90 or above\n- No Mercy is active\n- Only 1 cartridge available\n- Last combo action was Brutal Shell\n- Gnashing Fang combo is still not active", GNB.JobID)]
-    GNB_GF_Scuffed = 7371,
     #endregion
 
     #region No Mercy
@@ -2661,6 +2607,11 @@ public enum CustomComboPreset
     [CustomComboInfo("Reign Option", "Adds Reign/Noble/LionHeart to Fated Circle when appropriate.", GNB.JobID)]
     GNB_FC_Reign = 7604,
 
+    #endregion
+
+    #region Aurora Protection
+    [CustomComboInfo("Aurora Protection Feature", "Locks out Aurora if Aurora's effect is on the target by replacing it with Savage Blade.", GNB.JobID)]
+    GNB_AuroraProtection = 7023,
     #endregion
 
     #region Variant Skills
@@ -2847,8 +2798,11 @@ public enum CustomComboPreset
 
     #endregion
 
+    // Last Value = 7083
+    #endregion
+
     #region MACHINIST
-    
+
     #region Simple Mode
 
     [AutoAction(false, false)]
@@ -6200,7 +6154,6 @@ SMN.JobID)]
     #endregion
 
     #region Advanced ST
-
     [AutoAction(false, false)]
     [ConflictingCombos(WAR_ST_Simple)]
     [ReplaceSkill(WAR.HeavySwing)]
@@ -6209,208 +6162,187 @@ SMN.JobID)]
 
     [ParentCombo(WAR_ST_Advanced)]
     [CustomComboInfo("Balance Opener (Level 100)", "Adds the Balance opener at level 100.", WAR.JobID)]
-    WAR_ST_Advanced_BalanceOpener = 18058,
+    WAR_ST_BalanceOpener = 18058,
+
+    [ParentCombo(WAR_ST_Advanced)]
+    [CustomComboInfo("Storm's Eye Option", "Adds Storm's Eye into the rotation.", WAR.JobID)]
+    WAR_ST_StormsEye = 18005,
+
+    [ParentCombo(WAR_ST_Advanced)]
+    [CustomComboInfo("Inner Release Option", "Adds Berserk / Inner Release into the rotation.", WAR.JobID)]
+    WAR_ST_InnerRelease = 18003,
+
+    [ParentCombo(WAR_ST_Advanced)]
+    [CustomComboInfo("Fell Cleave Option", "Adds Inner Beast / Fell Cleave into the rotation.\n- Will use at set minimum Beast Gauge value or to consume Inner Release stacks\n- Also includes Inner Chaos when available", WAR.JobID)]
+    WAR_ST_FellCleave = 18006,
+
+    [ParentCombo(WAR_ST_Advanced)]
+    [CustomComboInfo("Infuriate Option", "Adds Infuriate into the rotation.", WAR.JobID)]
+    WAR_ST_Infuriate = 18007,
+
+    [ParentCombo(WAR_ST_Advanced)]
+    [CustomComboInfo("Onslaught Option", "Adds Onslaught into the rotation.", WAR.JobID)]
+    WAR_ST_Onslaught = 18008,
+
+    [ParentCombo(WAR_ST_Advanced)]
+    [CustomComboInfo("Upheaval Option", "Adds Upheaval into the rotation.", WAR.JobID)]
+    WAR_ST_Upheaval = 18009,
+
+    [ParentCombo(WAR_ST_Advanced)]
+    [CustomComboInfo("Primal Rend Option", "Adds Primal Rend into the rotation.", WAR.JobID)]
+    WAR_ST_PrimalRend = 18013,
+
+    [ParentCombo(WAR_ST_Advanced)]
+    [CustomComboInfo("Primal Wrath Option", "Adds Primal Wrath into the rotation.", WAR.JobID)]
+    WAR_ST_PrimalWrath = 18010,
+
+    [ParentCombo(WAR_ST_Advanced)]
+    [CustomComboInfo("Primal Ruination Option", "Adds Primal Ruination into the rotation.", WAR.JobID)]
+    WAR_ST_PrimalRuination = 18011,
+
+    [ParentCombo(WAR_ST_Advanced)]
+    [CustomComboInfo("Tomahawk Uptime Option", "Adds Tomahawk into the rotation when you are out of range.", WAR.JobID)]
+    WAR_ST_RangedUptime = 18004,
 
     [ParentCombo(WAR_ST_Advanced)]
     [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", WAR.JobID)]
     WAR_ST_Interrupt = 18066,
 
-    [ParentCombo(WAR_ST_Advanced)]
-    [CustomComboInfo("Storm's Eye Option", "Adds Storms Eye into the rotation.", WAR.JobID)]
-    WAR_ST_Advanced_StormsEye = 18005,
-
-    [ParentCombo(WAR_ST_Advanced)]
-    [CustomComboInfo("Tomahawk Uptime Option", "Adds Tomahawk into the rotation when you are out of range.", WAR.JobID)]
-    WAR_ST_Advanced_RangedUptime = 18004,
-
-    [ParentCombo(WAR_ST_Advanced)]
-    [CustomComboInfo("Inner Release Option", "Adds Berserk / Inner Release into the rotation.", WAR.JobID)]
-    WAR_ST_Advanced_InnerRelease = 18003,
-
-    [ParentCombo(WAR_ST_Advanced)]
-    [CustomComboInfo("Fell Cleave Option", "Adds Inner Beast / Fell Cleave into the rotation.\nWill use when you have the set minimum gauge, or under Inner Release buff.\nWill also use Nascent Chaos.", WAR.JobID)]
-    WAR_ST_Advanced_FellCleave = 18006,
-
-    [ParentCombo(WAR_ST_Advanced)]
-    [CustomComboInfo("Infuriate Option", "Adds Infuriate into the rotation.", WAR.JobID)]
-    WAR_ST_Advanced_Infuriate = 18007,
-
-    [ParentCombo(WAR_ST_Advanced)]
-    [CustomComboInfo("Onslaught Option", "Adds Onslaught into the rotation.", WAR.JobID)]
-    WAR_ST_Advanced_Onslaught = 18008,
-
-    [ParentCombo(WAR_ST_Advanced_Onslaught)]
-    [CustomComboInfo("Melee Onslaught Option", "Uses Onslaught when in the Target's target ring (or within 1 yalm) & when not moving.\nWill use as many stacks as selected in the above slider.", WAR.JobID)]
-    WAR_ST_Advanced_Onslaught_MeleeSpender = 18015,
-
-    [ParentCombo(WAR_ST_Advanced)]
-    [CustomComboInfo("Upheaval Option", "Adds Upheaval into the rotation.", WAR.JobID)]
-    WAR_ST_Advanced_Upheaval = 18009,
-
-    [ParentCombo(WAR_ST_Advanced)]
-    [CustomComboInfo("Primal Rend Option", "Adds Primal Rend into the rotation.\nOnly uses when in the Target's target ring (or within 1 yalm) & when not moving.", WAR.JobID)]
-    WAR_ST_Advanced_PrimalRend = 18013,
-
-    [ParentCombo(WAR_ST_Advanced)]
-    [CustomComboInfo("Primal Wrath Option", "Adds Primal Wrath into the rotation.", WAR.JobID)]
-    WAR_ST_Advanced_PrimalWrath = 18010,
-
-    [ParentCombo(WAR_ST_Advanced)]
-    [CustomComboInfo("Primal Ruination Option", "Adds Primal Ruination into the rotation.", WAR.JobID)]
-    WAR_ST_Advanced_PrimalRuination = 18011,
-
-    [ParentCombo(WAR_AoE_Advanced)]
-    [CustomComboInfo("Orogeny Option", "Adds Orogeny into the rotation.", WAR.JobID)]
-    WAR_AoE_Advanced_Orogeny = 18012,
-
-    [ParentCombo(WAR_ST_Advanced_PrimalRend)]
-    [CustomComboInfo("Primal Rend Late Option", "Uses Primal Rend after you consume 3 stacks of Inner Release & after Primal Wrath.", WAR.JobID)]
-    WAR_ST_Advanced_PrimalRend_Late = 18014,
-
     #region Mitigations
 
     [ParentCombo(WAR_ST_Advanced)]
     [CustomComboInfo("Mitigation Options", "Adds defensive actions into the rotation based on Health percentage remaining.", WAR.JobID)]
-    WAR_ST_Advanced_Mitigation = 18040,
+    WAR_ST_Mitigation = 18040,
 
-    [ParentCombo(WAR_ST_Advanced_Mitigation)]
+    [ParentCombo(WAR_ST_Mitigation)]
     [CustomComboInfo("Bloodwhetting Option", "Adds Raw Intuition / Bloodwhetting into the rotation based on Health percentage remaining.", WAR.JobID)]
-    WAR_ST_Advanced_Bloodwhetting = 18031,
+    WAR_ST_Bloodwhetting = 18031,
 
-    [ParentCombo(WAR_ST_Advanced_Mitigation)]
+    [ParentCombo(WAR_ST_Mitigation)]
     [CustomComboInfo("Equilibrium Option", "Adds Equilibrium into the rotation based on Health percentage remaining.", WAR.JobID)]
-    WAR_ST_Advanced_Equilibrium = 18043,
+    WAR_ST_Equilibrium = 18043,
 
-    [ParentCombo(WAR_ST_Advanced_Mitigation)]
+    [ParentCombo(WAR_ST_Mitigation)]
     [CustomComboInfo("Rampart Option", "Adds Rampart into the rotation based on Health percentage remaining.", WAR.JobID)]
-    WAR_ST_Advanced_Rampart = 18032,
+    WAR_ST_Rampart = 18032,
 
-    [ParentCombo(WAR_ST_Advanced_Mitigation)]
+    [ParentCombo(WAR_ST_Mitigation)]
     [CustomComboInfo("Thrill of Battle Option", "Adds Thrill of Battle into the rotation based on Health percentage remaining.", WAR.JobID)]
-    WAR_ST_Advanced_Thrill = 18042,
+    WAR_ST_Thrill = 18042,
 
-    [ParentCombo(WAR_ST_Advanced_Mitigation)]
+    [ParentCombo(WAR_ST_Mitigation)]
     [CustomComboInfo("Vengeance Option", "Adds Vengeance / Damnation into the rotation based on Health percentage remaining.", WAR.JobID)]
-    WAR_ST_Advanced_Vengeance = 18033,
+    WAR_ST_Vengeance = 18033,
 
-    [ParentCombo(WAR_ST_Advanced_Mitigation)]
+    [ParentCombo(WAR_ST_Mitigation)]
     [CustomComboInfo("Holmgang Option", "Adds Holmgang into the rotation based on Health percentage remaining.", WAR.JobID)]
-    WAR_ST_Advanced_Holmgang = 18034,
+    WAR_ST_Holmgang = 18034,
 
-    [ParentCombo(WAR_ST_Advanced_Mitigation)]
+    [ParentCombo(WAR_ST_Mitigation)]
     [CustomComboInfo("Reprisal Option", "Adds Reprisal into the rotation based on Health percentage remaining.", WAR.JobID)]
-    WAR_ST_Advanced_Reprisal = 18061,
+    WAR_ST_Reprisal = 18061,
 
-    [ParentCombo(WAR_ST_Advanced_Mitigation)]
+    [ParentCombo(WAR_ST_Mitigation)]
     [CustomComboInfo("Arm's Length Option", "Adds Arm's Length into the rotation based on Health percentage remaining.", WAR.JobID)]
-    WAR_ST_Advanced_ArmsLength = 18062,
+    WAR_ST_ArmsLength = 18062,
 
     #endregion
 
     #endregion
 
     #region Advanced AoE
-
     [AutoAction(true, false)]
     [ConflictingCombos(WAR_AoE_Simple)]
     [ReplaceSkill(WAR.Overpower)]
-    [CustomComboInfo("Advanced Mode - AoE",
-        "Replaces Overpower with a full one-button AoE rotation.\nThese features are ideal if you want to customize the rotation.",
-        WAR.JobID)]
+    [CustomComboInfo("Advanced Mode - AoE", "Replaces Overpower with a full one-button AoE rotation.\nThese features are ideal if you want to customize the rotation.", WAR.JobID)]
     WAR_AoE_Advanced = 18016,
 
     [ParentCombo(WAR_AoE_Advanced)]
-    [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", WAR.JobID)]
+    [CustomComboInfo("Berserk / Inner Release Option", "Adds Berserk / Inner Release into the AoE rotation.", WAR.JobID)]
+    WAR_AoE_InnerRelease = 18019,
+
+    [ParentCombo(WAR_AoE_Advanced)]
+    [CustomComboInfo("Steel Cyclone / Decimate Option", "Adds Steel Cyclone / Decimate into the AoE rotation.", WAR.JobID)]
+    WAR_AoE_Decimate = 18023,
+
+    [ParentCombo(WAR_AoE_Advanced)]
+    [CustomComboInfo("Infuriate Option", "Adds Infuriate into the AoE rotation.", WAR.JobID)]
+    WAR_AoE_Infuriate = 18018,
+
+    [ParentCombo(WAR_AoE_Advanced)]
+    [CustomComboInfo("Onslaught Option", "Adds Onslaught into the AoE rotation.", WAR.JobID)]
+    WAR_AoE_Onslaught = 18071,
+
+    [ParentCombo(WAR_AoE_Advanced)]
+    [CustomComboInfo("Orogeny Option", "Adds Orogeny into the AoE rotation.", WAR.JobID)]
+    WAR_AoE_Orogeny = 18012,
+
+    [ParentCombo(WAR_AoE_Advanced)]
+    [CustomComboInfo("Primal Rend Option", "Adds Primal Rend into the AoE rotation.", WAR.JobID)]
+    WAR_AoE_PrimalRend = 18021,
+
+    [ParentCombo(WAR_AoE_Advanced)]
+    [CustomComboInfo("Primal Wrath Option", "Adds Primal Wrath into the AoE rotation.", WAR.JobID)]
+    WAR_AoE_PrimalWrath = 18020,
+
+    [ParentCombo(WAR_AoE_Advanced)]
+    [CustomComboInfo("Primal Ruination Option", "Adds Primal Ruination into the AoE rotation.", WAR.JobID)]
+    WAR_AoE_PrimalRuination = 18022,
+
+    [ParentCombo(WAR_AoE_Advanced)]
+    [CustomComboInfo("Tomahawk Uptime Option", "Adds Tomahawk into the rotation when you are out of range.", WAR.JobID)]
+    WAR_AoE_RangedUptime = 18110,
+
+    [ParentCombo(WAR_AoE_Advanced)]
+    [CustomComboInfo("Interrupt Option", "Adds Interject to the AoE rotation when your target's cast is interruptible.", WAR.JobID)]
     WAR_AoE_Interrupt = 18067,
 
-    [ParentCombo(WAR_AoE_Advanced)]
-    [CustomComboInfo("Interrupt with Stun Option", "Adds Low Blow to the rotation when your target is casting, interruptible or not.", WAR.JobID)]
+    [ParentCombo(WAR_AoE_Interrupt)]
+    [CustomComboInfo("Interrupt with Stun Option", "Adds Low Blow to the AoE rotation when your target is casting, interruptible or not.", WAR.JobID)]
     WAR_AoE_Stun = 18068,
-
-    [ReplaceSkill(WAR.NascentFlash)]
-    [CustomComboInfo("Nascent Flash Feature", "Replace Nascent Flash with Raw intuition when level synced below 76.",
-        WAR.JobID)]
-    WAR_NascentFlash = 18017,
-
-    [ParentCombo(WAR_AoE_Advanced)]
-    [CustomComboInfo("Infuriate Option",
-        "Adds Infuriate into the rotation when gauge is below 50 and not under Inner Release.", WAR.JobID)]
-    WAR_AoE_Advanced_Infuriate = 18018,
-
-    [ParentCombo(WAR_AoE_Advanced)]
-    [CustomComboInfo("Berserk / Inner Release Option", "Adds Berserk / Inner Release into the rotation.", WAR.JobID)]
-    WAR_AoE_Advanced_InnerRelease = 18019,
-
-    [ParentCombo(WAR_AoE_Advanced)]
-    [CustomComboInfo("Primal Wrath Option", "Adds Primal Wrath into the rotation.", WAR.JobID)]
-    WAR_AoE_Advanced_PrimalWrath = 18020,
-
-    [ParentCombo(WAR_AoE_Advanced)]
-    [CustomComboInfo("Primal Rend Option", "Adds Primal Rend into the rotation.", WAR.JobID)]
-    WAR_AoE_Advanced_PrimalRend = 18021,
-
-    [ParentCombo(WAR_AoE_Advanced)]
-    [CustomComboInfo("Primal Ruination Option", "Adds Primal Ruination into the rotation.", WAR.JobID)]
-    WAR_AoE_Advanced_PrimalRuination = 18022,
-
-    [ParentCombo(WAR_AoE_Advanced)]
-    [CustomComboInfo("Steel Cyclone / Decimate Option", "Adds Steel Cyclone / Decimate into the rotation.", WAR.JobID)]
-    WAR_AoE_Advanced_Decimate = 18023,
 
     #region Mitigations
 
     [ParentCombo(WAR_AoE_Advanced)]
     [CustomComboInfo("Mitigation Options", "Adds defensive actions into the rotation based on Health percentage remaining.", WAR.JobID)]
-    WAR_AoE_Advanced_Mitigation = 18035,
+    WAR_AoE_Mitigation = 18035,
 
-    [ParentCombo(WAR_AoE_Advanced_Mitigation)]
+    [ParentCombo(WAR_AoE_Mitigation)]
     [CustomComboInfo("Bloodwhetting Option", "Adds Raw Intuition / Bloodwhetting into the rotation based on Health percentage remaining.", WAR.JobID)]
-    WAR_AoE_Advanced_Bloodwhetting = 18036,
+    WAR_AoE_Bloodwhetting = 18036,
 
-    [ParentCombo(WAR_AoE_Advanced_Mitigation)]
+    [ParentCombo(WAR_AoE_Mitigation)]
     [CustomComboInfo("Equilibrium Option", "Adds Equilibrium into the rotation based on Health percentage remaining.", WAR.JobID)]
-    WAR_AoE_Advanced_Equilibrium = 18044,
+    WAR_AoE_Equilibrium = 18044,
 
-    [ParentCombo(WAR_AoE_Advanced_Mitigation)]
+    [ParentCombo(WAR_AoE_Mitigation)]
     [CustomComboInfo("Rampart Option", "Adds Rampart into the rotation based on Health percentage remaining.", WAR.JobID)]
-    WAR_AoE_Advanced_Rampart = 18037,
+    WAR_AoE_Rampart = 18037,
 
-    [ParentCombo(WAR_AoE_Advanced_Mitigation)]
+    [ParentCombo(WAR_AoE_Mitigation)]
     [CustomComboInfo("Thrill of Battle Option", "Adds Thrill of Battle into the rotation based on Health percentage remaining.", WAR.JobID)]
-    WAR_AoE_Advanced_Thrill = 18041,
+    WAR_AoE_Thrill = 18041,
 
-    [ParentCombo(WAR_AoE_Advanced_Mitigation)]
+    [ParentCombo(WAR_AoE_Mitigation)]
     [CustomComboInfo("Vengeance Option", "Adds Vengeance / Damnation into the rotation based on Health percentage remaining.", WAR.JobID)]
-    WAR_AoE_Advanced_Vengeance = 18038,
+    WAR_AoE_Vengeance = 18038,
 
-    [ParentCombo(WAR_AoE_Advanced_Mitigation)]
+    [ParentCombo(WAR_AoE_Mitigation)]
     [CustomComboInfo("Holmgang Option", "Adds Holmgang into the rotation based on Health percentage remaining.", WAR.JobID)]
-    WAR_AoE_Advanced_Holmgang = 18039,
+    WAR_AoE_Holmgang = 18039,
 
-    [ParentCombo(WAR_AoE_Advanced_Mitigation)]
+    [ParentCombo(WAR_AoE_Mitigation)]
     [CustomComboInfo("Reprisal Option", "Adds Reprisal into the rotation based on Health percentage remaining.", WAR.JobID)]
-    WAR_AoE_Advanced_Reprisal = 18063,
+    WAR_AoE_Reprisal = 18063,
 
-    [ParentCombo(WAR_AoE_Advanced_Mitigation)]
+    [ParentCombo(WAR_AoE_Mitigation)]
     [CustomComboInfo("Arm's Length Option", "Adds Arm's Length into the rotation based on Health percentage remaining.", WAR.JobID)]
-    WAR_AoE_Advanced_ArmsLength = 18064,
+    WAR_AoE_ArmsLength = 18064,
 
     #endregion
 
     #endregion
     
-    #region Basic Combo
-
-    [ReplaceSkill(WAR.StormsPath)]
-    [CustomComboInfo("Storm's Path Combo", "Replace Storm's Path with its combo chain.", WAR.JobID)]
-    WAR_ST_StormsPathCombo = 18069,
-
-    [ReplaceSkill(WAR.StormsEye)]
-    [CustomComboInfo("Storm's Eye Combo", "Replace Storm's Eye with its combo chain.", WAR.JobID)]
-    WAR_ST_StormsEyeCombo = 18070,
-
-    #endregion
-
     #region One-Button Mitigation
     [ReplaceSkill(WAR.ThrillOfBattle)]
     [ConflictingCombos(WAR_ThrillEquilibrium)]
@@ -6458,14 +6390,22 @@ SMN.JobID)]
 
     #region Misc
 
+    #region Basic Combo
+    [ReplaceSkill(WAR.StormsPath)]
+    [CustomComboInfo("Storm's Path Combo", "Replace Storm's Path with its combo chain.", WAR.JobID)]
+    WAR_ST_StormsPathCombo = 18069,
+
+    [ReplaceSkill(WAR.StormsEye)]
+    [CustomComboInfo("Storm's Eye Combo", "Replace Storm's Eye with its combo chain.", WAR.JobID)]
+    WAR_ST_StormsEyeCombo = 18070,
+    #endregion
+
     [ReplaceSkill(WAR.FellCleave, WAR.Decimate)]
-    [CustomComboInfo("Infuriate on Fell Cleave / Decimate Feature",
-        "Turns Fell Cleave and Decimate into Infuriate if at or under set gauge value.", WAR.JobID)]
+    [CustomComboInfo("Infuriate on Fell Cleave / Decimate Feature", "Turns Fell Cleave and Decimate into Infuriate if at or under set gauge value.", WAR.JobID)]
     WAR_InfuriateFellCleave = 18024,
 
     [ParentCombo(WAR_InfuriateFellCleave)]
-    [CustomComboInfo("Inner Release Priority Option",
-        "Prevents the use of Infuriate while you have Inner Release stacks available.", WAR.JobID)]
+    [CustomComboInfo("Inner Release Priority Option", "Prevents the use of Infuriate while you have Inner Release stacks available.", WAR.JobID)]
     WAR_InfuriateFellCleave_IRFirst = 18027,
 
     [ReplaceSkill(WAR.StormsEye)]
@@ -6473,19 +6413,16 @@ SMN.JobID)]
     WAR_StormsEye = 18025,
 
     [ReplaceSkill(WAR.StormsPath)]
-    [CustomComboInfo("Storm's Eye Feature",
-        "Replaces Storm's Path with Storm's Eye when Surging Tempest buff needs refreshing.", WAR.JobID)]
+    [CustomComboInfo("Storm's Eye Feature", "Replaces Storm's Path with Storm's Eye when Surging Tempest buff needs refreshing.", WAR.JobID)]
     WAR_EyePath = 18057,
 
     [ReplaceSkill(WAR.Berserk, WAR.InnerRelease)]
-    [CustomComboInfo("Primal Combo Feature",
-        "Turns Berserk / Inner Release into the Primal combo (Primal Rend -> Primal Ruination) on use.", WAR.JobID)]
+    [CustomComboInfo("Primal Combo Feature", "Turns Berserk / Inner Release into the Primal combo (Primal Rend -> Primal Ruination) on use.", WAR.JobID)]
     WAR_PrimalCombo_InnerRelease = 18026,
 
     [Variant]
     [VariantParent(WAR_ST_Advanced, WAR_AoE_Advanced)]
-    [CustomComboInfo("Spirit Dart Option",
-        "Use Variant Spirit Dart whenever the debuff is not present or less than 3s.", WAR.JobID)]
+    [CustomComboInfo("Spirit Dart Option", "Use Variant Spirit Dart whenever the debuff is not present or less than 3s.", WAR.JobID)]
     WAR_Variant_SpiritDart = 18028,
 
     [Variant]
@@ -6508,9 +6445,170 @@ SMN.JobID)]
         WAR.JobID)]
     WAR_ThrillEquilibrium_BuffOnly = 18056,
 
+    [ReplaceSkill(WAR.NascentFlash)]
+    [CustomComboInfo("Nascent Flash Feature", "Replace Nascent Flash with Raw intuition when level synced below 76.", WAR.JobID)]
+    WAR_NascentFlash = 18017,
+
+    #region Bozja
+    [Bozja]
+    [CustomComboInfo("Lost Focus Option", "Use Lost Focus when available.", WAR.JobID)]
+    WAR_Bozja_LostFocus = 18072,
+
+    [Bozja]
+    [CustomComboInfo("Lost Font Of Power Option", "Use Lost Font Of Power when available.", WAR.JobID)]
+    WAR_Bozja_LostFontOfPower = 18073,
+
+    [Bozja]
+    [CustomComboInfo("Lost Slash Option", "Use Lost Slash when available.", WAR.JobID)]
+    WAR_Bozja_LostSlash = 18074,
+
+    [Bozja]
+    [CustomComboInfo("Lost Death Option", "Use Lost Death when available.", WAR.JobID)]
+    WAR_Bozja_LostDeath = 18075,
+
+    [Bozja]
+    [CustomComboInfo("Banner Of Noble Ends Option", "Use Banner Of Noble Ends when available.", WAR.JobID)]
+    WAR_Bozja_BannerOfNobleEnds = 18076,
+
+    [Bozja]
+    [ParentCombo(WAR_Bozja_BannerOfNobleEnds)]
+    [CustomComboInfo("Only with `Lost Font Of Power` Option", "Use only under Lost Font of Power.", WAR.JobID)]
+    WAR_Bozja_PowerEnds = 18077,
+
+    [Bozja]
+    [CustomComboInfo("Banner Of Honored Sacrifice Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_BannerOfHonoredSacrifice = 18078,
+
+    [Bozja]
+    [ParentCombo(WAR_Bozja_BannerOfHonoredSacrifice)]
+    [CustomComboInfo("Only with `Lost Font Of Power` Option", "Use only under Lost Font of Power.", WAR.JobID)]
+    WAR_Bozja_PowerSacrifice = 18079,
+
+    [Bozja]
+    [CustomComboInfo("Banner Of Honed Acuity Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_BannerOfHonedAcuity = 18080,
+
+    [Bozja]
+    [CustomComboInfo("Lost Fair Trade Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostFairTrade = 18081,
+
+    [Bozja]
+    [CustomComboInfo("Lost Assassination Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostAssassination = 18082,
+
+    [Bozja]
+    [CustomComboInfo("Lost Manawall Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostManawall = 18083,
+
+    [Bozja]
+    [CustomComboInfo("Banner Of Tireless Conviction Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_BannerOfTirelessConviction = 18084,
+
+    [Bozja]
+    [CustomComboInfo("Lost Blood Rage Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostBloodRage = 18085,
+
+    [Bozja]
+    [CustomComboInfo("Banner Of Solemn Clarity Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_BannerOfSolemnClarity = 18086,
+
+    [Bozja]
+    [CustomComboInfo("Lost Cure Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostCure = 18087,
+
+    [Bozja]
+    [CustomComboInfo("Lost Cure II Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostCure2 = 18088,
+
+    [Bozja]
+    [CustomComboInfo("Lost Cure III Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostCure3 = 18089,
+
+    [Bozja]
+    [CustomComboInfo("Lost Cure IV Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostCure4 = 18090,
+
+    [Bozja]
+    [CustomComboInfo("Lost Arise Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostArise = 18091,
+
+    [Bozja]
+    [CustomComboInfo("Lost Sacrifice Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostSacrifice = 18092,
+
+    [Bozja]
+    [CustomComboInfo("Lost Reraise Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostReraise = 18093,
+
+    [Bozja]
+    [CustomComboInfo("Lost Spellforge Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostSpellforge = 18094,
+
+    [Bozja]
+    [CustomComboInfo("Lost Steel Sting Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostSteelsting = 18095,
+
+    [Bozja]
+    [CustomComboInfo("Lost Protect Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostProtect = 18096,
+
+    [Bozja]
+    [CustomComboInfo("Lost Shell Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostShell = 18097,
+
+    [Bozja]
+    [CustomComboInfo("Lost Reflect Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostReflect = 18098,
+
+    [Bozja]
+    [CustomComboInfo("Lost Bravery Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostBravery = 18099,
+
+    [Bozja]
+    [CustomComboInfo("Lost Aethershield Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostAethershield = 18100,
+
+    [Bozja]
+    [CustomComboInfo("Lost Protect II Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostProtect2 = 18101,
+
+    [Bozja]
+    [CustomComboInfo("Lost Shell II Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostShell2 = 18102,
+
+    [Bozja]
+    [CustomComboInfo("Lost Bubble Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostBubble = 18103,
+
+    [Bozja]
+    [CustomComboInfo("Lost Stealth Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostStealth = 18104,
+
+    [Bozja]
+    [CustomComboInfo("Lost Swift Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostSwift = 18105,
+
+    [Bozja]
+    [CustomComboInfo("Lost Font Of Skill Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostFontOfSkill = 18106,
+
+    [Bozja]
+    [CustomComboInfo("Lost Impetus Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostImpetus = 18107,
+
+    [Bozja]
+    [CustomComboInfo("Lost Paralyze III Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostParalyze3 = 18108,
+
+    [Bozja]
+    [CustomComboInfo("Lost Rampage Option", "Use when available.", WAR.JobID)]
+    WAR_Bozja_LostRampage = 18109,
+
     #endregion
 
-    // Last value = 18070
+    #endregion
+
+    // Last Value = 18110
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -2466,6 +2466,10 @@ public enum CustomComboPreset
     [ParentCombo(GNB_Mit_OneButton)]
     [CustomComboInfo("Nebula Option", "Adds Nebula to the one-button mitigation.", GNB.JobID)]
     GNB_Mit_Nebula = 7083,
+
+    [ReplaceSkill(GNB.HeartOfLight)]
+    [CustomComboInfo("One-Button Mitigation Party Feature", "Replaces Heart of Light with Reprisal when ready.", WAR.JobID)]
+    GNB_Mit_Party = 7085,
     #endregion
 
     #region Misc
@@ -2798,7 +2802,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last Value = 7083
+    // Last Value = 7085
     #endregion
 
     #region MACHINIST
@@ -6345,7 +6349,6 @@ SMN.JobID)]
     
     #region One-Button Mitigation
     [ReplaceSkill(WAR.ThrillOfBattle)]
-    [ConflictingCombos(WAR_ThrillEquilibrium)]
     [CustomComboInfo("One-Button Mitigation Feature", "Replaces Thrill Of Battle with an all-in-one mitigation button.", WAR.JobID)]
     WAR_Mit_OneButton = 18045,
 
@@ -6384,6 +6387,10 @@ SMN.JobID)]
     [ParentCombo(WAR_Mit_OneButton)]
     [CustomComboInfo("Vengeance Option", "Adds Vengeance to the one-button mitigation.", WAR.JobID)]
     WAR_Mit_Vengeance = 18054,
+
+    [ReplaceSkill(WAR.ShakeItOff)]
+    [CustomComboInfo("One-Button Mitigation Party Feature", "Replaces Shake It Off with Reprisal when ready.", WAR.JobID)]
+    WAR_Mit_Party = 18111,
     #endregion
 
     #region Misc
@@ -6600,7 +6607,7 @@ SMN.JobID)]
 
     #endregion
 
-    // Last Value = 18110
+    // Last Value = 18111
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/GNB/GNB.cs
+++ b/WrathCombo/Combos/PvE/GNB/GNB.cs
@@ -9,60 +9,22 @@ namespace WrathCombo.Combos.PvE;
 
 internal partial class GNB : Tank
 {
-    internal class GNB_ST_BasicCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_ST_BasicCombo;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not SolidBarrel)
-                return actionID;
-
-            if (ComboTimer > 0)
-            {
-                if (ComboAction is KeenEdge && LevelChecked(BrutalShell))
-                    return BrutalShell;
-
-                if (ComboAction is BrutalShell && LevelChecked(SolidBarrel))
-                    return SolidBarrel;
-            }
-
-            return KeenEdge;
-        }
-    }
-
     #region Simple Mode - Single Target
-
     internal class GNB_ST_Simple : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_ST_Simple;
         protected override uint Invoke(uint actionID)
         {
-            //Our Button
-            if (actionID is not KeenEdge)
+            if (actionID != KeenEdge)
                 return actionID;
 
-            #region Non-Standard
-
-            //Variant
-            uint variantAction = GetVariantAction();
-            if (variantAction != 0)
-                return variantAction;
-
-            //Bozja
-            if (Bozja.IsInBozja)
-            {
-                uint bozjaAction = GetBozjaAction();
-                if (bozjaAction != 0)
-                    return bozjaAction;
-            }
-
-            //Interject
+            #region Non-Rotation
             if (Role.CanInterject())
                 return Role.Interject;
+            if (ShouldUseOther)
+                return OtherAction;
 
             #region Mitigations
-
             if (Config.GNB_ST_MitsOptions != 1)
             {
                 if (InCombat() && !MitUsed)
@@ -86,24 +48,22 @@ internal partial class GNB : Tank
                         return Aurora;
                 }
             }
-
             #endregion
 
             #endregion
 
-            #region Standard
-
+            #region Rotation
             //Priority hack for increasing Continuation priority when inside late weave window
             if (CanDelayedWeave())
             {
-                if (ShouldUseContinuation())
+                if (ShouldUseContinuation)
                     return OriginalHook(Continuation);
             }
-            if (ShouldUseLightningShot())
+            if (ShouldUseLightningShot)
                 return LightningShot;
-            if (ShouldUseBloodfest())
+            if (ShouldUseBloodfest)
                 return Bloodfest;
-            if (ShouldUseNoMercy())
+            if (ShouldUseNoMercy)
                 return NoMercy;
             if (JustUsed(BurstStrike, 5f) && LevelChecked(Hypervelocity) && HasStatusEffect(Buffs.ReadyToBlast))
             {
@@ -113,25 +73,25 @@ internal partial class GNB : Tank
             }
             //with SKS, we want Zone first because it can drift really bad while Bow usually remains static
             //without SKS, we don't really care since both usually remain static
-            if (SlowGNB ? ShouldUseBowShock() : ShouldUseZone())
+            if (SlowGNB ? ShouldUseBowShock : ShouldUseZone)
                 return SlowGNB ? BowShock : OriginalHook(DangerZone);
-            if (SlowGNB ? ShouldUseZone() : ShouldUseBowShock())
+            if (SlowGNB ? ShouldUseZone : ShouldUseBowShock)
                 return SlowGNB ? OriginalHook(DangerZone) : BowShock;
-            if (ShouldUseContinuation() &&
+            if (ShouldUseContinuation &&
                 (CanWeave() || //normal
                 CanDelayedWeave(0.6f, 0f))) //send asap if about to lose due to GCD
                 return OriginalHook(Continuation);
             if (LevelChecked(DoubleDown) && JustUsed(NoMercy, 5f) && GunStep == 0 && ComboAction is BrutalShell && Ammo == 1)
                 return SolidBarrel;
-            if (ShouldUseGnashingFang())
+            if (ShouldUseGnashingFang)
                 return GnashingFang;
-            if (ShouldUseDoubleDown())
+            if (ShouldUseDoubleDown)
                 return DoubleDown;
-            if (ShouldUseSonicBreak())
+            if (ShouldUseSonicBreak)
                 return SonicBreak;
-            if (ShouldUseReignOfBeasts())
+            if (ShouldUseReignOfBeasts)
                 return ReignOfBeasts;
-            if (ShouldUseBurstStrike() ||
+            if (ShouldUseBurstStrike ||
                 LevelChecked(DoubleDown) &&
                 NMcd < 1 && Ammo == 3 && !InOdd)
                 return BurstStrike;
@@ -150,47 +110,29 @@ internal partial class GNB : Tank
                     return SolidBarrel;
                 }
             }
-
+            return STCombo;
             #endregion
-
-            return KeenEdge;
         }
     }
 
     #endregion
 
     #region Advanced Mode - Single Target
-
     internal class GNB_ST_Advanced : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_ST_Advanced;
         protected override uint Invoke(uint actionID)
         {
-            //Our Button
-            if (actionID is not KeenEdge)
+            if (actionID != KeenEdge)
                 return actionID;
 
-            #region Non-Standard
-
-            //Variant
-            uint variantAction = GetVariantAction();
-            if (variantAction != 0)
-                return variantAction;
-
-            //Bozja
-            if (Bozja.IsInBozja)
-            {
-                uint bozjaAction = GetBozjaAction();
-                if (bozjaAction != 0)
-                    return bozjaAction;
-            }
-
-            //Interject
+            #region Non-Rotation
             if (IsEnabled(CustomComboPreset.GNB_ST_Interrupt) && Role.CanInterject())
                 return Role.Interject;
+            if (ShouldUseOther)
+                return OtherAction;
 
             #region Mitigations
-
             if (IsEnabled(CustomComboPreset.GNB_ST_Mitigation) && InCombat() && !MitUsed)
             {
                 if (IsEnabled(CustomComboPreset.GNB_ST_Superbolide) && ActionReady(Superbolide) && HPP < Config.GNB_ST_Superbolide_Health &&
@@ -227,9 +169,8 @@ internal partial class GNB : Tank
 
             #endregion
 
-            #region Standard
-
-            if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Opener) && 
+            #region Rotation
+            if (IsEnabled(CustomComboPreset.GNB_ST_Opener) && 
                 Opener().FullOpener(ref actionID))
                 return actionID;
             
@@ -237,16 +178,16 @@ internal partial class GNB : Tank
             if (CanDelayedWeave())
             {
                 if (IsEnabled(CustomComboPreset.GNB_ST_Continuation) &&
-                    ShouldUseContinuation())
+                    ShouldUseContinuation)
                     return OriginalHook(Continuation);
             }
-            if (IsEnabled(CustomComboPreset.GNB_ST_RangedUptime) && ShouldUseLightningShot())
+            if (IsEnabled(CustomComboPreset.GNB_ST_RangedUptime) && ShouldUseLightningShot)
                 return LightningShot;
-            if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Cooldowns))
+            if (IsEnabled(CustomComboPreset.GNB_ST_Advanced))
             {
-                if (IsEnabled(CustomComboPreset.GNB_ST_Bloodfest) && ShouldUseBloodfest())
+                if (IsEnabled(CustomComboPreset.GNB_ST_Bloodfest) && ShouldUseBloodfest)
                     return Bloodfest;
-                if (IsEnabled(CustomComboPreset.GNB_ST_NoMercy) && ShouldUseNoMercy() && GetTargetHPPercent() > STStopNM &&
+                if (IsEnabled(CustomComboPreset.GNB_ST_NoMercy) && ShouldUseNoMercy && GetTargetHPPercent() > STStopNM &&
                     (Config.GNB_ST_NoMercy_SubOption == 0 || Config.GNB_ST_NoMercy_SubOption == 1 && InBossEncounter()))
                     return NoMercy;
                 if (IsEnabled(CustomComboPreset.GNB_ST_Continuation) && IsEnabled(CustomComboPreset.GNB_ST_NoMercy) &&
@@ -260,29 +201,29 @@ internal partial class GNB : Tank
             if (IsEnabled(CustomComboPreset.GNB_ST_Scuffed) &&
                 LevelChecked(DoubleDown) && JustUsed(NoMercy, 5f) && GunStep == 0 && ComboAction is BrutalShell && Ammo == 1)
                 return SolidBarrel;
-            if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_Cooldowns))
+            if (IsEnabled(CustomComboPreset.GNB_ST_Advanced))
             {
                 //with SKS, we want Zone first because it can drift really bad while Bow usually remains static
                 //without SKS, we don't really care since both usually remain static
-                if (SlowGNB ? IsEnabled(CustomComboPreset.GNB_ST_BowShock) && ShouldUseBowShock() : IsEnabled(CustomComboPreset.GNB_ST_Zone) && ShouldUseZone())
+                if (SlowGNB ? IsEnabled(CustomComboPreset.GNB_ST_BowShock) && ShouldUseBowShock : IsEnabled(CustomComboPreset.GNB_ST_Zone) && ShouldUseZone)
                     return SlowGNB ? BowShock : OriginalHook(DangerZone);
-                if (SlowGNB ? IsEnabled(CustomComboPreset.GNB_ST_Zone) && ShouldUseZone() : IsEnabled(CustomComboPreset.GNB_ST_BowShock) && ShouldUseBowShock())
+                if (SlowGNB ? IsEnabled(CustomComboPreset.GNB_ST_Zone) && ShouldUseZone : IsEnabled(CustomComboPreset.GNB_ST_BowShock) && ShouldUseBowShock)
                     return SlowGNB ? OriginalHook(DangerZone) : BowShock;
-                if (IsEnabled(CustomComboPreset.GNB_ST_Continuation) && ShouldUseContinuation() &&
+                if (IsEnabled(CustomComboPreset.GNB_ST_Continuation) && ShouldUseContinuation &&
                     (CanWeave() || //normal
                     CanDelayedWeave(0.6f, 0f))) //send asap if about to lose due to GCD
                     return OriginalHook(Continuation);
-                if (IsEnabled(CustomComboPreset.GNB_ST_GnashingFang) && ShouldUseGnashingFang())
+                if (IsEnabled(CustomComboPreset.GNB_ST_GnashingFang) && ShouldUseGnashingFang)
                     return GnashingFang;
-                if (IsEnabled(CustomComboPreset.GNB_ST_DoubleDown) && ShouldUseDoubleDown())
+                if (IsEnabled(CustomComboPreset.GNB_ST_DoubleDown) && ShouldUseDoubleDown)
                     return DoubleDown;
-                if (IsEnabled(CustomComboPreset.GNB_ST_SonicBreak) && ShouldUseSonicBreak())
+                if (IsEnabled(CustomComboPreset.GNB_ST_SonicBreak) && ShouldUseSonicBreak)
                     return SonicBreak;
-                if (IsEnabled(CustomComboPreset.GNB_ST_Reign) && ShouldUseReignOfBeasts())
+                if (IsEnabled(CustomComboPreset.GNB_ST_Reign) && ShouldUseReignOfBeasts)
                     return OriginalHook(ReignOfBeasts);
                 if (IsEnabled(CustomComboPreset.GNB_ST_BurstStrike))
                 {
-                    if (ShouldUseBurstStrike() ||
+                    if (ShouldUseBurstStrike ||
                         IsEnabled(CustomComboPreset.GNB_ST_NoMercy) &&
                         LevelChecked(DoubleDown) && NMcd < 1 && Ammo == 3 && !InOdd)
                         return BurstStrike;
@@ -292,64 +233,30 @@ internal partial class GNB : Tank
                 return OriginalHook(GnashingFang);
             if (IsEnabled(CustomComboPreset.GNB_ST_Reign) && GunStep is 3 or 4)
                 return OriginalHook(ReignOfBeasts);
-            if (ComboTimer > 0)
-            {
-                if (LevelChecked(BrutalShell) && ComboAction == KeenEdge)
-                    return BrutalShell;
-                if (LevelChecked(SolidBarrel) && ComboAction == BrutalShell)
-                {
-                    if (IsEnabled(CustomComboPreset.GNB_ST_Overcap) &&
-                        LevelChecked(BurstStrike) && Ammo == MaxCartridges())
-                        return BurstStrike;
-                    return SolidBarrel;
-                }
-            }
-
+            return STCombo;
             #endregion
-
-            return KeenEdge;
         }
     }
-
     #endregion
 
     #region Simple Mode - AoE
-
     internal class GNB_AoE_Simple : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_AoE_Simple;
         protected override uint Invoke(uint actionID)
         {
-            //Our button
-            if (actionID is not DemonSlice)
+            if (actionID != DemonSlice)
                 return actionID;
 
-            #region Non-Standard
-
-            //Variant
-            uint variantAction = GetVariantAction();
-            if (variantAction != 0)
-                return variantAction;
-
-            //Bozja
-            if (Bozja.IsInBozja)
-            {
-                uint bozjaAction = GetBozjaAction();
-                if (bozjaAction != 0)
-                    return bozjaAction;
-            }
-
-            #region Stuns
-
+            #region Non-Rotation
             if (Role.CanInterject())
                 return Role.Interject;
             if (Role.CanLowBlow())
                 return Role.LowBlow;
-
-            #endregion
+            if (ShouldUseOther)
+                return OtherAction;
 
             #region Mitigations
-
             if (Config.GNB_AoE_MitsOptions != 1)
             {
                 if (InCombat() && !MitUsed)
@@ -373,13 +280,11 @@ internal partial class GNB : Tank
                         return Aurora;
                 }
             }
-
             #endregion
 
             #endregion
 
-            #region Standard
-
+            #region Rotation
             if (InCombat())
             {
                 if (CanWeave())
@@ -389,11 +294,11 @@ internal partial class GNB : Tank
                     if (LevelChecked(FatedBrand) && HasStatusEffect(Buffs.ReadyToRaze))
                         return FatedBrand;
                 }
-                if (ShouldUseBowShock())
+                if (ShouldUseBowShock)
                     return BowShock;
-                if (ShouldUseZone())
+                if (ShouldUseZone)
                     return OriginalHook(DangerZone);
-                if (ShouldUseBloodfest())
+                if (ShouldUseBloodfest)
                     return Bloodfest;
                 if (CanSB && HasNM && !HasStatusEffect(Buffs.ReadyToRaze))
                     return SonicBreak;
@@ -401,72 +306,34 @@ internal partial class GNB : Tank
                     return DoubleDown;
                 if (CanReign || GunStep is 3 or 4)
                     return OriginalHook(ReignOfBeasts);
-                if (CanFC && (HasNM && (IsOnCooldown(DoubleDown) || !LevelChecked(DoubleDown)) && GunStep == 0 || BFcd < 6))
-                    return FatedCircle;
-                if (Ammo > 0 && !LevelChecked(FatedCircle) && LevelChecked(BurstStrike) && HasNM && GunStep == 0)
-                    return BurstStrike;
+                if (CanBS && ((HasNM && (IsOnCooldown(DoubleDown) || !LevelChecked(DoubleDown)) && GunStep == 0) || BFcd < 6 || (ComboAction == DemonSlice && Ammo == MaxCartridges())))
+                    return LevelChecked(FatedCircle) ? FatedCircle : BurstStrike;
             }
-            if (ComboTimer > 0)
-            {
-                if (ComboAction == DemonSlice && LevelChecked(DemonSlaughter))
-                {
-                    if (Ammo == MaxCartridges())
-                    {
-                        if (LevelChecked(FatedCircle))
-                            return FatedCircle;
-                        if (!LevelChecked(FatedCircle))
-                            return BurstStrike;
-                    }
-                    if (Ammo != MaxCartridges())
-                        return DemonSlaughter;
-                }
-            }
-
+            return AOECombo;
             #endregion
-
-            return DemonSlice;
         }
     }
-
     #endregion
 
     #region Advanced Mode - AoE
-
     internal class GNB_AoE_Advanced : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_AoE_Advanced;
         protected override uint Invoke(uint actionID)
         {
-            //Our Button
-            if (actionID is not DemonSlice)
+            if (actionID != DemonSlice)
                 return actionID;
 
-            #region Non-Standard
-
-            //Variant
-            uint variantAction = GetVariantAction();
-            if (variantAction != 0)
-                return variantAction;
-
-            //Bozja
-            if (Bozja.IsInBozja)
-            {
-                uint bozjaAction = GetBozjaAction();
-                if (bozjaAction != 0)
-                    return bozjaAction;
-            }
-
-            #region Stuns
+            #region Non-Rotation
 
             if (IsEnabled(CustomComboPreset.GNB_AoE_Interrupt) && Role.CanInterject())
                 return Role.Interject;
             if (IsEnabled(CustomComboPreset.GNB_AoE_Stun) && Role.CanLowBlow())
                 return Role.LowBlow;
-
-            #endregion
+            if (ShouldUseOther)
+                return OtherAction;
 
             #region Mitigations
-
             if (IsEnabled(CustomComboPreset.GNB_AoE_Mitigation) && InCombat() && !MitUsed)
             {
                 if (IsEnabled(CustomComboPreset.GNB_AoE_Superbolide) && ActionReady(Superbolide) && HPP < Config.GNB_AoE_Superbolide_Health &&
@@ -505,19 +372,18 @@ internal partial class GNB : Tank
 
             #endregion
 
-            #region Standard
-
+            #region Rotation
             if (InCombat())
             {
                 if (CanWeave())
                 {
-                    if (IsEnabled(CustomComboPreset.GNB_AoE_NoMercy) && ActionReady(NoMercy) && GetTargetHPPercent() > AoEStopNM)
+                    if (IsEnabled(CustomComboPreset.GNB_AoE_NoMercy) && ShouldUseNoMercy && GetTargetHPPercent() > AoEStopNM)
                         return NoMercy;
-                    if (IsEnabled(CustomComboPreset.GNB_AoE_BowShock) && ShouldUseBowShock())
+                    if (IsEnabled(CustomComboPreset.GNB_AoE_BowShock) && ShouldUseBowShock)
                         return BowShock;
-                    if (IsEnabled(CustomComboPreset.GNB_AoE_Zone) && ShouldUseZone())
+                    if (IsEnabled(CustomComboPreset.GNB_AoE_Zone) && ShouldUseZone)
                         return OriginalHook(DangerZone);
-                    if (IsEnabled(CustomComboPreset.GNB_AoE_Bloodfest) && ShouldUseBloodfest())
+                    if (IsEnabled(CustomComboPreset.GNB_AoE_Bloodfest) && ShouldUseBloodfest)
                         return Bloodfest;
                     if (LevelChecked(FatedBrand) && HasStatusEffect(Buffs.ReadyToRaze))
                         return FatedBrand;
@@ -528,67 +394,42 @@ internal partial class GNB : Tank
                     return DoubleDown;
                 if (IsEnabled(CustomComboPreset.GNB_AoE_Reign) && (CanReign || GunStep is 3 or 4))
                     return OriginalHook(ReignOfBeasts);
-                if (IsEnabled(CustomComboPreset.GNB_AoE_FatedCircle) && CanFC && (HasNM && (!ActionReady(DoubleDown) || !IsEnabled(CustomComboPreset.GNB_AoE_DoubleDown)) && GunStep == 0 || IsEnabled(CustomComboPreset.GNB_AoE_Bloodfest) && BFcd < 6))
-                    return FatedCircle;
-                if (IsEnabled(CustomComboPreset.GNB_AoE_noFatedCircle) && Ammo > 0 && !LevelChecked(FatedCircle) && LevelChecked(BurstStrike) && HasNM && GunStep == 0)
-                    return BurstStrike;
-            }
-            if (ComboTimer > 0)
-            {
-                if (ComboAction == DemonSlice &&
-                    LevelChecked(DemonSlaughter))
+                if (IsEnabled(CustomComboPreset.GNB_AoE_FatedCircle) && CanBS)
                 {
-                    if (Ammo == MaxCartridges())
-                    {
-                        if (IsEnabled(CustomComboPreset.GNB_AoE_Overcap) &&
-                            LevelChecked(FatedCircle))
-                            return FatedCircle;
-                        if (IsEnabled(CustomComboPreset.GNB_AoE_BSOvercap) &&
-                            !LevelChecked(FatedCircle))
-                            return BurstStrike;
-                    }
-                    if (Ammo != MaxCartridges() ||
-                        Ammo == MaxCartridges() &&
-                        !LevelChecked(FatedCircle) && !IsEnabled(CustomComboPreset.GNB_AoE_BSOvercap) || !IsEnabled(CustomComboPreset.GNB_AoE_Overcap))
-                        return DemonSlaughter;
+                    if ((HasNM && (IsOnCooldown(DoubleDown) || !LevelChecked(DoubleDown) || !IsEnabled(CustomComboPreset.GNB_AoE_DoubleDown)) && GunStep == 0) || //burst
+                        (LevelChecked(Bloodfest) && IsEnabled(CustomComboPreset.GNB_AoE_Bloodfest) && BFcd < 6) || //Bloodfest prep
+                        (Config.GNB_AoE_Overcap_Choice == 0 && ComboAction == DemonSlice && Ammo == MaxCartridges()))
+                        return LevelChecked(FatedCircle) ? FatedCircle : Config.GNB_AoE_FatedCircle_BurstStrike == 0 ? BurstStrike : ComboAction == DemonSlice ? DemonSlaughter : DemonSlice;
                 }
             }
-
+            return AOECombo;
             #endregion
-
-            return DemonSlice;
         }
     }
-
     #endregion
 
     #region Gnashing Fang Features
-
     internal class GNB_GF_Features : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_GF_Features;
         protected override uint Invoke(uint actionID)
         {
-            bool gFchoice = Config.GNB_GF_Features_Choice == 0; //Gnashing Fang as button
-            bool nMchoice = Config.GNB_GF_Features_Choice == 1; //No Mercy as button
-
-            //Our Button
-            if (gFchoice && actionID is not GnashingFang ||
-                nMchoice && actionID is not NoMercy)
+            bool GFchoice = Config.GNB_GF_Features_Choice == 0; //Gnashing Fang as button
+            bool NMchoice = Config.GNB_GF_Features_Choice == 1; //No Mercy as button
+            if ((GFchoice && actionID != GnashingFang) || (NMchoice && actionID != NoMercy))
                 return actionID;
-
             if (IsEnabled(CustomComboPreset.GNB_GF_Features))
             {
                 //Priority hack for ensuring Continuation is used on late weave at the very latest
                 if (CanDelayedWeave())
                 {
                     if (IsEnabled(CustomComboPreset.GNB_GF_Continuation) &&
-                        ShouldUseContinuation())
+                        ShouldUseContinuation)
                         return OriginalHook(Continuation);
                 }
-                if (IsEnabled(CustomComboPreset.GNB_GF_Bloodfest) && ShouldUseBloodfest())
+                if (IsEnabled(CustomComboPreset.GNB_GF_Bloodfest) && ShouldUseBloodfest)
                     return Bloodfest;
-                if (IsEnabled(CustomComboPreset.GNB_GF_NoMercy) && ShouldUseNoMercy())
+                if (IsEnabled(CustomComboPreset.GNB_GF_NoMercy) && ShouldUseNoMercy)
                     return NoMercy;
                 if (IsEnabled(CustomComboPreset.GNB_GF_Continuation) && JustUsed(BurstStrike, 5f) && LevelChecked(Hypervelocity) && HasStatusEffect(Buffs.ReadyToBlast))
                 {
@@ -596,30 +437,28 @@ internal partial class GNB : Tank
                         CanDelayedWeave(0.6f, 0f)) //send asap if about to lose due to GCD
                         return Hypervelocity;
                 }
-                if (IsEnabled(CustomComboPreset.GNB_GF_Continuation) && ShouldUseContinuation() &&
+                if (IsEnabled(CustomComboPreset.GNB_GF_Continuation) && ShouldUseContinuation &&
                     (CanWeave() || //normal
                     CanDelayedWeave(0.6f, 0f))) //send asap if about to lose due to GCD
                     return OriginalHook(Continuation);
-                if (IsEnabled(CustomComboPreset.GNB_GF_Scuffed) && LevelChecked(DoubleDown) && JustUsed(NoMercy, 5f) && GunStep == 0 && ComboAction is BrutalShell && Ammo == 1)
-                    return SolidBarrel;
                 //with SKS, we want Zone first because it can drift really bad while Bow usually remains static
                 //without SKS, we don't really care since both usually remain static
-                if (SlowGNB ? IsEnabled(CustomComboPreset.GNB_GF_BowShock) && ShouldUseBowShock() : IsEnabled(CustomComboPreset.GNB_GF_Zone) && ShouldUseZone())
+                if (SlowGNB ? IsEnabled(CustomComboPreset.GNB_GF_BowShock) && ShouldUseBowShock : IsEnabled(CustomComboPreset.GNB_GF_Zone) && ShouldUseZone)
                     return SlowGNB ? BowShock : OriginalHook(DangerZone);
-                if (SlowGNB ? IsEnabled(CustomComboPreset.GNB_GF_Zone) && ShouldUseZone() : IsEnabled(CustomComboPreset.GNB_GF_BowShock) && ShouldUseBowShock())
+                if (SlowGNB ? IsEnabled(CustomComboPreset.GNB_GF_Zone) && ShouldUseZone : IsEnabled(CustomComboPreset.GNB_GF_BowShock) && ShouldUseBowShock)
                     return SlowGNB ? OriginalHook(DangerZone) : BowShock;
-                if (ShouldUseGnashingFang())
+                if (ShouldUseGnashingFang)
                     return GnashingFang;
-                if (IsEnabled(CustomComboPreset.GNB_GF_DoubleDown) && ShouldUseDoubleDown())
+                if (IsEnabled(CustomComboPreset.GNB_GF_DoubleDown) && ShouldUseDoubleDown)
                     return DoubleDown;
-                if (IsEnabled(CustomComboPreset.GNB_GF_SonicBreak) && ShouldUseSonicBreak())
+                if (IsEnabled(CustomComboPreset.GNB_GF_SonicBreak) && ShouldUseSonicBreak)
                     return SonicBreak;
-                if (IsEnabled(CustomComboPreset.GNB_GF_Reign) && ShouldUseReignOfBeasts())
+                if (IsEnabled(CustomComboPreset.GNB_GF_Reign) && ShouldUseReignOfBeasts)
                     return OriginalHook(ReignOfBeasts);
                 if (IsEnabled(CustomComboPreset.GNB_GF_Features) &&
                     IsEnabled(CustomComboPreset.GNB_GF_BurstStrike))
                 {
-                    if (ShouldUseBurstStrike() ||
+                    if (ShouldUseBurstStrike ||
                         IsEnabled(CustomComboPreset.GNB_GF_NoMercy) &&
                         LevelChecked(DoubleDown) && NMcd < 1 && Ammo == 3 && !InOdd)
                         return BurstStrike;
@@ -629,24 +468,20 @@ internal partial class GNB : Tank
                 if (IsEnabled(CustomComboPreset.GNB_GF_Reign) && GunStep is 3 or 4)
                     return OriginalHook(ReignOfBeasts);
             }
-
             return actionID;
         }
     }
-
     #endregion
 
     #region Burst Strike Features
-
     internal class GNB_BS_Features : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_BS_Features;
         protected override uint Invoke(uint actionID)
         {
-            //Our Button
-            if (actionID is not BurstStrike)
+            var useDD = IsEnabled(CustomComboPreset.GNB_BS_DoubleDown) && CanDD;
+            if (actionID != BurstStrike)
                 return actionID;
-
             if (IsEnabled(CustomComboPreset.GNB_BS_Continuation))
             {
                 if (IsEnabled(CustomComboPreset.GNB_BS_Hypervelocity) && LevelChecked(Hypervelocity) && (JustUsed(BurstStrike, 1) || HasStatusEffect(Buffs.ReadyToBlast)))
@@ -654,38 +489,34 @@ internal partial class GNB : Tank
                 if (!IsEnabled(CustomComboPreset.GNB_BS_Hypervelocity) && CanContinue && (HasStatusEffect(Buffs.ReadyToRip) || HasStatusEffect(Buffs.ReadyToTear) || HasStatusEffect(Buffs.ReadyToGouge) || LevelChecked(Hypervelocity) && HasStatusEffect(Buffs.ReadyToBlast)))
                     return OriginalHook(Continuation);
             }
-            if (IsEnabled(CustomComboPreset.GNB_BS_Bloodfest) && ShouldUseBloodfest())
+            if (IsEnabled(CustomComboPreset.GNB_BS_Bloodfest) && ShouldUseBloodfest)
                 return Bloodfest;
-            if (IsEnabled(CustomComboPreset.GNB_BS_DoubleDown) && CanDD && Ammo == 1)
+            if (useDD && Ammo == 1)
                 return DoubleDown;
             if (IsEnabled(CustomComboPreset.GNB_BS_GnashingFang) && (CanGF || GunStep is 1 or 2))
                 return OriginalHook(GnashingFang);
-            //TODO: add prio hack to get rid of this redundant check
-            if (IsEnabled(CustomComboPreset.GNB_BS_DoubleDown) && CanDD && Ammo > 1)
+            if (useDD && Ammo > 1)
                 return DoubleDown;
             if (IsEnabled(CustomComboPreset.GNB_BS_Reign) && (CanReign || GunStep is 3 or 4))
                 return OriginalHook(ReignOfBeasts);
-
             return actionID;
         }
     }
-
     #endregion
 
     #region Fated Circle Features
-
     internal class GNB_FC_Features : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_FC_Features;
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is not FatedCircle) return actionID;
-
+            if (actionID != FatedCircle) 
+                return actionID;
             if (IsEnabled(CustomComboPreset.GNB_FC_Continuation) && HasStatusEffect(Buffs.ReadyToRaze) && LevelChecked(FatedBrand))
                 return FatedBrand;
             if (IsEnabled(CustomComboPreset.GNB_FC_DoubleDown) && IsEnabled(CustomComboPreset.GNB_FC_DoubleDown_NM) && CanDD && HasNM)
                 return DoubleDown;
-            if (IsEnabled(CustomComboPreset.GNB_FC_Bloodfest) && ShouldUseBloodfest())
+            if (IsEnabled(CustomComboPreset.GNB_FC_Bloodfest) && ShouldUseBloodfest)
                 return Bloodfest;
             if (IsEnabled(CustomComboPreset.GNB_FC_BowShock) && CanBow)
                 return BowShock;
@@ -693,23 +524,19 @@ internal partial class GNB : Tank
                 return DoubleDown;
             if (IsEnabled(CustomComboPreset.GNB_FC_Reign) && (CanReign || GunStep is 3 or 4))
                 return OriginalHook(ReignOfBeasts);
-
             return actionID;
         }
     }
-
     #endregion
 
     #region No Mercy Features
-
     internal class GNB_NM_Features : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_NM_Features;
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is not NoMercy)
+            if (actionID != NoMercy)
                 return actionID;
-
             if (Config.GNB_NM_Features_Weave == 0 && CanWeave() || Config.GNB_NM_Features_Weave == 1)
             {
                 var useZone = IsEnabled(CustomComboPreset.GNB_NM_Zone) && CanZone && NMcd is < 57.5f and > 17f;
@@ -726,7 +553,6 @@ internal partial class GNB : Tank
                 if (SlowGNB ? useZone : useBow)
                     return SlowGNB ? OriginalHook(DangerZone) : BowShock;
             }
-
             return actionID;
         }
     }
@@ -734,54 +560,43 @@ internal partial class GNB : Tank
     #endregion
 
     #region Aurora Protection
-
     internal class GNB_AuroraProtection : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_AuroraProtection;
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not Aurora)
-                return actionID;
-
-            if (HasFriendlyTarget() && HasStatusEffect(Buffs.Aurora, CurrentTarget, true) ||
-                !HasFriendlyTarget() && HasStatusEffect(Buffs.Aurora, anyOwner: true))
-                return All.SavageBlade;
-
-            return actionID;
-        }
+        protected override uint Invoke(uint actionID) => actionID != Aurora ? actionID :
+            (HasFriendlyTarget() && HasStatusEffect(Buffs.Aurora, CurrentTarget, true)) ||
+            (!HasFriendlyTarget() && HasStatusEffect(Buffs.Aurora, anyOwner: true)) ? All.SavageBlade : actionID;
     }
-
     #endregion
 
     #region One-Button Mitigation
-
     internal class GNB_Mit_OneButton : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_Mit_OneButton;
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is not Camouflage)
+            if (actionID != Camouflage)
                 return actionID;
-
-            if (IsEnabled(CustomComboPreset.GNB_Mit_Superbolide_Max) &&
-                ActionReady(Superbolide) &&
+            if (IsEnabled(CustomComboPreset.GNB_Mit_Superbolide_Max) && ActionReady(Superbolide) &&
                 HPP <= Config.GNB_Mit_Superbolide_Health &&
-                ContentCheck.IsInConfiguredContent(
-                    Config.GNB_Mit_Superbolide_Difficulty,
-                    Config.GNB_Mit_Superbolide_DifficultyListSet
-                ))
+                ContentCheck.IsInConfiguredContent(Config.GNB_Mit_Superbolide_Difficulty, Config.GNB_Mit_Superbolide_DifficultyListSet))
                 return Superbolide;
-
             foreach(int priority in Config.GNB_Mit_Priorities.Items.OrderBy(x => x))
             {
                 int index = Config.GNB_Mit_Priorities.IndexOf(priority);
                 if (CheckMitigationConfigMeetsRequirements(index, out uint action))
                     return action;
             }
-
             return actionID;
         }
     }
-
     #endregion
+
+    internal class GNB_ST_BasicCombo : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_ST_BasicCombo;
+        protected override uint Invoke(uint actionID) => actionID != SolidBarrel ? actionID :
+            ComboTimer > 0 && ComboAction is KeenEdge && LevelChecked(BrutalShell) ? BrutalShell :
+            ComboTimer > 0 && ComboAction is BrutalShell && LevelChecked(SolidBarrel) ? SolidBarrel : KeenEdge;
+    }
 }

--- a/WrathCombo/Combos/PvE/GNB/GNB.cs
+++ b/WrathCombo/Combos/PvE/GNB/GNB.cs
@@ -559,16 +559,6 @@ internal partial class GNB : Tank
 
     #endregion
 
-    #region Aurora Protection
-    internal class GNB_AuroraProtection : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_AuroraProtection;
-        protected override uint Invoke(uint actionID) => actionID != Aurora ? actionID :
-            (HasFriendlyTarget() && HasStatusEffect(Buffs.Aurora, CurrentTarget, true)) ||
-            (!HasFriendlyTarget() && HasStatusEffect(Buffs.Aurora, anyOwner: true)) ? All.SavageBlade : actionID;
-    }
-    #endregion
-
     #region One-Button Mitigation
     internal class GNB_Mit_OneButton : CustomCombo
     {
@@ -589,6 +579,24 @@ internal partial class GNB : Tank
             }
             return actionID;
         }
+    }
+    #endregion
+
+    #region Reprisal -> Heart of Light
+    internal class GNB_Mit_Party : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_Mit_Party;
+        protected override uint Invoke(uint action) => action != HeartOfLight ? action : ActionReady(Role.Reprisal) ? Role.Reprisal : action;
+    }
+    #endregion
+
+    #region Aurora Protection
+    internal class GNB_AuroraProtection : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_AuroraProtection;
+        protected override uint Invoke(uint actionID) => actionID != Aurora ? actionID :
+            (HasFriendlyTarget() && HasStatusEffect(Buffs.Aurora, CurrentTarget, true)) ||
+            (!HasFriendlyTarget() && HasStatusEffect(Buffs.Aurora, anyOwner: true)) ? All.SavageBlade : actionID;
     }
     #endregion
 

--- a/WrathCombo/Combos/PvE/GNB/GNB_Config.cs
+++ b/WrathCombo/Combos/PvE/GNB/GNB_Config.cs
@@ -3,7 +3,6 @@ using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
 using WrathCombo.Extensions;
 using WrathCombo.Window.Functions;
-using static WrathCombo.Window.Functions.UserConfig;
 using BossAvoidance = WrathCombo.Combos.PvE.All.Enums.BossAvoidance;
 using PartyRequirement = WrathCombo.Combos.PvE.All.Enums.PartyRequirement;
 
@@ -13,9 +12,6 @@ internal partial class GNB
 {
     internal static class Config
     {
-        private const int NumberMitigationOptions = 8;
-
-        
         public static UserInt
             GNB_Opener_StartChoice = new ("GNB_Opener_StartChoice", 0),
             GNB_Opener_NM = new("GNB_Opener_NM", 0),
@@ -36,7 +32,9 @@ internal partial class GNB
             GNB_ST_Reprisal_Health = new("GNB_ST_Reprisal_Health", 0),
             GNB_ST_Reprisal_SubOption = new("GNB_ST_Reprisal_Option", 0),
             GNB_ST_ArmsLength_Health = new("GNB_ST_ArmsLength_Health", 0),
+            GNB_ST_NoMercyStop = new("GNB_ST_NoMercyStop", 5),
             GNB_ST_NoMercy_SubOption = new("GNB_ST_NoMercy_SubOption", 1),
+            GNB_ST_Overcap_Choice = new("GNB_ST_Overcap_Choice", 0),
             GNB_AoE_MitsOptions = new("GNB_AoE_MitsOptions", 0),
             GNB_AoE_Corundum_Health = new("GNB_AoE_CorundumOption", 90),
             GNB_AoE_Corundum_SubOption = new("GNB_AoE_Corundum_Option", 0),
@@ -54,13 +52,13 @@ internal partial class GNB
             GNB_AoE_Reprisal_Health = new("GNB_AoE_Reprisal_Health", 0),
             GNB_AoE_Reprisal_SubOption = new("GNB_AoE_Reprisal_Option", 0),
             GNB_AoE_ArmsLength_Health = new("GNB_AoE_ArmsLength_Health", 0),
-            GNB_ST_NoMercyStop = new("GNB_ST_NoMercyStop", 5),
+            GNB_AoE_FatedCircle_BurstStrike = new("GNB_AoE_FatedCircle_BurstStrike", 1),
+            GNB_AoE_Overcap_Choice = new("GNB_AoE_Overcap_Choice", 0),
             GNB_AoE_NoMercyStop = new("GNB_AoE_NoMercyStop", 5),
             GNB_NM_Features_Weave = new("GNB_NM_Feature_Weave", 0),
             GNB_GF_Features_Choice = new("GNB_GF_Choice", 0),
+            GNB_GF_Overcap_Choice = new("GNB_GF_Overcap_Choice", 0),
             GNB_ST_Balance_Content = new("GNB_ST_Balance_Content", 1),
-
-            //One-Button Mitigation
             GNB_Mit_Superbolide_Health = new("GNB_Mit_Superbolide_Health", 30),
             GNB_Mit_Corundum_Health = new("GNB_Mit_Corundum_Health", 60),
             GNB_Mit_Aurora_Charges = new("GNB_Mit_Aurora_Charges", 0),
@@ -70,11 +68,7 @@ internal partial class GNB
             GNB_Mit_ArmsLength_Boss = new("GNB_Mit_ArmsLength_Boss", (int)BossAvoidance.On),
             GNB_Mit_ArmsLength_EnemyCount = new("GNB_Mit_ArmsLength_EnemyCount", 0),
             GNB_Mit_Nebula_Health = new("GNB_Mit_Nebula_Health", 50),
-
-            //Variant
             GNB_VariantCure = new("GNB_VariantCure"),
-
-            //Bozja
             GNB_Bozja_LostCure_Health = new("GNB_Bozja_LostCure_Health", 50),
             GNB_Bozja_LostCure2_Health = new("GNB_Bozja_LostCure2_Health", 50),
             GNB_Bozja_LostCure3_Health = new("GNB_Bozja_LostCure3_Health", 50),
@@ -86,455 +80,360 @@ internal partial class GNB
             GNB_Mit_Priorities = new("GNB_Mit_Priorities");
 
         public static UserBoolArray
-            GNB_Mit_Superbolide_Difficulty = new("GNB_Mit_Superbolide_Difficulty",
-                [true, false]);
+            GNB_Mit_Superbolide_Difficulty = new("GNB_Mit_Superbolide_Difficulty", [true, false]);
 
         public static readonly ContentCheck.ListSet GNB_Mit_Superbolide_DifficultyListSet = ContentCheck.ListSet.Halved;
+
+        private const int NumMitigationOptions = 8;
 
         internal static void Draw(CustomComboPreset preset)
         {
             switch (preset)
             {
-                case CustomComboPreset.GNB_Bozja_LostCure:
-                    DrawSliderInt(1, 100, GNB_Bozja_LostCure_Health,
-                        "Player HP% to be \nless than or equal to:", 200);
-                    break;
-
-                case CustomComboPreset.GNB_Bozja_LostCure2:
-                    DrawSliderInt(1, 100, GNB_Bozja_LostCure2_Health,
-                        "Player HP% to be \nless than or equal to:", 200);
-                    break;
-
-                case CustomComboPreset.GNB_Bozja_LostCure3:
-                    DrawSliderInt(1, 100, GNB_Bozja_LostCure3_Health,
-                        "Player HP% to be \nless than or equal to:", 200);
-                    break;
-
-                case CustomComboPreset.GNB_Bozja_LostCure4:
-                    DrawSliderInt(1, 100, GNB_Bozja_LostCure4_Health,
-                        "Player HP% to be \nless than or equal to:", 200);
-                    break;
-
-                case CustomComboPreset.GNB_Bozja_LostAethershield:
-                    DrawSliderInt(1, 100, GNB_Bozja_LostAethershield_Health,
-                        "Player HP% to be \nless than or equal to:", 200);
-                    break;
-
-                case CustomComboPreset.GNB_Bozja_LostReraise:
-                    DrawSliderInt(1, 100, GNB_Bozja_LostReraise_Health,
-                        "Player HP% to be \nless than or equal to:", 200);
-                    break;
-
-                case CustomComboPreset.GNB_Variant_Cure:
-                    DrawSliderInt(1, 100, GNB_VariantCure,
-                        "Player HP% to be \nless than or equal to:", 200);
-
-                    break;
-
-                case CustomComboPreset.GNB_ST_Simple:
-                    DrawHorizontalRadioButton(GNB_ST_MitsOptions,
-                        "Include Mitigations",
-                        "Enables the use of mitigations in Simple Mode.", 0);
-
-                    DrawHorizontalRadioButton(GNB_ST_MitsOptions,
-                        "Exclude Mitigations",
-                        "Disables the use of mitigations in Simple Mode.", 1);
-                    break;
-
-                case CustomComboPreset.GNB_AoE_Simple:
-                    DrawHorizontalRadioButton(GNB_AoE_MitsOptions,
-                        "Include Mitigations",
-                        "Enables the use of mitigations in Simple Mode.", 0);
-
-                    DrawHorizontalRadioButton(GNB_AoE_MitsOptions,
-                        "Exclude Mitigations",
-                        "Disables the use of mitigations in Simple Mode.", 1);
-                    break;
-
-                case CustomComboPreset.GNB_ST_Advanced_Opener:
-
-                    ImGui.Spacing();
-
-                    DrawHorizontalRadioButton(GNB_Opener_NM,
-                        $"Normal {NoMercy.ActionName()}",
-                        $"Uses {NoMercy.ActionName()} normally in all Openers", 0);
-
-                    DrawHorizontalRadioButton(GNB_Opener_NM,
-                        $"Early {NoMercy.ActionName()}",
-                        $"Uses {NoMercy.ActionName()} as soon as possible in all Openers", 1);
-
-                    ImGui.Spacing();
-
-                    if (DrawHorizontalRadioButton(GNB_Opener_StartChoice,
-                        $"Normal Opener",
-                        $"Starts opener with {LightningShot.ActionName()}", 0))
+                #region Single-Target
+                case CustomComboPreset.GNB_ST_Opener:
+                    UserConfig.DrawHorizontalRadioButton(GNB_Opener_NM,
+                        $"Normal {NoMercy.ActionName()}", $"Uses {NoMercy.ActionName()} normally in all openers", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_Opener_NM,
+                        $"Early {NoMercy.ActionName()}", $"Uses {NoMercy.ActionName()} as soon as possible in all openers", 1);
+                    
+                    if (UserConfig.DrawHorizontalRadioButton(GNB_Opener_StartChoice,
+                        $"Normal Opener", $"Starts opener with {LightningShot.ActionName()}", 0))
                     {
                         if (!CustomComboFunctions.InCombat())
                             Opener().OpenerStep = 1;
                     }    
-
-                    DrawHorizontalRadioButton(GNB_Opener_StartChoice,
-                        $"Early Opener",
-                        $"Starts opener with {KeenEdge.ActionName()} instead, skipping {LightningShot.ActionName()}", 1);
-
-                    ImGui.Spacing();
-
-                    DrawBossOnlyChoice(GNB_ST_Balance_Content);
+                    UserConfig.DrawHorizontalRadioButton(GNB_Opener_StartChoice,
+                        $"Early Opener", $"Starts opener with {KeenEdge.ActionName()} instead, skipping {LightningShot.ActionName()}", 1);
+                    
+                    UserConfig.DrawBossOnlyChoice(GNB_ST_Balance_Content);
                     break;
-
 
                 case CustomComboPreset.GNB_ST_NoMercy:
-                    DrawHorizontalRadioButton(GNB_ST_NoMercy_SubOption,
-                        "All content", $"Uses {ActionWatching.GetActionName(NoMercy)} regardless of content.", 0);
-
-                    DrawHorizontalRadioButton(GNB_ST_NoMercy_SubOption,
-                        "Boss encounters Only", $"Only uses {ActionWatching.GetActionName(NoMercy)} when in Boss encounters.", 1);
-                    DrawSliderInt(0, 75, GNB_ST_NoMercyStop,
-                        " Stop usage if Target\n HP% is below set value.\n (To Disable, set to 0)");
-
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_NoMercy_SubOption,
+                        "All content", $"Uses {ActionWatching.GetActionName(NoMercy)} regardless of content", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_NoMercy_SubOption,
+                        "Boss encounters Only", $"Only uses {ActionWatching.GetActionName(NoMercy)} when in Boss encounters", 1);
+                    
+                    UserConfig.DrawSliderInt(0, 75, GNB_ST_NoMercyStop,
+                        " Stop usage if Target HP% is below set value.\n  To disable this, set value to 0");
                     break;
 
+                case CustomComboPreset.GNB_ST_BurstStrike:
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_Overcap_Choice,
+                        "Include Overcap Protection", $"Includes {BurstStrike.ActionName()} to prevent overcapping on cartridges", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_Overcap_Choice,
+                        "Exclude Overcap Protection", $"Excludes {BurstStrike.ActionName()}, regardless of cartridge count", 1);
+                    break;
+                #endregion
+
+                #region AoE
                 case CustomComboPreset.GNB_AoE_NoMercy:
-                    DrawSliderInt(0, 75, GNB_AoE_NoMercyStop,
-                        " Stop usage if Target\n HP% is below set value.\n (To Disable, set to 0)");
-
+                    UserConfig.DrawSliderInt(0, 75, GNB_AoE_NoMercyStop,
+                        " Stop usage if Target HP% is below set value.\n To disable this, set value to 0");
                     break;
 
+                case CustomComboPreset.GNB_AoE_FatedCircle:
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_Overcap_Choice,
+                        "Include Overcap Protection", $"Includes {FatedCircle.ActionName()} to prevent overcapping on cartridges", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_Overcap_Choice,
+                        "Exclude Overcap Protection", $"Excludes {FatedCircle.ActionName()}, regardless of cartridge count", 1);
+                    ImGui.Spacing();
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_FatedCircle_BurstStrike,
+                        "Include Burst Strike", $"Includes {BurstStrike.ActionName()} instead when {FatedCircle.ActionName()} is unavailable", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_FatedCircle_BurstStrike,
+                        "Exclude Burst Strike", $"Excludes {BurstStrike.ActionName()} when {FatedCircle.ActionName()} is unavailable", 1);
+                    break;
+                #endregion
+
+                #region Mitigations
                 case CustomComboPreset.GNB_ST_Corundum:
-                    DrawSliderInt(1, 100, GNB_ST_Corundum_Health,
+                    UserConfig.DrawSliderInt(1, 100, GNB_ST_Corundum_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
-                    DrawHorizontalRadioButton(GNB_ST_Corundum_SubOption,
-                        "All Enemies",
-                        $"Uses {HeartOfCorundum.ActionName()} regardless of targeted enemy type.", 0);
-
-                    DrawHorizontalRadioButton(GNB_ST_Corundum_SubOption,
-                        "Bosses Only",
-                        $"Only ses {HeartOfCorundum.ActionName()} when the targeted enemy is a boss.", 1);
-
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_Corundum_SubOption,
+                        "All Enemies", $"Uses {HeartOfCorundum.ActionName()} regardless of targeted enemy type.", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_Corundum_SubOption,
+                        "Bosses Only", $"Only ses {HeartOfCorundum.ActionName()} when the targeted enemy is a boss.", 1);
                     break;
 
                 case CustomComboPreset.GNB_AoE_Corundum:
-                    DrawSliderInt(1, 100, GNB_AoE_Corundum_Health,
+                    UserConfig.DrawSliderInt(1, 100, GNB_AoE_Corundum_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
-                    DrawHorizontalRadioButton(GNB_AoE_Corundum_SubOption,
-                        "All Enemies",
-                        $"Uses {HeartOfCorundum.ActionName()} regardless of targeted enemy type.", 0);
-
-                    DrawHorizontalRadioButton(GNB_AoE_Corundum_SubOption,
-                        "Bosses Only",
-                        $"Only uses {HeartOfCorundum.ActionName()} when the targeted enemy is a boss.", 1);
-
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_Corundum_SubOption,
+                        "All Enemies", $"Uses {HeartOfCorundum.ActionName()} regardless of targeted enemy type.", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_Corundum_SubOption,
+                        "Bosses Only", $"Only uses {HeartOfCorundum.ActionName()} when the targeted enemy is a boss.", 1);
                     break;
 
                 case CustomComboPreset.GNB_ST_Aurora:
-                    DrawSliderInt(1, 100, GNB_ST_Aurora_Health,
+                    UserConfig.DrawSliderInt(1, 100, GNB_ST_Aurora_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-                    DrawSliderInt(0, 1, GNB_ST_Aurora_Charges,
+                    UserConfig.DrawSliderInt(0, 1, GNB_ST_Aurora_Charges,
                         "How many charges to keep ready?\n (0 = Use All)");
-
-                    DrawHorizontalRadioButton(GNB_ST_Aurora_SubOption,
-                        "All Enemies",
-                        $"Uses {Aurora.ActionName()} regardless of targeted enemy type.", 0);
-
-                    DrawHorizontalRadioButton(GNB_ST_Aurora_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Aurora.ActionName()} when the targeted enemy is a boss.", 1);
-
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_Aurora_SubOption,
+                        "All Enemies", $"Uses {Aurora.ActionName()} regardless of targeted enemy type.", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_Aurora_SubOption,
+                        "Bosses Only", $"Only uses {Aurora.ActionName()} when the targeted enemy is a boss.", 1);
                     break;
 
                 case CustomComboPreset.GNB_AoE_Aurora:
-                    DrawSliderInt(1, 100, GNB_AoE_Aurora_Health,
+                    UserConfig.DrawSliderInt(1, 100, GNB_AoE_Aurora_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-                    DrawSliderInt(0, 1, GNB_AoE_Aurora_Charges,
+                    UserConfig.DrawSliderInt(0, 1, GNB_AoE_Aurora_Charges,
                         "How many charges to keep ready?\n (0 = Use All)");
-
-                    DrawHorizontalRadioButton(GNB_AoE_Aurora_SubOption,
-                        "All Enemies",
-                        $"Uses {Aurora.ActionName()} regardless of targeted enemy type.", 0);
-
-                    DrawHorizontalRadioButton(GNB_AoE_Aurora_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Aurora.ActionName()} when the targeted enemy is a boss.", 1);
-
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_Aurora_SubOption,
+                        "All Enemies", $"Uses {Aurora.ActionName()} regardless of targeted enemy type.", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_Aurora_SubOption,
+                        "Bosses Only", $"Only uses {Aurora.ActionName()} when the targeted enemy is a boss.", 1);
                     break;
 
                 case CustomComboPreset.GNB_ST_Rampart:
-                    DrawSliderInt(1, 100, GNB_ST_Rampart_Health,
+                    UserConfig.DrawSliderInt(1, 100, GNB_ST_Rampart_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
-                    DrawHorizontalRadioButton(GNB_ST_Rampart_SubOption,
-                        "All Enemies",
-                        $"Uses {Role.Rampart.ActionName()} regardless of targeted enemy type.", 0);
-
-                    DrawHorizontalRadioButton(GNB_ST_Rampart_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Role.Rampart.ActionName()} when the targeted enemy is a boss.", 1);
-
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_Rampart_SubOption,
+                        "All Enemies", $"Uses {Role.Rampart.ActionName()} regardless of targeted enemy type.", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_Rampart_SubOption,
+                        "Bosses Only", $"Only uses {Role.Rampart.ActionName()} when the targeted enemy is a boss.", 1);
                     break;
 
                 case CustomComboPreset.GNB_AoE_Rampart:
-                    DrawSliderInt(1, 100, GNB_AoE_Rampart_Health,
+                    UserConfig.DrawSliderInt(1, 100, GNB_AoE_Rampart_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
-                    DrawHorizontalRadioButton(GNB_AoE_Rampart_SubOption,
-                        "All Enemies",
-                        $"Uses {Role.Rampart.ActionName()} regardless of targeted enemy type.", 0);
-
-                    DrawHorizontalRadioButton(GNB_AoE_Rampart_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Role.Rampart.ActionName()} when the targeted enemy is a boss.", 1);
-
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_Rampart_SubOption,
+                        "All Enemies", $"Uses {Role.Rampart.ActionName()} regardless of targeted enemy type.", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_Rampart_SubOption,
+                        "Bosses Only", $"Only uses {Role.Rampart.ActionName()} when the targeted enemy is a boss.", 1);
                     break;
 
                 case CustomComboPreset.GNB_ST_Camouflage:
-                    DrawSliderInt(1, 100, GNB_ST_Camouflage_Health,
+                    UserConfig.DrawSliderInt(1, 100, GNB_ST_Camouflage_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
-                    DrawHorizontalRadioButton(GNB_ST_Camouflage_SubOption,
-                        "All Enemies",
-                        $"Uses {Camouflage.ActionName()} regardless of targeted enemy type.", 0);
-
-                    DrawHorizontalRadioButton(GNB_ST_Camouflage_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Camouflage.ActionName()} when the targeted enemy is a boss.", 1);
-
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_Camouflage_SubOption,
+                        "All Enemies", $"Uses {Camouflage.ActionName()} regardless of targeted enemy type.", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_Camouflage_SubOption,
+                        "Bosses Only", $"Only uses {Camouflage.ActionName()} when the targeted enemy is a boss.", 1);
                     break;
 
                 case CustomComboPreset.GNB_AoE_Camouflage:
-                    DrawSliderInt(1, 100, GNB_AoE_Camouflage_Health,
+                    UserConfig.DrawSliderInt(1, 100, GNB_AoE_Camouflage_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
-                    DrawHorizontalRadioButton(GNB_AoE_Camouflage_SubOption,
-                        "All Enemies",
-                        $"Uses {Camouflage.ActionName()} regardless of targeted enemy type.", 0);
-
-                    DrawHorizontalRadioButton(GNB_AoE_Camouflage_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Camouflage.ActionName()} when the targeted enemy is a boss.", 1);
-
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_Camouflage_SubOption,
+                        "All Enemies", $"Uses {Camouflage.ActionName()} regardless of targeted enemy type.", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_Camouflage_SubOption,
+                        "Bosses Only", $"Only uses {Camouflage.ActionName()} when the targeted enemy is a boss.", 1);
                     break;
 
                 case CustomComboPreset.GNB_ST_Nebula:
-                    DrawSliderInt(1, 100, GNB_ST_Nebula_Health,
+                    UserConfig.DrawSliderInt(1, 100, GNB_ST_Nebula_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
-                    DrawHorizontalRadioButton(GNB_ST_Nebula_SubOption,
-                        "All Enemies",
-                        $"Uses {Nebula.ActionName()} regardless of targeted enemy type.", 0);
-
-                    DrawHorizontalRadioButton(GNB_ST_Nebula_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Nebula.ActionName()} when the targeted enemy is a boss.", 1);
-
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_Nebula_SubOption,
+                        "All Enemies", $"Uses {Nebula.ActionName()} regardless of targeted enemy type.", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_Nebula_SubOption,
+                        "Bosses Only", $"Only uses {Nebula.ActionName()} when the targeted enemy is a boss.", 1);
                     break;
 
                 case CustomComboPreset.GNB_AoE_Nebula:
-                    DrawSliderInt(1, 100, GNB_AoE_Nebula_Health,
+                    UserConfig.DrawSliderInt(1, 100, GNB_AoE_Nebula_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
-                    DrawHorizontalRadioButton(GNB_AoE_Nebula_SubOption,
-                        "All Enemies",
-                        $"Uses {Nebula.ActionName()} regardless of targeted enemy type.", 0);
-
-                    DrawHorizontalRadioButton(GNB_AoE_Nebula_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Nebula.ActionName()} when the targeted enemy is a boss.", 1);
-
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_Nebula_SubOption,
+                        "All Enemies", $"Uses {Nebula.ActionName()} regardless of targeted enemy type.", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_Nebula_SubOption,
+                        "Bosses Only", $"Only uses {Nebula.ActionName()} when the targeted enemy is a boss.", 1);
                     break;
 
                 case CustomComboPreset.GNB_ST_Superbolide:
-                    DrawSliderInt(1, 100, GNB_ST_Superbolide_Health,
+                    UserConfig.DrawSliderInt(1, 100, GNB_ST_Superbolide_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
-                    DrawHorizontalRadioButton(GNB_ST_Superbolide_SubOption,
-                        "All Enemies",
-                        $"Uses {Superbolide.ActionName()} regardless of targeted enemy type.", 0);
-
-                    DrawHorizontalRadioButton(GNB_ST_Superbolide_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Superbolide.ActionName()} when the targeted enemy is a boss.", 1);
-
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_Superbolide_SubOption,
+                        "All Enemies", $"Uses {Superbolide.ActionName()} regardless of targeted enemy type.", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_Superbolide_SubOption,
+                        "Bosses Only", $"Only uses {Superbolide.ActionName()} when the targeted enemy is a boss.", 1);
                     break;
 
                 case CustomComboPreset.GNB_AoE_Superbolide:
-                    DrawSliderInt(1, 100, GNB_AoE_Superbolide_Health,
+                    UserConfig.DrawSliderInt(1, 100, GNB_AoE_Superbolide_Health,
                         "Player HP% to be \nless than or equal to:", 200);
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_Superbolide_SubOption,
+                        "All Enemies", $"Uses {Superbolide.ActionName()} regardless of targeted enemy type.", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_Superbolide_SubOption,
+                        "Bosses Only", $"Only uses {Superbolide.ActionName()} when the targeted enemy is a boss.", 1);
+                    break;
 
-                    DrawHorizontalRadioButton(GNB_AoE_Superbolide_SubOption,
-                        "All Enemies",
-                        $"Uses {Superbolide.ActionName()} regardless of targeted enemy type.", 0);
+                case CustomComboPreset.GNB_ST_Reprisal:
+                    UserConfig.DrawSliderInt(1, 100, GNB_ST_Reprisal_Health,
+                        "Player HP% to be \nless than or equal to:", 200);
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_Reprisal_SubOption,
+                        "All Enemies", $"Uses {Role.Reprisal.ActionName()} regardless of targeted enemy type.", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_Reprisal_SubOption,
+                        "Bosses Only", $"Only uses {Role.Reprisal.ActionName()} when the targeted enemy is a boss.", 1);
+                    break;
 
-                    DrawHorizontalRadioButton(GNB_AoE_Superbolide_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Superbolide.ActionName()} when the targeted enemy is a boss.", 1);
-
+                case CustomComboPreset.GNB_AoE_Reprisal:
+                    UserConfig.DrawSliderInt(1, 100, GNB_AoE_Reprisal_Health,
+                        "Player HP% to be \nless than or equal to:", 200);
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_Reprisal_SubOption,
+                        "All Enemies", $"Uses {Role.Reprisal.ActionName()} regardless of targeted enemy type.", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_Reprisal_SubOption,
+                        "Bosses Only", $"Only uses {Role.Reprisal.ActionName()} when the targeted enemy is a boss.", 1);
                     break;
 
                 #region One-Button Mitigation
 
                 case CustomComboPreset.GNB_Mit_Superbolide_Max:
-                    DrawDifficultyMultiChoice(
-                        GNB_Mit_Superbolide_Difficulty,
-                        GNB_Mit_Superbolide_DifficultyListSet,
-                        "Select what difficulties Superbolide should be used in:"
-                    );
-
-                    DrawSliderInt(1, 100, GNB_Mit_Superbolide_Health,
-                        "Player HP% to be \nless than or equal to:",
-                        200, SliderIncrements.Fives);
+                    UserConfig.DrawDifficultyMultiChoice(GNB_Mit_Superbolide_Difficulty, GNB_Mit_Superbolide_DifficultyListSet,
+                        "Select what difficulties Superbolide should be used in:");
+                    UserConfig.DrawSliderInt(1, 100, GNB_Mit_Superbolide_Health, "Player HP% to be \nless than or equal to:", 200, SliderIncrements.Fives);
                     break;
 
                 case CustomComboPreset.GNB_Mit_Corundum:
-                    DrawSliderInt(1, 100, GNB_Mit_Corundum_Health,
+                    UserConfig.DrawSliderInt(1, 100, GNB_Mit_Corundum_Health,
                         "HP% to use at or below (100 = Disable check)",
                         sliderIncrement: SliderIncrements.Ones);
-
-                    DrawPriorityInput(GNB_Mit_Priorities,
-                        NumberMitigationOptions, 0,
+                    UserConfig.DrawPriorityInput(GNB_Mit_Priorities, NumMitigationOptions, 0,
                         "Heart of Corundum Priority:");
                     break;
 
                 case CustomComboPreset.GNB_Mit_Aurora:
-                    DrawSliderInt(0, 1, GNB_Mit_Aurora_Charges,
+                    UserConfig.DrawSliderInt(0, 1, GNB_Mit_Aurora_Charges,
                         "How many charges to keep ready?\n (0 = Use All)");
-
-                    DrawSliderInt(1, 100, GNB_Mit_Aurora_Health,
+                    UserConfig.DrawSliderInt(1, 100, GNB_Mit_Aurora_Health,
                         "HP% to use at or below (100 = Disable check)",
                         sliderIncrement: SliderIncrements.Ones);
-
-                    DrawPriorityInput(GNB_Mit_Priorities,
-                        NumberMitigationOptions, 1,
+                    UserConfig.DrawPriorityInput(GNB_Mit_Priorities, NumMitigationOptions, 1,
                         "Aurora Priority:");
                     break;
 
                 case CustomComboPreset.GNB_Mit_Camouflage:
-                    DrawPriorityInput(GNB_Mit_Priorities,
-                        NumberMitigationOptions, 2,
+                    UserConfig.DrawPriorityInput(GNB_Mit_Priorities, NumMitigationOptions, 2,
                         "Camouflage Priority:");
                     break;
 
                 case CustomComboPreset.GNB_Mit_Reprisal:
-                    DrawPriorityInput(GNB_Mit_Priorities,
-                        NumberMitigationOptions, 3,
+                    UserConfig.DrawPriorityInput(GNB_Mit_Priorities, NumMitigationOptions, 3,
                         "Reprisal Priority:");
                     break;
 
                 case CustomComboPreset.GNB_Mit_HeartOfLight:
                     ImGui.Indent();
-                    DrawHorizontalRadioButton(
-                        GNB_Mit_HeartOfLight_PartyRequirement,
-                        "Require party",
-                        "Will not use Heart of Light unless there are 2 or more party members.",
+                    UserConfig.DrawHorizontalRadioButton(GNB_Mit_HeartOfLight_PartyRequirement,
+                        "Require party", "Will not use Heart of Light unless there are 2 or more party members.",
                         (int)PartyRequirement.Yes);
-                    DrawHorizontalRadioButton(
-                        GNB_Mit_HeartOfLight_PartyRequirement,
-                        "Use Always",
-                        "Will not require a party for Heart of Light.",
+                    UserConfig.DrawHorizontalRadioButton(GNB_Mit_HeartOfLight_PartyRequirement,
+                        "Use Always", "Will not require a party for Heart of Light.",
                         (int)PartyRequirement.No);
                     ImGui.Unindent();
-
                     ImGui.NewLine();
-                    DrawPriorityInput(GNB_Mit_Priorities,
-                        NumberMitigationOptions, 4,
+                    UserConfig.DrawPriorityInput(GNB_Mit_Priorities, NumMitigationOptions, 4,
                         "Heart of Light Priority:");
                     break;
 
                 case CustomComboPreset.GNB_Mit_Rampart:
-                    DrawSliderInt(1, 100, GNB_Mit_Rampart_Health,
+                    UserConfig.DrawSliderInt(1, 100, GNB_Mit_Rampart_Health,
                         "HP% to use at or below (100 = Disable check)",
                         sliderIncrement: SliderIncrements.Ones);
-
-                    DrawPriorityInput(GNB_Mit_Priorities,
-                        NumberMitigationOptions, 5,
+                    UserConfig.DrawPriorityInput(GNB_Mit_Priorities, NumMitigationOptions, 5,
                         "Rampart Priority:");
                     break;
 
                 case CustomComboPreset.GNB_Mit_ArmsLength:
                     ImGui.Indent();
-                    DrawHorizontalRadioButton(
-                        GNB_Mit_ArmsLength_Boss, "All Enemies",
-                        "Will use Arm's Length regardless of the type of enemy.",
+                    UserConfig.DrawHorizontalRadioButton(GNB_Mit_ArmsLength_Boss, 
+                        "All Enemies", "Will use Arm's Length regardless of the type of enemy.",
                         (int)BossAvoidance.Off, 125f);
-                    DrawHorizontalRadioButton(
-                        GNB_Mit_ArmsLength_Boss, "Avoid Bosses",
-                        "Will try not to use Arm's Length when in a boss fight.",
+                    UserConfig.DrawHorizontalRadioButton(
+                        GNB_Mit_ArmsLength_Boss, 
+                        "Avoid Bosses", "Will try not to use Arm's Length when in a boss fight.",
                         (int)BossAvoidance.On, 125f);
                     ImGui.Unindent();
-
                     ImGui.NewLine();
-                    DrawSliderInt(0, 3, GNB_Mit_ArmsLength_EnemyCount,
+                    UserConfig.DrawSliderInt(0, 3, GNB_Mit_ArmsLength_EnemyCount,
                         "How many enemies should be nearby? (0 = No Requirement)");
-
-                    DrawPriorityInput(GNB_Mit_Priorities,
-                        NumberMitigationOptions, 6,
+                    UserConfig.DrawPriorityInput(GNB_Mit_Priorities, NumMitigationOptions, 6,
                         "Arm's Length Priority:");
                     break;
 
                 case CustomComboPreset.GNB_Mit_Nebula:
-                    DrawSliderInt(1, 100, GNB_Mit_Nebula_Health,
+                    UserConfig.DrawSliderInt(1, 100, GNB_Mit_Nebula_Health,
                         "HP% to use at or below (100 = Disable check)",
                         sliderIncrement: SliderIncrements.Ones);
-
-                    DrawPriorityInput(GNB_Mit_Priorities,
-                        NumberMitigationOptions, 7,
+                    UserConfig.DrawPriorityInput(GNB_Mit_Priorities, NumMitigationOptions, 7,
                         "Nebula Priority:");
                     break;
+                #endregion
 
                 #endregion
 
-                case CustomComboPreset.GNB_ST_Reprisal:
-                    DrawSliderInt(1, 100, GNB_ST_Reprisal_Health,
-                        "Player HP% to be \nless than or equal to:", 200);
-
-                    DrawHorizontalRadioButton(GNB_ST_Reprisal_SubOption,
-                        "All Enemies",
-                        $"Uses {Role.Reprisal.ActionName()} regardless of targeted enemy type.", 0);
-
-                    DrawHorizontalRadioButton(GNB_ST_Reprisal_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Role.Reprisal.ActionName()} when the targeted enemy is a boss.", 1);
-                    break;
-
-                case CustomComboPreset.GNB_AoE_Reprisal:
-                    DrawSliderInt(1, 100, GNB_AoE_Reprisal_Health,
-                        "Player HP% to be \nless than or equal to:", 200);
-
-                    DrawHorizontalRadioButton(GNB_AoE_Reprisal_SubOption,
-                        "All Enemies",
-                        $"Uses {Role.Reprisal.ActionName()} regardless of targeted enemy type.", 0);
-
-                    DrawHorizontalRadioButton(GNB_AoE_Reprisal_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Role.Reprisal.ActionName()} when the targeted enemy is a boss.", 1);
-                    break;
-
+                #region Other
                 case CustomComboPreset.GNB_NM_Features:
-
-                    DrawHorizontalRadioButton(GNB_NM_Features_Weave,
-                        "Weave-Only",
-                        "Uses cooldowns only when inside a weave window (excludes No Mercy)", 0);
-
-                    DrawHorizontalRadioButton(GNB_NM_Features_Weave,
-                        "On Cooldown",
-                        "Uses cooldowns as soon as possible", 1);
-
+                    UserConfig.DrawHorizontalRadioButton(GNB_NM_Features_Weave,
+                        "Weave-Only", "Uses cooldowns only when inside a weave window (excludes No Mercy)", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_NM_Features_Weave,
+                        "On Cooldown", "Uses cooldowns as soon as possible", 1);
                     break;
 
                 case CustomComboPreset.GNB_GF_Features:
+                    UserConfig.DrawHorizontalRadioButton(GNB_GF_Features_Choice,
+                        "Replace Gnashing Fang", $"Use this feature as intended on {GnashingFang.ActionName()}", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_GF_Features_Choice,
+                        "Replace No Mercy", $"Use this feature instead on {NoMercy.ActionName()}\nWARNING: This WILL conflict with 'No Mercy Features'!", 1);
+                    break;
 
-                    DrawHorizontalRadioButton(GNB_GF_Features_Choice,
-                        "Replace Gnashing Fang",
-                        $"Use this feature as intended on {GnashingFang.ActionName()}", 0);
+                case CustomComboPreset.GNB_GF_BurstStrike:
+                    UserConfig.DrawHorizontalRadioButton(GNB_GF_Overcap_Choice,
+                        "Include Overcap Protection", $"Includes {BurstStrike.ActionName()} to prevent overcapping on cartridges", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_GF_Overcap_Choice,
+                        "Exclude Overcap Protection", $"Excludes {BurstStrike.ActionName()}, regardless of cartridge count", 1);
+                    break;
 
-                    DrawHorizontalRadioButton(GNB_GF_Features_Choice,
-                        "Replace No Mercy",
-                        $"Use this feature instead on {NoMercy.ActionName()}\nWARNING: This WILL conflict with 'No Mercy Features'!", 1);
+                case CustomComboPreset.GNB_ST_Simple:
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_MitsOptions,
+                        "Include Mitigations", "Enables the use of mitigations in Simple Mode.", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_ST_MitsOptions,
+                        "Exclude Mitigations", "Disables the use of mitigations in Simple Mode.", 1);
+                    break;
 
-                    break;            
+                case CustomComboPreset.GNB_AoE_Simple:
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_MitsOptions,
+                        "Include Mitigations", "Enables the use of mitigations in Simple Mode.", 0);
+                    UserConfig.DrawHorizontalRadioButton(GNB_AoE_MitsOptions,
+                        "Exclude Mitigations", "Disables the use of mitigations in Simple Mode.", 1);
+                    break;
 
-               
+                case CustomComboPreset.GNB_Bozja_LostCure:
+                    UserConfig.DrawSliderInt(1, 100, GNB_Bozja_LostCure_Health,
+                        "Player HP% to be \nless than or equal to:", 200);
+                    break;
+
+                case CustomComboPreset.GNB_Bozja_LostCure2:
+                    UserConfig.DrawSliderInt(1, 100, GNB_Bozja_LostCure2_Health,
+                        "Player HP% to be \nless than or equal to:", 200);
+                    break;
+
+                case CustomComboPreset.GNB_Bozja_LostCure3:
+                    UserConfig.DrawSliderInt(1, 100, GNB_Bozja_LostCure3_Health,
+                        "Player HP% to be \nless than or equal to:", 200);
+                    break;
+
+                case CustomComboPreset.GNB_Bozja_LostCure4:
+                    UserConfig.DrawSliderInt(1, 100, GNB_Bozja_LostCure4_Health,
+                        "Player HP% to be \nless than or equal to:", 200);
+                    break;
+
+                case CustomComboPreset.GNB_Bozja_LostAethershield:
+                    UserConfig.DrawSliderInt(1, 100, GNB_Bozja_LostAethershield_Health,
+                        "Player HP% to be \nless than or equal to:", 200);
+                    break;
+
+                case CustomComboPreset.GNB_Bozja_LostReraise:
+                    UserConfig.DrawSliderInt(1, 100, GNB_Bozja_LostReraise_Health,
+                        "Player HP% to be \nless than or equal to:", 200);
+                    break;
+
+                case CustomComboPreset.GNB_Variant_Cure:
+                    UserConfig.DrawSliderInt(1, 100, GNB_VariantCure,
+                        "Player HP% to be \nless than or equal to:", 200);
+                    break;
+                    #endregion
             }
         }
     }

--- a/WrathCombo/Combos/PvE/GNB/GNB_Helper.cs
+++ b/WrathCombo/Combos/PvE/GNB/GNB_Helper.cs
@@ -18,20 +18,16 @@ internal partial class GNB : Tank
     internal static byte Ammo => GetJobGauge<GNBGauge>().Ammo;
     internal static byte GunStep => GetJobGauge<GNBGauge>().AmmoComboStep;
     internal static float HPP => PlayerHealthPercentageHp();
-    internal static float GFcd => GetCooldownRemainingTime(GnashingFang);
     internal static float NMcd => GetCooldownRemainingTime(NoMercy);
-    internal static float DDcd => GetCooldownRemainingTime(DoubleDown);
     internal static float BFcd => GetCooldownRemainingTime(Bloodfest);
     internal static bool HasNM => NMcd is >= 39.5f and <= 60;
-    internal static bool HasBreak => HasStatusEffect(Buffs.ReadyToBreak);
     internal static bool HasReign => HasStatusEffect(Buffs.ReadyToReign);
     internal static bool CanBS => LevelChecked(BurstStrike) && Ammo > 0;
-    internal static bool CanFC => LevelChecked(FatedCircle) && Ammo > 0;
-    internal static bool CanGF => LevelChecked(GnashingFang) && GFcd < 0.6f && !HasStatusEffect(Buffs.ReadyToBlast) && GunStep == 0 && Ammo > 0;
-    internal static bool CanDD => LevelChecked(DoubleDown) && DDcd < 0.6f && Ammo > 0;
+    internal static bool CanGF => LevelChecked(GnashingFang) && GetCooldownRemainingTime(GnashingFang) < 0.6f && !HasStatusEffect(Buffs.ReadyToBlast) && GunStep == 0 && Ammo > 0;
+    internal static bool CanDD => LevelChecked(DoubleDown) && GetCooldownRemainingTime(DoubleDown) < 0.6f && Ammo > 0;
     internal static bool CanBF => LevelChecked(Bloodfest) && BFcd < 0.6f;
     internal static bool CanZone => LevelChecked(DangerZone) && GetCooldownRemainingTime(OriginalHook(DangerZone)) < 0.6f;
-    internal static bool CanSB => LevelChecked(SonicBreak) && HasBreak;
+    internal static bool CanSB => LevelChecked(SonicBreak) && HasStatusEffect(Buffs.ReadyToBreak);
     internal static bool CanBow => LevelChecked(BowShock) && GetCooldownRemainingTime(BowShock) < 0.6f;
     internal static bool CanContinue => LevelChecked(Continuation);
     internal static bool CanReign => LevelChecked(ReignOfBeasts) && GunStep == 0 && HasReign;
@@ -56,7 +52,7 @@ internal partial class GNB : Tank
     public static Lv90SlowEarlyNM GNBLv90SlowEarlyNM = new();
     public static Lv100SlowEarlyNM GNBLv100SlowEarlyNM = new();
 
-    public static WrathOpener Opener() => (!IsEnabled(CustomComboPreset.GNB_ST_Advanced_Opener) || !LevelChecked(DoubleDown)) ? WrathOpener.Dummy : GetOpener(Config.GNB_Opener_NM == 0);
+    public static WrathOpener Opener() => (!IsEnabled(CustomComboPreset.GNB_ST_Opener) || !LevelChecked(DoubleDown)) ? WrathOpener.Dummy : GetOpener(Config.GNB_Opener_NM == 0);
     private static WrathOpener GetOpener(bool isNormal)
     {
         if (FastGNB || MidGNB)
@@ -305,10 +301,8 @@ internal partial class GNB : Tank
     {
         if (Variant.CanCure(CustomComboPreset.GNB_Variant_Cure, Config.GNB_VariantCure))
             return Variant.Cure;
-
         if (Variant.CanSpiritDart(CustomComboPreset.GNB_Variant_SpiritDart) && CanWeave())
             return Variant.SpiritDart;
-        
         if (Variant.CanUltimatum(CustomComboPreset.GNB_Variant_Ultimatum) && CanWeave())
             return Variant.Ultimatum;
 
@@ -322,41 +316,33 @@ internal partial class GNB : Tank
         bool CanUse(uint action) => HasActionEquipped(action) && IsOffCooldown(action);
         bool IsEnabledAndUsable(CustomComboPreset preset, uint action) => IsEnabled(preset) && CanUse(action);
 
-        //Out-of-Combat
         if (!InCombat() && IsEnabledAndUsable(CustomComboPreset.GNB_Bozja_LostStealth, Bozja.LostStealth))
             return Bozja.LostStealth;
 
-        //OGCDs
         if (CanWeave())
         {
             foreach (var (preset, action) in new[]
-            {
-            (CustomComboPreset.GNB_Bozja_LostFocus, Bozja.LostFocus),
+            { (CustomComboPreset.GNB_Bozja_LostFocus, Bozja.LostFocus),
             (CustomComboPreset.GNB_Bozja_LostFontOfPower, Bozja.LostFontOfPower),
             (CustomComboPreset.GNB_Bozja_LostSlash, Bozja.LostSlash),
             (CustomComboPreset.GNB_Bozja_LostFairTrade, Bozja.LostFairTrade),
-            (CustomComboPreset.GNB_Bozja_LostAssassination, Bozja.LostAssassination),
-        })
-                if (IsEnabledAndUsable(preset, action))
-                    return action;
+            (CustomComboPreset.GNB_Bozja_LostAssassination, Bozja.LostAssassination), })
+            if (IsEnabledAndUsable(preset, action))
+                return action;
 
             foreach (var (preset, action, powerPreset) in new[]
-            {
-            (CustomComboPreset.GNB_Bozja_BannerOfNobleEnds, Bozja.BannerOfNobleEnds, CustomComboPreset.GNB_Bozja_PowerEnds),
-            (CustomComboPreset.GNB_Bozja_BannerOfHonoredSacrifice, Bozja.BannerOfHonoredSacrifice, CustomComboPreset.GNB_Bozja_PowerSacrifice)
-        })
-                if (IsEnabledAndUsable(preset, action) && (!IsEnabled(powerPreset) || JustUsed(Bozja.LostFontOfPower, 5f)))
-                    return action;
+            { (CustomComboPreset.GNB_Bozja_BannerOfNobleEnds, Bozja.BannerOfNobleEnds, CustomComboPreset.GNB_Bozja_PowerEnds),
+            (CustomComboPreset.GNB_Bozja_BannerOfHonoredSacrifice, Bozja.BannerOfHonoredSacrifice, CustomComboPreset.GNB_Bozja_PowerSacrifice) })
+            if (IsEnabledAndUsable(preset, action) && (!IsEnabled(powerPreset) || JustUsed(Bozja.LostFontOfPower, 5f)))
+                return action;
 
             if (IsEnabledAndUsable(CustomComboPreset.GNB_Bozja_BannerOfHonedAcuity, Bozja.BannerOfHonedAcuity) &&
                 !HasStatusEffect(Bozja.Buffs.BannerOfTranscendentFinesse))
                 return Bozja.BannerOfHonedAcuity;
         }
 
-        //GCDs
         foreach (var (preset, action, condition) in new[]
-        {
-        (CustomComboPreset.GNB_Bozja_LostDeath, Bozja.LostDeath, true),
+        { (CustomComboPreset.GNB_Bozja_LostDeath, Bozja.LostDeath, true),
         (CustomComboPreset.GNB_Bozja_LostCure, Bozja.LostCure, PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostCure_Health),
         (CustomComboPreset.GNB_Bozja_LostArise, Bozja.LostArise, GetTargetHPPercent() == 0 && !HasStatusEffect(RoleActions.Magic.Buffs.Raise)),
         (CustomComboPreset.GNB_Bozja_LostReraise, Bozja.LostReraise, PlayerHealthPercentageHp() <= Config.GNB_Bozja_LostReraise_Health),
@@ -364,16 +350,14 @@ internal partial class GNB : Tank
         (CustomComboPreset.GNB_Bozja_LostShell, Bozja.LostShell, !HasStatusEffect(Bozja.Buffs.LostShell)),
         (CustomComboPreset.GNB_Bozja_LostBravery, Bozja.LostBravery, !HasStatusEffect(Bozja.Buffs.LostBravery)),
         (CustomComboPreset.GNB_Bozja_LostBubble, Bozja.LostBubble, !HasStatusEffect(Bozja.Buffs.LostBubble)),
-        (CustomComboPreset.GNB_Bozja_LostParalyze3, Bozja.LostParalyze3, !JustUsed(Bozja.LostParalyze3, 60f))
-        })
-            if (IsEnabledAndUsable(preset, action) && condition)
-                return action;
+        (CustomComboPreset.GNB_Bozja_LostParalyze3, Bozja.LostParalyze3, !JustUsed(Bozja.LostParalyze3, 60f)) })
+        if (IsEnabledAndUsable(preset, action) && condition)
+            return action;
 
         if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSpellforge) &&
             CanUse(Bozja.LostSpellforge) &&
             (!HasStatusEffect(Bozja.Buffs.LostSpellforge) || !HasStatusEffect(Bozja.Buffs.LostSteelsting)))
             return Bozja.LostSpellforge;
-
         if (IsEnabled(CustomComboPreset.GNB_Bozja_LostSteelsting) &&
             CanUse(Bozja.LostSteelsting) &&
             (!HasStatusEffect(Bozja.Buffs.LostSpellforge) || !HasStatusEffect(Bozja.Buffs.LostSteelsting)))
@@ -381,38 +365,47 @@ internal partial class GNB : Tank
 
         return 0; //No conditions met
     }
-
-    #endregion
-
-    #region Cooldowns
-
-    #region OGCDs
-    internal static bool ShouldUseNoMercy()
+    internal static uint OtherAction
     {
-        var minimum = NMcd < 0.6f && InCombat() && HasBattleTarget();
-        var three = (InOdd && (Ammo >= 2 || (ComboAction is BrutalShell && Ammo == 1))) || (!InOdd && Ammo != 3);
-        var two = TraitLevelChecked(Traits.CartridgeCharge) ? Ammo > 0 : NMcd < 0.6f;
-        var condition = minimum && (TraitLevelChecked(Traits.CartridgeChargeII) ? three : two);
-        return ((SlowGNB && condition && CanWeave()) ||
-            (MidGNB && condition && (InOdd ? CanWeave() : CanLateWeave)) ||
-            (FastGNB && condition && CanLateWeave));
+        get
+        {
+            if (GetVariantAction() is uint va && va != 0)
+                return va;
+            if (Bozja.IsInBozja && GetBozjaAction() is uint ba && ba != 0)
+                return ba;
+            return 0;
+        }
     }
-    internal static bool ShouldUseBloodfest() => HasBattleTarget() && CanWeave() && CanBF && Ammo == 0;
-    internal static bool ShouldUseZone() => CanZone && CanWeave() && NMcd is < 57.5f and > 17f;
-    internal static bool ShouldUseBowShock() => CanBow && CanWeave() && NMcd is < 57.5f and >= 40;
-    internal static bool ShouldUseContinuation() => CanContinue && (HasStatusEffect(Buffs.ReadyToRip) || HasStatusEffect(Buffs.ReadyToTear) || HasStatusEffect(Buffs.ReadyToGouge) || 
+    internal static bool ShouldUseOther => OtherAction != 0;
+    #endregion
+
+    #region Rotation
+    internal static bool ShouldUseNoMercy
+    {
+        get
+        {
+            var minimum = NMcd < 0.6f && InCombat() && HasBattleTarget();
+            var three = (InOdd && (Ammo >= 2 || (ComboAction is BrutalShell && Ammo == 1))) || (!InOdd && Ammo != 3);
+            var two = TraitLevelChecked(Traits.CartridgeCharge) ? Ammo > 0 : NMcd < 0.6f;
+            var condition = minimum && (TraitLevelChecked(Traits.CartridgeChargeII) ? three : two);
+            return (SlowGNB && condition && CanWeave()) || (MidGNB && condition && (InOdd ? CanWeave() : CanLateWeave)) || (FastGNB && condition && CanLateWeave);
+        }
+    }
+    internal static bool ShouldUseBloodfest => HasBattleTarget() && CanWeave() && CanBF && Ammo == 0;
+    internal static bool ShouldUseZone => CanZone && CanWeave() && NMcd is < 57.5f and > 17f;
+    internal static bool ShouldUseBowShock => CanBow && CanWeave() && NMcd is < 57.5f and >= 40;
+    internal static bool ShouldUseContinuation => CanContinue && (HasStatusEffect(Buffs.ReadyToRip) || HasStatusEffect(Buffs.ReadyToTear) || HasStatusEffect(Buffs.ReadyToGouge) || 
         (LevelChecked(Hypervelocity) && HasStatusEffect(Buffs.ReadyToBlast) && (LevelChecked(DoubleDown) ? (SlowGNB ? NMcd is > 1.5f || CanDelayedWeave(0.6f, 0) : (FastGNB || MidGNB)) : !LevelChecked(DoubleDown))));
-    #endregion
-
-    #region GCDs
-    internal static bool ShouldUseLightningShot() => LevelChecked(LightningShot) && !InMeleeRange() && HasBattleTarget();
-    internal static bool ShouldUseGnashingFang() => CanGF && (NMcd is > 17 and < 35 || JustUsed(NoMercy, 6f));
-    internal static bool ShouldUseDoubleDown() => CanDD && HasNM && (IsOnCooldown(GnashingFang) || Ammo == 1);
-    internal static bool ShouldUseSonicBreak() => CanSB && ((IsOnCooldown(GnashingFang) || !LevelChecked(GnashingFang)) && (IsOnCooldown(DoubleDown) || !LevelChecked(DoubleDown)));
-    internal static bool ShouldUseReignOfBeasts() => CanReign && IsOnCooldown(GnashingFang) && IsOnCooldown(DoubleDown) && !HasStatusEffect(Buffs.ReadyToBreak) && GunStep == 0;
-    internal static bool ShouldUseBurstStrike() => (CanBS && HasNM && IsOnCooldown(GnashingFang) && (IsOnCooldown(DoubleDown) || (!LevelChecked(DoubleDown) && Ammo > 0)) && !HasReign && GunStep == 0);
-    #endregion
-
+    internal static bool ShouldUseGnashingFang => CanGF && (NMcd is > 17 and < 35 || JustUsed(NoMercy, 6f));
+    internal static bool ShouldUseDoubleDown => CanDD && HasNM && (IsOnCooldown(GnashingFang) || Ammo == 1);
+    internal static bool ShouldUseSonicBreak => CanSB && ((IsOnCooldown(GnashingFang) || !LevelChecked(GnashingFang)) && (IsOnCooldown(DoubleDown) || !LevelChecked(DoubleDown)));
+    internal static bool ShouldUseReignOfBeasts => CanReign && IsOnCooldown(GnashingFang) && IsOnCooldown(DoubleDown) && !HasStatusEffect(Buffs.ReadyToBreak) && GunStep == 0;
+    internal static bool ShouldUseBurstStrike => (CanBS && HasNM && IsOnCooldown(GnashingFang) && (IsOnCooldown(DoubleDown) || (!LevelChecked(DoubleDown) && Ammo > 0)) && !HasReign && GunStep == 0);
+    internal static uint STCombo 
+        => ComboTimer > 0 ? ComboAction == KeenEdge && LevelChecked(BrutalShell) ? BrutalShell : ComboAction == BrutalShell && LevelChecked(SolidBarrel)
+        ? (Config.GNB_ST_Overcap_Choice == 0 && LevelChecked(BurstStrike) && Ammo == MaxCartridges() ? BurstStrike : SolidBarrel) : KeenEdge : KeenEdge;
+    internal static uint AOECombo => (ComboTimer > 0 && ComboAction == DemonSlice && LevelChecked(DemonSlaughter) && (Ammo != MaxCartridges() || Config.GNB_AoE_Overcap_Choice == 1)) ? DemonSlaughter : DemonSlice;
+    internal static bool ShouldUseLightningShot => LevelChecked(LightningShot) && !InMeleeRange() && HasBattleTarget();
     #endregion
 
     #region IDs

--- a/WrathCombo/Combos/PvE/GNB/GNB_Helper.cs
+++ b/WrathCombo/Combos/PvE/GNB/GNB_Helper.cs
@@ -389,9 +389,9 @@ internal partial class GNB : Tank
     #region OGCDs
     internal static bool ShouldUseNoMercy()
     {
-        var minimum = ActionReady(NoMercy) && InCombat() && HasBattleTarget();
-        var three = InOdd && (Ammo >= 2 || (ComboAction is BrutalShell && Ammo == 1)) || (!InOdd && Ammo != 3);
-        var two = TraitLevelChecked(Traits.CartridgeCharge) ? Ammo > 0 : ActionReady(NoMercy);
+        var minimum = NMcd < 0.6f && InCombat() && HasBattleTarget();
+        var three = (InOdd && (Ammo >= 2 || (ComboAction is BrutalShell && Ammo == 1))) || (!InOdd && Ammo != 3);
+        var two = TraitLevelChecked(Traits.CartridgeCharge) ? Ammo > 0 : NMcd < 0.6f;
         var condition = minimum && (TraitLevelChecked(Traits.CartridgeChargeII) ? three : two);
         if ((SlowGNB && condition && CanWeave()) ||
             (MidGNB && condition && (InOdd ? CanWeave() : CanLateWeave)) ||

--- a/WrathCombo/Combos/PvE/GNB/GNB_Helper.cs
+++ b/WrathCombo/Combos/PvE/GNB/GNB_Helper.cs
@@ -393,12 +393,9 @@ internal partial class GNB : Tank
         var three = (InOdd && (Ammo >= 2 || (ComboAction is BrutalShell && Ammo == 1))) || (!InOdd && Ammo != 3);
         var two = TraitLevelChecked(Traits.CartridgeCharge) ? Ammo > 0 : NMcd < 0.6f;
         var condition = minimum && (TraitLevelChecked(Traits.CartridgeChargeII) ? three : two);
-        if ((SlowGNB && condition && CanWeave()) ||
+        return ((SlowGNB && condition && CanWeave()) ||
             (MidGNB && condition && (InOdd ? CanWeave() : CanLateWeave)) ||
-            (FastGNB && condition && CanLateWeave))
-            return true;
-
-        return false;
+            (FastGNB && condition && CanLateWeave));
     }
     internal static bool ShouldUseBloodfest() => HasBattleTarget() && CanWeave() && CanBF && Ammo == 0;
     internal static bool ShouldUseZone() => CanZone && CanWeave() && NMcd is < 57.5f and > 17f;

--- a/WrathCombo/Combos/PvE/WAR/WAR.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR.cs
@@ -9,10 +9,10 @@ internal partial class WAR : Tank
     internal class WAR_ST_Simple : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_ST_Simple;
-        protected override uint Invoke(uint actionID)
+        protected override uint Invoke(uint action)
         {
-            if (actionID != HeavySwing)
-                return actionID;
+            if (action != HeavySwing)
+                return action;
             if (ShouldUseOther)
                 return OtherAction;
 
@@ -73,10 +73,10 @@ internal partial class WAR : Tank
     internal class WAR_ST_Advanced : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_ST_Advanced;
-        protected override uint Invoke(uint actionID)
+        protected override uint Invoke(uint action)
         {
-            if (actionID != HeavySwing)
-                return actionID;
+            if (action != HeavySwing)
+                return action;
             if (ShouldUseOther)
                 return OtherAction;
             if (IsEnabled(CustomComboPreset.WAR_ST_Interrupt)
@@ -125,8 +125,8 @@ internal partial class WAR : Tank
             #endregion
 
             #region Rotation
-            if (IsEnabled(CustomComboPreset.WAR_ST_BalanceOpener) && Opener().FullOpener(ref actionID))
-                return actionID;
+            if (IsEnabled(CustomComboPreset.WAR_ST_BalanceOpener) && Opener().FullOpener(ref action))
+                return action;
             if (IsEnabled(CustomComboPreset.WAR_ST_RangedUptime) && ShouldUseTomahawk)
                 return CanPRend(Config.WAR_ST_PrimalRend_Distance, Config.WAR_ST_PrimalRend_Movement == 1 || (Config.WAR_ST_PrimalRend_Movement == 0 && !IsMoving())) ? PrimalRend : CanWeave() && CanOnslaught(Config.WAR_ST_Onslaught_Charges, Config.WAR_ST_Onslaught_Distance, Config.WAR_ST_Onslaught_Movement == 1 || (Config.WAR_ST_Onslaught_Movement == 0 && !IsMoving())) ? Onslaught : Tomahawk;
             if (IsEnabled(CustomComboPreset.WAR_ST_InnerRelease) && ShouldUseInnerRelease(Config.WAR_ST_IRStop))
@@ -158,10 +158,10 @@ internal partial class WAR : Tank
     internal class WAR_AoE_Simple : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_AoE_Simple;
-        protected override uint Invoke(uint actionID)
+        protected override uint Invoke(uint action)
         {
-            if (actionID != Overpower)
-                return actionID;
+            if (action != Overpower)
+                return action;
             if (ShouldUseOther)
                 return OtherAction;
             if (Role.CanInterject())
@@ -222,10 +222,10 @@ internal partial class WAR : Tank
     internal class WAR_AoE_Advanced : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_AoE_Advanced;
-        protected override uint Invoke(uint actionID)
+        protected override uint Invoke(uint action)
         {
-            if (actionID != Overpower)
-                return actionID; //Our button
+            if (action != Overpower)
+                return action; //Our button
             if (ShouldUseOther)
                 return OtherAction;
             if (IsEnabled(CustomComboPreset.WAR_AoE_Interrupt) && Role.CanInterject())
@@ -295,10 +295,10 @@ internal partial class WAR : Tank
     internal class WAR_Mit_OneButton : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_Mit_OneButton;
-        protected override uint Invoke(uint actionID)
+        protected override uint Invoke(uint action)
         {
-            if (actionID != ThrillOfBattle)
-                return actionID;
+            if (action != ThrillOfBattle)
+                return action;
             if (IsEnabled(CustomComboPreset.WAR_Mit_Holmgang_Max) && ActionReady(Holmgang) &&
                 PlayerHealthPercentageHp() <= Config.WAR_Mit_Holmgang_Health &&
                 ContentCheck.IsInConfiguredContent(Config.WAR_Mit_Holmgang_Difficulty, Config.WAR_Mit_Holmgang_DifficultyListSet))
@@ -306,10 +306,10 @@ internal partial class WAR : Tank
             foreach(int priority in Config.WAR_Mit_Priorities.Items.OrderBy(x => x))
             {
                 int index = Config.WAR_Mit_Priorities.IndexOf(priority);
-                if (CheckMitigationConfigMeetsRequirements(index, out uint action))
+                if (CheckMitigationConfigMeetsRequirements(index, out uint actionID))
                     return action;
             }
-            return actionID;
+            return action;
         }
     }
     #endregion
@@ -337,7 +337,7 @@ internal partial class WAR : Tank
     internal class WAR_EyePath : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_EyePath;
-        protected override uint Invoke(uint action) => action == StormsPath && GetStatusEffectRemainingTime(Buffs.SurgingTempest) <= Config.WAR_EyePath_Refresh ? StormsEye : action;
+        protected override uint Invoke(uint action) => action != StormsPath ? action : GetStatusEffectRemainingTime(Buffs.SurgingTempest) <= Config.WAR_EyePath_Refresh ? StormsEye : action;
     }
     #endregion
 
@@ -349,16 +349,15 @@ internal partial class WAR : Tank
             ComboTimer > 0 && ComboAction == HeavySwing && LevelChecked(Maim) ? Maim :
             ComboTimer > 0 && ComboAction == Maim && LevelChecked(StormsEye) ? StormsEye : HeavySwing;
     }
-
     #endregion
 
     #region Primal Combo -> Inner Release
     internal class WAR_PrimalCombo_InnerRelease : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_PrimalCombo_InnerRelease;
-        protected override uint Invoke(uint actionID) => actionID is not (Berserk or InnerRelease) ? OriginalHook(actionID) :
+        protected override uint Invoke(uint action) => action is not (Berserk or InnerRelease) ? OriginalHook(action) :
             LevelChecked(PrimalRend) && HasStatusEffect(Buffs.PrimalRendReady) ? PrimalRend :
-            LevelChecked(PrimalRuination) && HasStatusEffect(Buffs.PrimalRuinationReady) ? PrimalRuination : OriginalHook(actionID);
+            LevelChecked(PrimalRuination) && HasStatusEffect(Buffs.PrimalRuinationReady) ? PrimalRuination : OriginalHook(action);
     }
     #endregion
 
@@ -366,9 +365,9 @@ internal partial class WAR : Tank
     internal class WAR_InfuriateFellCleave : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_InfuriateFellCleave;
-        protected override uint Invoke(uint actionID) => actionID is not (InnerBeast or FellCleave or SteelCyclone or Decimate) ? actionID :
+        protected override uint Invoke(uint action) => action is not (InnerBeast or FellCleave or SteelCyclone or Decimate) ? action :
             (InCombat() && BeastGauge <= Config.WAR_Infuriate_Range && GetRemainingCharges(Infuriate) > Config.WAR_Infuriate_Charges && ActionReady(Infuriate) &&
-            !HasNC && (!HasIR.Stacks || IsNotEnabled(CustomComboPreset.WAR_InfuriateFellCleave_IRFirst))) ? OriginalHook(Infuriate) : actionID;
+            !HasNC && (!HasIR.Stacks || IsNotEnabled(CustomComboPreset.WAR_InfuriateFellCleave_IRFirst))) ? OriginalHook(Infuriate) : action;
     }
     #endregion
 
@@ -376,18 +375,15 @@ internal partial class WAR : Tank
     internal class WAR_NascentFlash : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_NascentFlash;
-        protected override uint Invoke(uint actionID) => actionID is NascentFlash && LevelChecked(NascentFlash) ? NascentFlash : RawIntuition;
+        protected override uint Invoke(uint action) => action != RawIntuition ? action : ActionReady(NascentFlash) ? NascentFlash : action;
     }
     #endregion
 
-    #region Equilibrium -> Thrill of Battle
+    #region Thrill of Battle -> Equilibrium
     internal class WAR_ThrillEquilibrium : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_ThrillEquilibrium;
-
-        protected override uint Invoke(uint actionID) => actionID != ThrillOfBattle ? actionID :
-            (!IsEnabled(CustomComboPreset.WAR_ThrillEquilibrium_BuffOnly) && IsOnCooldown(ThrillOfBattle)) ||
-            (IsEnabled(CustomComboPreset.WAR_ThrillEquilibrium_BuffOnly) && HasStatusEffect(Buffs.ThrillOfBattle)) ? Equilibrium : ThrillOfBattle;
+        protected override uint Invoke(uint action) => action != Equilibrium ? action : ActionReady(ThrillOfBattle) ? ThrillOfBattle : action;
     }
     #endregion
 }

--- a/WrathCombo/Combos/PvE/WAR/WAR.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR.cs
@@ -314,25 +314,6 @@ internal partial class WAR : Tank
     }
     #endregion
 
-    #region Basic Combos
-    internal class WAR_ST_StormsPathCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_ST_StormsPathCombo;
-        protected override uint Invoke(uint id) => (id != StormsPath) ? id :
-            (ComboTimer > 0 && ComboAction == HeavySwing && LevelChecked(Maim)) ? Maim :
-            (ComboTimer > 0 && ComboAction == Maim && LevelChecked(StormsPath)) ? StormsPath :
-            HeavySwing;
-    }
-    internal class WAR_ST_StormsEyeCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_ST_StormsEyeCombo;
-        protected override uint Invoke(uint id) => (id != StormsEye) ? id :
-            (ComboTimer > 0 && ComboAction == HeavySwing && LevelChecked(Maim)) ? Maim :
-            (ComboTimer > 0 && ComboAction == Maim && LevelChecked(StormsEye)) ? StormsEye :
-            HeavySwing;
-    }
-    #endregion
-
     #region Storm's Eye -> Storm's Path
     internal class WAR_EyePath : CustomCombo
     {
@@ -384,6 +365,33 @@ internal partial class WAR : Tank
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_ThrillEquilibrium;
         protected override uint Invoke(uint action) => action != Equilibrium ? action : ActionReady(ThrillOfBattle) ? ThrillOfBattle : action;
+    }
+    #endregion
+
+    #region Reprisal -> Shake It Off
+    internal class WAR_Mit_Party : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_Mit_Party;
+        protected override uint Invoke(uint action) => action != ShakeItOff ? action : ActionReady(Role.Reprisal) ? Role.Reprisal : action;
+    }
+    #endregion
+
+    #region Basic Combos
+    internal class WAR_ST_StormsPathCombo : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_ST_StormsPathCombo;
+        protected override uint Invoke(uint id) => (id != StormsPath) ? id :
+            (ComboTimer > 0 && ComboAction == HeavySwing && LevelChecked(Maim)) ? Maim :
+            (ComboTimer > 0 && ComboAction == Maim && LevelChecked(StormsPath)) ? StormsPath :
+            HeavySwing;
+    }
+    internal class WAR_ST_StormsEyeCombo : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_ST_StormsEyeCombo;
+        protected override uint Invoke(uint id) => (id != StormsEye) ? id :
+            (ComboTimer > 0 && ComboAction == HeavySwing && LevelChecked(Maim)) ? Maim :
+            (ComboTimer > 0 && ComboAction == Maim && LevelChecked(StormsEye)) ? StormsEye :
+            HeavySwing;
     }
     #endregion
 }

--- a/WrathCombo/Combos/PvE/WAR/WAR.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR.cs
@@ -5,960 +5,389 @@ namespace WrathCombo.Combos.PvE;
 
 internal partial class WAR : Tank
 {
-    internal class WAR_ST_StormsPathCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_ST_StormsPathCombo;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not StormsPath)
-                return actionID;
-
-            if (ComboTimer > 0)
-            {
-                if (ComboAction is HeavySwing && LevelChecked(Maim))
-                    return Maim;
-
-                if (ComboAction is Maim && LevelChecked(StormsPath))
-                    return StormsPath;
-            }
-
-            return HeavySwing;
-        }
-    }
-
-    internal class WAR_ST_StormsEyeCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_ST_StormsEyeCombo;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not StormsEye)
-                return actionID;
-
-            if (ComboTimer > 0)
-            {
-                if (ComboAction is HeavySwing && LevelChecked(Maim))
-                    return Maim;
-
-                if (ComboAction is Maim && LevelChecked(StormsEye))
-                    return StormsEye;
-            }
-
-            return HeavySwing;
-        }
-    }
-
     #region Simple Mode - Single Target
-
     internal class WAR_ST_Simple : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_ST_Simple;
-
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is not HeavySwing)
-                return actionID; //Our button
-
-
-            bool justMitted = JustUsed(OriginalHook(RawIntuition), 4f) ||
-                              JustUsed(OriginalHook(Vengeance), 5f) ||
-                              JustUsed(ThrillOfBattle, 5f) ||
-                              JustUsed(Role.Rampart, 5f) ||
-                              JustUsed(Holmgang, 9f);
-
-            // Interrupt
-            if (Role.CanInterject())
-                return Role.Interject;
-
-            #region Variant
-
-            if (Variant.CanSpiritDart(CustomComboPreset.WAR_Variant_SpiritDart))
-                return Variant.SpiritDart;
-
-            if (Variant.CanUltimatum(CustomComboPreset.WAR_Variant_Ultimatum, WeaveTypes.Weave))
-                return Variant.Ultimatum;
-
-            if (Variant.CanCure(CustomComboPreset.WAR_Variant_Cure, Config.WAR_VariantCure))
-                return Variant.Cure;
-
-            #endregion
+            if (actionID != HeavySwing)
+                return actionID;
+            if (ShouldUseOther)
+                return OtherAction;
 
             #region Mitigations
-
             if (Config.WAR_ST_MitsOptions != 1)
             {
-                if (InCombat() && //Player is in combat
-                    !justMitted) //Player has not used a mitigation ability in the last 4-9 seconds
+                if (!InCombat() || MitUsed)
+                    return 0;
+                else
                 {
-                    //Holmgang
-                    if (ActionReady(Holmgang) && //Holmgang is ready
-                        PlayerHealthPercentageHp() < 30) //Player's health is below 30%
+                    if (ActionReady(Holmgang) && PlayerHealthPercentageHp() < 30)
                         return Holmgang;
-
                     if (IsPlayerTargeted())
                     {
-                        //Vengeance / Damnation
-                        if (ActionReady(OriginalHook(Vengeance)) && //Vengeance is ready
-                            PlayerHealthPercentageHp() < 60) //Player's health is below 60%
+                        if (ActionReady(OriginalHook(Vengeance)) && PlayerHealthPercentageHp() < 60)
                             return OriginalHook(Vengeance);
-
-                        //Rampart
-                        if (Role.CanRampart(80)) //Player's health is below 80%
+                        if (Role.CanRampart(80))
                             return Role.Rampart;
-
-                        //Reprisal
-                        if (Role.CanReprisal(90)) //Player's health is below 90%
+                        if (Role.CanReprisal(90))
                             return Role.Reprisal;
                     }
-
-                    //Thrill
-                    if (ActionReady(ThrillOfBattle) && //Thrill is ready
-                        PlayerHealthPercentageHp() < 70) //Player's health is below 80%
+                    if (ActionReady(ThrillOfBattle) && PlayerHealthPercentageHp() < 70)
                         return ThrillOfBattle;
-
-                    //Equilibrium
-                    if (ActionReady(Equilibrium) && //Equilibrium is ready
-                        PlayerHealthPercentageHp() < 50) //Player's health is below 30%
+                    if (ActionReady(Equilibrium) && PlayerHealthPercentageHp() < 50)
                         return Equilibrium;
-
-                    //Bloodwhetting
-                    if (ActionReady(OriginalHook(RawIntuition)) && //Bloodwhetting
-                        PlayerHealthPercentageHp() < 90) //Player's health is below 95%
+                    if (ActionReady(OriginalHook(RawIntuition)) && PlayerHealthPercentageHp() < 90)
                         return OriginalHook(Bloodwhetting);
                 }
             }
-
             #endregion
 
-            if (LevelChecked(Tomahawk) && //Tomahawk is available
-                !InMeleeRange() && //not in melee range
-                HasBattleTarget()) //has a target
+            #region Rotation
+            if (ShouldUseTomahawk)
                 return Tomahawk;
-
-            if (CanWeave()) //in weave window
-            {
-                if (InCombat() && //in combat
-                    ActionReady(Infuriate) && //Infuriate is ready
-                    !HasStatusEffect(Buffs.NascentChaos) && //does not have Nascent Chaos
-                    !HasStatusEffect(Buffs.InnerReleaseStacks) && //does not have Inner Release stacks
-                    Beastgauge <= 40) //gauge is less than or equal to 40
-                    return Infuriate;
-
-                //pre-Surging Tempest IR
-                if (InCombat() && //in combat
-                    ActionReady(OriginalHook(Berserk)) && //Berserk is ready
-                    !LevelChecked(StormsEye)) //does not have Storm's Eye
-                    return OriginalHook(Berserk);
-            }
-
-            if (HasStatusEffect(Buffs.SurgingTempest) && //has Surging Tempest
-                InCombat()) //in combat
-            {
-                if (CanWeave()) //in weave window
-                {
-                    if (ActionReady(OriginalHook(Berserk))) //Berserk is ready
-                        return OriginalHook(Berserk);
-
-                    if (ActionReady(Upheaval)) //Upheaval is ready
-                        return Upheaval;
-
-                    if (LevelChecked(PrimalWrath) && //Primal Wrath is available
-                        HasStatusEffect(Buffs.Wrathful)) //has Wrathful
-                        return PrimalWrath;
-
-                    if (LevelChecked(Onslaught) && //Onslaught is available
-                        GetRemainingCharges(Onslaught) > 1) //has more than 1 charge
-                    {
-                        if (!IsMoving() && //not moving
-                            GetTargetDistance() <= 1 && //within 1y of target
-                            (GetCooldownRemainingTime(InnerRelease) > 40 || !LevelChecked(InnerRelease))) //IR is not ready or available
-                            return Onslaught;
-                    }
-                }
-
-                if (HasStatusEffect(Buffs.PrimalRendReady) && //has Primal Rend ready
-                    !JustUsed(InnerRelease) && //has not just used IR
-                    !IsMoving() && //not moving
-                    GetTargetDistance() <= 1) //within 1y of target
-                    return PrimalRend;
-
-                if (HasStatusEffect(Buffs.PrimalRuinationReady) && //has Primal Ruination ready
-                    LevelChecked(PrimalRuination)) //Primal Ruination is available
-                    return PrimalRuination;
-
-                if (LevelChecked(InnerBeast)) //Inner Beast is available
-                {
-                    if (HasStatusEffect(Buffs.InnerReleaseStacks) || HasStatusEffect(Buffs.NascentChaos) && LevelChecked(InnerChaos)) //has IR stacks or Nascent Chaos and Inner Chaos
-                        return OriginalHook(InnerBeast);
-
-                    if (HasStatusEffect(Buffs.NascentChaos) && //has Nascent Chaos
-                        !LevelChecked(InnerChaos) && //does not have Inner Chaos
-                        Beastgauge >= 50) //gauge is greater than or equal to 50
-                        return OriginalHook(Decimate);
-                }
-            }
-
-            if (ComboTimer > 0) //in combo window
-            {
-                if (LevelChecked(InnerBeast) && //Inner Beast is available
-                    Beastgauge >= 90 && //gauge is greater than or equal to 90
-                    (!LevelChecked(StormsEye) || HasStatusEffect(Buffs.SurgingTempest, anyOwner: true))) //does not have Storm's Eye or has Surging Tempest
-                    return OriginalHook(InnerBeast);
-
-                if (LevelChecked(Maim) && //Maim is available
-                    ComboAction == HeavySwing) //last combo move was Heavy Swing
-                    return Maim;
-
-                if (LevelChecked(StormsPath) && //Storm's Path is available
-                    ComboAction == Maim) //last combo move was Maim
-                {
-                    if (LevelChecked(StormsEye) && //Storm's Eye is available
-                        GetStatusEffectRemainingTime(Buffs.SurgingTempest) <= 29) //Surging Tempest is about to expire
-                        return StormsEye;
-                    return StormsPath;
-                }
-            }
-
-            return HeavySwing;
+            if (ShouldUseInnerRelease())
+                return OriginalHook(Berserk);
+            if (ShouldUseInfuriate())
+                return Infuriate;
+            if (ShouldUseUpheaval)
+                return Upheaval;
+            if (ShouldUsePrimalWrath)
+                return PrimalWrath;
+            if (ShouldUseOnslaught(1, 3.5f, !IsMoving()))
+                return Onslaught;
+            if (ShouldUsePrimalRend(3.5f, !IsMoving()))
+                return PrimalRend;
+            if (ShouldUsePrimalRuination)
+                return PrimalRuination;
+            if (ShouldUseFellCleave())
+                return OriginalHook(InnerBeast);
+            return STCombo;
+            #endregion
         }
     }
-
     #endregion
 
     #region Advanced Mode - Single Target
-
     internal class WAR_ST_Advanced : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_ST_Advanced;
-
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is not HeavySwing)
-                return actionID; //Our button
-
-            bool justMitted = JustUsed(OriginalHook(RawIntuition), 4f) ||
-                              JustUsed(OriginalHook(Vengeance), 5f) ||
-                              JustUsed(ThrillOfBattle, 5f) ||
-                              JustUsed(Role.Rampart, 5f) ||
-                              JustUsed(Holmgang, 9f);
-
-            // Interrupt
+            if (actionID != HeavySwing)
+                return actionID;
+            if (ShouldUseOther)
+                return OtherAction;
             if (IsEnabled(CustomComboPreset.WAR_ST_Interrupt)
                 && Role.CanInterject())
                 return Role.Interject;
 
-            #region Variant
-
-            if (Variant.CanSpiritDart(CustomComboPreset.WAR_Variant_SpiritDart))
-                return Variant.SpiritDart;
-
-            if (Variant.CanUltimatum(CustomComboPreset.WAR_Variant_Ultimatum, WeaveTypes.Weave))
-                return Variant.Ultimatum;
-
-            if (Variant.CanCure(CustomComboPreset.WAR_Variant_Cure, Config.WAR_VariantCure))
-                return Variant.Cure;
-
-            #endregion
-
             #region Mitigations
-
-            if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Mitigation) && //Mitigation option is enabled
-                InCombat() && //Player is in combat
-                !justMitted) //Player has not used a mitigation ability in the last 4-9 seconds
+            if (IsEnabled(CustomComboPreset.WAR_ST_Mitigation) && InCombat() && !MitUsed)
             {
-                //Holmgang
-                if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Holmgang) && //Holmgang option is enabled
-                    ActionReady(Holmgang) && //Holmgang is ready
-                    PlayerHealthPercentageHp() <= Config.WAR_ST_Holmgang_Health && //Player's health is below selected threshold
-                    (Config.WAR_ST_Holmgang_SubOption == 0 || //Holmgang is enabled for all targets
-                     TargetIsBoss() && Config.WAR_ST_Holmgang_SubOption == 1)) //Holmgang is enabled for bosses only
+                if (IsEnabled(CustomComboPreset.WAR_ST_Holmgang) && ActionReady(Holmgang) &&
+                    PlayerHealthPercentageHp() <= Config.WAR_ST_Holmgang_Health &&
+                    (Config.WAR_ST_Holmgang_SubOption == 0 || (TargetIsBoss() && Config.WAR_ST_Holmgang_SubOption == 1)))
                     return Holmgang;
-
                 if (IsPlayerTargeted())
                 {
-                    //Vengeance / Damnation
-                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Vengeance) && //Vengeance option is enabled
-                        ActionReady(OriginalHook(Vengeance)) && //Vengeance is ready
-                        PlayerHealthPercentageHp() <= Config.WAR_ST_Vengeance_Health && //Player's health is below selected threshold
-                        (Config.WAR_ST_Vengeance_SubOption == 0 || //Vengeance is enabled for all targets
-                         TargetIsBoss() && Config.WAR_ST_Vengeance_SubOption == 1)) //Vengeance is enabled for bosses only
+                    if (IsEnabled(CustomComboPreset.WAR_ST_Vengeance) && ActionReady(OriginalHook(Vengeance)) &&
+                        PlayerHealthPercentageHp() <= Config.WAR_ST_Vengeance_Health &&
+                        (Config.WAR_ST_Vengeance_SubOption == 0 || (TargetIsBoss() && Config.WAR_ST_Vengeance_SubOption == 1)))
                         return OriginalHook(Vengeance);
-
-                    //Rampart
-                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Rampart) && //Rampart option is enabled
-                        Role.CanRampart(Config.WAR_ST_Rampart_Health) && //Player's health is below selected threshold
-                        (Config.WAR_ST_Rampart_SubOption == 0 || //Rampart is enabled for all targets
-                         TargetIsBoss() && Config.WAR_ST_Rampart_SubOption == 1)) //Rampart is enabled for bosses only
+                    if (IsEnabled(CustomComboPreset.WAR_ST_Rampart) &&
+                        Role.CanRampart(Config.WAR_ST_Rampart_Health) &&
+                        (Config.WAR_ST_Rampart_SubOption == 0 || (TargetIsBoss() && Config.WAR_ST_Rampart_SubOption == 1)))
                         return Role.Rampart;
-
-                    //Reprisal
-                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Reprisal) && //Reprisal option is enabled
-                        Role.CanReprisal(Config.WAR_ST_Reprisal_Health) && //Player's health is below selected threshold
-                        (Config.WAR_ST_Reprisal_SubOption == 0 || //Reprisal is enabled for all targets
-                         TargetIsBoss() && Config.WAR_ST_Reprisal_SubOption == 1)) //Reprisal is enabled for bosses only
+                    if (IsEnabled(CustomComboPreset.WAR_ST_Reprisal) &&
+                        Role.CanReprisal(Config.WAR_ST_Reprisal_Health) &&
+                        (Config.WAR_ST_Reprisal_SubOption == 0 || (TargetIsBoss() && Config.WAR_ST_Reprisal_SubOption == 1)))
                         return Role.Reprisal;
-
-                    //Arms Length
-                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_ArmsLength) &&
-                        PlayerHealthPercentageHp() <= Config.WAR_ST_ArmsLength_Health &&
-                        Role.CanArmsLength())
+                    if (IsEnabled(CustomComboPreset.WAR_ST_ArmsLength) && Role.CanArmsLength() &&
+                        PlayerHealthPercentageHp() <= Config.WAR_ST_ArmsLength_Health)
                         return Role.ArmsLength;
                 }
-
-                //Thrill
-                if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Thrill) && //Thrill option is enabled
-                    ActionReady(ThrillOfBattle) && //Thrill is ready
-                    PlayerHealthPercentageHp() <= Config.WAR_ST_Thrill_Health && //Player's health is below selected threshold
-                    (Config.WAR_ST_Thrill_SubOption == 0 || //Thrill is enabled for all targets
-                     TargetIsBoss() && Config.WAR_ST_Thrill_SubOption == 1)) //Thrill is enabled for bosses only
+                if (IsEnabled(CustomComboPreset.WAR_ST_Thrill) && ActionReady(ThrillOfBattle) &&
+                    PlayerHealthPercentageHp() <= Config.WAR_ST_Thrill_Health &&
+                    (Config.WAR_ST_Thrill_SubOption == 0 || (TargetIsBoss() && Config.WAR_ST_Thrill_SubOption == 1)))
                     return ThrillOfBattle;
-
-                //Equilibrium
-                if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Equilibrium) && //Equilibrium option is enabled
-                    ActionReady(Equilibrium) && //Equilibrium is ready
-                    PlayerHealthPercentageHp() <= Config.WAR_ST_Equilibrium_Health && //Player's health is below selected threshold
-                    (Config.WAR_ST_Equilibrium_SubOption == 0 || //Equilibrium is enabled for all targets
-                     TargetIsBoss() && Config.WAR_ST_Equilibrium_SubOption == 1)) //Equilibrium is enabled for bosses only
+                if (IsEnabled(CustomComboPreset.WAR_ST_Equilibrium) && ActionReady(Equilibrium) &&
+                    PlayerHealthPercentageHp() <= Config.WAR_ST_Equilibrium_Health &&
+                    (Config.WAR_ST_Equilibrium_SubOption == 0 || (TargetIsBoss() && Config.WAR_ST_Equilibrium_SubOption == 1)))
                     return Equilibrium;
-
-                //Bloodwhetting
-                if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Bloodwhetting) && //Bloodwhetting option is enabled
-                    ActionReady(OriginalHook(RawIntuition)) && //Bloodwhetting is ready
-                    PlayerHealthPercentageHp() <= Config.WAR_AoE_Bloodwhetting_Health && //Player's health is below selected threshold
-                    (Config.WAR_AoE_Bloodwhetting_SubOption == 0 || //Bloodwhetting is enabled for all targets
-                     TargetIsBoss() && Config.WAR_AoE_Bloodwhetting_SubOption == 1)) //Bloodwhetting is enabled for bosses only
+                if (IsEnabled(CustomComboPreset.WAR_ST_Bloodwhetting) && ActionReady(OriginalHook(RawIntuition)) &&
+                    PlayerHealthPercentageHp() <= Config.WAR_AoE_Bloodwhetting_Health &&
+                    (Config.WAR_AoE_Bloodwhetting_SubOption == 0 || (TargetIsBoss() && Config.WAR_AoE_Bloodwhetting_SubOption == 1)))
                     return OriginalHook(RawIntuition);
             }
 
             #endregion
 
-            if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_RangedUptime) && //Ranged uptime option is enabled
-                LevelChecked(Tomahawk) && //Tomahawk is available
-                !InMeleeRange() && //not in melee range
-                HasBattleTarget()) //has a target
-                return Tomahawk;
-
-            if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_BalanceOpener) &&
-                Opener().FullOpener(ref actionID))
+            #region Rotation
+            if (IsEnabled(CustomComboPreset.WAR_ST_BalanceOpener) && Opener().FullOpener(ref actionID))
                 return actionID;
-
-            if (CanWeave()) //in weave window
-            {
-                if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Infuriate) && //Infuriate option is enabled
-                    InCombat() && //in combat
-                    ActionReady(Infuriate) && //Infuriate is ready
-                    !HasStatusEffect(Buffs.NascentChaos) && //does not have Nascent Chaos
-                    !HasStatusEffect(Buffs.InnerReleaseStacks) && //does not have Inner Release stacks
-                    Beastgauge <= Config.WAR_InfuriateSTGauge && //gauge is less than or equal to selected threshold
-                    GetRemainingCharges(Infuriate) > Config.WAR_KeepInfuriateCharges) //has more than selected charges
-                    return Infuriate;
-
-                if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_InnerRelease) && //Inner Release option is enabled
-                    InCombat() && //in combat
-                    ActionReady(OriginalHook(Berserk)) && //Berserk is ready
-                    !LevelChecked(StormsEye)) //does not have Storm's Eye
-                    return OriginalHook(Berserk);
-            }
-
-            if (InCombat() && //in combat
-                HasStatusEffect(Buffs.SurgingTempest)) //has Surging Tempest
-            {
-                if (CanWeave()) //in weave window
-                {
-                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_InnerRelease) && //Inner Release option is enabled
-                        ActionReady(OriginalHook(Berserk)) && //Berserk is ready
-                        !HasStatusEffect(Buffs.Wrathful)) //Not Wrathful
-                        return OriginalHook(Berserk);
-
-                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Upheaval) && //Upheaval option is enabled
-                        ActionReady(Upheaval)) //Upheaval is ready
-                        return Upheaval;
-
-                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_PrimalWrath) && //Primal Wrath option is enabled
-                        LevelChecked(PrimalWrath) && //Primal Wrath is available
-                        HasStatusEffect(Buffs.Wrathful)) //has Wrathful
-                        return PrimalWrath;
-
-                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_Onslaught) && //Onslaught option is enabled
-                        LevelChecked(Onslaught) && //Onslaught is available
-                        GetRemainingCharges(Onslaught) > Config.WAR_KeepOnslaughtCharges) //has more than selected charges
-                    {
-                        if (IsNotEnabled(CustomComboPreset.WAR_ST_Advanced_Onslaught_MeleeSpender) || //Melee spender option is disabled
-                            IsEnabled(CustomComboPreset.WAR_ST_Advanced_Onslaught_MeleeSpender) && //Melee spender option is enabled
-                            !IsMoving() && GetTargetDistance() <= 1 && //not moving and within 1y of target
-                            (GetCooldownRemainingTime(InnerRelease) > 40 || !LevelChecked(InnerRelease))) //IR is not ready or available
-                            return Onslaught;
-                    }
-                }
-
-                if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_PrimalRend) && //Primal Rend option is enabled
-                    HasStatusEffect(Buffs.PrimalRendReady) && //has Primal Rend ready
-                    !JustUsed(InnerRelease)) //has not just used IR
-                {
-                    if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_PrimalRend_Late) && //Primal Rend late option is enabled
-                        GetStatusEffectStacks(Buffs.InnerReleaseStacks) is 0 && //does not have IR stacks
-                        GetStatusEffectStacks(Buffs.BurgeoningFury) is 0 && //does not have Burgeoning Fury stacks
-                        !HasStatusEffect(Buffs.Wrathful)) //does not have Wrathful
-                        return PrimalRend;
-
-                    if (IsNotEnabled(CustomComboPreset.WAR_ST_Advanced_PrimalRend_Late) && //Primal Rend late option is disabled
-                        !IsMoving() && GetTargetDistance() <= 1) //not moving & within 1y of target
-                        return PrimalRend;
-                }
-
-                if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_PrimalRuination) && //Primal Ruination option is enabled
-                    LevelChecked(PrimalRuination) && //Primal Ruination is available
-                    HasStatusEffect(Buffs.PrimalRuinationReady)) //has Primal Ruination ready
-                    return PrimalRuination;
-
-                if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_FellCleave) && //Fell Cleave option is enabled
-                    LevelChecked(InnerBeast)) //Inner Beast is available
-                {
-                    if (HasStatusEffect(Buffs.InnerReleaseStacks) || HasStatusEffect(Buffs.NascentChaos) && LevelChecked(InnerChaos)) //has IR stacks or Nascent Chaos and Inner Chaos
-                        return OriginalHook(InnerBeast);
-
-                    if (HasStatusEffect(Buffs.NascentChaos) && //has Nascent Chaos
-                        !LevelChecked(InnerChaos) && //Inner Chaos is not available
-                        Beastgauge >= 50) //gauge is greater than or equal to 50
-                        return OriginalHook(Decimate);
-                }
-            }
-
-            if (ComboTimer > 0) //in combo window
-            {
-                if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_FellCleave) && //Fell Cleave option is enabled
-                    LevelChecked(InnerBeast) && //Inner Beast is available
-                    (!LevelChecked(StormsEye) || HasStatusEffect(Buffs.SurgingTempest, anyOwner: true)) && //does not have Storm's Eye or has Surging Tempest
-                    Beastgauge >= Config.WAR_FellCleaveGauge) //gauge is greater than or equal to selected threshold
-                    return OriginalHook(InnerBeast);
-
-                if (LevelChecked(Maim) && //Maim is available
-                    ComboAction == HeavySwing) //last combo move was Heavy Swing
-                    return Maim;
-
-                if (IsEnabled(CustomComboPreset.WAR_ST_Advanced_StormsEye) && //Storm's Eye option is enabled
-                    LevelChecked(StormsPath) && //Storm's Path is available
-                    ComboAction == Maim) //last combo move was Maim
-                {
-                    if (LevelChecked(StormsEye) && //Storm's Eye is available
-                        GetStatusEffectRemainingTime(Buffs.SurgingTempest) <= Config.WAR_SurgingRefreshRange) //Surging Tempest less than or equal to selected threshold
-                        return StormsEye; //Storm's Eye
-                    return StormsPath; //Storm's Path instead if conditions are not met
-                }
-                if (IsNotEnabled(CustomComboPreset.WAR_ST_Advanced_StormsEye) && //Storm's Eye option is disabled
-                    LevelChecked(StormsPath) && //Storm's Path is available
-                    ComboAction == Maim) //last combo move was Maim
-                    return StormsPath;
-            }
-
-            return HeavySwing;
+            if (IsEnabled(CustomComboPreset.WAR_ST_RangedUptime) && ShouldUseTomahawk)
+                return CanPRend(Config.WAR_ST_PrimalRend_Distance, Config.WAR_ST_PrimalRend_Movement == 1 || (Config.WAR_ST_PrimalRend_Movement == 0 && !IsMoving())) ? PrimalRend : CanWeave() && CanOnslaught(Config.WAR_ST_Onslaught_Charges, Config.WAR_ST_Onslaught_Distance, Config.WAR_ST_Onslaught_Movement == 1 || (Config.WAR_ST_Onslaught_Movement == 0 && !IsMoving())) ? Onslaught : Tomahawk;
+            if (IsEnabled(CustomComboPreset.WAR_ST_InnerRelease) && ShouldUseInnerRelease(Config.WAR_ST_IRStop))
+                return OriginalHook(Berserk);
+            if (IsEnabled(CustomComboPreset.WAR_ST_Infuriate) && ShouldUseInfuriate(Config.WAR_ST_Infuriate_Gauge, Config.WAR_ST_Infuriate_Charges))
+                return Infuriate;
+            if (IsEnabled(CustomComboPreset.WAR_ST_Upheaval) && ShouldUseUpheaval)
+                return Upheaval;
+            if (IsEnabled(CustomComboPreset.WAR_ST_PrimalWrath) && ShouldUsePrimalWrath)
+                return PrimalWrath;
+            if (IsEnabled(CustomComboPreset.WAR_ST_Onslaught) && ShouldUseOnslaught(Config.WAR_ST_Onslaught_Charges, Config.WAR_ST_Onslaught_Distance, Config.WAR_ST_Onslaught_Movement == 1 || (Config.WAR_ST_Onslaught_Movement == 0 && !IsMoving())))
+                return Onslaught;
+            if (IsEnabled(CustomComboPreset.WAR_ST_PrimalRend) && 
+                ShouldUsePrimalRend(Config.WAR_ST_PrimalRend_Distance, Config.WAR_ST_PrimalRend_Movement == 1 || (Config.WAR_ST_PrimalRend_Movement == 0 && !IsMoving())) &&
+                (Config.WAR_ST_PrimalRend_EarlyLate == 0 || (Config.WAR_ST_PrimalRend_EarlyLate == 1 && (GetStatusEffectRemainingTime(Buffs.PrimalRendReady) <= 15 || (!HasIR.Stacks && !HasBF.Stacks && !HasWrath)))))
+                return PrimalRend;
+            if (IsEnabled(CustomComboPreset.WAR_ST_PrimalRuination) && ShouldUsePrimalRuination)
+                return PrimalRuination;
+            if (IsEnabled(CustomComboPreset.WAR_ST_FellCleave) && ShouldUseFellCleave(Config.WAR_ST_FellCleave_Gauge))
+                return OriginalHook(InnerBeast);
+            return STCombo;
+            #endregion
         }
     }
 
     #endregion
 
     #region Simple Mode - AoE
-
     internal class WAR_AoE_Simple : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_AoE_Simple;
-
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is not Overpower)
-                return actionID; //Our button
-
-            bool justMitted = JustUsed(OriginalHook(RawIntuition), 4f) ||
-                              JustUsed(OriginalHook(Vengeance), 5f) ||
-                              JustUsed(ThrillOfBattle, 5f) ||
-                              JustUsed(Role.Rampart, 5f) ||
-                              JustUsed(Holmgang, 9f);
-
-            #region Stuns
-
-            // Interrupt
+            if (actionID != Overpower)
+                return actionID;
+            if (ShouldUseOther)
+                return OtherAction;
             if (Role.CanInterject())
                 return Role.Interject;
-
-            // Stun
             if (Role.CanLowBlow())
                 return Role.LowBlow;
 
-            #endregion
-
-            #region Variant
-
-            if (Variant.CanSpiritDart(CustomComboPreset.WAR_Variant_SpiritDart))
-                return Variant.SpiritDart;
-
-            if (Variant.CanUltimatum(CustomComboPreset.WAR_Variant_Ultimatum, WeaveTypes.Weave))
-                return Variant.Ultimatum;
-
-            if (Variant.CanCure(CustomComboPreset.WAR_Variant_Cure, Config.WAR_VariantCure))
-                return Variant.Cure;
-
-            #endregion
-
             #region Mitigations
-
             if (Config.WAR_AoE_MitsOptions != 1)
             {
-                if (InCombat() && //Player is in combat
-                    !justMitted) //Player has not used a mitigation ability in the last 4-9 seconds
+                if (InCombat() && !MitUsed)
                 {
-                    //Holmgang
-                    if (ActionReady(Holmgang) && //Holmgang is ready
-                        PlayerHealthPercentageHp() < 30) //Player's health is below 30%
+                    if (ActionReady(Holmgang) && PlayerHealthPercentageHp() < 30)
                         return Holmgang;
-
                     if (IsPlayerTargeted())
                     {
-                        //Vengeance / Damnation
-                        if (ActionReady(OriginalHook(Vengeance)) && //Vengeance is ready
-                            PlayerHealthPercentageHp() < 60) //Player's health is below 60%
+                        if (ActionReady(OriginalHook(Vengeance)) && PlayerHealthPercentageHp() < 60)
                             return OriginalHook(Vengeance);
-
-                        //Rampart
-                        if (Role.CanRampart(80)) //Player's health is below 80%
+                        if (Role.CanRampart(80))
                             return Role.Rampart;
-
-                        //Reprisal
                         if (Role.CanReprisal(90, checkTargetForDebuff: false))
                             return Role.Reprisal;
                     }
-
-                    //Thrill
-                    if (ActionReady(ThrillOfBattle) && //Thrill is ready
-                        PlayerHealthPercentageHp() < 70) //Player's health is below 80%
+                    if (ActionReady(ThrillOfBattle) && PlayerHealthPercentageHp() < 70)
                         return ThrillOfBattle;
-
-                    //Equilibrium
-                    if (ActionReady(Equilibrium) && //Equilibrium is ready
-                        PlayerHealthPercentageHp() < 50) //Player's health is below 30%
+                    if (ActionReady(Equilibrium) && PlayerHealthPercentageHp() < 50)
                         return Equilibrium;
-
-                    //Bloodwhetting
-                    if (ActionReady(OriginalHook(RawIntuition)) && //Bloodwhetting
-                        PlayerHealthPercentageHp() < 90) //Player's health is below 95%
+                    if (ActionReady(OriginalHook(RawIntuition)) && PlayerHealthPercentageHp() < 90)
                         return OriginalHook(Bloodwhetting);
                 }
             }
-
             #endregion
 
-            if (CanWeave()) //in weave window
-            {
-                if (InCombat() && //in combat
-                    ActionReady(Infuriate) && //Infuriate is ready
-                    !HasStatusEffect(Buffs.NascentChaos) && //does not have Nascent Chaos
-                    !HasStatusEffect(Buffs.InnerReleaseStacks) && //does not have Inner Release stacks
-                    Beastgauge <= 40) //gauge is less than or equal to 40
-                    return Infuriate;
-
-                if (InCombat() && //in combat
-                    ActionReady(OriginalHook(Berserk)) && //Berserk is ready
-                    !LevelChecked(MythrilTempest)) //does not have Mythril Tempest
-                    return OriginalHook(Berserk);
-            }
-
-            if (InCombat() && //in combat
-                HasStatusEffect(Buffs.SurgingTempest)) //has Surging Tempest
-            {
-                if (CanWeave()) //in weave window
-                {
-                    if (ActionReady(OriginalHook(Berserk))) //Berserk is ready
-                        return OriginalHook(Berserk);
-
-                    if (ActionReady(Orogeny)) //Orogeny is ready
-                        return Orogeny;
-
-                    if (LevelChecked(PrimalWrath) && //Primal Wrath is available
-                        HasStatusEffect(Buffs.Wrathful)) //has Wrathful
-                        return PrimalWrath;
-                }
-
-                if (LevelChecked(PrimalRend) && //Primal Rend is available
-                    HasStatusEffect(Buffs.PrimalRendReady)) //has Primal Rend ready
-                    return PrimalRend;
-
-                if (LevelChecked(PrimalRuination) && //Primal Ruination is available
-                    HasStatusEffect(Buffs.PrimalRuinationReady)) //has Primal Ruination ready
-                    return PrimalRuination;
-
-                if (LevelChecked(SteelCyclone) && //Steel Cyclone is available
-                    (Beastgauge >= 90 || HasStatusEffect(Buffs.InnerReleaseStacks) || HasStatusEffect(Buffs.NascentChaos))) //gauge is greater than or equal to 90 or has IR stacks or Nascent Chaos
-                    return OriginalHook(SteelCyclone);
-            }
-
-            if (ComboTimer > 0) //in combo window
-            {
-                if (LevelChecked(MythrilTempest) && //Mythril Tempest is available
-                    ComboAction == Overpower) //last combo move was Overpower
-                    return MythrilTempest;
-            }
-
-            return Overpower;
+            #region Rotation
+            if (ShouldUseInfuriate())
+                return Infuriate;
+            if (ShouldUseInnerRelease())
+                return OriginalHook(Berserk);
+            if (ShouldUseUpheaval)
+                return LevelChecked(Orogeny) ? Orogeny : Upheaval;
+            if (ShouldUsePrimalWrath)
+                return PrimalWrath;
+            if (ShouldUseOnslaught(1, 3.5f, !IsMoving()))
+                return Onslaught;
+            if (ShouldUsePrimalRend(3.5f, !IsMoving()))
+                return PrimalRend;
+            if (ShouldUsePrimalRuination)
+                return PrimalRuination;
+            if (ShouldUseFellCleave())
+                return OriginalHook(Decimate);
+            return AOECombo;
+            #endregion
         }
     }
-
     #endregion
 
     #region Advanced Mode - AoE
-
     internal class WAR_AoE_Advanced : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_AoE_Advanced;
-
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is not Overpower)
+            if (actionID != Overpower)
                 return actionID; //Our button
-
-            bool justMitted = JustUsed(OriginalHook(RawIntuition), 4f) ||
-                              JustUsed(OriginalHook(Vengeance), 5f) ||
-                              JustUsed(ThrillOfBattle, 5f) ||
-                              JustUsed(Role.Rampart, 5f) ||
-                              JustUsed(Holmgang, 9f);
-
-            #region Stuns
-
-            // Interrupt
-            if (IsEnabled(CustomComboPreset.WAR_AoE_Interrupt)
-                && Role.CanInterject())
+            if (ShouldUseOther)
+                return OtherAction;
+            if (IsEnabled(CustomComboPreset.WAR_AoE_Interrupt) && Role.CanInterject())
                 return Role.Interject;
-
-            // Stun
-            if (IsEnabled(CustomComboPreset.WAR_AoE_Stun)
-                && Role.CanLowBlow())
+            if (IsEnabled(CustomComboPreset.WAR_AoE_Stun) && Role.CanLowBlow())
                 return Role.LowBlow;
 
-            #endregion
-
-            #region Variant
-
-            if (Variant.CanSpiritDart(CustomComboPreset.WAR_Variant_SpiritDart))
-                return Variant.SpiritDart;
-
-            if (Variant.CanUltimatum(CustomComboPreset.WAR_Variant_Ultimatum, WeaveTypes.Weave))
-                return Variant.Ultimatum;
-
-            if (Variant.CanCure(CustomComboPreset.WAR_Variant_Cure, Config.WAR_VariantCure))
-                return Variant.Cure;
-
-            #endregion
-
             #region Mitigations
-
-            if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Mitigation) && //Mitigation option is enabled
-                InCombat() && //Player is in combat
-                !justMitted) //Player has not used a mitigation ability in the last 4-9 seconds
+            if (IsEnabled(CustomComboPreset.WAR_AoE_Mitigation) && InCombat() && !MitUsed)
             {
-                //Holmgang
-                if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Holmgang) && //Holmgang option is enabled
-                    ActionReady(Holmgang) && //Holmgang is ready
-                    PlayerHealthPercentageHp() <= Config.WAR_AoE_Holmgang_Health && //Player's health is below selected threshold
-                    (Config.WAR_AoE_Holmgang_SubOption == 0 || //Holmgang is enabled for all targets
-                     TargetIsBoss() && Config.WAR_AoE_Holmgang_SubOption == 1)) //Holmgang is enabled for bosses only
+                if (IsEnabled(CustomComboPreset.WAR_AoE_Holmgang) && ActionReady(Holmgang) && PlayerHealthPercentageHp() <= Config.WAR_AoE_Holmgang_Health &&
+                    (Config.WAR_AoE_Holmgang_SubOption == 0 || (TargetIsBoss() && Config.WAR_AoE_Holmgang_SubOption == 1)))
                     return Holmgang;
-
                 if (IsPlayerTargeted())
                 {
-                    //Vengeance / Damnation
-                    if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Vengeance) && //Vengeance option is enabled
-                        ActionReady(OriginalHook(Vengeance)) && //Vengeance is ready
-                        PlayerHealthPercentageHp() <= Config.WAR_AoE_Vengeance_Health && //Player's health is below selected threshold
-                        (Config.WAR_AoE_Vengeance_SubOption == 0 || //Vengeance is enabled for all targets
-                         TargetIsBoss() && Config.WAR_AoE_Vengeance_SubOption == 1)) //Vengeance is enabled for bosses only
+                    if (IsEnabled(CustomComboPreset.WAR_AoE_Vengeance) && ActionReady(OriginalHook(Vengeance)) && PlayerHealthPercentageHp() <= Config.WAR_AoE_Vengeance_Health &&
+                        (Config.WAR_AoE_Vengeance_SubOption == 0 || (TargetIsBoss() && Config.WAR_AoE_Vengeance_SubOption == 1)))
                         return OriginalHook(Vengeance);
-
-                    //Rampart
-                    if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Rampart) && //Rampart option is enabled
-                        Role.CanRampart(Config.WAR_AoE_Rampart_Health) && //Player's health is below selected threshold
-                        (Config.WAR_AoE_Rampart_SubOption == 0 || //Rampart is enabled for all targets
-                         TargetIsBoss() && Config.WAR_AoE_Rampart_SubOption == 1)) //Rampart is enabled for bosses only
+                    if (IsEnabled(CustomComboPreset.WAR_AoE_Rampart) && Role.CanRampart(Config.WAR_AoE_Rampart_Health) &&
+                        (Config.WAR_AoE_Rampart_SubOption == 0 || (TargetIsBoss() && Config.WAR_AoE_Rampart_SubOption == 1)))
                         return Role.Rampart;
-
-                    //Reprisal
-                    if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Reprisal) && //Reprisal option is enabled
-                        Role.CanReprisal(Config.WAR_AoE_Reprisal_Health, checkTargetForDebuff: false) && //Player's health is below selected threshold
-                        (Config.WAR_AoE_Reprisal_SubOption == 0 || //Reprisal is enabled for all targets
-                         TargetIsBoss() && Config.WAR_AoE_Reprisal_SubOption == 1)) //Reprisal is enabled for bosses only
+                    if (IsEnabled(CustomComboPreset.WAR_AoE_Reprisal) && Role.CanReprisal(Config.WAR_AoE_Reprisal_Health, checkTargetForDebuff: false) &&
+                        (Config.WAR_AoE_Reprisal_SubOption == 0 || (TargetIsBoss() && Config.WAR_AoE_Reprisal_SubOption == 1)))
                         return Role.Reprisal;
-
-                    //Arms Length
-                    if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_ArmsLength) &&
-                        PlayerHealthPercentageHp() <= Config.WAR_AoE_ArmsLength_Health &&
-                        Role.CanArmsLength())
+                    if (IsEnabled(CustomComboPreset.WAR_AoE_ArmsLength) && PlayerHealthPercentageHp() <= Config.WAR_AoE_ArmsLength_Health && Role.CanArmsLength())
                         return Role.ArmsLength;
                 }
-                //Thrill
-                if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Thrill) && //Thrill option is enabled
-                    ActionReady(ThrillOfBattle) && //Thrill is ready
-                    PlayerHealthPercentageHp() <= Config.WAR_AoE_Thrill_Health && //Player's health is below selected threshold
-                    (Config.WAR_AoE_Thrill_SubOption == 0 || //Thrill is enabled for all targets
-                     TargetIsBoss() && Config.WAR_AoE_Thrill_SubOption == 1)) //Thrill is enabled for bosses only
+                if (IsEnabled(CustomComboPreset.WAR_AoE_Thrill) && ActionReady(ThrillOfBattle) && PlayerHealthPercentageHp() <= Config.WAR_AoE_Thrill_Health &&
+                    (Config.WAR_AoE_Thrill_SubOption == 0 || (TargetIsBoss() && Config.WAR_AoE_Thrill_SubOption == 1)))
                     return ThrillOfBattle;
-
-                //Equilibrium
-                if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Equilibrium) && //Equilibrium option is enabled
-                    ActionReady(Equilibrium) && //Equilibrium is ready
-                    PlayerHealthPercentageHp() <= Config.WAR_AoE_Equilibrium_Health && //Player's health is below selected threshold
-                    (Config.WAR_AoE_Equilibrium_SubOption == 0 || //Equilibrium is enabled for all targets
-                     TargetIsBoss() && Config.WAR_AoE_Equilibrium_SubOption == 1)) //Equilibrium is enabled for bosses only
+                if (IsEnabled(CustomComboPreset.WAR_AoE_Equilibrium) && ActionReady(Equilibrium) && PlayerHealthPercentageHp() <= Config.WAR_AoE_Equilibrium_Health &&
+                    (Config.WAR_AoE_Equilibrium_SubOption == 0 || (TargetIsBoss() && Config.WAR_AoE_Equilibrium_SubOption == 1)))
                     return Equilibrium;
-
-                //Bloodwhetting
-                if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Bloodwhetting) && //Bloodwhetting option is enabled
-                    ActionReady(OriginalHook(RawIntuition)) && //Bloodwhetting is ready
-                    PlayerHealthPercentageHp() <= Config.WAR_AoE_Bloodwhetting_Health && //Player's health is below selected threshold
-                    (Config.WAR_AoE_Bloodwhetting_SubOption == 0 || //Bloodwhetting is enabled for all targets
-                     TargetIsBoss() && Config.WAR_AoE_Bloodwhetting_SubOption == 1)) //Bloodwhetting is enabled for bosses only
+                if (IsEnabled(CustomComboPreset.WAR_AoE_Bloodwhetting) && ActionReady(OriginalHook(RawIntuition)) && PlayerHealthPercentageHp() <= Config.WAR_AoE_Bloodwhetting_Health &&
+                    (Config.WAR_AoE_Bloodwhetting_SubOption == 0 || (TargetIsBoss() && Config.WAR_AoE_Bloodwhetting_SubOption == 1)))
                     return OriginalHook(RawIntuition);
             }
-
             #endregion
 
-            if (CanWeave()) //in weave window
-            {
-                if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Infuriate) && //Infuriate option is enabled
-                    InCombat() && //in combat
-                    ActionReady(Infuriate) && //Infuriate is ready
-                    !HasStatusEffect(Buffs.NascentChaos) && //does not have Nascent Chaos
-                    !HasStatusEffect(Buffs.InnerReleaseStacks) && //does not have Inner Release stacks
-                    Beastgauge <= Config.WAR_InfuriateSTGauge) //gauge is less than or equal to selected threshold
-                    return Infuriate;
-
-                if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_InnerRelease) && //Inner Release option is enabled
-                    InCombat() && //in combat
-                    ActionReady(OriginalHook(Berserk)) && //Berserk is ready
-                    !LevelChecked(MythrilTempest)) //does not have Mythril Tempest
-                    return OriginalHook(Berserk);
-            }
-
-            if (InCombat() && //in combat
-                HasStatusEffect(Buffs.SurgingTempest)) //has Surging Tempest
-            {
-                if (CanWeave()) //in weave window
-                {
-                    if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_InnerRelease) && //Inner Release option is enabled
-                        ActionReady(OriginalHook(Berserk)) && //Berserk is ready
-                        !HasStatusEffect(Buffs.Wrathful)) //Not Wrathful
-                        return OriginalHook(Berserk);
-
-                    if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Orogeny) && //Orogeny option is enabled
-                        ActionReady(Orogeny)) //Orogeny is ready
-                        return Orogeny;
-
-                    if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_PrimalWrath) && //Primal Wrath option is enabled
-                        LevelChecked(PrimalWrath) && //Primal Wrath is available
-                        HasStatusEffect(Buffs.Wrathful)) //has Wrathful
-                        return PrimalWrath;
-                }
-
-                if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_PrimalRend) && //Primal Rend option is enabled
-                    LevelChecked(PrimalRend) && //Primal Rend is available
-                    HasStatusEffect(Buffs.PrimalRendReady)) //has Primal Rend ready
-                    return PrimalRend;
-
-                if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_PrimalRuination) && //Primal Ruination option is enabled
-                    HasStatusEffect(Buffs.PrimalRuinationReady) && //has Primal Ruination ready
-                    LevelChecked(PrimalRuination)) //Primal Ruination is available
-                    return PrimalRuination;
-
-                if (IsEnabled(CustomComboPreset.WAR_AoE_Advanced_Decimate) && //Decimate option is enabled
-                    LevelChecked(SteelCyclone) && //Steel Cyclone is available
-                    (Beastgauge >= Config.WAR_DecimateGauge || HasStatusEffect(Buffs.InnerReleaseStacks) || HasStatusEffect(Buffs.NascentChaos))) //gauge is greater than or equal to selected threshold or has IR stacks or Nascent Chaos
-                    return OriginalHook(SteelCyclone);
-            }
-
-            if (ComboTimer > 0) //in combo window
-            {
-                if (LevelChecked(MythrilTempest) && //Mythril Tempest is available
-                    ComboAction == Overpower) //last combo move was Overpower
-                    return MythrilTempest;
-            }
-
-            return Overpower;
-        }
-    }
-
-    #endregion
-
-    #region Storm's Eye -> Storm's Path
-
-    internal class WAR_EyePath : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_EyePath;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID != StormsPath)
-                return actionID;
-
-            if (GetStatusEffectRemainingTime(Buffs.SurgingTempest) <= Config.WAR_EyePath_Refresh) //Surging Tempest less than or equal to selected threshold
-                return StormsEye;
-
-            return actionID;
-        }
-    }
-
-    #endregion
-
-    #region Storm's Eye Combo -> Storm's Eye
-
-    internal class WAR_StormsEye : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_StormsEye;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not StormsEye)
-                return actionID;
-
-            if (ComboTimer > 0) //In combo
-            {
-                if (ComboAction == HeavySwing && //Last move was Heavy Swing
-                    LevelChecked(Maim)) //Maim is available
-                    return Maim;
-
-                if (ComboAction == Maim && //Last move was Maim
-                    LevelChecked(StormsEye)) //Storm's Eye is available
-                    return StormsEye;
-            }
-
-            return HeavySwing;
-        }
-    }
-
-    #endregion
-
-    #region Primal Combo -> Inner Release
-
-    internal class WAR_PrimalCombo_InnerRelease : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_PrimalCombo_InnerRelease;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not (Berserk or InnerRelease))
-                return OriginalHook(actionID);
-
-            if (LevelChecked(PrimalRend) && //Primal Rend is available
-                HasStatusEffect(Buffs.PrimalRendReady)) //Primal Rend is ready
+            #region Rotation
+            if (IsEnabled(CustomComboPreset.WAR_AoE_RangedUptime) && ShouldUseTomahawk)
+                return CanPRend(Config.WAR_AoE_PrimalRend_Distance, Config.WAR_AoE_PrimalRend_Movement == 1 || (Config.WAR_AoE_PrimalRend_Movement == 0 && !IsMoving())) ? PrimalRend : CanWeave() && CanOnslaught(Config.WAR_AoE_Onslaught_Charges, Config.WAR_AoE_Onslaught_Distance, Config.WAR_AoE_Onslaught_Movement == 1 || (Config.WAR_AoE_Onslaught_Movement == 0 && !IsMoving())) ? Onslaught : Tomahawk;
+            if (IsEnabled(CustomComboPreset.WAR_AoE_InnerRelease) && ShouldUseInnerRelease(Config.WAR_AoE_IRStop))
+                return OriginalHook(Berserk);
+            if (IsEnabled(CustomComboPreset.WAR_AoE_Infuriate) && ShouldUseInfuriate(Config.WAR_AoE_Infuriate_Gauge, Config.WAR_AoE_Infuriate_Charges))
+                return Infuriate;
+            if (IsEnabled(CustomComboPreset.WAR_AoE_Orogeny) && ShouldUseUpheaval)
+                return LevelChecked(Orogeny) ? Orogeny : Upheaval;
+            if (IsEnabled(CustomComboPreset.WAR_AoE_PrimalWrath) && ShouldUsePrimalWrath)
+                return PrimalWrath;
+            if (IsEnabled(CustomComboPreset.WAR_AoE_Onslaught) && ShouldUseOnslaught(Config.WAR_AoE_Onslaught_Charges, Config.WAR_AoE_Onslaught_Distance, Config.WAR_AoE_Onslaught_Movement == 1 || (Config.WAR_AoE_Onslaught_Movement == 0 && !IsMoving())))
+                return Onslaught;
+            if (IsEnabled(CustomComboPreset.WAR_AoE_PrimalRend) && ShouldUsePrimalRend(Config.WAR_AoE_PrimalRend_Distance, Config.WAR_AoE_PrimalRend_Movement == 1 || (Config.WAR_AoE_PrimalRend_Movement == 0 && !IsMoving())) &&
+                (Config.WAR_AoE_PrimalRend_EarlyLate == 0 || (Config.WAR_AoE_PrimalRend_EarlyLate == 1 && (GetStatusEffectRemainingTime(Buffs.PrimalRendReady) <= 15 || (!HasIR.Stacks && !HasBF.Stacks && !HasWrath)))))
                 return PrimalRend;
-
-            if (LevelChecked(PrimalRuination) && //Primal Ruination is available
-                HasStatusEffect(Buffs.PrimalRuinationReady)) //Primal Ruination is ready
+            if (IsEnabled(CustomComboPreset.WAR_AoE_PrimalRuination) && ShouldUsePrimalRuination)
                 return PrimalRuination;
-
-            return OriginalHook(actionID);
+            if (IsEnabled(CustomComboPreset.WAR_AoE_Decimate) && ShouldUseFellCleave(Config.WAR_AoE_Decimate_Gauge))
+                return OriginalHook(Decimate);
+            return AOECombo;
+            #endregion
         }
     }
-
-    #endregion
-
-    #region Infuriate -> Fell Cleave / Decimate
-
-    internal class WAR_InfuriateFellCleave : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_InfuriateFellCleave;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not (InnerBeast or FellCleave or SteelCyclone or Decimate))
-                return actionID;
-
-            bool hasNascent = HasStatusEffect(Buffs.NascentChaos);
-            bool hasInnerRelease = HasStatusEffect(Buffs.InnerReleaseStacks);
-
-            if (InCombat() && //is in combat
-                Beastgauge <= Config.WAR_InfuriateRange && //Beast Gauge is below selected threshold
-                ActionReady(Infuriate) && //Infuriate is ready
-                !hasNascent //does not have Nascent Chaos
-                && (!hasInnerRelease || IsNotEnabled(CustomComboPreset.WAR_InfuriateFellCleave_IRFirst))) //does not have Inner Release stacks or IRFirst option is disabled
-                return OriginalHook(Infuriate);
-
-            return actionID;
-        }
-    }
-
     #endregion
 
     #region One-Button Mitigation
-
     internal class WAR_Mit_OneButton : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_Mit_OneButton;
-
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is not ThrillOfBattle)
-                return actionID; //Our button
-
-            if (IsEnabled(CustomComboPreset.WAR_Mit_Holmgang_Max) &&
-                ActionReady(Holmgang) &&
+            if (actionID != ThrillOfBattle)
+                return actionID;
+            if (IsEnabled(CustomComboPreset.WAR_Mit_Holmgang_Max) && ActionReady(Holmgang) &&
                 PlayerHealthPercentageHp() <= Config.WAR_Mit_Holmgang_Health &&
-                ContentCheck.IsInConfiguredContent(
-                    Config.WAR_Mit_Holmgang_Difficulty,
-                    Config.WAR_Mit_Holmgang_DifficultyListSet
-                ))
+                ContentCheck.IsInConfiguredContent(Config.WAR_Mit_Holmgang_Difficulty, Config.WAR_Mit_Holmgang_DifficultyListSet))
                 return Holmgang;
-
             foreach(int priority in Config.WAR_Mit_Priorities.Items.OrderBy(x => x))
             {
                 int index = Config.WAR_Mit_Priorities.IndexOf(priority);
                 if (CheckMitigationConfigMeetsRequirements(index, out uint action))
                     return action;
             }
-
             return actionID;
         }
     }
-
     #endregion
 
-    #region Nascent Flash -> Raw Intuition
-
-    internal class WAR_NascentFlash : CustomCombo
+    #region Basic Combos
+    internal class WAR_ST_StormsPathCombo : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_NascentFlash;
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_ST_StormsPathCombo;
+        protected override uint Invoke(uint id) => (id != StormsPath) ? id :
+            (ComboTimer > 0 && ComboAction == HeavySwing && LevelChecked(Maim)) ? Maim :
+            (ComboTimer > 0 && ComboAction == Maim && LevelChecked(StormsPath)) ? StormsPath :
+            HeavySwing;
+    }
+    internal class WAR_ST_StormsEyeCombo : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_ST_StormsEyeCombo;
+        protected override uint Invoke(uint id) => (id != StormsEye) ? id :
+            (ComboTimer > 0 && ComboAction == HeavySwing && LevelChecked(Maim)) ? Maim :
+            (ComboTimer > 0 && ComboAction == Maim && LevelChecked(StormsEye)) ? StormsEye :
+            HeavySwing;
+    }
+    #endregion
 
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not NascentFlash)
-                return actionID;
+    #region Storm's Eye -> Storm's Path
+    internal class WAR_EyePath : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_EyePath;
+        protected override uint Invoke(uint action) => action == StormsPath && GetStatusEffectRemainingTime(Buffs.SurgingTempest) <= Config.WAR_EyePath_Refresh ? StormsEye : action;
+    }
+    #endregion
 
-            if (LevelChecked(NascentFlash))
-                return NascentFlash;
-            return RawIntuition;
-        }
+    #region Storm's Eye Combo -> Storm's Eye
+    internal class WAR_StormsEye : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_StormsEye;
+        protected override uint Invoke(uint action) => action != StormsEye ? action :
+            ComboTimer > 0 && ComboAction == HeavySwing && LevelChecked(Maim) ? Maim :
+            ComboTimer > 0 && ComboAction == Maim && LevelChecked(StormsEye) ? StormsEye : HeavySwing;
     }
 
     #endregion
 
-    #region Equilibrium -> Thrill of Battle
+    #region Primal Combo -> Inner Release
+    internal class WAR_PrimalCombo_InnerRelease : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_PrimalCombo_InnerRelease;
+        protected override uint Invoke(uint actionID) => actionID is not (Berserk or InnerRelease) ? OriginalHook(actionID) :
+            LevelChecked(PrimalRend) && HasStatusEffect(Buffs.PrimalRendReady) ? PrimalRend :
+            LevelChecked(PrimalRuination) && HasStatusEffect(Buffs.PrimalRuinationReady) ? PrimalRuination : OriginalHook(actionID);
+    }
+    #endregion
 
+    #region Infuriate -> Fell Cleave / Decimate
+    internal class WAR_InfuriateFellCleave : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_InfuriateFellCleave;
+        protected override uint Invoke(uint actionID) => actionID is not (InnerBeast or FellCleave or SteelCyclone or Decimate) ? actionID :
+            (InCombat() && BeastGauge <= Config.WAR_Infuriate_Range && GetRemainingCharges(Infuriate) > Config.WAR_Infuriate_Charges && ActionReady(Infuriate) &&
+            !HasNC && (!HasIR.Stacks || IsNotEnabled(CustomComboPreset.WAR_InfuriateFellCleave_IRFirst))) ? OriginalHook(Infuriate) : actionID;
+    }
+    #endregion
+
+    #region Nascent Flash -> Raw Intuition
+    internal class WAR_NascentFlash : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_NascentFlash;
+        protected override uint Invoke(uint actionID) => actionID is NascentFlash && LevelChecked(NascentFlash) ? NascentFlash : RawIntuition;
+    }
+    #endregion
+
+    #region Equilibrium -> Thrill of Battle
     internal class WAR_ThrillEquilibrium : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WAR_ThrillEquilibrium;
 
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not ThrillOfBattle)
-                return actionID;
-
-            if (!IsEnabled(CustomComboPreset.WAR_ThrillEquilibrium_BuffOnly) &&
-                IsOnCooldown(ThrillOfBattle))
-                return Equilibrium;
-
-            if (IsEnabled(CustomComboPreset.WAR_ThrillEquilibrium_BuffOnly) &&
-                HasStatusEffect(Buffs.ThrillOfBattle))
-                return Equilibrium;
-
-            return ThrillOfBattle;
-        }
+        protected override uint Invoke(uint actionID) => actionID != ThrillOfBattle ? actionID :
+            (!IsEnabled(CustomComboPreset.WAR_ThrillEquilibrium_BuffOnly) && IsOnCooldown(ThrillOfBattle)) ||
+            (IsEnabled(CustomComboPreset.WAR_ThrillEquilibrium_BuffOnly) && HasStatusEffect(Buffs.ThrillOfBattle)) ? Equilibrium : ThrillOfBattle;
     }
-
     #endregion
 }

--- a/WrathCombo/Combos/PvE/WAR/WAR_Config.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR_Config.cs
@@ -1,5 +1,4 @@
 using ImGuiNET;
-using System.Numerics;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
 using WrathCombo.Extensions;
@@ -13,18 +12,18 @@ internal partial class WAR
 {
     internal static class Config
     {
-        private const int numberMitigationOptions = 8;
-
         public static UserInt
-            WAR_InfuriateRange = new("WAR_InfuriateRange", 40),
+            WAR_Infuriate_Charges = new("WAR_Infuriate_Charges", 0),
+            WAR_Infuriate_Range = new("WAR_Infuriate_Range", 0),
             WAR_SurgingRefreshRange = new("WAR_SurgingRefreshRange", 10),
-            WAR_KeepOnslaughtCharges = new("WAR_KeepOnslaughtCharges", 1),
-            WAR_KeepInfuriateCharges = new("WAR_KeepInfuriateCharges", 0),
-            WAR_FellCleaveGauge = new("WAR_FellCleaveGauge", 90),
-            WAR_DecimateGauge = new("WAR_DecimateGauge", 90),
-            WAR_InfuriateSTGauge = new("WAR_InfuriateSTGauge", 40),
-            WAR_InfuriateAoEGauge = new("WAR_InfuriateAoEGauge", 40),
             WAR_EyePath_Refresh = new("WAR_EyePath", 10),
+            WAR_ST_Infuriate_Charges = new("WAR_ST_Infuriate_Charges", 0),
+            WAR_ST_Infuriate_Gauge = new("WAR_ST_Infuriate_Gauge", 40),
+            WAR_ST_FellCleave_Gauge = new("WAR_ST_FellCleave_Gauge", 90),
+            WAR_ST_Onslaught_Charges = new("WAR_ST_Onslaught_Charges", 0),
+            WAR_ST_Onslaught_Movement = new("WAR_ST_Onslaught_Movement", 0),
+            WAR_ST_PrimalRend_Movement = new("WAR_ST_PrimalRend_Movement", 0),
+            WAR_ST_PrimalRend_EarlyLate = new("WAR_ST_PrimalRend_EarlyLate", 0),
             WAR_ST_Bloodwhetting_Health = new("WAR_ST_BloodwhettingOption", 90),
             WAR_ST_Bloodwhetting_SubOption = new("WAR_ST_Bloodwhetting_SubOpt", 0),
             WAR_ST_Equilibrium_Health = new("WAR_ST_EquilibriumOption", 50),
@@ -40,6 +39,16 @@ internal partial class WAR
             WAR_ST_Reprisal_Health = new("WAR_ST_Reprisal_Health", 80),
             WAR_ST_Reprisal_SubOption = new("WAR_ST_Reprisal_SubOpt", 0),
             WAR_ST_ArmsLength_Health = new("WAR_ST_ArmsLength_Health", 80),
+            WAR_ST_MitsOptions = new("WAR_ST_MitsOptions", 0),
+            WAR_ST_IRStop = new("WAR_ST_IRStop", 0),
+            WAR_AoE_Infuriate_Charges = new("WAR_AoE_Infuriate_Charges", 0),
+            WAR_AoE_Infuriate_Gauge = new("WAR_AoE_Infuriate_Gauge", 40),
+            WAR_AoE_Decimate_Gauge = new("WAR_AoE_Decimate_Gauge", 90),
+            WAR_AoE_Onslaught_Charges = new("WAR_AoE_Onslaught_Charges", 0),
+            WAR_AoE_Onslaught_Movement = new("WAR_AoE_Onslaught_Movement", 0),
+            WAR_AoE_PrimalRend_Movement = new("WAR_AoE_PrimalRend_Movement", 0),
+            WAR_AoE_PrimalRend_EarlyLate = new("WAR_AoE_PrimalRend_EarlyLate", 0),
+            WAR_AoE_OrogenyUpheaval = new("WAR_AoE_OrogenyUpheaval", 0),
             WAR_AoE_Bloodwhetting_Health = new("WAR_AoE_BloodwhettingOption", 90),
             WAR_AoE_Bloodwhetting_SubOption = new("WAR_AoE_Bloodwhetting_SubOpt", 0),
             WAR_AoE_Equilibrium_Health = new("WAR_AoE_EquilibriumOption", 50),
@@ -55,12 +64,10 @@ internal partial class WAR
             WAR_AoE_Reprisal_Health = new("WAR_AoE_Reprisal_Health", 80),
             WAR_AoE_Reprisal_SubOption = new("WAR_AoE_Reprisal_SubOpt", 0),
             WAR_AoE_ArmsLength_Health = new("WAR_AoE_ArmsLength_Health", 80),
-            WAR_ST_MitsOptions = new("WAR_ST_MitsOptions", 0),
             WAR_AoE_MitsOptions = new("WAR_AoE_MitsOptions", 0),
+            WAR_AoE_IRStop = new("WAR_AoE_IRStop", 0),
             WAR_VariantCure = new("WAR_VariantCure"),
             WAR_BalanceOpener_Content = new("WAR_BalanceOpener_Content", 1),
-
-            //One-Button Mitigation
             WAR_Mit_Holmgang_Health = new("WAR_Mit_Holmgang_Health", 30),
             WAR_Mit_Bloodwhetting_Health = new("WAR_Mit_Bloodwhetting_Health", 70),
             WAR_Mit_Equilibrium_Health = new("WAR_Mit_Equilibrium_Health", 45),
@@ -69,405 +76,392 @@ internal partial class WAR
             WAR_Mit_ShakeItOff_PartyRequirement = new("WAR_Mit_ShakeItOff_PartyRequirement", (int) PartyRequirement.Yes),
             WAR_Mit_ArmsLength_Boss = new("WAR_Mit_ArmsLength_Boss", (int) BossAvoidance.On),
             WAR_Mit_ArmsLength_EnemyCount = new("WAR_Mit_ArmsLength_EnemyCount", 0),
-            WAR_Mit_Vengeance_Health = new("WAR_Mit_Vengeance_Health", 50);
+            WAR_Mit_Vengeance_Health = new("WAR_Mit_Vengeance_Health", 50),
+            WAR_Bozja_LostCure_Health = new("WAR_Bozja_LostCure_Health", 50),
+            WAR_Bozja_LostCure2_Health = new("WAR_Bozja_LostCure2_Health", 50),
+            WAR_Bozja_LostCure3_Health = new("WAR_Bozja_LostCure3_Health", 50),
+            WAR_Bozja_LostCure4_Health = new("WAR_Bozja_LostCure4_Health", 50),
+            WAR_Bozja_LostAethershield_Health = new("WAR_Bozja_LostAethershield_Health", 70),
+            WAR_Bozja_LostReraise_Health = new("WAR_Bozja_LostReraise_Health", 10);
+
+        public static UserFloat
+            WAR_ST_Onslaught_Distance = new("WAR_ST_Ons_Distance", 3.0f),
+            WAR_ST_PrimalRend_Distance = new("WAR_ST_PR_Distance", 3.0f),
+            WAR_AoE_Onslaught_Distance = new("WAR_AoE_Ons_Distance", 3.0f),
+            WAR_AoE_PrimalRend_Distance = new("WAR_AoE_PR_Distance", 3.0f);
 
         public static UserIntArray
             WAR_Mit_Priorities = new("WAR_Mit_Priorities");
 
         public static UserBoolArray
-            WAR_Mit_Holmgang_Difficulty = new("WAR_Mit_Holmgang_Difficulty",
-                [true, false]);
+            WAR_Mit_Holmgang_Difficulty = new("WAR_Mit_Holmgang_Difficulty", [true, false]);
 
-        public static readonly ContentCheck.ListSet
-            WAR_Mit_Holmgang_DifficultyListSet =
-                ContentCheck.ListSet.Halved;
+        public static readonly ContentCheck.ListSet WAR_Mit_Holmgang_DifficultyListSet = ContentCheck.ListSet.Halved;
+
+        private const int NumMitigationOptions = 8;
 
         internal static void Draw(CustomComboPreset preset)
         {
             switch (preset)
             {
-                case CustomComboPreset.WAR_ST_Advanced_BalanceOpener:
+                #region Single-Target
+                case CustomComboPreset.WAR_ST_BalanceOpener:
                     UserConfig.DrawBossOnlyChoice(WAR_BalanceOpener_Content);
                     break;
 
-                case CustomComboPreset.WAR_Variant_Cure:
-                    UserConfig.DrawSliderInt(1, 100, WAR_VariantCure,
-                        "Player HP% to be \nless than or equal to:", 200);
-
-                    break;
-
-                case CustomComboPreset.WAR_InfuriateFellCleave:
-                    UserConfig.DrawSliderInt(0, 50, WAR_InfuriateRange,
-                        "Use when gauge is less than or equal to:");
-
-                    break;
-
-                case CustomComboPreset.WAR_ST_Advanced_StormsEye:
+                case CustomComboPreset.WAR_ST_StormsEye:
                     UserConfig.DrawSliderInt(0, 30, WAR_SurgingRefreshRange,
-                        $"Seconds remaining before refreshing {Buffs.SurgingTempest.StatusName()} buff");
-
+                        $" Seconds remaining before refreshing {Buffs.SurgingTempest.StatusName()} buff:");
                     break;
 
-                case CustomComboPreset.WAR_EyePath:
-                    UserConfig.DrawSliderInt(0, 30, WAR_EyePath_Refresh,
-                        $"Seconds remaining before refreshing {Buffs.SurgingTempest.StatusName()} buff");
-
+                case CustomComboPreset.WAR_ST_InnerRelease:
+                    UserConfig.DrawSliderInt(0, 75, WAR_ST_IRStop,
+                        " Stop usage if Target HP% is below set value.\n To disable this, set value to 0");
                     break;
 
-                case CustomComboPreset.WAR_ST_Advanced_Onslaught:
-                    UserConfig.DrawSliderInt(0, 2, WAR_KeepOnslaughtCharges,
-                        "How many charges to keep ready?\n (0 = Use All)");
-
+                case CustomComboPreset.WAR_ST_Onslaught:
+                    UserConfig.DrawHorizontalRadioButton(WAR_ST_Onslaught_Movement,
+                            "Stationary Only", "Uses Onslaught only while stationary", 0);
+                    UserConfig.DrawHorizontalRadioButton(WAR_ST_Onslaught_Movement,
+                            "Any Movement", "Uses Onslaught regardless of any movement conditions.\nNOTE: This could possibly get you killed", 1);
+                    ImGui.Spacing();
+                    UserConfig.DrawSliderInt(0, 2, WAR_ST_Onslaught_Charges,
+                        " How many charges to keep ready?\n (0 = Use All)");
+                    ImGui.SetCursorPosX(48);
+                    UserConfig.DrawSliderFloat(1, 20, WAR_ST_Onslaught_Distance,
+                        " Use when Distance from target is less than or equal to:");
                     break;
 
-                case CustomComboPreset.WAR_ST_Advanced_Infuriate:
-                    UserConfig.DrawSliderInt(0, 2, WAR_KeepInfuriateCharges,
-                        "How many charges to keep ready?\n (0 = Use All)");
-
-                    UserConfig.DrawSliderInt(0, 50, WAR_InfuriateSTGauge,
-                        "Use when gauge is less than or equal to:");
-
+                case CustomComboPreset.WAR_ST_Infuriate:
+                    UserConfig.DrawSliderInt(0, 2, WAR_ST_Infuriate_Charges,
+                        " How many charges to keep ready?\n (0 = Use All)");
+                    UserConfig.DrawSliderInt(0, 50, WAR_ST_Infuriate_Gauge,
+                        " Use when Beast Gauge is less than or equal to:");
                     break;
 
-                case CustomComboPreset.WAR_ST_Advanced_FellCleave:
-                    UserConfig.DrawSliderInt(50, 100, WAR_FellCleaveGauge,
-                        "Minimum gauge required to spend");
-
+                case CustomComboPreset.WAR_ST_FellCleave:
+                    UserConfig.DrawSliderInt(50, 100, WAR_ST_FellCleave_Gauge,
+                        " Minimum Beast Gauge required to spend:");
                     break;
 
-                case CustomComboPreset.WAR_AoE_Advanced_Decimate:
-                    UserConfig.DrawSliderInt(50, 100, WAR_DecimateGauge,
-                        "Minimum gauge required to spend");
+                case CustomComboPreset.WAR_ST_PrimalRend:
+                    UserConfig.DrawHorizontalRadioButton(WAR_ST_PrimalRend_EarlyLate,
+                        "Early", "Uses Primal Rend ASAP", 0);
+                    UserConfig.DrawHorizontalRadioButton(WAR_ST_PrimalRend_EarlyLate,
+                        "Late", "Uses Primal Rend after consumption of all Inner Release stacks", 1);
+                    ImGui.NewLine();
+                    UserConfig.DrawHorizontalRadioButton(WAR_ST_PrimalRend_Movement,
+                        "Stationary Only", "Uses Primal Rend only while stationary", 0);
+                    UserConfig.DrawHorizontalRadioButton(WAR_ST_PrimalRend_Movement,
+                        "Any Movement", "Uses Primal Rend regardless of any movement conditions.\nNOTE: This could possibly get you killed", 1);
+                    ImGui.Spacing();
+                    ImGui.SetCursorPosX(48);
+                    UserConfig.DrawSliderFloat(1, 20, WAR_ST_PrimalRend_Distance,
+                        " Use when Distance from target is less than or equal to:");
+                    break;
+                #endregion
 
+                #region AoE
+                case CustomComboPreset.WAR_AoE_Decimate:
+                    UserConfig.DrawSliderInt(50, 100, WAR_AoE_Decimate_Gauge,
+                        "Minimum gauge required to spend:");
                     break;
 
-                case CustomComboPreset.WAR_AoE_Advanced_Infuriate:
-                    UserConfig.DrawSliderInt(0, 50, WAR_InfuriateAoEGauge,
+                case CustomComboPreset.WAR_AoE_InnerRelease:
+                    UserConfig.DrawSliderInt(0, 75, WAR_AoE_IRStop,
+                        " Stop usage if Target HP% is below set value.\n To disable this, set value to 0");
+                    break;
+
+
+                case CustomComboPreset.WAR_AoE_Infuriate:
+                    UserConfig.DrawSliderInt(0, 2, WAR_AoE_Infuriate_Charges,
+                        " How many charges to keep ready?\n (0 = Use All)");
+                    UserConfig.DrawSliderInt(0, 50, WAR_AoE_Infuriate_Gauge,
                         "Use when gauge is under or equal to");
-
                     break;
-                
-                case CustomComboPreset.WAR_ST_Advanced_Bloodwhetting:
+
+                case CustomComboPreset.WAR_AoE_Onslaught:
+                    UserConfig.DrawHorizontalRadioButton(WAR_AoE_Onslaught_Movement,
+                            "Stationary Only", "Uses Onslaught only while stationary", 0);
+                    UserConfig.DrawHorizontalRadioButton(WAR_AoE_Onslaught_Movement,
+                            "Any Movement", "Uses Onslaught regardless of any movement conditions.\nNOTE: This could possibly get you killed", 1);
+                    ImGui.Spacing();
+                    UserConfig.DrawSliderInt(0, 2, WAR_AoE_Onslaught_Charges,
+                        " How many charges to keep ready?\n (0 = Use All)");
+                    ImGui.SetCursorPosX(48);
+                    UserConfig.DrawSliderFloat(1, 20, WAR_AoE_Onslaught_Distance,
+                        " Use when Distance from target is less than or equal to:");
+                    break;
+
+                case CustomComboPreset.WAR_AoE_PrimalRend:
+                    UserConfig.DrawHorizontalRadioButton(WAR_AoE_PrimalRend_EarlyLate,
+                        "Early", "Uses Primal Rend ASAP", 0);
+                    UserConfig.DrawHorizontalRadioButton(WAR_AoE_PrimalRend_EarlyLate,
+                        "Late", "Uses Primal Rend after consumption of all Inner Release stacks", 1);
+                    ImGui.NewLine();
+                    UserConfig.DrawHorizontalRadioButton(WAR_AoE_PrimalRend_Movement,
+                        "Stationary Only", "Uses Primal Rend only while stationary", 0);
+                    UserConfig.DrawHorizontalRadioButton(WAR_AoE_PrimalRend_Movement,
+                        "Any Movement", "Uses Primal Rend regardless of any movement conditions.\nNOTE: This could possibly get you killed", 1);
+                    ImGui.Spacing();
+                    ImGui.SetCursorPosX(48);
+                    UserConfig.DrawSliderFloat(1, 20, WAR_AoE_PrimalRend_Distance,
+                        " Use when Distance from target is less than or equal to:");
+                    break;
+
+                case CustomComboPreset.WAR_AoE_Orogeny:
+                    UserConfig.DrawHorizontalRadioButton(WAR_AoE_OrogenyUpheaval,
+                        "Include Upheaval", "Enables the use of Upheaval in AoE rotation if Orogeny is unavailable", 0);
+                    UserConfig.DrawHorizontalRadioButton(WAR_AoE_OrogenyUpheaval,
+                        "Exclude Upheaval", "Disables the use of Upheaval in AoE rotation", 1);
+                    break;
+                #endregion
+
+                #region Mitigations
+                case CustomComboPreset.WAR_ST_Bloodwhetting:
                     UserConfig.DrawSliderInt(1, 100, WAR_ST_Bloodwhetting_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
                     UserConfig.DrawHorizontalRadioButton(WAR_ST_Bloodwhetting_SubOption,
-                        "All Enemies",
-                        $"Uses {Bloodwhetting.ActionName()} regardless of targeted enemy type.", 0);
-
+                        "All Enemies", $"Uses {Bloodwhetting.ActionName()} regardless of targeted enemy type", 0);
                     UserConfig.DrawHorizontalRadioButton(WAR_ST_Bloodwhetting_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Bloodwhetting.ActionName()} when the targeted enemy is a boss.", 1);
-
+                        "Bosses Only", $"Only uses {Bloodwhetting.ActionName()} when the targeted enemy is a boss", 1);
                     break;
 
-                case CustomComboPreset.WAR_AoE_Advanced_Bloodwhetting:
+                case CustomComboPreset.WAR_AoE_Bloodwhetting:
                     UserConfig.DrawSliderInt(1, 100, WAR_AoE_Bloodwhetting_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
                     UserConfig.DrawHorizontalRadioButton(WAR_AoE_Bloodwhetting_SubOption,
-                        "All Enemies",
-                        $"Uses {Bloodwhetting.ActionName()} regardless of targeted enemy type.", 0);
-
+                        "All Enemies", $"Uses {Bloodwhetting.ActionName()} regardless of targeted enemy type", 0);
                     UserConfig.DrawHorizontalRadioButton(WAR_AoE_Bloodwhetting_SubOption,
-                        "Bosses Only",
-                       $"Only uses {Bloodwhetting.ActionName()} when the targeted enemy is a boss.", 1);
-
+                        "Bosses Only", $"Only uses {Bloodwhetting.ActionName()} when the targeted enemy is a boss", 1);
                     break;
 
-                case CustomComboPreset.WAR_ST_Advanced_Equilibrium:
+                case CustomComboPreset.WAR_ST_Equilibrium:
                     UserConfig.DrawSliderInt(1, 100, WAR_ST_Equilibrium_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
                     UserConfig.DrawHorizontalRadioButton(WAR_ST_Equilibrium_SubOption,
-                        "All Enemies",
-                        $"Uses {Equilibrium.ActionName()} regardless of targeted enemy type.", 0);
-
+                        "All Enemies", $"Uses {Equilibrium.ActionName()} regardless of targeted enemy type", 0);
                     UserConfig.DrawHorizontalRadioButton(WAR_ST_Equilibrium_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Equilibrium.ActionName()} when the targeted enemy is a boss.", 1);
-
+                        "Bosses Only", $"Only uses {Equilibrium.ActionName()} when the targeted enemy is a boss", 1);
                     break;
 
-                case CustomComboPreset.WAR_AoE_Advanced_Equilibrium:
+                case CustomComboPreset.WAR_AoE_Equilibrium:
                     UserConfig.DrawSliderInt(1, 100, WAR_AoE_Equilibrium_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
                     UserConfig.DrawHorizontalRadioButton(WAR_AoE_Equilibrium_SubOption,
-                        "All Enemies",
-                        $"Uses {Equilibrium.ActionName()} regardless of targeted enemy type.", 0);
-
+                        "All Enemies", $"Uses {Equilibrium.ActionName()} regardless of targeted enemy type", 0);
                     UserConfig.DrawHorizontalRadioButton(WAR_AoE_Equilibrium_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Equilibrium.ActionName()} when the targeted enemy is a boss.", 1);
-
+                        "Bosses Only", $"Only uses {Equilibrium.ActionName()} when the targeted enemy is a boss", 1);
                     break;
 
-                case CustomComboPreset.WAR_ST_Advanced_Rampart:
+                case CustomComboPreset.WAR_ST_Rampart:
                     UserConfig.DrawSliderInt(1, 100, WAR_ST_Rampart_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
                     UserConfig.DrawHorizontalRadioButton(WAR_ST_Rampart_SubOption,
-                        "All Enemies",
-                        $"Uses {Role.Rampart.ActionName()} regardless of targeted enemy type.", 0);
-
+                        "All Enemies", $"Uses {Role.Rampart.ActionName()} regardless of targeted enemy type", 0);
                     UserConfig.DrawHorizontalRadioButton(WAR_ST_Rampart_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Role.Rampart.ActionName()} when the targeted enemy is a boss.", 1);
-
+                        "Bosses Only",  $"Only uses {Role.Rampart.ActionName()} when the targeted enemy is a boss", 1);
                     break;
 
-                case CustomComboPreset.WAR_AoE_Advanced_Rampart:
+                case CustomComboPreset.WAR_AoE_Rampart:
                     UserConfig.DrawSliderInt(1, 100, WAR_AoE_Rampart_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
                     UserConfig.DrawHorizontalRadioButton(WAR_AoE_Rampart_SubOption,
-                        "All Enemies",
-                        $"Uses {Role.Rampart.ActionName()} regardless of targeted enemy type.", 0);
-
+                        "All Enemies", $"Uses {Role.Rampart.ActionName()} regardless of targeted enemy type", 0);
                     UserConfig.DrawHorizontalRadioButton(WAR_AoE_Rampart_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Role.Rampart.ActionName()} when the targeted enemy is a boss.", 1);
-
+                        "Bosses Only", $"Only uses {Role.Rampart.ActionName()} when the targeted enemy is a boss", 1);
                     break;
 
-                case CustomComboPreset.WAR_ST_Advanced_Thrill:
+                case CustomComboPreset.WAR_ST_Thrill:
                     UserConfig.DrawSliderInt(1, 100, WAR_ST_Thrill_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
                     UserConfig.DrawHorizontalRadioButton(WAR_ST_Thrill_SubOption,
-                        "All Enemies",
-                        $"Uses {ThrillOfBattle.ActionName()} regardless of targeted enemy type.", 0);
-
+                        "All Enemies", $"Uses {ThrillOfBattle.ActionName()} regardless of targeted enemy type", 0);
                     UserConfig.DrawHorizontalRadioButton(WAR_ST_Thrill_SubOption,
-                        "Bosses Only",
-                        $"Only uses {ThrillOfBattle.ActionName()} when the targeted enemy is a boss.", 1);
-
+                        "Bosses Only", $"Only uses {ThrillOfBattle.ActionName()} when the targeted enemy is a boss", 1);
                     break;
 
-                case CustomComboPreset.WAR_AoE_Advanced_Thrill:
+                case CustomComboPreset.WAR_AoE_Thrill:
                     UserConfig.DrawSliderInt(1, 100, WAR_AoE_Thrill_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
                     UserConfig.DrawHorizontalRadioButton(WAR_AoE_Thrill_SubOption,
-                        "All Enemies",
-                        $"Uses {ThrillOfBattle.ActionName()} regardless of targeted enemy type.", 0);
-
+                        "All Enemies", $"Uses {ThrillOfBattle.ActionName()} regardless of targeted enemy type", 0);
                     UserConfig.DrawHorizontalRadioButton(WAR_AoE_Thrill_SubOption,
-                        "Bosses Only",
-                        $"Only uses {ThrillOfBattle.ActionName()} when the targeted enemy is a boss.", 1);
-
+                        "Bosses Only", $"Only uses {ThrillOfBattle.ActionName()} when the targeted enemy is a boss", 1);
                     break;
 
-                case CustomComboPreset.WAR_ST_Advanced_Vengeance:
+                case CustomComboPreset.WAR_ST_Vengeance:
                     UserConfig.DrawSliderInt(1, 100, WAR_ST_Vengeance_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
                     UserConfig.DrawHorizontalRadioButton(WAR_ST_Vengeance_SubOption,
-                        "All Enemies",
-                        $"Uses {Vengeance.ActionName()} regardless of targeted enemy type.", 0);
-
+                        "All Enemies", $"Uses {Vengeance.ActionName()} regardless of targeted enemy type", 0);
                     UserConfig.DrawHorizontalRadioButton(WAR_ST_Vengeance_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Vengeance.ActionName()} when the targeted enemy is a boss.", 1);
-
+                        "Bosses Only", $"Only uses {Vengeance.ActionName()} when the targeted enemy is a boss", 1);
                     break;
 
-                case CustomComboPreset.WAR_AoE_Advanced_Vengeance:
+                case CustomComboPreset.WAR_AoE_Vengeance:
                     UserConfig.DrawSliderInt(1, 100, WAR_AoE_Vengeance_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
                     UserConfig.DrawHorizontalRadioButton(WAR_AoE_Vengeance_SubOption,
-                        "All Enemies",
-                        $"Uses {Vengeance.ActionName()} regardless of targeted enemy type.", 0);
-
+                        "All Enemies", $"Uses {Vengeance.ActionName()} regardless of targeted enemy type", 0);
                     UserConfig.DrawHorizontalRadioButton(WAR_AoE_Vengeance_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Vengeance.ActionName()} when the targeted enemy is a boss.", 1);
-
+                        "Bosses Only", $"Only uses {Vengeance.ActionName()} when the targeted enemy is a boss", 1);
                     break;
 
-                case CustomComboPreset.WAR_ST_Advanced_Holmgang:
+                case CustomComboPreset.WAR_ST_Holmgang:
                     UserConfig.DrawSliderInt(1, 100, WAR_ST_Holmgang_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
                     UserConfig.DrawHorizontalRadioButton(WAR_ST_Holmgang_SubOption,
-                        "All Enemies",
-                        $"Uses {Holmgang.ActionName()} regardless of targeted enemy type.", 0);
-
+                        "All Enemies", $"Uses {Holmgang.ActionName()} regardless of targeted enemy type", 0);
                     UserConfig.DrawHorizontalRadioButton(WAR_ST_Holmgang_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Holmgang.ActionName()} when the targeted enemy is a boss.", 1);
-
+                        "Bosses Only", $"Only uses {Holmgang.ActionName()} when the targeted enemy is a boss", 1);
                     break;
 
-                case CustomComboPreset.WAR_AoE_Advanced_Holmgang:
+                case CustomComboPreset.WAR_AoE_Holmgang:
                     UserConfig.DrawSliderInt(1, 100, WAR_AoE_Holmgang_Health,
                         "Player HP% to be \nless than or equal to:", 200);
-
                     UserConfig.DrawHorizontalRadioButton(WAR_AoE_Holmgang_SubOption,
-                        "All Enemies",
-                        $"Uses {Holmgang.ActionName()} regardless of targeted enemy type.", 0);
-
+                        "All Enemies", $"Uses {Holmgang.ActionName()} regardless of targeted enemy type", 0);
                     UserConfig.DrawHorizontalRadioButton(WAR_AoE_Holmgang_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Holmgang.ActionName()} when the targeted enemy is a boss.", 1);
-
+                        "Bosses Only", $"Only uses {Holmgang.ActionName()} when the targeted enemy is a boss", 1);
                     break;
 
-                case CustomComboPreset.WAR_ST_Simple:
-                    UserConfig.DrawHorizontalRadioButton(WAR_ST_MitsOptions,
-                        "Include Mitigations",
-                        "Enables the use of mitigations in Simple Mode.", 0);
-
-                    UserConfig.DrawHorizontalRadioButton(WAR_ST_MitsOptions,
-                        "Exclude Mitigations",
-                        "Disables the use of mitigations in Simple Mode.", 1);
-                    break;
-
-                case CustomComboPreset.WAR_AoE_Simple:
-                    UserConfig.DrawHorizontalRadioButton(WAR_AoE_MitsOptions,
-                        "Include Mitigations",
-                        "Enables the use of mitigations in Simple Mode.", 0);
-
-                    UserConfig.DrawHorizontalRadioButton(WAR_AoE_MitsOptions,
-                        "Exclude Mitigations",
-                        "Disables the use of mitigations in Simple Mode.", 1);
-                    break;
-
-                case CustomComboPreset.WAR_ST_Advanced_Reprisal:
+                case CustomComboPreset.WAR_ST_Reprisal:
                     UserConfig.DrawSliderInt(1, 100, WAR_ST_Reprisal_Health,
                         "Player HP% to be \nless than or equal to:", 200);
                     UserConfig.DrawHorizontalRadioButton(WAR_ST_Reprisal_SubOption,
-                        "All Enemies",
-                        $"Uses {Role.Reprisal.ActionName()} regardless of targeted enemy type.", 0);
+                        "All Enemies", $"Uses {Role.Reprisal.ActionName()} regardless of targeted enemy type", 0);
                     UserConfig.DrawHorizontalRadioButton(WAR_ST_Reprisal_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Role.Reprisal.ActionName()} when the targeted enemy is a boss.", 1);
+                        "Bosses Only", $"Only uses {Role.Reprisal.ActionName()} when the targeted enemy is a boss", 1);
                     break;
 
-                case CustomComboPreset.WAR_AoE_Advanced_Reprisal:
+                case CustomComboPreset.WAR_AoE_Reprisal:
                     UserConfig.DrawSliderInt(1, 100, WAR_AoE_Reprisal_Health,
                         "Player HP% to be \nless than or equal to:", 200);
                     UserConfig.DrawHorizontalRadioButton(WAR_AoE_Reprisal_SubOption,
-                        "All Enemies",
-                        $"Uses {Role.Reprisal.ActionName()} regardless of targeted enemy type.", 0);
+                        "All Enemies", $"Uses {Role.Reprisal.ActionName()} regardless of targeted enemy type", 0);
                     UserConfig.DrawHorizontalRadioButton(WAR_AoE_Reprisal_SubOption,
-                        "Bosses Only",
-                        $"Only uses {Role.Reprisal.ActionName()} when the targeted enemy is a boss.", 1);
+                        "Bosses Only", $"Only uses {Role.Reprisal.ActionName()} when the targeted enemy is a boss", 1);
                     break;               
 
                 #region One-Button Mitigation
 
                 case CustomComboPreset.WAR_Mit_Holmgang_Max:
-                    UserConfig.DrawDifficultyMultiChoice(
-                        WAR_Mit_Holmgang_Difficulty,
-                        WAR_Mit_Holmgang_DifficultyListSet,
-                        "Select what difficulties Holmgang should be used in:"
-                    );
+                    UserConfig.DrawDifficultyMultiChoice(WAR_Mit_Holmgang_Difficulty, WAR_Mit_Holmgang_DifficultyListSet, 
+                        "Select what difficulties Holmgang should be used in:");
 
                     UserConfig.DrawSliderInt(1, 100, WAR_Mit_Holmgang_Health,
-                        "Player HP% to be \nless than or equal to:",
-                        200, SliderIncrements.Fives);
+                        "Player HP% to be \nless than or equal to:", 200, SliderIncrements.Fives);
                     break;
 
                 case CustomComboPreset.WAR_Mit_Bloodwhetting:
                     UserConfig.DrawSliderInt(1, 100, WAR_Mit_Bloodwhetting_Health,
-                        "HP% to use at or below",
-                        sliderIncrement: SliderIncrements.Ones);
+                        "HP% to use at or below", sliderIncrement: SliderIncrements.Ones);
 
-                    UserConfig.DrawPriorityInput(WAR_Mit_Priorities,
-                        numberMitigationOptions, 0,
+                    UserConfig.DrawPriorityInput(WAR_Mit_Priorities, NumMitigationOptions, 0, 
                         "Bloodwhetting Priority:");
                     break;
 
                 case CustomComboPreset.WAR_Mit_Equilibrium:
                     UserConfig.DrawSliderInt(1, 100, WAR_Mit_Equilibrium_Health,
-                        "HP% to use at or below",
-                        sliderIncrement: SliderIncrements.Ones);
+                        "HP% to use at or below", sliderIncrement: SliderIncrements.Ones);
 
-                    UserConfig.DrawPriorityInput(WAR_Mit_Priorities,
-                        numberMitigationOptions, 1,
+                    UserConfig.DrawPriorityInput(WAR_Mit_Priorities, NumMitigationOptions, 1,
                         "Equilibrium Priority:");
                     break;
 
                 case CustomComboPreset.WAR_Mit_Reprisal:
-                    UserConfig.DrawPriorityInput(WAR_Mit_Priorities,
-                        numberMitigationOptions, 2,
+                    UserConfig.DrawPriorityInput(WAR_Mit_Priorities, NumMitigationOptions, 2,
                         "Reprisal Priority:");
                     break;
 
                 case CustomComboPreset.WAR_Mit_ThrillOfBattle:
                     UserConfig.DrawSliderInt(1, 100, WAR_Mit_ThrillOfBattle_Health,
-                        "HP% to use at or below (100 = Disable check)",
-                        sliderIncrement: SliderIncrements.Ones);
+                        "HP% to use at or below (100 = Disable check)", sliderIncrement: SliderIncrements.Ones);
 
-                    UserConfig.DrawPriorityInput(WAR_Mit_Priorities,
-                        numberMitigationOptions, 3,
+                    UserConfig.DrawPriorityInput(WAR_Mit_Priorities, NumMitigationOptions, 3,
                         "Thrill Of Battle Priority:");
                     break;
 
                 case CustomComboPreset.WAR_Mit_Rampart:
                     UserConfig.DrawSliderInt(1, 100, WAR_Mit_Rampart_Health,
-                        "HP% to use at or below (100 = Disable check)",
-                        sliderIncrement: SliderIncrements.Ones);
+                        "HP% to use at or below (100 = Disable check)", sliderIncrement: SliderIncrements.Ones);
 
-                    UserConfig.DrawPriorityInput(WAR_Mit_Priorities,
-                        numberMitigationOptions, 4,
+                    UserConfig.DrawPriorityInput(WAR_Mit_Priorities, NumMitigationOptions, 4,
                         "Rampart Priority:");
                     break;
 
                 case CustomComboPreset.WAR_Mit_ShakeItOff:
                     ImGui.Indent();
-                    UserConfig.DrawHorizontalRadioButton(
-                        WAR_Mit_ShakeItOff_PartyRequirement,
-                        "Require party",
-                        "Will not use Shake It Off unless there are 2 or more party members.",
-                        outputValue: (int) PartyRequirement.Yes);
-                    UserConfig.DrawHorizontalRadioButton(
-                        WAR_Mit_ShakeItOff_PartyRequirement,
-                        "Use Always",
-                        "Will not require a party for Shake It Off.",
-                        outputValue: (int) PartyRequirement.No);
+                    UserConfig.DrawHorizontalRadioButton(WAR_Mit_ShakeItOff_PartyRequirement,
+                        "Require party", "Will not use Shake It Off unless there are 2 or more party members.",
+                        outputValue: (int)PartyRequirement.Yes);
+                    UserConfig.DrawHorizontalRadioButton(WAR_Mit_ShakeItOff_PartyRequirement,
+                        "Use Always", "Will not require a party for Shake It Off.",
+                        outputValue: (int)PartyRequirement.No);
                     ImGui.Unindent();
 
                     ImGui.NewLine();
-                    UserConfig.DrawPriorityInput(WAR_Mit_Priorities,
-                        numberMitigationOptions, 5,
+                    UserConfig.DrawPriorityInput(WAR_Mit_Priorities, NumMitigationOptions, 5,
                         "Shake It Off Priority:");
                     break;
 
                 case CustomComboPreset.WAR_Mit_ArmsLength:
                     ImGui.Indent();
-                    UserConfig.DrawHorizontalRadioButton(
-                        WAR_Mit_ArmsLength_Boss, "All Enemies",
-                        "Will use Arm's Length regardless of the type of enemy.",
-                        outputValue: (int) BossAvoidance.Off, itemWidth: 125f);
-                    UserConfig.DrawHorizontalRadioButton(
-                        WAR_Mit_ArmsLength_Boss, "Avoid Bosses",
-                        "Will try not to use Arm's Length when in a boss fight.",
-                        outputValue: (int) BossAvoidance.On, itemWidth: 125f);
+                    UserConfig.DrawHorizontalRadioButton(WAR_Mit_ArmsLength_Boss, 
+                        "All Enemies", "Will use Arm's Length regardless of the type of enemy.",
+                        outputValue: (int)BossAvoidance.Off, itemWidth: 125f);
+                    UserConfig.DrawHorizontalRadioButton(WAR_Mit_ArmsLength_Boss,
+                        "Avoid Bosses","Will try not to use Arm's Length when in a boss fight.",
+                        outputValue: (int)BossAvoidance.On, itemWidth: 125f);
                     ImGui.Unindent();
-
                     ImGui.NewLine();
                     UserConfig.DrawSliderInt(0, 3, WAR_Mit_ArmsLength_EnemyCount,
                         "How many enemies should be nearby? (0 = No Requirement)");
-
-                    UserConfig.DrawPriorityInput(WAR_Mit_Priorities,
-                        numberMitigationOptions, 6,
-                        "Arm's Length Priority:");
+                    UserConfig.DrawPriorityInput(WAR_Mit_Priorities, NumMitigationOptions, 6, "Arm's Length Priority:");
                     break;
 
                 case CustomComboPreset.WAR_Mit_Vengeance:
                     UserConfig.DrawSliderInt(1, 100, WAR_Mit_Vengeance_Health,
                         "HP% to use at or below (100 = Disable check)",
                         sliderIncrement: SliderIncrements.Ones);
+                    UserConfig.DrawPriorityInput(WAR_Mit_Priorities, NumMitigationOptions, 7, "Vengeance Priority:");
+                    break;
+                #endregion
 
-                    UserConfig.DrawPriorityInput(WAR_Mit_Priorities,
-                        numberMitigationOptions, 7,
-                        "Vengeance Priority:");
+                #endregion
+
+                #region Other
+                case CustomComboPreset.WAR_ST_Simple:
+                    UserConfig.DrawHorizontalRadioButton(WAR_ST_MitsOptions,
+                        "Include Mitigations", "Enables the use of mitigations in Simple Mode.", 0);
+                    UserConfig.DrawHorizontalRadioButton(WAR_ST_MitsOptions,
+                        "Exclude Mitigations", "Disables the use of mitigations in Simple Mode.", 1);
                     break;
 
+                case CustomComboPreset.WAR_AoE_Simple:
+                    UserConfig.DrawHorizontalRadioButton(WAR_AoE_MitsOptions,
+                        "Include Mitigations", "Enables the use of mitigations in Simple Mode.", 0);
+                    UserConfig.DrawHorizontalRadioButton(WAR_AoE_MitsOptions,
+                        "Exclude Mitigations", "Disables the use of mitigations in Simple Mode.", 1);
+                    break;
+
+                case CustomComboPreset.WAR_InfuriateFellCleave:
+                    UserConfig.DrawSliderInt(0, 2, WAR_Infuriate_Charges,
+                        " How many charges to keep ready?\n (0 = Use All)");
+                    UserConfig.DrawSliderInt(0, 50, WAR_Infuriate_Range,
+                        " Use when Beast Gauge is\n less than or equal to:");
+                    break;
+
+                case CustomComboPreset.WAR_EyePath:
+                    UserConfig.DrawSliderInt(0, 30, WAR_EyePath_Refresh,
+                        $" Seconds remaining before refreshing {Buffs.SurgingTempest.StatusName()} buff:");
+                    break;
+
+                case CustomComboPreset.WAR_Variant_Cure:
+                    UserConfig.DrawSliderInt(1, 100, WAR_VariantCure,
+                        " Player HP% to be less than or equal to:", 200);
+                    break;
                     #endregion
             }
         }

--- a/WrathCombo/Combos/PvE/WAR/WAR_Helper.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR_Helper.cs
@@ -1,100 +1,39 @@
-﻿using Dalamud.Game.ClientState.JobGauge.Types;
+﻿#region Dependencies
+using Dalamud.Game.ClientState.JobGauge.Types;
 using System.Collections.Generic;
+using WrathCombo.Combos.PvE.Content;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 using PartyRequirement = WrathCombo.Combos.PvE.All.Enums.PartyRequirement;
+#endregion
 
 namespace WrathCombo.Combos.PvE;
 
-internal partial class WAR
+internal partial class WAR : Tank
 {
-    internal static WAROpenerMaxLevel1 Opener1 = new();
+    #region Variables
     internal static WARGauge Gauge = GetJobGauge<WARGauge>(); //WAR gauge
-    internal static int Beastgauge => Gauge.BeastGauge;
-
-    #region Mitigation Priority
-
-    /// <summary>
-    ///     The list of Mitigations to use in the One-Button Mitigation combo.<br />
-    ///     The order of the list needs to match the order in
-    ///     <see cref="CustomComboPreset" />.
-    /// </summary>
-    /// <value>
-    ///     <c>Action</c> is the action to use.<br />
-    ///     <c>Preset</c> is the preset to check if the action is enabled.<br />
-    ///     <c>Logic</c> is the logic for whether to use the action.
-    /// </value>
-    /// <remarks>
-    ///     Each logic check is already combined with checking if the preset is
-    ///     enabled and if the action is <see cref="ActionReady(uint)">ready</see>
-    ///     and <see cref="LevelChecked(uint)">level-checked</see>.<br />
-    ///     Do not add any of these checks to <c>Logic</c>.
-    /// </remarks>
-    private static (uint Action, CustomComboPreset Preset, System.Func<bool> Logic)[]
-        PrioritizedMitigation =>
-    [
-        //Bloodwhetting
-        (OriginalHook(RawIntuition), CustomComboPreset.WAR_Mit_Bloodwhetting,
-            () => !HasStatusEffect(Buffs.RawIntuition) &&
-                  !HasStatusEffect(Buffs.BloodwhettingDefenseLong) &&
-                  PlayerHealthPercentageHp() <= Config.WAR_Mit_Bloodwhetting_Health),
-        //Equilibrium
-        (Equilibrium, CustomComboPreset.WAR_Mit_Equilibrium,
-            () => PlayerHealthPercentageHp() <= Config.WAR_Mit_Equilibrium_Health),
-        // Reprisal
-        (Role.Reprisal, CustomComboPreset.WAR_Mit_Reprisal,
-            () => Role.CanReprisal(checkTargetForDebuff: false)),
-        //Thrill of Battle
-        (ThrillOfBattle, CustomComboPreset.WAR_Mit_ThrillOfBattle,
-            () => PlayerHealthPercentageHp() <= Config.WAR_Mit_ThrillOfBattle_Health),
-        //Rampart
-        (Role.Rampart, CustomComboPreset.WAR_Mit_Rampart,
-            () => Role.CanRampart(Config.WAR_Mit_Rampart_Health)),
-        //Shake it Off
-        (ShakeItOff, CustomComboPreset.WAR_Mit_ShakeItOff,
-            () => !HasStatusEffect(Buffs.ShakeItOff) &&
-                  Config.WAR_Mit_ShakeItOff_PartyRequirement ==
-                  (int)PartyRequirement.No ||
-                  IsInParty()),
-        //Arm's Length
-        (Role.ArmsLength, CustomComboPreset.WAR_Mit_ArmsLength,
-            () => Role.CanArmsLength(Config.WAR_Mit_ArmsLength_EnemyCount,
-                Config.WAR_Mit_ArmsLength_Boss)),
-        //Vengeance
-        (OriginalHook(Vengeance), CustomComboPreset.WAR_Mit_Vengeance,
-            () => PlayerHealthPercentageHp() <= Config.WAR_Mit_Vengeance_Health)
-    ];
-
-    /// <summary>
-    ///     Given the index of a mitigation in <see cref="PrioritizedMitigation" />,
-    ///     checks if the mitigation is ready and meets the provided requirements.
-    /// </summary>
-    /// <param name="index">
-    ///     The index of the mitigation in <see cref="PrioritizedMitigation" />,
-    ///     which is the order of the mitigation in <see cref="CustomComboPreset" />.
-    /// </param>
-    /// <param name="action">
-    ///     The variable to set to the action to, if the mitigation is set to be
-    ///     used.
-    /// </param>
-    /// <returns>
-    ///     Whether the mitigation is ready, enabled, and passes the provided logic
-    ///     check.
-    /// </returns>
-    private static bool CheckMitigationConfigMeetsRequirements
-        (int index, out uint action)
-    {
-        action = PrioritizedMitigation[index].Action;
-        return ActionReady(action) && LevelChecked(action) &&
-               PrioritizedMitigation[index].Logic() &&
-               IsEnabled(PrioritizedMitigation[index].Preset);
-    }
-
+    internal static int BeastGauge => Gauge.BeastGauge;
+    internal static int MaxDashCharges => TraitLevelChecked(Traits.EnhancedOnslaught) ? 3 : LevelChecked(Onslaught) ? 2 : 0;
+    internal static bool CanInfuriate(int gauge = 50, int charges = 0) => InCombat() && ActionReady(Infuriate) && !HasNC && GetRemainingCharges(Infuriate) > charges && BeastGauge <= gauge;
+    internal static bool CanOnslaught(int charges = 0, float distance = 20, bool movement = true) => ActionReady(Onslaught) && GetRemainingCharges(Onslaught) > charges && GetTargetDistance() <= distance && movement;
+    internal static bool CanPRend(float distance = 20, bool movement = true) => LevelChecked(PrimalRend) && HasStatusEffect(Buffs.PrimalRendReady) && GetTargetDistance() <= distance && movement;
+    internal static bool CanFC(int gauge = 50) => LevelChecked(OriginalHook(InnerBeast)) && (HasIR.Stacks || (BeastGauge >= 50 && ((HasNC && BeastGauge >= gauge && LevelChecked(InnerChaos)) || IR.Cooldown is < 1f or > 40f)) || BeastGauge >= gauge);
+    internal static (float Cooldown, float Status, int Stacks) IR => (GetCooldownRemainingTime(OriginalHook(Berserk)), GetStatusEffectRemainingTime(Buffs.InnerReleaseBuff), GetStatusEffectStacks(Buffs.InnerReleaseStacks));
+    internal static (float Status, int Stacks) BF => (GetStatusEffectRemainingTime(Buffs.BurgeoningFury), GetStatusEffectStacks(Buffs.BurgeoningFury));
+    internal static (bool Status, bool Stacks) HasIR => (IR.Status > 0, IR.Stacks > 0 || HasStatusEffect(Buffs.InnerReleaseStacks));
+    internal static (bool Status, bool Stacks) HasBF => (BF.Status > 0 || HasStatusEffect(Buffs.BurgeoningFury), (BF.Stacks > 0 || HasStatusEffect(Buffs.BurgeoningFury)));
+    internal static bool HasST => !LevelChecked(StormsEye) || HasStatusEffect(Buffs.SurgingTempest);
+    internal static bool HasNC => HasStatusEffect(Buffs.NascentChaos);
+    internal static bool HasWrath => HasStatusEffect(Buffs.Wrathful);
+    internal static bool Minimal => InCombat() && HasBattleTarget();
+    internal static bool MitUsed => JustUsed(OriginalHook(RawIntuition), 4f) || JustUsed(OriginalHook(Vengeance), 5f) || JustUsed(ThrillOfBattle, 5f) || JustUsed(Role.Rampart, 5f) || JustUsed(Holmgang, 9f);
     #endregion
 
     #region Openers
-
+    //TODO: add some stuff similar to GNB
+    internal static WAROpenerMaxLevel1 Opener1 = new();
     internal static WrathOpener Opener()
     {
         if (Opener1.LevelChecked)
@@ -133,118 +72,319 @@ internal partial class WAR
             Infuriate,
             InnerChaos
         ];
-
         public override int MinOpenerLevel => 100;
         public override int MaxOpenerLevel => 109;
-
         internal override UserData ContentCheckConfig => Config.WAR_BalanceOpener_Content;
-
-        public override bool HasCooldowns() =>
-            IsOffCooldown(InnerRelease) &&
-            IsOffCooldown(Upheaval) &&
-            GetRemainingCharges(Infuriate) >= 2 &&
-            GetRemainingCharges(Onslaught) >= 3;
+        public override bool HasCooldowns() => IsOffCooldown(InnerRelease) && IsOffCooldown(Upheaval) && GetRemainingCharges(Infuriate) >= 2 && GetRemainingCharges(Onslaught) >= 3;
     }
 
     #endregion
 
-    #region ID's
+    #region Helpers
+    internal static uint GetVariantAction()
+    {
+        if (Variant.CanCure(CustomComboPreset.WAR_Variant_Cure, Config.WAR_VariantCure))
+            return Variant.Cure;
+        if (Variant.CanSpiritDart(CustomComboPreset.WAR_Variant_SpiritDart) && CanWeave())
+            return Variant.SpiritDart;
+        if (Variant.CanUltimatum(CustomComboPreset.WAR_Variant_Ultimatum) && CanWeave())
+            return Variant.Ultimatum;
 
-    public const byte ClassID = 3; //Marauder (MRD) 
+        return 0; //No conditions met
+    }
+    internal static uint GetBozjaAction()
+    {
+        if (!Bozja.IsInBozja)
+            return 0;
+
+        bool CanUse(uint action) => HasActionEquipped(action) && IsOffCooldown(action);
+        bool IsEnabledAndUsable(CustomComboPreset preset, uint action) => IsEnabled(preset) && CanUse(action);
+
+        //Out-of-Combat
+        if (!InCombat() && IsEnabledAndUsable(CustomComboPreset.WAR_Bozja_LostStealth, Bozja.LostStealth))
+            return Bozja.LostStealth;
+        //OGCDs
+        if (CanWeave())
+        {
+            foreach (var (preset, action) in new[]
+            {
+            (CustomComboPreset.WAR_Bozja_LostFocus, Bozja.LostFocus),
+            (CustomComboPreset.WAR_Bozja_LostFontOfPower, Bozja.LostFontOfPower),
+            (CustomComboPreset.WAR_Bozja_LostSlash, Bozja.LostSlash),
+            (CustomComboPreset.WAR_Bozja_LostFairTrade, Bozja.LostFairTrade),
+            (CustomComboPreset.WAR_Bozja_LostAssassination, Bozja.LostAssassination),
+        })
+                if (IsEnabledAndUsable(preset, action))
+                    return action;
+
+            foreach (var (preset, action, powerPreset) in new[]
+            {
+            (CustomComboPreset.WAR_Bozja_BannerOfNobleEnds, Bozja.BannerOfNobleEnds, CustomComboPreset.WAR_Bozja_PowerEnds),
+            (CustomComboPreset.WAR_Bozja_BannerOfHonoredSacrifice, Bozja.BannerOfHonoredSacrifice, CustomComboPreset.WAR_Bozja_PowerSacrifice)
+        })
+                if (IsEnabledAndUsable(preset, action) && (!IsEnabled(powerPreset) || JustUsed(Bozja.LostFontOfPower, 5f)))
+                    return action;
+
+            if (IsEnabledAndUsable(CustomComboPreset.WAR_Bozja_BannerOfHonedAcuity, Bozja.BannerOfHonedAcuity) &&
+                !HasStatusEffect(Bozja.Buffs.BannerOfTranscendentFinesse))
+                return Bozja.BannerOfHonedAcuity;
+        }
+        //GCDs
+        foreach (var (preset, action, condition) in new[]
+        {
+        (CustomComboPreset.WAR_Bozja_LostDeath, Bozja.LostDeath, true),
+        (CustomComboPreset.WAR_Bozja_LostCure, Bozja.LostCure, PlayerHealthPercentageHp() <= Config.WAR_Bozja_LostCure_Health),
+        (CustomComboPreset.WAR_Bozja_LostArise, Bozja.LostArise, GetTargetHPPercent() == 0 && !HasStatusEffect(RoleActions.Magic.Buffs.Raise)),
+        (CustomComboPreset.WAR_Bozja_LostReraise, Bozja.LostReraise, PlayerHealthPercentageHp() <= Config.WAR_Bozja_LostReraise_Health),
+        (CustomComboPreset.WAR_Bozja_LostProtect, Bozja.LostProtect, !HasStatusEffect(Bozja.Buffs.LostProtect)),
+        (CustomComboPreset.WAR_Bozja_LostShell, Bozja.LostShell, !HasStatusEffect(Bozja.Buffs.LostShell)),
+        (CustomComboPreset.WAR_Bozja_LostBravery, Bozja.LostBravery, !HasStatusEffect(Bozja.Buffs.LostBravery)),
+        (CustomComboPreset.WAR_Bozja_LostBubble, Bozja.LostBubble, !HasStatusEffect(Bozja.Buffs.LostBubble)),
+        (CustomComboPreset.WAR_Bozja_LostParalyze3, Bozja.LostParalyze3, !JustUsed(Bozja.LostParalyze3, 60f))
+        })
+            if (IsEnabledAndUsable(preset, action) && condition)
+                return action;
+        if (IsEnabled(CustomComboPreset.WAR_Bozja_LostSpellforge) &&
+            CanUse(Bozja.LostSpellforge) &&
+            (!HasStatusEffect(Bozja.Buffs.LostSpellforge) || !HasStatusEffect(Bozja.Buffs.LostSteelsting)))
+            return Bozja.LostSpellforge;
+        if (IsEnabled(CustomComboPreset.WAR_Bozja_LostSteelsting) &&
+            CanUse(Bozja.LostSteelsting) &&
+            (!HasStatusEffect(Bozja.Buffs.LostSpellforge) || !HasStatusEffect(Bozja.Buffs.LostSteelsting)))
+            return Bozja.LostSteelsting;
+
+        return 0; //No conditions met
+    }
+    internal static uint OtherAction
+    {
+        get
+        {
+            if (GetVariantAction() is uint va && va != 0)
+                return va;
+            if (Bozja.IsInBozja && GetBozjaAction() is uint ba && ba != 0)
+                return ba;
+            return 0;
+        }
+    }
+    internal static bool ShouldUseOther => OtherAction != 0;
+    #endregion
+
+    #region Rotation
+    internal static bool ShouldUseInnerRelease(int targetHP = 0) => ActionReady(OriginalHook(Berserk)) && !HasWrath && CanWeave() && (HasST || !LevelChecked(StormsEye)) && Minimal && GetTargetHPPercent() >= targetHP;
+    internal static bool ShouldUseInfuriate(int gauge = 40, int charges = 0) => CanInfuriate() && CanWeave() && !HasNC && !HasIR.Stacks && BeastGauge <= gauge && GetRemainingCharges(Infuriate) > charges && Minimal;
+    internal static bool ShouldUseUpheaval => ActionReady(Upheaval) && CanWeave() && HasST && InMeleeRange() && Minimal;
+    internal static bool ShouldUsePrimalWrath => LevelChecked(PrimalWrath) && HasWrath && HasST && GetTargetDistance() <= 4.99f && Minimal;
+    internal static bool ShouldUseOnslaught(int charges = 0, float distance = 20, bool movement = true) => CanOnslaught(charges, distance, movement) && CanWeave() && HasST && (IR.Cooldown > 40 || GetRemainingCharges(Onslaught) == MaxDashCharges);
+    internal static bool ShouldUsePrimalRuination => LevelChecked(PrimalRuination) && HasStatusEffect(Buffs.PrimalRuinationReady) && HasST;
+    internal static bool ShouldUsePrimalRend(float distance = 20, bool movement = true) => CanPRend(distance, movement) && !JustUsed(InnerRelease) && HasST;
+    internal static bool ShouldUseFellCleave(int gauge = 90) => CanFC(gauge) && HasST && InMeleeRange() && Minimal;
+    internal static bool ShouldUseTomahawk => LevelChecked(Tomahawk) && !InMeleeRange() && HasBattleTarget();
+    internal static uint STCombo 
+        => ComboTimer > 0 ? LevelChecked(Maim) && ComboAction == HeavySwing ? Maim
+        : LevelChecked(StormsPath) && ComboAction == Maim
+        ? (LevelChecked(StormsEye) && GetStatusEffectRemainingTime(Buffs.SurgingTempest) <= 29
+        ? StormsEye : StormsPath) : HeavySwing : HeavySwing;
+    internal static uint AOECombo => (ComboTimer > 0 && LevelChecked(MythrilTempest) && ComboAction == Overpower) ? MythrilTempest : Overpower;
+    #endregion
+
+    #region Mitigation Priorities
+    /// <summary>
+    /// The list of Mitigations to use in the One-Button Mitigation combo.<br />
+    /// The order of the list needs to match the order in
+    /// <see cref="CustomComboPreset" />.
+    /// </summary>
+    /// <value>
+    /// <c>Action</c> is the action to use.<br />
+    /// <c>Preset</c> is the preset to check if the action is enabled.<br />
+    /// <c>Logic</c> is the logic for whether to use the action.
+    /// </value>
+    /// <remarks>
+    /// Each logic check is already combined with checking if the preset is
+    /// enabled and if the action is <see cref="ActionReady(uint)">ready</see>
+    /// and <see cref="LevelChecked(uint)">level-checked</see>.<br />
+    /// Do not add any of these checks to <c>Logic</c>.
+    /// </remarks>
+    private static (uint Action, CustomComboPreset Preset, System.Func<bool> Logic)[]
+        PrioritizedMitigation =>
+        [
+            //Bloodwhetting
+            (OriginalHook(RawIntuition), CustomComboPreset.WAR_Mit_Bloodwhetting,
+            () => !HasStatusEffect(Buffs.RawIntuition) && !HasStatusEffect(Buffs.BloodwhettingDefenseLong) && PlayerHealthPercentageHp() <= Config.WAR_Mit_Bloodwhetting_Health),
+            //Equilibrium
+            (Equilibrium, CustomComboPreset.WAR_Mit_Equilibrium,
+            () => PlayerHealthPercentageHp() <= Config.WAR_Mit_Equilibrium_Health),
+            // Reprisal
+            (Role.Reprisal, CustomComboPreset.WAR_Mit_Reprisal,
+            () => Role.CanReprisal(checkTargetForDebuff: false)),
+            //Thrill of Battle
+            (ThrillOfBattle, CustomComboPreset.WAR_Mit_ThrillOfBattle,
+            () => PlayerHealthPercentageHp() <= Config.WAR_Mit_ThrillOfBattle_Health),
+            //Rampart
+            (Role.Rampart, CustomComboPreset.WAR_Mit_Rampart,
+            () => Role.CanRampart(Config.WAR_Mit_Rampart_Health)),
+            //Shake it Off
+            (ShakeItOff, CustomComboPreset.WAR_Mit_ShakeItOff,
+            () => !HasStatusEffect(Buffs.ShakeItOff) && (Config.WAR_Mit_ShakeItOff_PartyRequirement == (int)PartyRequirement.No || IsInParty())),
+            //Arm's Length
+            (Role.ArmsLength, CustomComboPreset.WAR_Mit_ArmsLength,
+            () => Role.CanArmsLength(Config.WAR_Mit_ArmsLength_EnemyCount, Config.WAR_Mit_ArmsLength_Boss)),
+            //Vengeance
+            (OriginalHook(Vengeance), CustomComboPreset.WAR_Mit_Vengeance,
+            () => PlayerHealthPercentageHp() <= Config.WAR_Mit_Vengeance_Health)
+        ];
+
+    /// <summary>
+    /// Given the index of a mitigation in <see cref="PrioritizedMitigation" />,
+    /// checks if the mitigation is ready and meets the provided requirements.
+    /// </summary>
+    /// <param name="index">
+    /// The index of the mitigation in <see cref="PrioritizedMitigation" />,
+    /// which is the order of the mitigation in <see cref="CustomComboPreset" />.
+    /// </param>
+    /// <param name="action">
+    /// The variable to set to the action to, if the mitigation is set to be used.
+    /// </param>
+    /// <returns>
+    /// Whether the mitigation is ready, enabled, and passes the provided logic check.
+    /// </returns>
+    private static bool CheckMitigationConfigMeetsRequirements(int index, out uint action)
+    {
+        action = PrioritizedMitigation[index].Action;
+        return ActionReady(action) && LevelChecked(action) &&
+            PrioritizedMitigation[index].Logic() &&
+            IsEnabled(PrioritizedMitigation[index].Preset);
+    }
+    #endregion
+
+    #region IDs
+
+    public const byte ClassID = 3; //Marauder (MRD)
     public const byte JobID = 21; //Warrior (WAR)
-    public const uint //Actions
+
+    #region Actions
+    public const uint
+
     #region Offensive
-
-        HeavySwing = 31, //Lv1, instant, GCD, range 3, single-target, targets=Hostile
-        Maim = 37, //Lv4, instant, GCD, range 3, single-target, targets=Hostile
-        Berserk = 38, //Lv6, instant, 60.0s CD (group 10), range 0, single-target, targets=Self
-        Overpower = 41, //Lv10, instant, GCD, range 0, AOE 5 circle, targets=Self
-        Tomahawk = 46, //Lv15, instant, GCD, range 20, single-target, targets=Hostile
-        StormsPath = 42, //Lv26, instant, GCD, range 3, single-target, targets=Hostile
-        InnerBeast = 49, //Lv35, instant, GCD, range 3, single-target, targets=Hostile
-        MythrilTempest = 16462, //Lv40, instant, GCD, range 0, AOE 5 circle, targets=Self
-        SteelCyclone = 51, //Lv45, instant, GCD, range 0, AOE 5 circle, targets=Self
-        StormsEye = 45, //Lv50, instant, GCD, range 3, single-target, targets=Hostile
-        Infuriate = 52, //Lv50, instant, 60.0s CD (group 19/70) (2 charges), range 0, single-target, targets=Self
-        FellCleave = 3549, //Lv54, instant, GCD, range 3, single-target, targets=Hostile
-        Decimate = 3550, //Lv60, instant, GCD, range 0, AOE 5 circle, targets=Self
-        Onslaught = 7386, //Lv62, instant, 30.0s CD (group 7/71) (2-3 charges), range 20, single-target, targets=Hostile
-        Upheaval = 7387, //Lv64, instant, 30.0s CD (group 8), range 3, single-target, targets=Hostile
-        InnerRelease = 7389, //Lv70, instant, 60.0s CD (group 11), range 0, single-target, targets=Self
-        ChaoticCyclone = 16463, //Lv72, instant, GCD, range 0, AOE 5 circle, targets=Self
-        InnerChaos = 16465, //Lv80, instant, GCD, range 3, single-target, targets=Hostile
-        Orogeny = 25752, //Lv86, instant, 30.0s CD (group 8), range 0, AOE 5 circle, targets=Self
-        PrimalRend = 25753, //Lv90, instant, GCD, range 20, AOE 5 circle, targets=Hostile, animLock=1.150
-        PrimalWrath = 36924, //Lv96, instant, 1.0s CD (group 0), range 0, AOE 5 circle, targets=Self
-        PrimalRuination = 36925, //Lv100, instant, GCD, range 3, AOE 5 circle, targets=Hostile
-
+    HeavySwing = 31, //Lv1, instant, GCD, range 3, single-target, targets=Hostile
+    Maim = 37, //Lv4, instant, GCD, range 3, single-target, targets=Hostile
+    Berserk = 38, //Lv6, instant, 60.0s CD (group 10), range 0, single-target, targets=Self
+    Overpower = 41, //Lv10, instant, GCD, range 0, AOE 5 circle, targets=Self
+    Tomahawk = 46, //Lv15, instant, GCD, range 20, single-target, targets=Hostile
+    StormsPath = 42, //Lv26, instant, GCD, range 3, single-target, targets=Hostile
+    InnerBeast = 49, //Lv35, instant, GCD, range 3, single-target, targets=Hostile
+    MythrilTempest = 16462, //Lv40, instant, GCD, range 0, AOE 5 circle, targets=Self
+    SteelCyclone = 51, //Lv45, instant, GCD, range 0, AOE 5 circle, targets=Self
+    StormsEye = 45, //Lv50, instant, GCD, range 3, single-target, targets=Hostile
+    Infuriate = 52, //Lv50, instant, 60.0s CD (group 19/70) (2 charges), range 0, single-target, targets=Self
+    FellCleave = 3549, //Lv54, instant, GCD, range 3, single-target, targets=Hostile
+    Decimate = 3550, //Lv60, instant, GCD, range 0, AOE 5 circle, targets=Self
+    Onslaught = 7386, //Lv62, instant, 30.0s CD (group 7/71) (2-3 charges), range 20, single-target, targets=Hostile
+    Upheaval = 7387, //Lv64, instant, 30.0s CD (group 8), range 3, single-target, targets=Hostile
+    InnerRelease = 7389, //Lv70, instant, 60.0s CD (group 11), range 0, single-target, targets=Self
+    ChaoticCyclone = 16463, //Lv72, instant, GCD, range 0, AOE 5 circle, targets=Self
+    InnerChaos = 16465, //Lv80, instant, GCD, range 3, single-target, targets=Hostile
+    Orogeny = 25752, //Lv86, instant, 30.0s CD (group 8), range 0, AOE 5 circle, targets=Self
+    PrimalRend = 25753, //Lv90, instant, GCD, range 20, AOE 5 circle, targets=Hostile, animLock=1.150
+    PrimalWrath = 36924, //Lv96, instant, 1.0s CD (group 0), range 0, AOE 5 circle, targets=Self
+    PrimalRuination = 36925, //Lv100, instant, GCD, range 3, AOE 5 circle, targets=Hostile
     #endregion
+
     #region Defensive
-
-        Defiance = 48, //Lv10, instant, 2.0s CD (group 1), range 0, single-target, targets=Self
-        ReleaseDefiance = 32066, //Lv10, instant, 1.0s CD (group 1), range 0, single-target, targets=Self
-        ThrillOfBattle = 40, //Lv30, instant, 90.0s CD (group 15), range 0, single-target, targets=Self
-        Vengeance = 44, //Lv38, instant, 120.0s CD (group 21), range 0, single-target, targets=Self
-        Holmgang = 43, //Lv42, instant, 240.0s CD (group 24), range 6, single-target, targets=Self/Hostile
-        RawIntuition = 3551, //Lv56, instant, 25.0s CD (group 6), range 0, single-target, targets=Self
-        Equilibrium = 3552, //Lv58, instant, 60.0s CD (group 13), range 0, single-target, targets=Self
-        ShakeItOff = 7388, //Lv68, instant, 90.0s CD (group 14), range 0, AOE 30 circle, targets=Self
-        NascentFlash = 16464, //Lv76, instant, 25.0s CD (group 6), range 30, single-target, targets=Party
-        Bloodwhetting = 25751, //Lv82, instant, 25.0s CD (group 6), range 0, single-target, targets=Self
-        Damnation = 36923, //Lv92, instant, 120.0s CD (group 21), range 0, single-target, targets=Self
-
+    Defiance = 48, //Lv10, instant, 2.0s CD (group 1), range 0, single-target, targets=Self
+    ReleaseDefiance = 32066, //Lv10, instant, 1.0s CD (group 1), range 0, single-target, targets=Self
+    ThrillOfBattle = 40, //Lv30, instant, 90.0s CD (group 15), range 0, single-target, targets=Self
+    Vengeance = 44, //Lv38, instant, 120.0s CD (group 21), range 0, single-target, targets=Self
+    Holmgang = 43, //Lv42, instant, 240.0s CD (group 24), range 6, single-target, targets=Self/Hostile
+    RawIntuition = 3551, //Lv56, instant, 25.0s CD (group 6), range 0, single-target, targets=Self
+    Equilibrium = 3552, //Lv58, instant, 60.0s CD (group 13), range 0, single-target, targets=Self
+    ShakeItOff = 7388, //Lv68, instant, 90.0s CD (group 14), range 0, AOE 30 circle, targets=Self
+    NascentFlash = 16464, //Lv76, instant, 25.0s CD (group 6), range 30, single-target, targets=Party
+    Bloodwhetting = 25751, //Lv82, instant, 25.0s CD (group 6), range 0, single-target, targets=Self
+    Damnation = 36923, //Lv92, instant, 120.0s CD (group 21), range 0, single-target, targets=Self
     #endregion
 
-        //Limit Break
-        LandWaker = 4240; //LB3, instant, range 0, AOE 50 circle, targets=Self, animLock=3.860
+    //Limit Break
+    LandWaker = 4240; //LB3, instant, range 0, AOE 50 circle, targets=Self, animLock=3.860
+    #endregion
 
+    #region Traits
+    public static class Traits
+    {
+        public const ushort
+        None = 0,
+        TankMastery = 318, // L1
+        TheBeastWithin = 249, // L35, gauge generation
+        InnerBeastMastery = 265, // L54, IB->FC upgrade
+        SteelCycloneMastery = 266, // L60, steel cyclone -> decimate upgrade
+        EnhancedInfuriate = 157, // L66, gauge spenders reduce cd by 5
+        BerserkMastery = 218, // L70, berserk -> IR upgrade
+        NascentChaos = 267, // L72, decimate -> chaotic cyclone after infuriate
+        MasteringTheBeast = 268, // L74, mythril tempest gives gauge
+        EnhancedShakeItOff = 417, // L76, adds heal
+        EnhancedThrillOfBattle = 269, // L78, adds incoming heal buff
+        RawIntuitionMastery = 418, // L82, raw intuition -> bloodwhetting
+        EnhancedNascentFlash = 419, // L82, duration increase
+        EnhancedEquilibrium = 420, // L84, adds hot
+        MeleeMastery1 = 505, // L84, potency increase
+        EnhancedOnslaught = 421, // L88, 3rd onslaught charge
+        VengeanceMastery = 567, // L92, vengeance -> damnation
+        EnhancedRampart = 639, // L94, adds incoming heal buff
+        MeleeMastery2 = 654, // L94, potency increase
+        EnhancedInnerRelease = 568, // L96, primal wrath mechanic
+        EnhancedReprisal = 640, // L98, extend duration to 15s
+        EnhancedPrimalRend = 569; // L100, primal ruination mechanic
+    }
+    #endregion
+
+    #region Buffs
     public static class Buffs
     {
         public const ushort
+
         #region Offensive
-
-            SurgingTempest = 2677, //applied by Storm's Eye, Mythril Tempest to self, damage buff
-            NascentChaos = 1897, //applied by Infuriate to self, converts next FC to IC
-            Berserk = 86, //applied by Berserk to self, next 3 GCDs are crit dhit
-            InnerReleaseStacks = 1177, //applied by Inner Release to self, next 3 GCDs should be free FCs
-            InnerReleaseBuff = 1303, //applied by Inner Release to self, 15s buff
-            PrimalRendReady = 2624, //applied by Inner Release to self, allows casting PR
-            InnerStrength = 2663, //applied by Inner Release to self, immunes
-            BurgeoningFury = 3833, //applied by Fell Cleave to self, 3 stacks turns into wrathful
-            Wrathful = 3901, //3rd stack of Burgeoning Fury turns into this, allows Primal Wrath
-            PrimalRuinationReady = 3834, //applied by Primal Rend to self
-
+        SurgingTempest = 2677, //applied by Storm's Eye, Mythril Tempest to self, damage buff
+        NascentChaos = 1897, //applied by Infuriate to self, converts next FC to IC
+        Berserk = 86, //applied by Berserk to self, next 3 GCDs are crit dhit
+        InnerReleaseStacks = 1177, //applied by Inner Release to self, next 3 GCDs should be free FCs
+        InnerReleaseBuff = 1303, //applied by Inner Release to self, 15s buff
+        PrimalRendReady = 2624, //applied by Inner Release to self, allows casting PR
+        InnerStrength = 2663, //applied by Inner Release to self, immunes
+        BurgeoningFury = 3833, //applied by Fell Cleave to self, 3 stacks turns into wrathful
+        Wrathful = 3901, //3rd stack of Burgeoning Fury turns into this, allows Primal Wrath
+        PrimalRuinationReady = 3834, //applied by Primal Rend to self
         #endregion
+
         #region Defensive
-
-            VengeanceRetaliation = 89, //applied by Vengeance to self, retaliation for physical attacks
-            VengeanceDefense = 912, //applied by Vengeance to self, -30% damage taken
-            Damnation = 3832, //applied by Damnation to self, -40% damage taken and retaliation for physical attacks
-            PrimevalImpulse = 3900, //hot applied after hit under Damnation
-            ThrillOfBattle = 87, //applied by Thrill of Battle to self
-            Holmgang = 409, //applied by Holmgang to self
-            EquilibriumRegen = 2681, //applied by Equilibrium to self, hp regen
-            ShakeItOff = 1457, //applied by Shake It Off to self/target, damage shield
-            ShakeItOffHot = 2108, //applied by Shake It Off to self/target
-            RawIntuition = 735, //applied by Raw Intuition to self
-            NascentFlashSelf = 1857, //applied by Nascent Flash to self, heal on hit
-            NascentFlashTarget = 1858, //applied by Nascent Flash to target, -10% damage taken + heal on hit
-            BloodwhettingDefenseLong = 2678, //applied by Bloodwhetting to self, -10% damage taken + heal on hit for 8 sec
-            BloodwhettingDefenseShort = 2679, //applied by Bloodwhetting, Nascent Flash to self/target, -10% damage taken for 4 sec
-            BloodwhettingShield = 2680, //applied by Bloodwhetting, Nascent Flash to self/target, damage shield
-            Defiance = 91, //applied by Defiance to self, tank stance
-            ShieldWall = 194, //applied by Shield Wall to self/target
-            Stronghold = 195, //applied by Stronghold to self/target
-            LandWaker = 863; //applied by Land Waker to self/target
-
+        VengeanceRetaliation = 89, //applied by Vengeance to self, retaliation for physical attacks
+        VengeanceDefense = 912, //applied by Vengeance to self, -30% damage taken
+        Damnation = 3832, //applied by Damnation to self, -40% damage taken and retaliation for physical attacks
+        PrimevalImpulse = 3900, //hot applied after hit under Damnation
+        ThrillOfBattle = 87, //applied by Thrill of Battle to self
+        Holmgang = 409, //applied by Holmgang to self
+        EquilibriumRegen = 2681, //applied by Equilibrium to self, hp regen
+        ShakeItOff = 1457, //applied by Shake It Off to self/target, damage shield
+        ShakeItOffHot = 2108, //applied by Shake It Off to self/target
+        RawIntuition = 735, //applied by Raw Intuition to self
+        NascentFlashSelf = 1857, //applied by Nascent Flash to self, heal on hit
+        NascentFlashTarget = 1858, //applied by Nascent Flash to target, -10% damage taken + heal on hit
+        BloodwhettingDefenseLong = 2678, //applied by Bloodwhetting to self, -10% damage taken + heal on hit for 8 sec
+        BloodwhettingDefenseShort = 2679, //applied by Bloodwhetting, Nascent Flash to self/target, -10% damage taken for 4 sec
+        BloodwhettingShield = 2680, //applied by Bloodwhetting, Nascent Flash to self/target, damage shield
+        Defiance = 91, //applied by Defiance to self, tank stance
+        ShieldWall = 194, //applied by Shield Wall to self/target
+        Stronghold = 195, //applied by Stronghold to self/target
+        LandWaker = 863; //applied by Land Waker to self/target
         #endregion
     }
+    #endregion
 
+    #region Debuffs
     public static class Debuffs
     {
         public const ushort
             Placeholder = 1;
     }
+    #endregion
 
     #endregion
 }


### PR DESCRIPTION
# _GNB_
- [x] Fix issue with `No Mercy` forbidding immediate execution of other OGCDs
- [x] Implement `Reprisal -> Heart of Light Feature` 
- [x] Refactor `Overcap` options for both `Burst Strike` and `Fated Circle` into side-options for both skills
- [x] Refactor `Burst Strike AoE Overcap` option into a side-option for `Fated Circle`
![image](https://github.com/user-attachments/assets/a77f1974-479f-44a5-9276-d3f9f5e498dd)
- [x] Restore `Aurora Protection Feature`
- [x] Clean up menu
- [x] Minor redundancy cleanup

# _WAR_
- [x] Implement `Bozja` options
- These are virtually identical to `GNB`'s options. Nothing special here.
- [x] Implement `Reprisal -> Shake It Off Feature` 
- [x] Add option select for adding `Upheaval` into `Simple / Advanced - AoE` when `Orogeny` is still locked
![image](https://github.com/user-attachments/assets/82cd567b-07fc-4f9c-9b42-0b8958e9ae4c)
- [x] Add new side-options for `Onslaught` & `Primal Rend`
- Both options include adjustable `Distance` & `Movement` thresholds, while `Onslaught` also contains an adjustable `Charges` threshold.
- [x] Refactor `Primal Rend Late Option` into a side-option for `Primal Rend`
![image](https://github.com/user-attachments/assets/020065ae-0c43-40a7-b694-36fc54a082f5)
- [x] Refactor `Equilibrium to Thrill of Battle Feature` to be reversed.
- The feature will now be housed on `Equilibrium` and no longer causes a conflict with `One-Button Mitigation Feature`
![image](https://github.com/user-attachments/assets/ae2d3130-e5fc-4e5c-a8d8-28a0feeabd84)
- [x] Clean up menu
- [x] Heavily clean up code
