### PR TITLE
[Tanks] Add Single Target Stun

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1544,6 +1544,10 @@ public enum CustomComboPreset
     DRK_ST_CD_Interrupt = 5014,
 
     [ParentCombo(DRK_ST_CDs)]
+    [CustomComboInfo("Interrupt with Stun Option", "Adds Low Blow to the rotation when your target is casting.\nNot advised outside of overworld content, as it can waste a lot of Low Blows on un-stun-able enemies, etc. Will try to not use it in boss fights.", DRK.JobID)]
+    DRK_ST_CD_Stun = 5040,
+
+    [ParentCombo(DRK_ST_CDs)]
     [CustomComboInfo("Delirium on Cooldown",
         "Adds Delirium (or Blood Weapon at lower levels) to the rotation on cooldown and when Darkside is up.\n Will also spend 50 blood gauge if Delirium is nearly ready to protect from overcap.",
         DRK.JobID)]
@@ -1678,7 +1682,7 @@ public enum CustomComboPreset
     #endregion
 
     #endregion
-    // Last value = 5039
+    // Last value = 5040
 
     #region Advanced Multi Target Combo
 
@@ -1701,7 +1705,7 @@ public enum CustomComboPreset
     DRK_AoE_Interrupt = 5052,
 
     [ParentCombo(DRK_AoE_CDs)]
-    [CustomComboInfo("Interrupt with Stun Option", "Adds Low Blow to the rotation when your target's cast is interruptible.", DRK.JobID)]
+    [CustomComboInfo("Interrupt with Stun Option", "Adds Low Blow to the rotation when your target is casting.", DRK.JobID)]
     DRK_AoE_Stun = 5053,
 
     [ParentCombo(DRK_AoE_CDs)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -2256,6 +2256,10 @@ public enum CustomComboPreset
     [CustomComboInfo("Interrupt Option", "Adds Interject to the rotation when your target's cast is interruptible.", GNB.JobID)]
     GNB_ST_Interrupt = 7084,
 
+    [ParentCombo(GNB_ST_Advanced)]
+    [CustomComboInfo("Interrupt with Stun Option", "Adds Low Blow to the rotation when your target is casting.\nNot advised outside of overworld content, as it can waste a lot of Low Blows on un-stun-able enemies, etc. Will try to not use it in boss fights.", GNB.JobID)]
+    GNB_ST_Stun = 7085,
+
     #region Cooldowns
 
     [ParentCombo(GNB_ST_Advanced)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -2286,7 +2286,7 @@ public enum CustomComboPreset
 
     [ParentCombo(GNB_ST_Advanced)]
     [CustomComboInfo("Interrupt with Stun Option", "Adds Low Blow to the rotation when your target is casting.\nNot advised outside of overworld content, as it can waste a lot of Low Blows on un-stun-able enemies, etc. Will try to not use it in boss fights.", GNB.JobID)]
-    GNB_ST_Stun = 7085,
+    GNB_ST_Stun = 7086,
 
     #region Mitigations
 
@@ -2798,7 +2798,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last Value = 7085
+    // Last Value = 7086
     #endregion
 
     #region MACHINIST

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -3964,6 +3964,10 @@ public enum CustomComboPreset
     PLD_ST_Interrupt = 11058,
 
     [ParentCombo(PLD_ST_AdvancedMode)]
+    [CustomComboInfo("Interrupt with Stun Option", "Adds Low Blow to the rotation when your target is casting.\nNot advised outside of overworld content, as it can waste a lot of Low Blows on un-stun-able enemies, etc. Will try to not use it in boss fights.", PLD.JobID)]
+    PLD_ST_Stun = 11062,
+
+    [ParentCombo(PLD_ST_AdvancedMode)]
     [CustomComboInfo("Fight or Flight Option",
         "Adds Fight or Flight to Advanced Mode.\n- Uses after Royal Authority during opener.\n- Afterward, on cooldown alongside Requiescat.\n- Target HP must be at or above:",
         PLD.JobID)]
@@ -4257,7 +4261,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    //// Last value = 11061
+    //// Last value = 11062
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6220,6 +6220,10 @@ SMN.JobID)]
     WAR_ST_Interrupt = 18066,
 
     [ParentCombo(WAR_ST_Advanced)]
+    [CustomComboInfo("Interrupt with Stun Option", "Adds Low Blow to the rotation when your target is casting.\nNot advised outside of overworld content, as it can waste a lot of Low Blows on un-stun-able enemies, etc. Will try to not use it in boss fights.", WAR.JobID)]
+    WAR_ST_Stun = 18071,
+
+    [ParentCombo(WAR_ST_Advanced)]
     [CustomComboInfo("Storm's Eye Option", "Adds Storms Eye into the rotation.", WAR.JobID)]
     WAR_ST_Advanced_StormsEye = 18005,
 
@@ -6514,7 +6518,7 @@ SMN.JobID)]
 
     #endregion
 
