### PR TITLE
[BRD] Update to nowaste Handler

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -771,6 +771,10 @@ public enum CustomComboPreset
     BRD_ST_Adv_Balance_Standard = 3048,
 
     [ParentCombo(BRD_ST_AdvMode)]
+    [CustomComboInfo("Bard Songs Option", "This option adds the Bard's Songs to the Advanced Bard Feature.", BRD.JobID)]
+    BRD_Adv_Song = 3011,
+
+    [ParentCombo(BRD_ST_AdvMode)]
     [CustomComboInfo("Bard DoTs Option", "Enables the use of dot sub options below",
        BRD.JobID)]
     BRD_Adv_DoT = 3010,
@@ -788,10 +792,6 @@ public enum CustomComboPreset
     [CustomComboInfo("Raging Jaws Option",
         "Enable the snapshotting of DoTs, within the remaining time of Raging Strikes below:", BRD.JobID)]
     BRD_Adv_RagingJaws = 3025,
-
-    [ParentCombo(BRD_ST_AdvMode)]
-    [CustomComboInfo("Bard Songs Option", "This option adds the Bard's Songs to the Advanced Bard Feature.", BRD.JobID)]
-    BRD_Adv_Song = 3011,
 
     [ParentCombo(BRD_ST_AdvMode)]
     [CustomComboInfo("Buffs Option", "Adds buffs onto the Advanced Bard feature. \nEnable all to follow balance buff windows \nDisabling any buff will follow simple priority", BRD.JobID)]
@@ -841,12 +841,6 @@ public enum CustomComboPreset
     [ParentCombo(BRD_ST_AdvMode)]
     [CustomComboInfo("Interrupt Option", "Uses interrupt during the rotation if applicable.", BRD.JobID)]
     BRD_Adv_Interrupt = 3020,
-
-    [ParentCombo(BRD_ST_AdvMode)]
-    [CustomComboInfo("No Waste Option",
-        "Adds enemy health checking on mobs for buffs, DoTs and Songs.\nThey will not be reapplied if less than specified.",
-        BRD.JobID)]
-    BRD_Adv_NoWaste = 3019,
 
     [ParentCombo(BRD_ST_AdvMode)]
     [CustomComboInfo("Second Wind Option", "Uses Second Wind when below set HP percentage.", BRD.JobID)]
@@ -916,12 +910,6 @@ public enum CustomComboPreset
     [ParentCombo(BRD_AoE_AdvMode)]
     [CustomComboInfo("Apex Arrow Option", "Adds Apex Arrow and Blast shot", BRD.JobID)]
     BRD_AoE_ApexArrow = 3039,
-
-    [ParentCombo(BRD_AoE_AdvMode)]
-    [CustomComboInfo("AoE No Waste Option",
-        "Adds enemy health checking on targetted mob for songs.\nThey will not be reapplied if less than specified.",
-        BRD.JobID)]
-    BRD_AoE_Adv_NoWaste = 3033,
 
     [ParentCombo(BRD_AoE_AdvMode)]
     [CustomComboInfo("Second Wind Option", "Uses Second Wind when below set HP percentage.", BRD.JobID)]

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -1,6 +1,7 @@
 using Dalamud.Game.ClientState.JobGauge.Enums;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Data;
+using static WrathCombo.Combos.PvE.BRD.Config;
 namespace WrathCombo.Combos.PvE;
 
 internal partial class BRD : PhysicalRanged
@@ -252,9 +253,6 @@ internal partial class BRD : PhysicalRanged
                 return actionID;
 
             #region Variables
-
-            int targetHPThreshold = Config.BRD_AoENoWasteHPPercentage;
-            bool isEnemyHealthHigh = !IsEnabled(CustomComboPreset.BRD_AoE_Adv_NoWaste) || GetTargetHPPercent() > targetHPThreshold;
             bool ragingEnabled = IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs_Raging);
             bool battleVoiceEnabled = IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs_Battlevoice);
             bool barrageEnabled = IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs_Barrage);
@@ -274,7 +272,7 @@ internal partial class BRD : PhysicalRanged
 
             #region Songs
 