-    // Last value = 18070
+    // Last value = 18071
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
@@ -374,10 +374,10 @@ internal partial class DRK
             if ((flags.HasFlag(Combo.Simple) ||
                  IsSTEnabled(flags, Preset.DRK_ST_CD_Stun) ||
                  IsAoEEnabled(flags, Preset.DRK_AoE_Stun)) &&
-                !InBossEncounter() &&
                 !TargetIsBoss() &&
                 !JustUsed(Role.Interject) &&
-                Role.CanLowBlow())
+                Role.CanLowBlow() &&
+                !InBossEncounter())
                 return (action = Role.LowBlow) != 0;
 
             #endregion

--- a/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
@@ -371,9 +371,12 @@ internal partial class DRK
                 Role.CanInterject())
                 return (action = Role.Interject) != 0;
 
-            if (flags.HasFlag(Combo.AoE) &&
-                (flags.HasFlag(Combo.Simple) ||
-                 IsEnabled(Preset.DRK_AoE_Stun)) &&
+            if ((flags.HasFlag(Combo.Simple) ||
+                 IsSTEnabled(flags, Preset.DRK_ST_CD_Stun) ||
+                 IsAoEEnabled(flags, Preset.DRK_AoE_Stun)) &&
+                !InBossEncounter() &&
+                !TargetIsBoss() &&
+                !JustUsed(Role.Interject) &&
                 Role.CanLowBlow())
                 return (action = Role.LowBlow) != 0;
 

--- a/WrathCombo/Combos/PvE/GNB/GNB.cs
+++ b/WrathCombo/Combos/PvE/GNB/GNB.cs
@@ -57,9 +57,20 @@ internal partial class GNB : Tank
                     return bozjaAction;
             }
 
+            #region Stuns
+
             //Interject
             if (Role.CanInterject())
                 return Role.Interject;
+
+            // Stun
+            if (!TargetIsBoss()
+                && Role.CanLowBlow()
+                && !JustUsed(Role.Interject)
+                && !InBossEncounter())
+                return Role.LowBlow;
+
+            #endregion
 
             #region Mitigations
 
@@ -185,9 +196,21 @@ internal partial class GNB : Tank
                     return bozjaAction;
             }
 
+            #region Stuns
+
             //Interject
             if (IsEnabled(CustomComboPreset.GNB_ST_Interrupt) && Role.CanInterject())
                 return Role.Interject;
+
+            // Stun
+            if (IsEnabled(CustomComboPreset.GNB_ST_Stun)
+                && !TargetIsBoss()
+                && Role.CanLowBlow()
+                && !JustUsed(Role.Interject)
+                && !InBossEncounter())
+                return Role.LowBlow;
+
+            #endregion
 
             #region Mitigations
 
@@ -343,7 +366,7 @@ internal partial class GNB : Tank
 
             if (Role.CanInterject())
                 return Role.Interject;
-            if (Role.CanLowBlow())
+            if (Role.CanLowBlow() && !JustUsed(Role.Interject))
                 return Role.LowBlow;
 
             #endregion
@@ -460,7 +483,7 @@ internal partial class GNB : Tank
 
             if (IsEnabled(CustomComboPreset.GNB_AoE_Interrupt) && Role.CanInterject())
                 return Role.Interject;
-            if (IsEnabled(CustomComboPreset.GNB_AoE_Stun) && Role.CanLowBlow())
+            if (IsEnabled(CustomComboPreset.GNB_AoE_Stun) && Role.CanLowBlow() && !JustUsed(Role.Interject))
                 return Role.LowBlow;
 
             #endregion

--- a/WrathCombo/Combos/PvE/PLD/PLD.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD.cs
@@ -73,10 +73,13 @@ internal partial class PLD : Tank
 
             // Stun
             if (!TargetIsBoss()
-                && Role.CanLowBlow()
+                && TargetIsCasting()
                 && !JustUsed(Role.Interject)
                 && !InBossEncounter())
-                return Role.LowBlow;
+                if (ActionReady(ShieldBash) && !JustUsed(Role.LowBlow))
+                    return ShieldBash;
+                else if (Role.CanLowBlow() && !JustUsed(ShieldBash))
+                    return Role.LowBlow;
 
             // Variant Cure
             if (Variant.CanCure(CustomComboPreset.PLD_Variant_Cure, Config.PLD_VariantCure))
@@ -421,10 +424,13 @@ internal partial class PLD : Tank
             // Stun
             if (IsEnabled(CustomComboPreset.PLD_ST_Stun)
                 && !TargetIsBoss()
-                && Role.CanLowBlow()
+                && TargetIsCasting()
                 && !JustUsed(Role.Interject)
                 && !InBossEncounter())
-                return Role.LowBlow;
+                if (ActionReady(ShieldBash) && !JustUsed(Role.LowBlow))
+                    return ShieldBash;
+                else if (Role.CanLowBlow() && !JustUsed(ShieldBash))
+                    return Role.LowBlow;
 
             // Variant Cure
             if (Variant.CanCure(CustomComboPreset.PLD_Variant_Cure, Config.PLD_VariantCure))

--- a/WrathCombo/Combos/PvE/PLD/PLD.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD.cs
@@ -71,6 +71,13 @@ internal partial class PLD : Tank
             if (Role.CanInterject())
                 return Role.Interject;
 
+            // Stun
+            if (!TargetIsBoss()
+                && Role.CanLowBlow()
+                && !JustUsed(Role.Interject)
+                && !InBossEncounter())
+                return Role.LowBlow;
+
             // Variant Cure
             if (Variant.CanCure(CustomComboPreset.PLD_Variant_Cure, Config.PLD_VariantCure))
                 return Variant.Cure;
@@ -262,10 +269,10 @@ internal partial class PLD : Tank
                 return Role.Interject;
 
             // Stun
-            if (TargetIsCasting())
-                if (ActionReady(ShieldBash))
+            if (TargetIsCasting() && !JustUsed(Role.Interject))
+                if (ActionReady(ShieldBash) && !JustUsed(Role.LowBlow))
                     return ShieldBash;
-                else if (Role.CanLowBlow())
+                else if (Role.CanLowBlow() && !JustUsed(ShieldBash))
                     return Role.LowBlow;
 
             // Variant Cure
@@ -410,6 +417,14 @@ internal partial class PLD : Tank
             if (IsEnabled(CustomComboPreset.PLD_ST_Interrupt)
                 && Role.CanInterject())
                 return Role.Interject;
+
+            // Stun
+            if (IsEnabled(CustomComboPreset.PLD_ST_Stun)
+                && !TargetIsBoss()
+                && Role.CanLowBlow()
+                && !JustUsed(Role.Interject)
+                && !InBossEncounter())
+                return Role.LowBlow;
 
             // Variant Cure
             if (Variant.CanCure(CustomComboPreset.PLD_Variant_Cure, Config.PLD_VariantCure))
@@ -610,10 +625,10 @@ internal partial class PLD : Tank
                 return Role.Interject;
 
             // Stun
-            if (IsEnabled(CustomComboPreset.PLD_AoE_Stun) && TargetIsCasting())
-                if (ActionReady(ShieldBash))
+            if (IsEnabled(CustomComboPreset.PLD_AoE_Stun) && TargetIsCasting() && !JustUsed(Role.Interject))
+                if (ActionReady(ShieldBash) && !JustUsed(Role.LowBlow))
                     return ShieldBash;
-                else if (Role.CanLowBlow())
+                else if (Role.CanLowBlow() && !JustUsed(ShieldBash))
                     return Role.LowBlow;
 
             // Variant Cure

--- a/WrathCombo/Combos/PvE/WAR/WAR.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR.cs
@@ -67,9 +67,20 @@ internal partial class WAR : Tank
                               JustUsed(Role.Rampart, 5f) ||
                               JustUsed(Holmgang, 9f);
 
+            #region Stuns
+
             // Interrupt
             if (Role.CanInterject())
                 return Role.Interject;
+
+            // Stun
+            if (!TargetIsBoss()
+                && Role.CanLowBlow()
+                && !JustUsed(Role.Interject)
+                && !InBossEncounter())
+                return Role.LowBlow;
+
+            #endregion
 
             #region Variant
 
@@ -243,10 +254,22 @@ internal partial class WAR : Tank
                               JustUsed(Role.Rampart, 5f) ||
                               JustUsed(Holmgang, 9f);
 
+            #region Stuns
+
             // Interrupt
             if (IsEnabled(CustomComboPreset.WAR_ST_Interrupt)
                 && Role.CanInterject())
                 return Role.Interject;
+
+            // Stun
+            if (IsEnabled(CustomComboPreset.WAR_ST_Stun)
+                && !TargetIsBoss()
+                && Role.CanLowBlow()
+                && !JustUsed(Role.Interject)
+                && !InBossEncounter())
+                return Role.LowBlow;
+
+            #endregion
 
             #region Variant
 
@@ -481,7 +504,8 @@ internal partial class WAR : Tank
                 return Role.Interject;
 
             // Stun
-            if (Role.CanLowBlow())
+            if (Role.CanLowBlow()
+                && !JustUsed(Role.Interject))
                 return Role.LowBlow;
 
             #endregion
@@ -629,6 +653,7 @@ internal partial class WAR : Tank
 
             // Stun
             if (IsEnabled(CustomComboPreset.WAR_AoE_Stun)
+                && !JustUsed(Role.Interject)
                 && Role.CanLowBlow())
                 return Role.LowBlow;
 


### PR DESCRIPTION
- [X] Adds Single Target Stun to:
  - [X] DRK
  - [X] GNB
  - [X] PLD (`Shield Bash` and `Low Blow`)
  - [X] WAR
  - [X] Advanced Modes (has new Option for this)
  - [X] Simple Modes
- [X] Prevents Stuns from going off when `Interject` was just used (or `Shield Bash`, and vice versa, for PLD)