-            if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Songs) && isEnemyHealthHigh && InCombat() && (CanBardWeave || !BardHasTarget))
+            if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Songs) && InCombat() && (CanBardWeave || !BardHasTarget))
             {
                 if (SongChangePitchPerfect())
                     return PitchPerfect;
@@ -296,7 +294,8 @@ internal partial class BRD : PhysicalRanged
 
             #region Buffs
 
-            if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs) && CanBardWeave && isEnemyHealthHigh)
+            if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs) && CanBardWeave && (GetTargetHPPercent() > BRD_AoE_Adv_Buffs_Threshold) &&
+                (BRD_AoE_Adv_Buffs_SubOption == 0 || BRD_AoE_Adv_Buffs_SubOption == 1 && InBossEncounter()))
             {
                 if (allBuffsEnabled && !SongNone && LevelChecked(MagesBallad))
                 {
@@ -415,9 +414,7 @@ internal partial class BRD : PhysicalRanged
                 return actionID;
 
             #region Variables
-            int targetHPThreshold = Config.BRD_NoWasteHPPercentage;
             int ragingJawsRenewTime = Config.BRD_RagingJawsRenewTime;
-            bool isEnemyHealthHigh = !IsEnabled(CustomComboPreset.BRD_Adv_NoWaste) || GetTargetHPPercent() > targetHPThreshold;
             bool ragingEnabled = IsEnabled(CustomComboPreset.BRD_Adv_Buffs_Raging);
             bool battleVoiceEnabled = IsEnabled(CustomComboPreset.BRD_Adv_Buffs_Battlevoice);
             bool barrageEnabled = IsEnabled(CustomComboPreset.BRD_Adv_Buffs_Barrage);
@@ -455,7 +452,7 @@ internal partial class BRD : PhysicalRanged
 
             #region Songs
 
-            if (IsEnabled(CustomComboPreset.BRD_Adv_Song) && isEnemyHealthHigh && InCombat())
+            if (IsEnabled(CustomComboPreset.BRD_Adv_Song) && InCombat())
             {
                 if (SongChangePitchPerfect())
                     return PitchPerfect;
@@ -478,7 +475,8 @@ internal partial class BRD : PhysicalRanged
 
             #region Buffs
 
-            if (IsEnabled(CustomComboPreset.BRD_Adv_Buffs) && CanBardWeave && isEnemyHealthHigh)
+            if (IsEnabled(CustomComboPreset.BRD_Adv_Buffs) && CanBardWeave && (GetTargetHPPercent() > BRD_Adv_Buffs_Threshold) &&
+                (BRD_Adv_Buffs_SubOption == 0 || BRD_Adv_Buffs_SubOption == 1 && InBossEncounter()))
             {
                 if (allBuffsEnabled && !SongNone && LevelChecked(MagesBallad))
                 {                    
@@ -552,25 +550,24 @@ internal partial class BRD : PhysicalRanged
 
             #region Dot Management
 
-            if (isEnemyHealthHigh)
+            if (IsEnabled(CustomComboPreset.BRD_Adv_DoT) && (GetTargetHPPercent() > BRD_Adv_DoT_Threshold) &&
+                (BRD_Adv_DoT_SubOption == 0 || BRD_Adv_DoT_SubOption == 1 && InBossEncounter()))
             {
-                if (IsEnabled(CustomComboPreset.BRD_Adv_DoT))
+                if (IsEnabled(CustomComboPreset.BRD_Adv_IronJaws) && UseIronJaws())
+                    return IronJaws;
+
+                if (IsEnabled(CustomComboPreset.BRD_Adv_ApplyDots))
                 {
-                    if (IsEnabled(CustomComboPreset.BRD_Adv_IronJaws) && UseIronJaws())
-                        return IronJaws;
+                    if (ApplyBlueDot())
+                        return OriginalHook(Windbite);
 
-                    if (IsEnabled(CustomComboPreset.BRD_Adv_ApplyDots))
-                    {
-                        if (ApplyBlueDot())
-                            return OriginalHook(Windbite);
-
-                        if (ApplyPurpleDot())
-                            return OriginalHook(VenomousBite);
-                    }   
-                    if (IsEnabled(CustomComboPreset.BRD_Adv_RagingJaws) && RagingJawsRefresh() && RagingStrikesDuration < ragingJawsRenewTime)
-                        return IronJaws;
-                }
+                    if (ApplyPurpleDot())
+                        return OriginalHook(VenomousBite);
+                }   
+                if (IsEnabled(CustomComboPreset.BRD_Adv_RagingJaws) && RagingJawsRefresh() && RagingStrikesDuration < ragingJawsRenewTime)
+                    return IronJaws;
             }
+            
 
             #endregion
 

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -258,6 +258,8 @@ internal partial class BRD : PhysicalRanged
             bool barrageEnabled = IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs_Barrage);
             bool radiantEnabled = IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs_RadiantFinale);
             bool allBuffsEnabled = radiantEnabled && battleVoiceEnabled && ragingEnabled && barrageEnabled;
+            int buffThreshold = BRD_AoE_Adv_Buffs_SubOption == 1 || !InBossEncounter() ? BRD_AoE_Adv_Buffs_Threshold : 0;
+
             #endregion
 
             #region Variants
@@ -294,8 +296,7 @@ internal partial class BRD : PhysicalRanged
 
             #region Buffs
 
-            if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs) && CanBardWeave && (GetTargetHPPercent() > BRD_AoE_Adv_Buffs_Threshold) &&
-                (BRD_AoE_Adv_Buffs_SubOption == 0 || BRD_AoE_Adv_Buffs_SubOption == 1 && InBossEncounter()))
+            if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs) && CanBardWeave && GetTargetHPPercent() > buffThreshold)
             {
                 if (allBuffsEnabled && !SongNone && LevelChecked(MagesBallad))
                 {
@@ -420,6 +421,9 @@ internal partial class BRD : PhysicalRanged
             bool barrageEnabled = IsEnabled(CustomComboPreset.BRD_Adv_Buffs_Barrage);
             bool radiantEnabled = IsEnabled(CustomComboPreset.BRD_Adv_Buffs_RadiantFinale);
             bool allBuffsEnabled = radiantEnabled && battleVoiceEnabled && ragingEnabled && barrageEnabled;
+            int dotThreshold = BRD_Adv_DoT_SubOption == 1 || !InBossEncounter() ? BRD_Adv_DoT_Threshold : 0;
+            int buffThreshold = BRD_Adv_Buffs_SubOption == 1 || !InBossEncounter() ? BRD_Adv_Buffs_Threshold : 0;
+
             #endregion
 
             #region Variants
@@ -475,8 +479,7 @@ internal partial class BRD : PhysicalRanged
 
             #region Buffs
 
-            if (IsEnabled(CustomComboPreset.BRD_Adv_Buffs) && CanBardWeave && (GetTargetHPPercent() > BRD_Adv_Buffs_Threshold) &&
-                (BRD_Adv_Buffs_SubOption == 0 || BRD_Adv_Buffs_SubOption == 1 && InBossEncounter()))
+            if (IsEnabled(CustomComboPreset.BRD_Adv_Buffs) && CanBardWeave && GetTargetHPPercent() > buffThreshold)
             {
                 if (allBuffsEnabled && !SongNone && LevelChecked(MagesBallad))
                 {                    
@@ -550,8 +553,7 @@ internal partial class BRD : PhysicalRanged
 
             #region Dot Management
 
-            if (IsEnabled(CustomComboPreset.BRD_Adv_DoT) && (GetTargetHPPercent() > BRD_Adv_DoT_Threshold) &&
-                (BRD_Adv_DoT_SubOption == 0 || BRD_Adv_DoT_SubOption == 1 && InBossEncounter()))
+            if (IsEnabled(CustomComboPreset.BRD_Adv_DoT) && GetTargetHPPercent() > dotThreshold)
             {
                 if (IsEnabled(CustomComboPreset.BRD_Adv_IronJaws) && UseIronJaws())
                     return IronJaws;

--- a/WrathCombo/Combos/PvE/BRD/BRD_Config.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Config.cs
@@ -9,14 +9,18 @@ internal partial class BRD
     internal static class Config
     {
         public static UserInt
-            BRD_RagingJawsRenewTime = new("ragingJawsRenewTime"),
-            BRD_NoWasteHPPercentage = new("noWasteHpPercentage"),
-            BRD_AoENoWasteHPPercentage = new("AoENoWasteHpPercentage"),
+            BRD_RagingJawsRenewTime = new("ragingJawsRenewTime"),            
             BRD_STSecondWindThreshold = new("BRD_STSecondWindThreshold"),
             BRD_AoESecondWindThreshold = new("BRD_AoESecondWindThreshold"),
             BRD_VariantCure = new("BRD_VariantCure"),
             BRD_Adv_Opener_Selection = new("BRD_Adv_Opener_Selection", 0),
-            BRD_Balance_Content = new("BRD_Balance_Content", 1);
+            BRD_Balance_Content = new("BRD_Balance_Content", 1),
+            BRD_Adv_DoT_Threshold = new("BRD_Adv_DoT_Threshold", 1),
+            BRD_Adv_DoT_SubOption = new("BRD_Adv_DoT_SubOption", 1),
+            BRD_Adv_Buffs_Threshold = new ("BRD_Adv_Buffs_Threshold", 1),
+            BRD_Adv_Buffs_SubOption = new ("BRD_Adv_Buffs_SubOption", 1),
+            BRD_AoE_Adv_Buffs_Threshold = new("BRD_AoE_Adv_Buffs_Threshold", 1),
+            BRD_AoE_Adv_Buffs_SubOption = new("BRD_AoE_Adv_Buffs_SubOption", 1);
 
         internal static void Draw(CustomComboPreset preset)
         {
@@ -38,14 +42,40 @@ internal partial class BRD
 
                     break;
 
-                case CustomComboPreset.BRD_Adv_NoWaste:
-                    DrawSliderInt(1, 10, BRD_NoWasteHPPercentage, "Remaining target HP percentage");
+
+                case CustomComboPreset.BRD_Adv_DoT:
+                    DrawHorizontalRadioButton(BRD_Adv_DoT_SubOption,
+                        "All content", $"Uses Dots regardless of content.", 0);
+
+                    DrawHorizontalRadioButton(BRD_Adv_DoT_SubOption,
+                        "Boss encounters Only", $"Only uses Dots when in Boss encounters.", 1);
+
+                    DrawSliderInt(0, 10, BRD_Adv_DoT_Threshold,
+                        $"Stop using Dots on targets below this HP % (0% = always use).");
 
                     break;
 
-                case CustomComboPreset.BRD_AoE_Adv_NoWaste:
-                    DrawSliderInt(1, 50, BRD_AoENoWasteHPPercentage,
-                        "Remaining target HP percentage");
+                case CustomComboPreset.BRD_Adv_Buffs:
+                    DrawHorizontalRadioButton(BRD_Adv_Buffs_SubOption,
+                        "All content", $"Uses Buffs regardless of content.", 0);
+
+                    DrawHorizontalRadioButton(BRD_Adv_Buffs_SubOption,
+                        "Boss encounters Only", $"Only uses Buffs when in Boss encounters.", 1);
+
+                    DrawSliderInt(0, 10, BRD_Adv_Buffs_Threshold,
+                        $"Stop using Buffs on targets below this HP % (0% = always use).");
+
+                    break;
+
+                case CustomComboPreset.BRD_AoE_Adv_Buffs:
+                    DrawHorizontalRadioButton(BRD_AoE_Adv_Buffs_SubOption,
+                        "All content", $"Uses Buffs regardless of content.", 0);
+
+                    DrawHorizontalRadioButton(BRD_AoE_Adv_Buffs_SubOption,
+                        "Boss encounters Only", $"Only uses Buffs when in Boss encounters.", 1);
+
+                    DrawSliderInt(0, 50, BRD_AoE_Adv_Buffs_Threshold,
+                        $"Stop using Buffs on targets below this HP % (0% = always use).");
 
                     break;
 

--- a/WrathCombo/Combos/PvE/BRD/BRD_Config.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Config.cs
@@ -1,3 +1,4 @@
+using Dalamud.Interface.Colors;
 using ImGuiNET;
 using WrathCombo.CustomComboNS.Functions;
 using static WrathCombo.Window.Functions.UserConfig;
@@ -44,38 +45,59 @@ internal partial class BRD
 
 
                 case CustomComboPreset.BRD_Adv_DoT:
-                    DrawHorizontalRadioButton(BRD_Adv_DoT_SubOption,
-                        "All content", $"Uses Dots regardless of content.", 0);
+
+                    DrawSliderInt(0, 100, BRD_Adv_DoT_Threshold,
+                        $"Stop using Dots on targets below this HP % (0% = always use, 100% = never use).");
+
+                    ImGui.Indent();
+
+                    ImGui.TextColored(ImGuiColors.DalamudYellow, "Select what kind of enemies the HP check should be applied to:");
 
                     DrawHorizontalRadioButton(BRD_Adv_DoT_SubOption,
-                        "Boss encounters Only", $"Only uses Dots when in Boss encounters.", 1);
+                        "Non-boss Encounters Only", $"Applies HP check to Non-Boss Encounters only", 0);
 
-                    DrawSliderInt(0, 10, BRD_Adv_DoT_Threshold,
-                        $"Stop using Dots on targets below this HP % (0% = always use).");
+                    DrawHorizontalRadioButton(BRD_Adv_DoT_SubOption,
+                        "All Content", $"Applies HP Check to All Content", 1);
+
+                    ImGui.Unindent();
 
                     break;
 
                 case CustomComboPreset.BRD_Adv_Buffs:
-                    DrawHorizontalRadioButton(BRD_Adv_Buffs_SubOption,
-                        "All content", $"Uses Buffs regardless of content.", 0);
+
+                    DrawSliderInt(0, 100, BRD_Adv_Buffs_Threshold,
+                       $"Stop using Buffs on targets below this HP % (0% = always use, 100% = never use).");
+
+                    ImGui.Indent();
+
+                    ImGui.TextColored(ImGuiColors.DalamudYellow, "Select what kind of enemies the HP check should be applied to:");
 
                     DrawHorizontalRadioButton(BRD_Adv_Buffs_SubOption,
-                        "Boss encounters Only", $"Only uses Buffs when in Boss encounters.", 1);
+                        "Non-boss Encounters Only", $"Applies HP check to Non-Boss Encounters only", 0);
 
-                    DrawSliderInt(0, 10, BRD_Adv_Buffs_Threshold,
-                        $"Stop using Buffs on targets below this HP % (0% = always use).");
+                    DrawHorizontalRadioButton(BRD_Adv_Buffs_SubOption,
+                        "All Content", $"Applies HP Check to All Content", 1);
+
+                    ImGui.Unindent();
 
                     break;
 
                 case CustomComboPreset.BRD_AoE_Adv_Buffs:
-                    DrawHorizontalRadioButton(BRD_AoE_Adv_Buffs_SubOption,
-                        "All content", $"Uses Buffs regardless of content.", 0);
+
+                    DrawSliderInt(0, 100, BRD_AoE_Adv_Buffs_Threshold,
+                        $"Stop using Buffs on targets below this HP % (0% = always use, 100% = never use).");
+
+                    ImGui.Indent();
+
+                    ImGui.TextColored(ImGuiColors.DalamudYellow, "Select what kind of enemies the HP check should be applied to:");
 
                     DrawHorizontalRadioButton(BRD_AoE_Adv_Buffs_SubOption,
-                        "Boss encounters Only", $"Only uses Buffs when in Boss encounters.", 1);
+                        "Non-boss Encounters Only", $"Applies HP check to Non-Boss Encounters only", 0);
 
-                    DrawSliderInt(0, 50, BRD_AoE_Adv_Buffs_Threshold,
-                        $"Stop using Buffs on targets below this HP % (0% = always use).");
+                    DrawHorizontalRadioButton(BRD_AoE_Adv_Buffs_SubOption,
+                        "All Content", $"Applies HP Check to All Content", 1);
+
+                    ImGui.Unindent();
 
                     break;
 


### PR DESCRIPTION
- [x] Added all content vs Non Bosses Radial to ST buffs, ST dots, and AoE buffs
- [x] Added health threshold to the same. Up to 100% for trash disabling
- [x] Removed health threshold from songs as they were written to be target neutral months ago
- [x] Removed no waste option from CCP as it is now baked into the buffs and dots options
![image](https://github.com/user-attachments/assets/b1f98cd4-a590-4455-9ca5-35d1e0e29eb0)

