### PR TITLE
[PCT] 7.2 Pictoverhaul

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -3,6 +3,7 @@ using System;
 using WrathCombo.Attributes;
 using WrathCombo.Combos.PvE;
 using WrathCombo.Combos.PvP;
+using static WrathCombo.Combos.PvE.PCT;
 namespace WrathCombo.Combos;
 
 /// <summary> Combo presets. </summary>
@@ -3643,21 +3644,40 @@ public enum CustomComboPreset
     PCT_ST_Advanced_Openers = 20006,
 
     [ParentCombo(PCT_ST_AdvancedMode)]
-    [CustomComboInfo("Prepull Motifs Feature", "Adds missing Motifs to the combo while out of combat.", PCT.JobID)]
-    PCT_ST_AdvancedMode_PrePullMotifs = 20008,
-
-    [ParentCombo(PCT_ST_AdvancedMode)]
-    [CustomComboInfo("Downtime Motifs Option", "Adds missing Motifs to the combo while no target is present in combat.",
-        PCT.JobID)]
-    PCT_ST_AdvancedMode_NoTargetMotifs = 20009,
-
-    [ParentCombo(PCT_ST_AdvancedMode)]
-    [CustomComboInfo("Starry Muse Burst Feature", "Adds selected spells below to the burst phase.", PCT.JobID)]
+    [CustomComboInfo("Optimal Burst Window Feature", "Uses an optimized rotation for burst window for Level 100", PCT.JobID)]
     PCT_ST_AdvancedMode_Burst_Phase = 20010,
 
-    //[ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
-    //[CustomComboInfo("Comet in Black Option", "Adds Comet in Black to the burst phase.", PCT.JobID)]
-    //PCT_ST_AdvancedMode_Burst_CometInBlack = 20011,
+    [ParentCombo(PCT_ST_AdvancedMode)]
+    [CustomComboInfo("Subtractive Palette Feature", "Adds Subtractive Palette to the combo.", PCT.JobID)]
+    PCT_ST_AdvancedMode_SubtractivePalette = 20025,
+
+    [ParentCombo(PCT_ST_AdvancedMode)]
+    [CustomComboInfo("Blizzard in Cyan Option", "Adds Blizzard in Cyan to the combo.", PCT.JobID)]
+    PCT_ST_AdvancedMode_BlizzardInCyan = 20033,
+
+    [ParentCombo(PCT_ST_AdvancedMode)]
+    [CustomComboInfo("Comet in Black Option", "Adds Comet in Black to the combo.", PCT.JobID)]
+    PCT_ST_AdvancedMode_CometinBlack = 20026,
+
+    [ParentCombo(PCT_ST_AdvancedMode)]
+    [CustomComboInfo("Living Muse Option", "Adds Living Muse.", PCT.JobID)]
+    PCT_ST_AdvancedMode_LivingMuse = 20022,
+
+    [ParentCombo(PCT_ST_AdvancedMode)]
+    [CustomComboInfo("Mog/Madeen Feature", "Adds Mog/Madeen to the combo.", PCT.JobID)]
+    PCT_ST_AdvancedMode_MogOfTheAges = 20024,
+
+    [ParentCombo(PCT_ST_AdvancedMode)]
+    [CustomComboInfo("Steel Muse Option", "Adds Steel Muse.", PCT.JobID)]
+    PCT_ST_AdvancedMode_SteelMuse = 20023,
+
+    [ParentCombo(PCT_ST_AdvancedMode)]
+    [CustomComboInfo("Hammer Stamp Combo Option", "Adds Hammer Stamp combo.", PCT.JobID)]
+    PCT_ST_AdvancedMode_HammerStampCombo = 20027,
+
+    [ParentCombo(PCT_ST_AdvancedMode)]
+    [CustomComboInfo("Scenic Muse Option", "Adds Scenic Muse.", PCT.JobID)]
+    PCT_ST_AdvancedMode_ScenicMuse = 20021,
 
     [ParentCombo(PCT_ST_AdvancedMode)]
     [CustomComboInfo("Star Prism Option", "Adds Star Prism to the Rotation.", PCT.JobID)]
@@ -3667,13 +3687,9 @@ public enum CustomComboPreset
     [CustomComboInfo("Rainbow Drip Option", "Adds Rainbow Drip to the rotation with Rainbow Birght Buff.", PCT.JobID)]
     PCT_ST_AdvancedMode_RainbowDrip = 20013,
 
-    //[ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
-    //[CustomComboInfo("Hammer Stamp Combo Option", "Adds Hammer Stamp Combo to the burst phase.", PCT.JobID)]
-    //PCT_ST_AdvancedMode_Burst_HammerCombo = 20014,
-
-    //[ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
-    //[CustomComboInfo("Blizzard in Cyan Option", "Adds Blizzard in Cyan to the burst phase.", PCT.JobID)]
-    //PCT_ST_AdvancedMode_Burst_BlizzardInCyan = 20015,
+    [ParentCombo(PCT_ST_AdvancedMode)]
+    [CustomComboInfo("Lucid Dreaming Option", "Adds Lucid Dreaming to the combo.", PCT.JobID)]
+    PCT_ST_AdvancedMode_LucidDreaming = 20034,
 
     [ParentCombo(PCT_ST_AdvancedMode)]
     [CustomComboInfo("Motif Selection Feature", "Add Selected Motifs to the combo.", PCT.JobID)]
@@ -3691,37 +3707,18 @@ public enum CustomComboPreset
     [CustomComboInfo("Weapon Motif Option", "Adds Weapon Motif.", PCT.JobID)]
     PCT_ST_AdvancedMode_WeaponMotif = 20019,
 
-    [ParentCombo(PCT_ST_AdvancedMode)]
-    [CustomComboInfo("Muse Selection Feature", "Adds Selected Muses to the combo.", PCT.JobID)]
-    PCT_ST_AdvancedMode_MuseFeature = 20020,
+    [ParentCombo(PCT_ST_AdvancedMode_MotifFeature)]
+    [CustomComboInfo("Prepull Motifs Feature", "Adds missing Motifs to the combo while out of combat.", PCT.JobID)]
+    PCT_ST_AdvancedMode_PrePullMotifs = 20008,
 
-    [ParentCombo(PCT_ST_AdvancedMode_MuseFeature)]
-    [CustomComboInfo("Scenic Muse Option", "Adds Scenic Muse.", PCT.JobID)]
-    PCT_ST_AdvancedMode_ScenicMuse = 20021,
+    [ParentCombo(PCT_ST_AdvancedMode_MotifFeature)]
+    [CustomComboInfo("Downtime Motifs Option", "Adds missing Motifs to the combo while no target is present in combat.",
+        PCT.JobID)]
+    PCT_ST_AdvancedMode_NoTargetMotifs = 20009,
 
-    [ParentCombo(PCT_ST_AdvancedMode_MuseFeature)]
-    [CustomComboInfo("Living Muse Option", "Adds Living Muse.", PCT.JobID)]
-    PCT_ST_AdvancedMode_LivingMuse = 20022,
-
-    [ParentCombo(PCT_ST_AdvancedMode_MuseFeature)]
-    [CustomComboInfo("Steel Muse Option", "Adds Steel Muse.", PCT.JobID)]
-    PCT_ST_AdvancedMode_SteelMuse = 20023,
-
-    [ParentCombo(PCT_ST_AdvancedMode)]
-    [CustomComboInfo("Mog/Madeen Feature", "Adds Mog/Madeen to the combo.", PCT.JobID)]
-    PCT_ST_AdvancedMode_MogOfTheAges = 20024,
-
-    [ParentCombo(PCT_ST_AdvancedMode)]
-    [CustomComboInfo("Subtractive Palette Feature", "Adds Subtractive Palette to the combo.", PCT.JobID)]
-    PCT_ST_AdvancedMode_SubtractivePalette = 20025,
-
-    [ParentCombo(PCT_ST_AdvancedMode)]
-    [CustomComboInfo("Comet in Black Option", "Adds Comet in Black to the combo.", PCT.JobID)]
-    PCT_ST_AdvancedMode_CometinBlack = 20026,
-
-    [ParentCombo(PCT_ST_AdvancedMode)]
-    [CustomComboInfo("Hammer Stamp Combo Option", "Adds Hammer Stamp combo.", PCT.JobID)]
-    PCT_ST_AdvancedMode_HammerStampCombo = 20027,
+    [ParentCombo(PCT_ST_AdvancedMode_MotifFeature)]
+    [CustomComboInfo("Swiftcast Motifs Option ", "Use swiftcast for motifs.", PCT.JobID)]
+    PCT_ST_AdvancedMode_SwiftMotifs = 20035,
 
     [ParentCombo(PCT_ST_AdvancedMode)]
     [CustomComboInfo("Movement Features", "Adds selected features to the combo while moving.", PCT.JobID)]
@@ -3732,30 +3729,16 @@ public enum CustomComboPreset
     PCT_ST_AdvancedMode_MovementOption_HammerStampCombo = 20029,
 
     [ParentCombo(PCT_ST_AdvancedMode_MovementFeature)]
-    [CustomComboInfo("Holy in White Option", "Adds Holy in White to the combo while moving.", PCT.JobID)]
+    [CustomComboInfo("Holy in White Option", "Adds Holy in White to the combo while moving. \n Prioritizes if Inspiration and Hyperphantasia are active.", PCT.JobID)]
     PCT_ST_AdvancedMode_MovementOption_HolyInWhite = 20030,
 
     [ParentCombo(PCT_ST_AdvancedMode_MovementFeature)]
-    [CustomComboInfo("Comet in Black Option", "Adds Comet in Black to the combo while moving.", PCT.JobID)]
+    [CustomComboInfo("Comet in Black Option", "Adds Comet in Black to the combo while moving. \n Prioritizes if Inspiration and Hyperphantasia are active.", PCT.JobID)]
     PCT_ST_AdvancedMode_MovementOption_CometinBlack = 20031,
 
     [ParentCombo(PCT_ST_AdvancedMode_MovementFeature)]
     [CustomComboInfo("Swiftcast Option ", "Adds Swiftcast to the combo while moving.", PCT.JobID)]
     PCT_ST_AdvancedMode_SwitfcastOption = 20032,
-
-    [ParentCombo(PCT_ST_AdvancedMode)]
-    [CustomComboInfo("Swiftcast Motifs Option ", "Use swiftcast for motifs.", PCT.JobID)]
-    PCT_ST_AdvancedMode_SwiftMotifs = 20035,
-
-    [ParentCombo(PCT_ST_AdvancedMode)]
-    [CustomComboInfo("Blizzard in Cyan Option", "Adds Blizzard in Cyan to the combo.", PCT.JobID)]
-    PCT_ST_AdvancedMode_BlizzardInCyan = 20033,
-
-    [ParentCombo(PCT_ST_AdvancedMode)]
-    [CustomComboInfo("Lucid Dreaming Option", "Adds Lucid Dreaming to the combo.", PCT.JobID)]
-    PCT_ST_AdvancedMode_LucidDreaming = 20034,
-
-    // Last value for ST = 20038
 
     #endregion
 
@@ -3770,37 +3753,52 @@ public enum CustomComboPreset
     PCT_AoE_AdvancedMode = 20040,
 
     [ParentCombo(PCT_AoE_AdvancedMode)]
-    [CustomComboInfo("Prepull Motifs Feature", "Adds missing Motifs to the combo while out of combat.", PCT.JobID)]
-    PCT_AoE_AdvancedMode_PrePullMotifs = 20041,
-
-    [ParentCombo(PCT_AoE_AdvancedMode_PrePullMotifs)]
-    [CustomComboInfo("Downtime Motifs Option", "Adds missing Motifs to the combo while no target is present in combat.",
-        PCT.JobID)]
-    PCT_AoE_AdvancedMode_NoTargetMotifs = 20042,
+    [CustomComboInfo("Subtractive Palette Feature", "Adds Subtractive Palette to the combo.", PCT.JobID)]
+    PCT_AoE_AdvancedMode_SubtractivePalette = 20058,
 
     [ParentCombo(PCT_AoE_AdvancedMode)]
-    [CustomComboInfo("Starry Muse Burst Feature", "Adds selected spells below to the burst phase.", PCT.JobID)]
-    PCT_AoE_AdvancedMode_Burst_Phase = 20043,
+    [CustomComboInfo("Blizzard II in Cyan Option", "Adds Blizzard II in Cyan to the combo.", PCT.JobID)]
+    PCT_AoE_AdvancedMode_BlizzardInCyan = 20066,
 
-    [ParentCombo(PCT_AoE_AdvancedMode_Burst_Phase)]
-    [CustomComboInfo("Comet in Black Option", "Adds Comet in Black to the burst phase.", PCT.JobID)]
-    PCT_AoE_AdvancedMode_Burst_CometInBlack = 20044,
+    [ParentCombo(PCT_AoE_AdvancedMode)]
+    [CustomComboInfo("Holy in White Option", "Adds Holy in White to the combo.", PCT.JobID)]
+    PCT_AoE_AdvancedMode_HolyinWhite = 20068,
 
-    [ParentCombo(PCT_AoE_AdvancedMode_Burst_Phase)]
+    [ParentCombo(PCT_AoE_AdvancedMode)]
+    [CustomComboInfo("Comet in Black Option", "Adds Comet in Black to the combo.", PCT.JobID)]
+    PCT_AoE_AdvancedMode_CometinBlack = 20059,
+
+    [ParentCombo(PCT_AoE_AdvancedMode)]
+    [CustomComboInfo("Living Muse Option", "Adds Living Muse.", PCT.JobID)]
+    PCT_AoE_AdvancedMode_LivingMuse = 20055,
+
+    [ParentCombo(PCT_AoE_AdvancedMode)]
+    [CustomComboInfo("Mog/Madeen Feature", "Adds Mog/Madeen to the combo.", PCT.JobID)]
+    PCT_AoE_AdvancedMode_MogOfTheAges = 20057,
+
+    [ParentCombo(PCT_AoE_AdvancedMode)]
+    [CustomComboInfo("Steel Muse Option", "Adds Steel Muse.", PCT.JobID)]
+    PCT_AoE_AdvancedMode_SteelMuse = 20056,
+
+    [ParentCombo(PCT_AoE_AdvancedMode)]
+    [CustomComboInfo("Hammer Stamp Combo Option", "Adds Hammer Stamp combo.", PCT.JobID)]
+    PCT_AoE_AdvancedMode_HammerStampCombo = 20060,
+
+    [ParentCombo(PCT_AoE_AdvancedMode)]
+    [CustomComboInfo("Scenic Muse Option", "Adds Scenic Muse.", PCT.JobID)]
+    PCT_AoE_AdvancedMode_ScenicMuse = 20054,
+
+    [ParentCombo(PCT_AoE_AdvancedMode)]
     [CustomComboInfo("Star Prism Option", "Adds Star Prism to the burst phase.", PCT.JobID)]
-    PCT_AoE_AdvancedMode_Burst_StarPrism = 20045,
+    PCT_AoE_AdvancedMode_StarPrism = 20045,
 
-    [ParentCombo(PCT_AoE_AdvancedMode_Burst_Phase)]
+    [ParentCombo(PCT_AoE_AdvancedMode)]
     [CustomComboInfo("Rainbow Drip Option", "Adds Rainbow Drip to the burst phase.", PCT.JobID)]
-    PCT_AoE_AdvancedMode_Burst_RainbowDrip = 20046,
+    PCT_AoE_AdvancedMode_RainbowDrip = 20046,
 
-    [ParentCombo(PCT_AoE_AdvancedMode_Burst_Phase)]
-    [CustomComboInfo("Hammer Stamp Combo Option", "Adds Hammer Stamp Combo to the burst phase.", PCT.JobID)]
-    PCT_AoE_AdvancedMode_Burst_HammerCombo = 20047,
-
-    [ParentCombo(PCT_AoE_AdvancedMode_Burst_Phase)]
-    [CustomComboInfo("Blizzard in Cyan Option", "Adds Blizzard in Cyan to the burst phase.", PCT.JobID)]
-    PCT_AoE_AdvancedMode_Burst_BlizzardInCyan = 20048,
+    [ParentCombo(PCT_AoE_AdvancedMode)]
+    [CustomComboInfo("Lucid Dreaming Option", "Adds Lucid Dreaming to the combo.", PCT.JobID)]
+    PCT_AoE_AdvancedMode_LucidDreaming = 20067,
 
     [ParentCombo(PCT_AoE_AdvancedMode)]
     [CustomComboInfo("Motif Selection Feature", "Add Selected Motifs to the combo.", PCT.JobID)]
@@ -3818,41 +3816,18 @@ public enum CustomComboPreset
     [CustomComboInfo("Weapon Motif Option", "Adds Weapon Motif.", PCT.JobID)]
     PCT_AoE_AdvancedMode_WeaponMotif = 20052,
 
-    [ParentCombo(PCT_AoE_AdvancedMode)]
-    [CustomComboInfo("Muse Selection Feature", "Adds Selected Muses to the combo.", PCT.JobID)]
-    PCT_AoE_AdvancedMode_MuseFeature = 20053,
+    [ParentCombo(PCT_AoE_AdvancedMode_MotifFeature)]
+    [CustomComboInfo("Prepull Motifs Feature", "Adds missing Motifs to the combo while out of combat.", PCT.JobID)]
+    PCT_AoE_AdvancedMode_PrePullMotifs = 20041,
 
-    [ParentCombo(PCT_AoE_AdvancedMode_MuseFeature)]
-    [CustomComboInfo("Scenic Muse Option", "Adds Scenic Muse.", PCT.JobID)]
-    PCT_AoE_AdvancedMode_ScenicMuse = 20054,
+    [ParentCombo(PCT_AoE_AdvancedMode_MotifFeature)]
+    [CustomComboInfo("Downtime Motifs Option", "Adds missing Motifs to the combo while no target is present in combat.",
+        PCT.JobID)]
+    PCT_AoE_AdvancedMode_NoTargetMotifs = 20042,
 
-    [ParentCombo(PCT_AoE_AdvancedMode_MuseFeature)]
-    [CustomComboInfo("Living Muse Option", "Adds Living Muse.", PCT.JobID)]
-    PCT_AoE_AdvancedMode_LivingMuse = 20055,
-
-    [ParentCombo(PCT_AoE_AdvancedMode_MuseFeature)]
-    [CustomComboInfo("Steel Muse Option", "Adds Steel Muse.", PCT.JobID)]
-    PCT_AoE_AdvancedMode_SteelMuse = 20056,
-
-    [ParentCombo(PCT_AoE_AdvancedMode)]
-    [CustomComboInfo("Mog/Madeen Feature", "Adds Mog/Madeen to the combo.", PCT.JobID)]
-    PCT_AoE_AdvancedMode_MogOfTheAges = 20057,
-
-    [ParentCombo(PCT_AoE_AdvancedMode)]
-    [CustomComboInfo("Subtractive Palette Feature", "Adds Subtractive Palette to the combo.", PCT.JobID)]
-    PCT_AoE_AdvancedMode_SubtractivePalette = 20058,
-
-    [ParentCombo(PCT_AoE_AdvancedMode)]
-    [CustomComboInfo("Comet in Black Option", "Adds Comet in Black to the combo.", PCT.JobID)]
-    PCT_AoE_AdvancedMode_CometinBlack = 20059,
-
-    [ParentCombo(PCT_AoE_AdvancedMode)]
-    [CustomComboInfo("Hammer Stamp Combo Option", "Adds Hammer Stamp combo.", PCT.JobID)]
-    PCT_AoE_AdvancedMode_HammerStampCombo = 20060,
-
-    [ParentCombo(PCT_AoE_AdvancedMode)]
-    [CustomComboInfo("Holy in White Option", "Adds Holy in White to the combo.", PCT.JobID)]
-    PCT_AoE_AdvancedMode_HolyinWhite = 20068,
+    [ParentCombo(PCT_AoE_AdvancedMode_MotifFeature)]
+    [CustomComboInfo("Swiftcast Motifs Option ", "Use swiftcast for motifs.", PCT.JobID)]
+    PCT_AoE_AdvancedMode_SwiftMotifs = 20069,
 
     [ParentCombo(PCT_AoE_AdvancedMode)]
     [CustomComboInfo("Movement Features", "Adds selected features to the combo while moving.", PCT.JobID)]
@@ -3863,25 +3838,20 @@ public enum CustomComboPreset
     PCT_AoE_AdvancedMode_MovementOption_HammerStampCombo = 20062,
 
     [ParentCombo(PCT_AoE_AdvancedMode_MovementFeature)]
-    [CustomComboInfo("Holy in White Option", "Adds Holy in White to the combo while moving.", PCT.JobID)]
+    [CustomComboInfo("Holy in White Option", "Adds Holy in White to the combo while moving.  \n Prioritizes if Inspiration and Hyperphantasia are active.", PCT.JobID)]
     PCT_AoE_AdvancedMode_MovementOption_HolyInWhite = 20063,
 
     [ParentCombo(PCT_AoE_AdvancedMode_MovementFeature)]
-    [CustomComboInfo("Comet in Black Option", "Adds Comet in Black to the combo while moving.", PCT.JobID)]
+    [CustomComboInfo("Comet in Black Option", "Adds Comet in Black to the combo while moving. \n Prioritizes if Inspiration and Hyperphantasia are active.", PCT.JobID)]
     PCT_AoE_AdvancedMode_MovementOption_CometinBlack = 20064,
 
     [ParentCombo(PCT_AoE_AdvancedMode_MovementFeature)]
     [CustomComboInfo("Swiftcast Option ", "Adds Swiftcast to the combo while moving.", PCT.JobID)]
     PCT_AoE_AdvancedMode_SwitfcastOption = 20065,
 
-    [ParentCombo(PCT_AoE_AdvancedMode)]
-    [CustomComboInfo("Blizzard in Cyan Option", "Adds Blizzard in Cyan to the combo.", PCT.JobID)]
-    PCT_AoE_AdvancedMode_BlizzardInCyan = 20066,
+    #endregion
 
-    [ParentCombo(PCT_AoE_AdvancedMode)]
-    [CustomComboInfo("Lucid Dreaming Option", "Adds Lucid Dreaming to the combo.", PCT.JobID)]
-    PCT_AoE_AdvancedMode_LucidDreaming = 20067,
-
+    #region Standalone Features
     [ReplaceSkill(PCT.FireInRed, PCT.FireIIinRed)]
     [ConflictingCombos(PCT_ST_SimpleMode, PCT_AoE_SimpleMode)]
     [CustomComboInfo("Combined Aetherhues Feature",

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -3655,25 +3655,25 @@ public enum CustomComboPreset
     [CustomComboInfo("Starry Muse Burst Feature", "Adds selected spells below to the burst phase.", PCT.JobID)]
     PCT_ST_AdvancedMode_Burst_Phase = 20010,
 
-    [ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
-    [CustomComboInfo("Comet in Black Option", "Adds Comet in Black to the burst phase.", PCT.JobID)]
-    PCT_ST_AdvancedMode_Burst_CometInBlack = 20011,
+    //[ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
+    //[CustomComboInfo("Comet in Black Option", "Adds Comet in Black to the burst phase.", PCT.JobID)]
+    //PCT_ST_AdvancedMode_Burst_CometInBlack = 20011,
 
-    [ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
-    [CustomComboInfo("Star Prism Option", "Adds Star Prism to the burst phase.", PCT.JobID)]
-    PCT_ST_AdvancedMode_Burst_StarPrism = 20012,
+    [ParentCombo(PCT_ST_AdvancedMode)]
+    [CustomComboInfo("Star Prism Option", "Adds Star Prism to the Rotation.", PCT.JobID)]
+    PCT_ST_AdvancedMode_StarPrism = 20012,
 
-    [ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
-    [CustomComboInfo("Rainbow Drip Option", "Adds Rainbow Drip to the burst phase.", PCT.JobID)]
-    PCT_ST_AdvancedMode_Burst_RainbowDrip = 20013,
+    [ParentCombo(PCT_ST_AdvancedMode)]
+    [CustomComboInfo("Rainbow Drip Option", "Adds Rainbow Drip to the rotation with Rainbow Birght Buff.", PCT.JobID)]
+    PCT_ST_AdvancedMode_RainbowDrip = 20013,
 
-    [ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
-    [CustomComboInfo("Hammer Stamp Combo Option", "Adds Hammer Stamp Combo to the burst phase.", PCT.JobID)]
-    PCT_ST_AdvancedMode_Burst_HammerCombo = 20014,
+    //[ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
+    //[CustomComboInfo("Hammer Stamp Combo Option", "Adds Hammer Stamp Combo to the burst phase.", PCT.JobID)]
+    //PCT_ST_AdvancedMode_Burst_HammerCombo = 20014,
 
-    [ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
-    [CustomComboInfo("Blizzard in Cyan Option", "Adds Blizzard in Cyan to the burst phase.", PCT.JobID)]
-    PCT_ST_AdvancedMode_Burst_BlizzardInCyan = 20015,
+    //[ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
+    //[CustomComboInfo("Blizzard in Cyan Option", "Adds Blizzard in Cyan to the burst phase.", PCT.JobID)]
+    //PCT_ST_AdvancedMode_Burst_BlizzardInCyan = 20015,
 
     [ParentCombo(PCT_ST_AdvancedMode)]
     [CustomComboInfo("Motif Selection Feature", "Add Selected Motifs to the combo.", PCT.JobID)]

--- a/WrathCombo/Combos/PvE/PCT/PCT.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT.cs
@@ -16,10 +16,9 @@ internal partial class PCT : Caster
                 return actionID;
 
             PCTGauge gauge = GetJobGauge<PCTGauge>();
-            bool canWeave = CanSpellWeave() || CanSpellWeave();
             
             // General Weaves
-            if (InCombat() && canWeave)
+            if (InCombat() && CanSpellWeave())
             {
                 // ScenicMuse
 
@@ -140,7 +139,7 @@ internal partial class PCT : Caster
             if (HasStatusEffect(Buffs.StarryMuse))
             {
 
-                if (CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
+                if (CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint)
                     return CometinBlack;
 
                 if (HammerStamp.LevelChecked() && HasStatusEffect(Buffs.HammerTime) && !HasStatusEffect(Buffs.Starstruck))
@@ -157,7 +156,7 @@ internal partial class PCT : Caster
             if (HasStatusEffect(Buffs.RainbowBright) && !HasStatusEffect(Buffs.StarryMuse))
                 return RainbowDrip;
 
-            if (CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(StarryMuse) > 30f)
+            if (CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint && GetCooldownRemainingTime(StarryMuse) > 30f)
                 return OriginalHook(CometinBlack);
 
             if (HammerStamp.LevelChecked() && HasStatusEffect(Buffs.HammerTime))
@@ -213,276 +212,207 @@ internal partial class PCT : Caster
             if (actionID is not FireInRed)
                 return actionID;
 
-            PCTGauge gauge = GetJobGauge<PCTGauge>();
-            bool canWeave = CanSpellWeave() || CanSpellWeave();
+            #region Enables and Configs
+           
             int creatureStop = Config.PCT_ST_CreatureStop;
             int landscapeStop = Config.PCT_ST_LandscapeStop;
             int weaponStop = Config.PCT_ST_WeaponStop;
 
+            bool prepullEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_PrePullMotifs);
+            bool openerEnabled = IsEnabled(CustomComboPreset.PCT_ST_Advanced_Openers);
+            bool burstPhaseEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_Phase);
+            bool noTargetMotifEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_NoTargetMotifs);
+            bool scenicMuseEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_ScenicMuse);
+            bool livingMuseEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LivingMuse);
+            bool steelMuseEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SteelMuse);
+            bool portraitEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MogOfTheAges);
+            bool paletteEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SubtractivePalette);
+            bool lucidDreamingEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LucidDreaming);
+            bool swiftMotifEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SwiftMotifs);
+            bool hammerMovementEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HammerStampCombo);
+            bool cometMovementEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_CometinBlack);
+            bool holyMovementEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HolyInWhite);
+            bool swiftcastMotifMovementEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SwitfcastOption);
+            bool landscapeMotifEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif);
+            bool creatureMotifEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif);
+            bool weaponMotifEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif);
+            bool starPrismEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_StarPrism);
+            bool rainbowDripEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_RainbowDrip);
+            bool cometEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CometinBlack);
+            bool hammerEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_HammerStampCombo);
+            bool blizzardComboEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_BlizzardInCyan);
+
+
+
+
+            #endregion
+
+            #region Variants
             // Variant Cure
             if (Variant.CanCure(CustomComboPreset.PCT_Variant_Cure, Config.PCT_VariantCure))
                 return Variant.Cure;
 
             // Variant Rampart
-            if (Variant.CanRampart(CustomComboPreset.PCT_Variant_Rampart,WeaveTypes.SpellWeave))
+            if (Variant.CanRampart(CustomComboPreset.PCT_Variant_Rampart, WeaveTypes.SpellWeave))
                 return Variant.Rampart;
+            #endregion
 
-            // Prepull logic
-            if ((IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_PrePullMotifs) && !InCombat()) || (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_NoTargetMotifs) && InCombat() && CurrentTarget == null))
+            #region Prepull
+            if ((prepullEnabled && !InCombat()) || (noTargetMotifEnabled && InCombat() && CurrentTarget == null))
             {
-                if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
+                if (CreatureMotifReady)
                     return OriginalHook(CreatureMotif);
-                if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasStatusEffect(Buffs.HammerTime))
+                if (WeaponMotifReady)
                     return OriginalHook(WeaponMotif);
-                if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && !HasStatusEffect(Buffs.StarryMuse))
+                if (LandscapeMotifReady)
                     return OriginalHook(LandscapeMotif);
-
             }
+            #endregion
 
-            // Check if Openers are enabled and determine which opener to execute based on current level
-            if (IsEnabled(CustomComboPreset.PCT_ST_Advanced_Openers) && 
-                Opener().FullOpener(ref actionID))
-                return actionID; 
-            
-            /* Lvl 92 Opener
-                    else if (!StarPrism.LevelChecked() && RainbowDrip.LevelChecked())
-                    {
-                        if (PCTOpenerLvl92.DoFullOpener(ref actionID))
-                            return actionID;
-                    }
-                    // Lvl 90 Opener
-                    else if (!StarPrism.LevelChecked() && !RainbowDrip.LevelChecked() && CometinBlack.LevelChecked())
-                    {
-                        if (PCTOpenerLvl90.DoFullOpener(ref actionID))
-                            return actionID;
-                    }
-                    // Lvl 80 Opener
-                    else if (!StarPrism.LevelChecked() && !CometinBlack.LevelChecked() && HolyInWhite.LevelChecked())
-                    {
-                        if (PCTOpenerLvl80.DoFullOpener(ref actionID))
-                            return actionID;
-                    }
-                    // Lvl 70 Opener
-                    else if (!StarPrism.LevelChecked() && !CometinBlack.LevelChecked() && !HolyInWhite.LevelChecked() && StarryMuse.LevelChecked())
-                    {
-                        if (PCTOpenerLvl70.DoFullOpener(ref actionID))
-                            return actionID;
-                    }
-                    */
+            #region Opener
+           
+            if (openerEnabled && Opener().FullOpener(ref actionID))
+                return actionID;
 
+            #endregion
+
+            #region Burst Window
+            if (burstPhaseEnabled && InCombat() && (ScenicCD <= 5 || HasStatusEffect(Buffs.StarryMuse)))
+                return BurstWindow(actionID);
+
+            #endregion
+
+            #region OGCD
             // General Weaves
-            if (InCombat() && canWeave)
+            if (InCombat() && CanSpellWeave())
             {
                 // ScenicMuse
-                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_ScenicMuse))
-                {
-                    if (ScenicMuse.LevelChecked() &&
-                        gauge.LandscapeMotifDrawn &&
-                        gauge.WeaponMotifDrawn &&
-                        IsOffCooldown(ScenicMuse))
-                    {
-                        return OriginalHook(ScenicMuse);
-                    }
-                }
-
+                if (scenicMuseEnabled && ScenicMuseReady && !burstPhaseEnabled)
+                    return OriginalHook(ScenicMuse);
+                    
                 // LivingMuse
-                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LivingMuse))
-                {
-                    if (LivingMuse.LevelChecked() &&
-                        gauge.CreatureMotifDrawn &&
-                        (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
-                         GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)))
-                    {
-                        if (HasCharges(OriginalHook(LivingMuse)))
-                        {
-                            if (!ScenicMuse.LevelChecked() ||
-                                GetCooldown(ScenicMuse).CooldownRemaining > GetCooldownChargeRemainingTime(LivingMuse))
-                            {
-                                return OriginalHook(LivingMuse);
-                            }
-                        }
-                    }
-                }
-
+                if (livingMuseEnabled && LivingMuseReady && 
+                    (!PortraitReady || GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)) &&
+                    (!LevelChecked(ScenicMuse) || ScenicCD > GetCooldownChargeRemainingTime(LivingMuse)))
+                    return OriginalHook(LivingMuse);
+                        
                 // SteelMuse
-                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SteelMuse))
-                {
-                    if (SteelMuse.LevelChecked() &&
-                        !HasStatusEffect(Buffs.HammerTime) &&
-                        gauge.WeaponMotifDrawn &&
-                        HasCharges(OriginalHook(SteelMuse)) &&
-                        (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining ||
-                         GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
-                         !ScenicMuse.LevelChecked()))
-                    {
-                        return OriginalHook(SteelMuse);
-                    }
-                }
-
-                // MogoftheAges
-                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MogOfTheAges))
-                {
-                    if (MogoftheAges.LevelChecked() &&
-                        (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) &&
-                        IsOffCooldown(OriginalHook(MogoftheAges)) &&
-                        (GetCooldownRemainingTime(StarryMuse) >= 60 || !ScenicMuse.LevelChecked()))
-                    {
-                        return OriginalHook(MogoftheAges);
-                    }
-                }
-
+                if (steelMuseEnabled && SteelMuseReady &&
+                    (SteelCD < ScenicCD || GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
+                    !LevelChecked(ScenicMuse)))
+                    return OriginalHook(SteelMuse);
+                    
+                // Portrait Mog or Madeen
+                if (portraitEnabled && PortraitReady && 
+                    IsOffCooldown(OriginalHook(MogoftheAges)) && 
+                    (ScenicCD >= 60 || !LevelChecked(ScenicMuse)))
+                    return OriginalHook(MogoftheAges);
+                    
                 // SubtractivePalette
-                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SubtractivePalette))
-                {
-                    if (SubtractivePalette.LevelChecked() &&
-                        !HasStatusEffect(Buffs.SubtractivePalette) &&
-                        !HasStatusEffect(Buffs.MonochromeTones))
-                    {
-                        if (HasStatusEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
-                        {
-                            return SubtractivePalette;
-                        }
-                    }
-                }
+                if (paletteEnabled && PaletteReady)
+                    return SubtractivePalette;
+                        
+                //LucidDreaming
+                if (lucidDreamingEnabled && Role.CanLucidDream(Config.PCT_ST_AdvancedMode_LucidOption))
+                    return Role.LucidDreaming;
             }
+            #endregion
 
+            #region Swiftcast Motifs
             // Swiftcast Motifs
-            if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SwiftMotifs) &&
-                HasStatusEffect(Role.Buffs.Swiftcast))
+            if (swiftMotifEnabled && HasStatusEffect(Role.Buffs.Swiftcast))
             {
-                if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasStatusEffect(Buffs.StarryMuse) && GetTargetHPPercent() > creatureStop)
+                if (CreatureMotifReady && GetTargetHPPercent() > creatureStop)
                     return OriginalHook(CreatureMotif);
-                if (!gauge.WeaponMotifDrawn && WeaponMotif.LevelChecked() && !HasStatusEffect(Buffs.HammerTime) && !HasStatusEffect(Buffs.StarryMuse) && GetTargetHPPercent() > weaponStop)
+                if (WeaponMotifReady && GetTargetHPPercent() > weaponStop)
                     return OriginalHook(WeaponMotif);
-                if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasStatusEffect(Buffs.StarryMuse) && GetTargetHPPercent() > landscapeStop)
+                if (LandscapeMotifReady && GetTargetHPPercent() > landscapeStop)
                     return OriginalHook(LandscapeMotif);
-
             }
 
-            // IsMoving logic
+            #endregion
+
+            #region Moving
             if (IsMoving() && InCombat())
             {
-                //increase priority for using casts as soon as possible to avoid losing DPS and ensure all abilities fit within buff windows
-                //previously, there were situations where Wrath prioritized using Hammer Combo over casts, which would prevent us from generating Rainbow Bright in time when movement is required
-                //so, if we have Hyperphantasia stacks and Inspiration is active from standing in PCT LeyLines, we burn it all down
-                bool hasPaint = gauge.Paint > 0;
-                bool burnStacks = GetStatusEffectStacks(Buffs.Hyperphantasia) > 0 && HasStatusEffect(Buffs.Inspiration) && hasPaint; //use casts asap if we have Hyperphantasia stacks and Inspiration is active from standing in PCT LeyLines
-                bool shouldHolyInWhite = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HolyInWhite) && HolyInWhite.LevelChecked() && hasPaint & !HasStatusEffect(Buffs.MonochromeTones); //normal conditions for Holy In White
-                bool shouldCometInBlack = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_CometinBlack) && CometinBlack.LevelChecked() && hasPaint && HasStatusEffect(Buffs.MonochromeTones); //normal conditions for Comet in Black
-                if (burnStacks && ((Config.BlackHyperphantasiaOption && shouldCometInBlack) || (Config.WhiteHyperphantasiaOption && shouldHolyInWhite)))
+                if (HyperPhantasiaMovementPaint())
                     return HasStatusEffect(Buffs.MonochromeTones) ? OriginalHook(CometinBlack) : OriginalHook(HolyInWhite);
 
-                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HammerStampCombo) && HammerStamp.LevelChecked() && HasStatusEffect(Buffs.HammerTime))
+                if (hammerMovementEnabled && HammerStamp.LevelChecked() && HasStatusEffect(Buffs.HammerTime))
                     return OriginalHook(HammerStamp);
 
-                if (shouldCometInBlack)
+                if (cometMovementEnabled && CometinBlack.LevelChecked() && HasPaint && HasStatusEffect(Buffs.MonochromeTones))
                     return OriginalHook(CometinBlack);
 
-                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_RainbowDrip))
-                {
-                    if (HasStatusEffect(Buffs.RainbowBright) || (HasStatusEffect(Buffs.RainbowBright) && GetStatusEffectRemainingTime(Buffs.StarryMuse) <= 3f))
-                        return RainbowDrip;
-                }
+                if (rainbowDripEnabled && HasStatusEffect(Buffs.RainbowBright))
+                    return RainbowDrip;
 
-                if (shouldHolyInWhite)
+                if (holyMovementEnabled && HolyInWhite.LevelChecked() && HasPaint & !HasStatusEffect(Buffs.MonochromeTones))
                     return OriginalHook(HolyInWhite);
 
-                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SwitfcastOption) && ActionReady(Role.Swiftcast) &&
-                    ((LevelChecked(CreatureMotif) && !gauge.CreatureMotifDrawn) ||
-                     (LevelChecked(WeaponMotif) && !gauge.WeaponMotifDrawn) ||
-                     (LevelChecked(LandscapeMotif) && !gauge.LandscapeMotifDrawn)))
+                if (swiftcastMotifMovementEnabled && ActionReady(Role.Swiftcast) &&
+                    (CreatureMotifReady || WeaponMotifReady || LandscapeMotifReady))
                     return Role.Swiftcast;
             }
+
+            #endregion
+
+            #region Pre_Burst Motifs
 
             //Prepare for Burst
             if (GetCooldownRemainingTime(ScenicMuse) <= 20)
             {
-                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif) && LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetTargetHPPercent() > landscapeStop)
+                if (landscapeMotifEnabled && LandscapeMotifReady && GetTargetHPPercent() > landscapeStop)
                     return OriginalHook(LandscapeMotif);
 
-                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif) && CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && GetTargetHPPercent() > creatureStop)
+                if (creatureMotifEnabled && CreatureMotifReady && GetTargetHPPercent() > creatureStop)
                     return OriginalHook(CreatureMotif);
 
-                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif) && WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasStatusEffect(Buffs.HammerTime) && GetTargetHPPercent() > weaponStop)
+                if (weaponMotifEnabled && WeaponMotifReady && GetTargetHPPercent() > weaponStop)
                     return OriginalHook(WeaponMotif);
             }
 
-            // Burst
-            if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_Phase) && HasStatusEffect(Buffs.StarryMuse))
-            {
+            #endregion
 
-                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_CometInBlack) && CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
-                    return CometinBlack;
+            #region GCDs
 
-                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_HammerCombo) && HammerStamp.LevelChecked() && HasStatusEffect(Buffs.HammerTime) && !HasStatusEffect(Buffs.Starstruck))
-                    return OriginalHook(HammerStamp);
+            //StarPrism
+            if (starPrismEnabled && HasStatusEffect(Buffs.Starstruck))
+                return StarPrism;
 
-                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_StarPrism))
-                {
-                    if (HasStatusEffect(Buffs.Starstruck) || (HasStatusEffect(Buffs.Starstruck) && GetStatusEffectRemainingTime(Buffs.Starstruck) <= 3f))
-                        return StarPrism;
-                }
-
-                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_RainbowDrip))
-                {
-                    if (HasStatusEffect(Buffs.RainbowBright) || (HasStatusEffect(Buffs.RainbowBright) && GetStatusEffectRemainingTime(Buffs.StarryMuse) <= 3f))
-                        return RainbowDrip;
-                }
-            }
-
-            if (HasStatusEffect(Buffs.RainbowBright) && !HasStatusEffect(Buffs.StarryMuse))
+            //RainbowDrip
+            if (rainbowDripEnabled && HasStatusEffect(Buffs.RainbowBright))
                 return RainbowDrip;
 
-            if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CometinBlack) && CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(StarryMuse) > 30f)
+            //Comet in Black
+            if (cometEnabled && CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint)
                 return OriginalHook(CometinBlack);
 
-            if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_HammerStampCombo) && HammerStamp.LevelChecked() && HasStatusEffect(Buffs.HammerTime))
+            //Hammer Stamp Combo
+            if (hammerEnabled && ActionReady(OriginalHook(HammerStamp)) && ScenicCD > 10)
                 return OriginalHook(HammerStamp);
+            
+            // LandscapeMotif
+            if (landscapeMotifEnabled && LandscapeMotifReady && GetTargetHPPercent() > landscapeStop && 
+                GetCooldownRemainingTime(ScenicMuse) <= 20)
+                return OriginalHook(LandscapeMotif);
 
-            if (!HasStatusEffect(Buffs.StarryMuse))
-            {
-                // LandscapeMotif
-                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif) && GetTargetHPPercent() > landscapeStop)
-                {
-                    if (LandscapeMotif.LevelChecked() &&
-                        !gauge.LandscapeMotifDrawn &&
-                        GetCooldownRemainingTime(ScenicMuse) <= 20)
-                    {
-                        return OriginalHook(LandscapeMotif);
-                    }
-                }
+            // CreatureMotif
+            if (creatureMotifEnabled && CreatureMotifReady &&  GetTargetHPPercent() > creatureStop &&
+                (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
+                return OriginalHook(CreatureMotif);                  
 
-                // CreatureMotif
-                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif) && GetTargetHPPercent() > creatureStop)
-                {
-                    if (CreatureMotif.LevelChecked() &&
-                        !gauge.CreatureMotifDrawn &&
-                        (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
-                    {
-                        return OriginalHook(CreatureMotif);
-                    }
-                }
+            // WeaponMotif
+            if (weaponMotifEnabled && WeaponMotifReady && GetTargetHPPercent() > weaponStop && 
+                (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
+                return OriginalHook(WeaponMotif);            
 
-                // WeaponMotif
-                if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif) && GetTargetHPPercent() > weaponStop)
-                {
-                    if (WeaponMotif.LevelChecked() &&
-                        !HasStatusEffect(Buffs.HammerTime) &&
-                        !gauge.WeaponMotifDrawn &&
-                        (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
-                    {
-                        return OriginalHook(WeaponMotif);
-                    }
-                }
-            }
-
-            if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LucidDreaming) && Role.CanLucidDream(Config.PCT_ST_AdvancedMode_LucidOption))
-                return Role.LucidDreaming;
-
-            if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_BlizzardInCyan) && BlizzardIIinCyan.LevelChecked() && HasStatusEffect(Buffs.SubtractivePalette))
+            //Subtractive Combo
+            if (blizzardComboEnabled && BlizzardIIinCyan.LevelChecked() && HasStatusEffect(Buffs.SubtractivePalette))
                 return OriginalHook(BlizzardinCyan);
 
             return actionID;
+            #endregion
         }
     }
 
@@ -496,7 +426,6 @@ internal partial class PCT : Caster
                 return actionID;
 
             PCTGauge gauge = GetJobGauge<PCTGauge>();
-            bool canWeave = CanSpellWeave();
 
             // Variant Cure
             if (Variant.CanCure(CustomComboPreset.PCT_Variant_Cure, Config.PCT_VariantCure))
@@ -519,7 +448,7 @@ internal partial class PCT : Caster
             }
 
             // General Weaves
-            if (InCombat() && canWeave)
+            if (InCombat() && CanSpellWeave())
             {
                 // LivingMuse
 
@@ -633,7 +562,7 @@ internal partial class PCT : Caster
             if (HasStatusEffect(Buffs.StarryMuse))
             {
                 // Check for CometInBlack
-                if (CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
+                if (CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint)
                     return CometinBlack;
 
                 // Check for HammerTime
@@ -652,7 +581,7 @@ internal partial class PCT : Caster
             if (HasStatusEffect(Buffs.RainbowBright) && !HasStatusEffect(Buffs.StarryMuse))
                 return RainbowDrip;
 
-            if (CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(StarryMuse) > 60)
+            if (CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint && GetCooldownRemainingTime(StarryMuse) > 60)
                 return OriginalHook(CometinBlack);
 
             if (HammerStamp.LevelChecked() && HasStatusEffect(Buffs.HammerTime))
@@ -692,7 +621,6 @@ internal partial class PCT : Caster
                 return actionID;
 
             PCTGauge gauge = GetJobGauge<PCTGauge>();
-            bool canWeave = CanSpellWeave();
             int creatureStop = Config.PCT_AoE_CreatureStop;
             int landscapeStop = Config.PCT_AoE_LandscapeStop;
             int weaponStop = Config.PCT_AoE_WeaponStop;
@@ -720,7 +648,7 @@ internal partial class PCT : Caster
             }
 
             // General Weaves
-            if (InCombat() && canWeave)
+            if (InCombat() && CanSpellWeave())
             {
                 // LivingMuse
                 if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LivingMuse))
@@ -841,7 +769,7 @@ internal partial class PCT : Caster
             if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_Phase) && HasStatusEffect(Buffs.StarryMuse))
             {
                 // Check for CometInBlack
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_CometInBlack) && CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
+                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_CometInBlack) && CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint)
                     return CometinBlack;
 
                 // Check for HammerTime
@@ -874,7 +802,7 @@ internal partial class PCT : Caster
             if (HasStatusEffect(Buffs.RainbowBright) && !HasStatusEffect(Buffs.StarryMuse))
                 return RainbowDrip;
 
-            if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CometinBlack) && CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(StarryMuse) > 60)
+            if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CometinBlack) && CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint && GetCooldownRemainingTime(StarryMuse) > 60)
                 return OriginalHook(CometinBlack);
 
             if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_HammerStampCombo) && HammerStamp.LevelChecked() && HasStatusEffect(Buffs.HammerTime))

--- a/WrathCombo/Combos/PvE/PCT/PCT.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT.cs
@@ -6,6 +6,8 @@ namespace WrathCombo.Combos.PvE;
 
 internal partial class PCT : Caster
 {
+
+    #region Single Target Combos
     internal class PCT_ST_SimpleMode : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PCT_ST_SimpleMode;
@@ -15,193 +17,168 @@ internal partial class PCT : Caster
             if (actionID is not FireInRed)
                 return actionID;
 
-            PCTGauge gauge = GetJobGauge<PCTGauge>();
-            
+            #region Variants
+            // Variant Cure
+            if (Variant.CanCure(CustomComboPreset.PCT_Variant_Cure, Config.PCT_VariantCure))
+                return Variant.Cure;
+
+            // Variant Rampart
+            if (Variant.CanRampart(CustomComboPreset.PCT_Variant_Rampart, WeaveTypes.SpellWeave))
+                return Variant.Rampart;
+            #endregion
+
+            #region Prepull
+            if ((!InCombat()) || (InCombat() && CurrentTarget == null))
+            {
+                if (CreatureMotifReady)
+                    return OriginalHook(CreatureMotif);
+                if (WeaponMotifReady)
+                    return OriginalHook(WeaponMotif);
+                if (LandscapeMotifReady)
+                    return OriginalHook(LandscapeMotif);
+            }
+            #endregion
+
+            #region Burst Window lvl 100 only
+            if (LevelChecked(StarPrism) &&InCombat() && (ScenicCD <= 5 || HasStatusEffect(Buffs.StarryMuse)))
+                return BurstWindow(actionID);
+
+            #endregion
+
+            #region OGCD
             // General Weaves
             if (InCombat() && CanSpellWeave())
             {
-                // ScenicMuse
-
-                if (ScenicMuse.LevelChecked() &&
-                    gauge.LandscapeMotifDrawn &&
-                    gauge.WeaponMotifDrawn &&
-                    IsOffCooldown(ScenicMuse))
-                {
+                // ScenicMuse pre-100
+                if (ScenicMuseReady && !LevelChecked(StarPrism))
                     return OriginalHook(ScenicMuse);
-                }
 
                 // LivingMuse
-
-                if (LivingMuse.LevelChecked() &&
-                    gauge.CreatureMotifDrawn &&
-                    (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
-                     GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)))
-                {
-                    if (HasCharges(OriginalHook(LivingMuse)))
-                    {
-                        if (!ScenicMuse.LevelChecked() ||
-                            GetCooldown(ScenicMuse).CooldownRemaining > GetCooldownChargeRemainingTime(LivingMuse))
-                        {
-                            return OriginalHook(LivingMuse);
-                        }
-                    }
-                }
+                if (LivingMuseReady &&
+                    (!PortraitReady || GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)) &&
+                    (!LevelChecked(ScenicMuse) || ScenicCD > GetCooldownChargeRemainingTime(LivingMuse)))
+                    return OriginalHook(LivingMuse);
 
                 // SteelMuse
-
-                if (SteelMuse.LevelChecked() &&
-                    !HasStatusEffect(Buffs.HammerTime) &&
-                    gauge.WeaponMotifDrawn &&
-                    HasCharges(OriginalHook(SteelMuse)) &&
-                    (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining ||
-                     GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
-                     !ScenicMuse.LevelChecked()))
-                {
+                if (SteelMuseReady &&
+                    (SteelCD < ScenicCD || GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
+                    !LevelChecked(ScenicMuse)))
                     return OriginalHook(SteelMuse);
-                }
 
-                // MogoftheAges
-
-                if (MogoftheAges.LevelChecked() &&
-                    (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) &&
+                // Portrait Mog or Madeen
+                if (PortraitReady &&
                     IsOffCooldown(OriginalHook(MogoftheAges)) &&
-                    (GetCooldownRemainingTime(StarryMuse) >= 60 || !ScenicMuse.LevelChecked()))
-                {
+                    (ScenicCD >= 60 || !LevelChecked(ScenicMuse)))
                     return OriginalHook(MogoftheAges);
-                }
-
-                // Swiftcast
-
-                if (IsMoving() &&
-                    IsOffCooldown(Role.Swiftcast) &&
-                    Role.Swiftcast.LevelChecked() &&
-                    !HasStatusEffect(Buffs.HammerTime) &&
-                    gauge.Paint < 1 &&
-                    (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
-                {
-                    return Role.Swiftcast;
-                }
 
                 // SubtractivePalette
+                if (PaletteReady)
+                    return SubtractivePalette;
 
-                if (SubtractivePalette.LevelChecked() &&
-                    !HasStatusEffect(Buffs.SubtractivePalette) &&
-                    !HasStatusEffect(Buffs.MonochromeTones))
-                {
-                    if (HasStatusEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
-                    {
-                        return SubtractivePalette;
-                    }
-                }
+                //LucidDreaming
+                if (Role.CanLucidDream(Config.PCT_ST_AdvancedMode_LucidOption))
+                    return Role.LucidDreaming;
             }
+            #endregion
 
+            #region Swiftcast Motifs
             // Swiftcast Motifs
             if (HasStatusEffect(Role.Buffs.Swiftcast))
             {
-                if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasStatusEffect(Buffs.StarryMuse))
+                if (CreatureMotifReady)
                     return OriginalHook(CreatureMotif);
-                if (!gauge.WeaponMotifDrawn && HammerMotif.LevelChecked() && !HasStatusEffect(Buffs.HammerTime) && !HasStatusEffect(Buffs.StarryMuse))
-                    return OriginalHook(HammerMotif);
-                if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasStatusEffect(Buffs.StarryMuse))
+                if (WeaponMotifReady)
+                    return OriginalHook(WeaponMotif);
+                if (LandscapeMotifReady)
                     return OriginalHook(LandscapeMotif);
             }
 
-            // IsMoving logic
+            #endregion
+
+            #region Moving
             if (IsMoving() && InCombat())
             {
+                if (HyperPhantasiaMovementPaint())
+                    return HasStatusEffect(Buffs.MonochromeTones) ? OriginalHook(CometinBlack) : OriginalHook(HolyInWhite);
+
                 if (HammerStamp.LevelChecked() && HasStatusEffect(Buffs.HammerTime))
                     return OriginalHook(HammerStamp);
 
-                if (CometinBlack.LevelChecked() && gauge.Paint >= 1 && HasStatusEffect(Buffs.MonochromeTones))
+                if (CometinBlack.LevelChecked() && HasPaint && HasStatusEffect(Buffs.MonochromeTones))
                     return OriginalHook(CometinBlack);
 
-                if (HasStatusEffect(Buffs.RainbowBright) || (HasStatusEffect(Buffs.RainbowBright) && GetStatusEffectRemainingTime(Buffs.StarryMuse) <= 3f))
+                if (HasStatusEffect(Buffs.RainbowBright))
                     return RainbowDrip;
 
-                if (HolyInWhite.LevelChecked() && gauge.Paint >= 1)
+                if (HolyInWhite.LevelChecked() && HasPaint & !HasStatusEffect(Buffs.MonochromeTones))
                     return OriginalHook(HolyInWhite);
+
+                if (ActionReady(Role.Swiftcast) &&
+                    (CreatureMotifReady || WeaponMotifReady || LandscapeMotifReady))
+                    return Role.Swiftcast;
             }
+
+            #endregion
+
+            #region Pre_Burst Motifs
 
             //Prepare for Burst
             if (GetCooldownRemainingTime(ScenicMuse) <= 20)
             {
-                if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn)
+                if (LandscapeMotifReady && GetTargetHPPercent() > 10)
                     return OriginalHook(LandscapeMotif);
 
-                if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
+                if (CreatureMotifReady && GetTargetHPPercent() > 10)
                     return OriginalHook(CreatureMotif);
 
-                if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasStatusEffect(Buffs.HammerTime))
+                if (WeaponMotifReady && GetTargetHPPercent() > 10)
                     return OriginalHook(WeaponMotif);
             }
 
-            // Burst
-            if (HasStatusEffect(Buffs.StarryMuse))
-            {
+            #endregion
 
-                if (CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint)
-                    return CometinBlack;
+            #region GCDs
 
-                if (HammerStamp.LevelChecked() && HasStatusEffect(Buffs.HammerTime) && !HasStatusEffect(Buffs.Starstruck))
-                    return OriginalHook(HammerStamp);
+            //StarPrism
+            if (HasStatusEffect(Buffs.Starstruck))
+                return StarPrism;
 
-                if (HasStatusEffect(Buffs.Starstruck) || (HasStatusEffect(Buffs.Starstruck) && GetStatusEffectRemainingTime(Buffs.Starstruck) <= 3f))
-                    return StarPrism;
-
-                if (HasStatusEffect(Buffs.RainbowBright) || (HasStatusEffect(Buffs.RainbowBright) && GetStatusEffectRemainingTime(Buffs.StarryMuse) <= 3f))
-                    return RainbowDrip;
-
-            }
-
-            if (HasStatusEffect(Buffs.RainbowBright) && !HasStatusEffect(Buffs.StarryMuse))
+            //RainbowDrip
+            if (HasStatusEffect(Buffs.RainbowBright))
                 return RainbowDrip;
 
-            if (CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint && GetCooldownRemainingTime(StarryMuse) > 30f)
+            //Comet in Black
+            if (CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint)
                 return OriginalHook(CometinBlack);
 
-            if (HammerStamp.LevelChecked() && HasStatusEffect(Buffs.HammerTime))
+            //Hammer Stamp Combo
+            if (ActionReady(OriginalHook(HammerStamp)) && ScenicCD > 10)
                 return OriginalHook(HammerStamp);
 
-            if (!HasStatusEffect(Buffs.StarryMuse))
-            {
-                // LandscapeMotif
+            // LandscapeMotif
+            if ( LandscapeMotifReady && GetTargetHPPercent() > 10 &&
+                GetCooldownRemainingTime(ScenicMuse) <= 20)
+                return OriginalHook(LandscapeMotif);
 
-                if (LandscapeMotif.LevelChecked() &&
-                    !gauge.LandscapeMotifDrawn &&
-                    GetCooldownRemainingTime(ScenicMuse) <= 20)
-                {
-                    return OriginalHook(LandscapeMotif);
-                }
+            // CreatureMotif
+            if (CreatureMotifReady && GetTargetHPPercent() > 10 &&
+                (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
+                return OriginalHook(CreatureMotif);
 
-                // CreatureMotif
+            // WeaponMotif
+            if (WeaponMotifReady && GetTargetHPPercent() > 10 &&
+                (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
+                return OriginalHook(WeaponMotif);
 
-                if (CreatureMotif.LevelChecked() &&
-                    !gauge.CreatureMotifDrawn &&
-                    (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
-                {
-                    return OriginalHook(CreatureMotif);
-                }
-
-                // WeaponMotif
-
-                if (WeaponMotif.LevelChecked() &&
-                    !HasStatusEffect(Buffs.HammerTime) &&
-                    !gauge.WeaponMotifDrawn &&
-                    (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
-                {
-                    return OriginalHook(WeaponMotif);
-                }
-            }
-
-            if (Role.CanLucidDream(6500))
-                return Role.LucidDreaming;
-
+            //Subtractive Combo
             if (BlizzardIIinCyan.LevelChecked() && HasStatusEffect(Buffs.SubtractivePalette))
                 return OriginalHook(BlizzardinCyan);
 
             return actionID;
+            #endregion
         }
-    }
+
+    }   
 
     internal class PCT_ST_AdvancedMode : CustomCombo
     {
@@ -277,7 +254,7 @@ internal partial class PCT : Caster
             #endregion
 
             #region Burst Window
-            if (burstPhaseEnabled && InCombat() && (ScenicCD <= 5 || HasStatusEffect(Buffs.StarryMuse)))
+            if (burstPhaseEnabled && LevelChecked(StarPrism) && InCombat() && (ScenicCD <= 5 || HasStatusEffect(Buffs.StarryMuse)))
                 return BurstWindow(actionID);
 
             #endregion
@@ -287,7 +264,7 @@ internal partial class PCT : Caster
             if (InCombat() && CanSpellWeave())
             {
                 // ScenicMuse
-                if (scenicMuseEnabled && ScenicMuseReady && !burstPhaseEnabled)
+                if (scenicMuseEnabled && ScenicMuseReady && (!burstPhaseEnabled || !LevelChecked(StarPrism)))
                     return OriginalHook(ScenicMuse);
                     
                 // LivingMuse
@@ -416,6 +393,10 @@ internal partial class PCT : Caster
         }
     }
 
+    #endregion
+
+    #region AOE Combos
+
     internal class PCT_AoE_SimpleMode : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PCT_AoE_SimpleMode;
@@ -425,8 +406,16 @@ internal partial class PCT : Caster
             if (actionID is not FireIIinRed)
                 return actionID;
 
-            PCTGauge gauge = GetJobGauge<PCTGauge>();
+            #region Enables and Configs
 
+            int creatureStop = 10;
+            int landscapeStop = 10;
+            int weaponStop = 10;
+            int holdPaintCharges = 2;
+
+            #endregion
+
+            #region Variants
             // Variant Cure
             if (Variant.CanCure(CustomComboPreset.PCT_Variant_Cure, Config.PCT_VariantCure))
                 return Variant.Cure;
@@ -434,180 +423,157 @@ internal partial class PCT : Caster
             // Variant Rampart
             if (Variant.CanRampart(CustomComboPreset.PCT_Variant_Rampart, WeaveTypes.SpellWeave))
                 return Variant.Rampart;
+            #endregion
 
-            // Prepull logic
-
-            if (!InCombat() || (InCombat() && CurrentTarget == null))
+            #region Prepull
+            if ((!InCombat()) || (InCombat() && CurrentTarget == null))
             {
-                if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
+                if (CreatureMotifReady)
                     return OriginalHook(CreatureMotif);
-                if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasStatusEffect(Buffs.HammerTime))
+                if (WeaponMotifReady)
                     return OriginalHook(WeaponMotif);
-                if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && !HasStatusEffect(Buffs.StarryMuse))
+                if (LandscapeMotifReady)
                     return OriginalHook(LandscapeMotif);
             }
+            #endregion
 
+            #region OGCD
             // General Weaves
             if (InCombat() && CanSpellWeave())
             {
-                // LivingMuse
-
-                if (LivingMuse.LevelChecked() &&
-                    gauge.CreatureMotifDrawn &&
-                    (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
-                     GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)))
-                {
-                    if (HasCharges(OriginalHook(LivingMuse)))
-                    {
-                        if (!ScenicMuse.LevelChecked() ||
-                            GetCooldown(ScenicMuse).CooldownRemaining > GetCooldownChargeRemainingTime(LivingMuse))
-                        {
-                            return OriginalHook(LivingMuse);
-                        }
-                    }
-                }
-
                 // ScenicMuse
-
-                if (ScenicMuse.LevelChecked() &&
-                    gauge.LandscapeMotifDrawn &&
-                    gauge.WeaponMotifDrawn &&
-                    IsOffCooldown(ScenicMuse))
-                {
+                if (ScenicMuseReady)
                     return OriginalHook(ScenicMuse);
-                }
+
+                // LivingMuse
+                if (LivingMuseReady &&
+                    (!PortraitReady || GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)) &&
+                    (!LevelChecked(ScenicMuse) || ScenicCD > GetCooldownChargeRemainingTime(LivingMuse)))
+                    return OriginalHook(LivingMuse);
 
                 // SteelMuse
-
-                if (SteelMuse.LevelChecked() &&
-                    !HasStatusEffect(Buffs.HammerTime) &&
-                    gauge.WeaponMotifDrawn &&
-                    HasCharges(OriginalHook(SteelMuse)) &&
-                    (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining ||
-                     GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
-                     !ScenicMuse.LevelChecked()))
-                {
+                if (SteelMuseReady &&
+                    (SteelCD < ScenicCD || GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
+                    !LevelChecked(ScenicMuse)))
                     return OriginalHook(SteelMuse);
-                }
 
-                // MogoftheAges
-
-                if (MogoftheAges.LevelChecked() &&
-                    (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) &&
-                    (IsOffCooldown(OriginalHook(MogoftheAges)) || !ScenicMuse.LevelChecked()))
-                {
+                // Portrait Mog or Madeen
+                if (PortraitReady &&
+                    IsOffCooldown(OriginalHook(MogoftheAges)) &&
+                    (ScenicCD >= 60 || !LevelChecked(ScenicMuse)))
                     return OriginalHook(MogoftheAges);
-                }
 
-                if (IsMoving() &&
-                    IsOffCooldown(Role.Swiftcast) &&
-                    Role.Swiftcast.LevelChecked() &&
-                    !HasStatusEffect(Buffs.HammerTime) &&
-                    gauge.Paint < 1 &&
-                    (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
-                {
-                    return Role.Swiftcast;
-                }
+                // SubtractivePalette
+                if (PaletteReady)
+                    return SubtractivePalette;
 
-                // Subtractive Palette
-                if (SubtractivePalette.LevelChecked() &&
-                    !HasStatusEffect(Buffs.SubtractivePalette) &&
-                    !HasStatusEffect(Buffs.MonochromeTones))
-                {
-                    if (HasStatusEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
-                        return SubtractivePalette;
-                }
+                //LucidDreaming
+                if (Role.CanLucidDream(Config.PCT_ST_AdvancedMode_LucidOption))
+                    return Role.LucidDreaming;
             }
+            #endregion
 
+            #region Swiftcast Motifs
+            // Swiftcast Motifs
             if (HasStatusEffect(Role.Buffs.Swiftcast))
             {
-                if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasStatusEffect(Buffs.StarryMuse))
+                if (CreatureMotifReady && GetTargetHPPercent() > creatureStop)
                     return OriginalHook(CreatureMotif);
-                if (!gauge.WeaponMotifDrawn && HammerMotif.LevelChecked() && !HasStatusEffect(Buffs.HammerTime) && !HasStatusEffect(Buffs.StarryMuse))
-                    return OriginalHook(HammerMotif);
-                if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasStatusEffect(Buffs.StarryMuse))
+                if (WeaponMotifReady && GetTargetHPPercent() > weaponStop)
+                    return OriginalHook(WeaponMotif);
+                if (LandscapeMotifReady && GetTargetHPPercent() > landscapeStop)
                     return OriginalHook(LandscapeMotif);
             }
 
+            #endregion
+
+            #region Moving
             if (IsMoving() && InCombat())
             {
+                if (HyperPhantasiaMovementPaint())
+                    return HasStatusEffect(Buffs.MonochromeTones) ? OriginalHook(CometinBlack) : OriginalHook(HolyInWhite);
+
                 if (HammerStamp.LevelChecked() && HasStatusEffect(Buffs.HammerTime))
                     return OriginalHook(HammerStamp);
 
-                if (CometinBlack.LevelChecked() && gauge.Paint >= 1 && HasStatusEffect(Buffs.MonochromeTones))
+                if (CometinBlack.LevelChecked() && HasPaint && HasStatusEffect(Buffs.MonochromeTones))
                     return OriginalHook(CometinBlack);
 
-                if (HasStatusEffect(Buffs.RainbowBright) || (HasStatusEffect(Buffs.RainbowBright) && GetStatusEffectRemainingTime(Buffs.StarryMuse) < 3))
+                if (HasStatusEffect(Buffs.RainbowBright))
                     return RainbowDrip;
 
-                if (HolyInWhite.LevelChecked() && gauge.Paint >= 1)
+                if (HolyInWhite.LevelChecked() && HasPaint & !HasStatusEffect(Buffs.MonochromeTones))
                     return OriginalHook(HolyInWhite);
 
+                if (ActionReady(Role.Swiftcast) &&
+                    (CreatureMotifReady || WeaponMotifReady || LandscapeMotifReady))
+                    return Role.Swiftcast;
             }
+
+            #endregion
+
+            #region Pre_Burst Motifs
 
             //Prepare for Burst
             if (GetCooldownRemainingTime(ScenicMuse) <= 20)
             {
-                if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn)
+                if (LandscapeMotifReady && GetTargetHPPercent() > landscapeStop)
                     return OriginalHook(LandscapeMotif);
 
-                if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
+                if (CreatureMotifReady && GetTargetHPPercent() > creatureStop)
                     return OriginalHook(CreatureMotif);
 
-                if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasStatusEffect(Buffs.HammerTime))
+                if (WeaponMotifReady && GetTargetHPPercent() > weaponStop)
                     return OriginalHook(WeaponMotif);
             }
 
-            // Burst
-            if (HasStatusEffect(Buffs.StarryMuse))
-            {
-                // Check for CometInBlack
-                if (CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint)
-                    return CometinBlack;
+            #endregion
 
-                // Check for HammerTime
-                if (HammerStamp.LevelChecked() && HasStatusEffect(Buffs.HammerTime) && !HasStatusEffect(Buffs.Starstruck))
-                    return OriginalHook(HammerStamp);
+            #region GCDs
 
-                // Check for Starstruck
-                if (HasStatusEffect(Buffs.Starstruck) || (HasStatusEffect(Buffs.Starstruck) && GetStatusEffectRemainingTime(Buffs.Starstruck) < 3))
-                    return StarPrism;
+            //StarPrism
+            if (HasStatusEffect(Buffs.Starstruck))
+                return StarPrism;
 
-                // Check for RainbowBright
-                if (HasStatusEffect(Buffs.RainbowBright) || (HasStatusEffect(Buffs.RainbowBright) && GetStatusEffectRemainingTime(Buffs.StarryMuse) < 3))
-                    return RainbowDrip;
-            }
-
-            if (HasStatusEffect(Buffs.RainbowBright) && !HasStatusEffect(Buffs.StarryMuse))
+            //RainbowDrip
+            if (HasStatusEffect(Buffs.RainbowBright))
                 return RainbowDrip;
 
-            if (CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint && GetCooldownRemainingTime(StarryMuse) > 60)
+            //Comet in Black
+            if (CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint)
                 return OriginalHook(CometinBlack);
 
-            if (HammerStamp.LevelChecked() && HasStatusEffect(Buffs.HammerTime))
+            //Hammer Stamp Combo
+            if (ActionReady(OriginalHook(HammerStamp)) && ScenicCD > 10)
                 return OriginalHook(HammerStamp);
 
-            if (!HasStatusEffect(Buffs.StarryMuse))
-            {
-                if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetCooldownRemainingTime(ScenicMuse) <= 20)
-                    return OriginalHook(LandscapeMotif);
+            // LandscapeMotif
+            if (LandscapeMotifReady && GetTargetHPPercent() > landscapeStop &&
+                GetCooldownRemainingTime(ScenicMuse) <= 20)
+                return OriginalHook(LandscapeMotif);
 
-                if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
-                    return OriginalHook(CreatureMotif);
+            // CreatureMotif
+            if (CreatureMotifReady && GetTargetHPPercent() > creatureStop &&
+                (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
+                return OriginalHook(CreatureMotif);
 
-                if (WeaponMotif.LevelChecked() && !HasStatusEffect(Buffs.HammerTime) && !gauge.WeaponMotifDrawn && (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
-                    return OriginalHook(WeaponMotif);
-            }
-            //Saves one Charge of White paint for movement/Black paint.
-            if (HolyInWhite.LevelChecked() && gauge.Paint >= 2)
-                return OriginalHook(HolyInWhite);
+            // WeaponMotif
+            if (WeaponMotifReady && GetTargetHPPercent() > weaponStop &&
+                (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
+                return OriginalHook(WeaponMotif);
 
-            if (Role.CanLucidDream(6500))
-                return Role.LucidDreaming;
-
+            //Subtractive Combo
             if (BlizzardIIinCyan.LevelChecked() && HasStatusEffect(Buffs.SubtractivePalette))
                 return OriginalHook(BlizzardIIinCyan);
+
+            //Holy In White
+            if (!HasStatusEffect(Buffs.StarryMuse) && !HasStatusEffect(Buffs.MonochromeTones) && gauge.Paint > holdPaintCharges)
+                return OriginalHook(HolyInWhite);
+
             return actionID;
+
+            #endregion
+
         }
     }
 
@@ -620,11 +586,39 @@ internal partial class PCT : Caster
             if (actionID is not FireIIinRed)
                 return actionID;
 
-            PCTGauge gauge = GetJobGauge<PCTGauge>();
+            #region Enables and Configs
+
             int creatureStop = Config.PCT_AoE_CreatureStop;
             int landscapeStop = Config.PCT_AoE_LandscapeStop;
             int weaponStop = Config.PCT_AoE_WeaponStop;
+            int holdPaintCharges = Config.PCT_AoE_AdvancedMode_HolyinWhiteOption;
 
+            bool prepullEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_PrePullMotifs);
+            bool noTargetMotifEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_NoTargetMotifs);
+            bool scenicMuseEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_ScenicMuse);
+            bool livingMuseEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LivingMuse);
+            bool steelMuseEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SteelMuse);
+            bool portraitEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MogOfTheAges);
+            bool paletteEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SubtractivePalette);
+            bool lucidDreamingEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LucidDreaming);
+            bool swiftMotifEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SwiftMotifs);
+            bool hammerMovementEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HammerStampCombo);
+            bool cometMovementEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_CometinBlack);
+            bool holyMovementEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HolyInWhite);
+            bool swiftcastMotifMovementEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SwitfcastOption);
+            bool landscapeMotifEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LandscapeMotif);
+            bool creatureMotifEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CreatureMotif);
+            bool weaponMotifEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_WeaponMotif);
+            bool starPrismEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_StarPrism);
+            bool rainbowDripEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_RainbowDrip);
+            bool cometEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CometinBlack);
+            bool hammerEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_HammerStampCombo);
+            bool blizzardComboEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_BlizzardInCyan);
+            bool holyInWhiteEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_HolyinWhite);
+
+            #endregion
+
+            #region Variants
             // Variant Cure
             if (Variant.CanCure(CustomComboPreset.PCT_Variant_Cure, Config.PCT_VariantCure))
                 return Variant.Cure;
@@ -632,211 +626,162 @@ internal partial class PCT : Caster
             // Variant Rampart
             if (Variant.CanRampart(CustomComboPreset.PCT_Variant_Rampart, WeaveTypes.SpellWeave))
                 return Variant.Rampart;
+            #endregion
 
-            // Prepull logic
-            if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_PrePullMotifs))
+            #region Prepull
+            if ((prepullEnabled && !InCombat()) || (noTargetMotifEnabled && InCombat() && CurrentTarget == null))
             {
-                if (!InCombat() || (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_NoTargetMotifs) && InCombat() && CurrentTarget == null))
-                {
-                    if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
-                        return OriginalHook(CreatureMotif);
-                    if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasStatusEffect(Buffs.HammerTime))
-                        return OriginalHook(WeaponMotif);
-                    if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && !HasStatusEffect(Buffs.StarryMuse))
-                        return OriginalHook(LandscapeMotif);
-                }
+                if (CreatureMotifReady)
+                    return OriginalHook(CreatureMotif);
+                if (WeaponMotifReady)
+                    return OriginalHook(WeaponMotif);
+                if (LandscapeMotifReady)
+                    return OriginalHook(LandscapeMotif);
             }
+            #endregion
 
+            #region OGCD
             // General Weaves
             if (InCombat() && CanSpellWeave())
             {
-                // LivingMuse
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LivingMuse))
-                {
-                    if (LivingMuse.LevelChecked() &&
-                        gauge.CreatureMotifDrawn &&
-                        (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
-                         GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)))
-                    {
-                        if (HasCharges(OriginalHook(LivingMuse)))
-                        {
-                            if (!ScenicMuse.LevelChecked() ||
-                                GetCooldown(ScenicMuse).CooldownRemaining > GetCooldownChargeRemainingTime(LivingMuse))
-                            {
-                                return OriginalHook(LivingMuse);
-                            }
-                        }
-                    }
-                }
-
                 // ScenicMuse
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_ScenicMuse))
-                {
-                    if (ScenicMuse.LevelChecked() &&
-                        gauge.LandscapeMotifDrawn &&
-                        gauge.WeaponMotifDrawn &&
-                        IsOffCooldown(ScenicMuse))
-                    {
-                        return OriginalHook(ScenicMuse);
-                    }
-                }
+                if (scenicMuseEnabled && ScenicMuseReady)
+                    return OriginalHook(ScenicMuse);
+
+                // LivingMuse
+                if (livingMuseEnabled && LivingMuseReady &&
+                    (!PortraitReady || GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)) &&
+                    (!LevelChecked(ScenicMuse) || ScenicCD > GetCooldownChargeRemainingTime(LivingMuse)))
+                    return OriginalHook(LivingMuse);
 
                 // SteelMuse
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SteelMuse))
-                {
-                    if (SteelMuse.LevelChecked() &&
-                        !HasStatusEffect(Buffs.HammerTime) &&
-                        gauge.WeaponMotifDrawn &&
-                        HasCharges(OriginalHook(SteelMuse)) &&
-                        (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining ||
-                         GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
-                         !ScenicMuse.LevelChecked()))
-                    {
-                        return OriginalHook(SteelMuse);
-                    }
-                }
+                if (steelMuseEnabled && SteelMuseReady &&
+                    (SteelCD < ScenicCD || GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
+                    !LevelChecked(ScenicMuse)))
+                    return OriginalHook(SteelMuse);
 
-                // MogoftheAges
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MogOfTheAges))
-                {
-                    if (MogoftheAges.LevelChecked() &&
-                        (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) &&
-                        (IsOffCooldown(OriginalHook(MogoftheAges)) || !ScenicMuse.LevelChecked()))
-                    {
-                        return OriginalHook(MogoftheAges);
-                    }
-                }
+                // Portrait Mog or Madeen
+                if (portraitEnabled && PortraitReady &&
+                    IsOffCooldown(OriginalHook(MogoftheAges)) &&
+                    (ScenicCD >= 60 || !LevelChecked(ScenicMuse)))
+                    return OriginalHook(MogoftheAges);
 
-                // Subtractive Palette
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SubtractivePalette) &&
-                    SubtractivePalette.LevelChecked() &&
-                    !HasStatusEffect(Buffs.SubtractivePalette) &&
-                    !HasStatusEffect(Buffs.MonochromeTones))
-                {
-                    if (HasStatusEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
-                        return SubtractivePalette;
-                }
+                // SubtractivePalette
+                if (paletteEnabled && PaletteReady)
+                    return SubtractivePalette;
+
+                //LucidDreaming
+                if (lucidDreamingEnabled && Role.CanLucidDream(Config.PCT_ST_AdvancedMode_LucidOption))
+                    return Role.LucidDreaming;
             }
+            #endregion
 
-            if (HasStatusEffect(Role.Buffs.Swiftcast))
+            #region Swiftcast Motifs
+            // Swiftcast Motifs
+            if (swiftMotifEnabled && HasStatusEffect(Role.Buffs.Swiftcast))
             {
-                if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasStatusEffect(Buffs.StarryMuse) && GetTargetHPPercent() > creatureStop)
+                if (CreatureMotifReady && GetTargetHPPercent() > creatureStop)
                     return OriginalHook(CreatureMotif);
-                if (!gauge.WeaponMotifDrawn && HammerMotif.LevelChecked() && !HasStatusEffect(Buffs.HammerTime) && !HasStatusEffect(Buffs.StarryMuse) && GetTargetHPPercent() > weaponStop)
-                    return OriginalHook(HammerMotif);
-                if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasStatusEffect(Buffs.StarryMuse) && GetTargetHPPercent() > landscapeStop)
+                if (WeaponMotifReady && GetTargetHPPercent() > weaponStop)
+                    return OriginalHook(WeaponMotif);
+                if (LandscapeMotifReady && GetTargetHPPercent() > landscapeStop)
                     return OriginalHook(LandscapeMotif);
             }
 
+            #endregion
+
+            #region Moving
             if (IsMoving() && InCombat())
             {
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HammerStampCombo) && HammerStamp.LevelChecked() && HasStatusEffect(Buffs.HammerTime))
+                if (HyperPhantasiaMovementPaint())
+                    return HasStatusEffect(Buffs.MonochromeTones) ? OriginalHook(CometinBlack) : OriginalHook(HolyInWhite);
+
+                if (hammerMovementEnabled && HammerStamp.LevelChecked() && HasStatusEffect(Buffs.HammerTime))
                     return OriginalHook(HammerStamp);
 
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_CometinBlack) && CometinBlack.LevelChecked() && gauge.Paint >= 1 && HasStatusEffect(Buffs.MonochromeTones))
+                if (cometMovementEnabled && CometinBlack.LevelChecked() && HasPaint && HasStatusEffect(Buffs.MonochromeTones))
                     return OriginalHook(CometinBlack);
 
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_RainbowDrip))
-                {
-                    if (HasStatusEffect(Buffs.RainbowBright) || (HasStatusEffect(Buffs.RainbowBright) && GetStatusEffectRemainingTime(Buffs.StarryMuse) < 3))
-                        return RainbowDrip;
-                }
+                if (rainbowDripEnabled && HasStatusEffect(Buffs.RainbowBright))
+                    return RainbowDrip;
 
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HolyInWhite) && HolyInWhite.LevelChecked() && gauge.Paint >= 1)
+                if (holyMovementEnabled && HolyInWhite.LevelChecked() && HasPaint & !HasStatusEffect(Buffs.MonochromeTones))
                     return OriginalHook(HolyInWhite);
 
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SwitfcastOption) && ActionReady(Role.Swiftcast) &&
-                    ((LevelChecked(CreatureMotif) && !gauge.CreatureMotifDrawn) ||
-                     (LevelChecked(WeaponMotif) && !gauge.WeaponMotifDrawn) ||
-                     (LevelChecked(LandscapeMotif) && !gauge.LandscapeMotifDrawn)))
+                if (swiftcastMotifMovementEnabled && ActionReady(Role.Swiftcast) &&
+                    (CreatureMotifReady || WeaponMotifReady || LandscapeMotifReady))
                     return Role.Swiftcast;
             }
+
+            #endregion
+
+            #region Pre_Burst Motifs
 
             //Prepare for Burst
             if (GetCooldownRemainingTime(ScenicMuse) <= 20)
             {
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LandscapeMotif) && LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetTargetHPPercent() > landscapeStop)
+                if (landscapeMotifEnabled && LandscapeMotifReady && GetTargetHPPercent() > landscapeStop)
                     return OriginalHook(LandscapeMotif);
 
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CreatureMotif) && CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && GetTargetHPPercent() > creatureStop)
+                if (creatureMotifEnabled && CreatureMotifReady && GetTargetHPPercent() > creatureStop)
                     return OriginalHook(CreatureMotif);
 
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_WeaponMotif) && WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasStatusEffect(Buffs.HammerTime) && GetTargetHPPercent() > weaponStop)
+                if (weaponMotifEnabled && WeaponMotifReady && GetTargetHPPercent() > weaponStop)
                     return OriginalHook(WeaponMotif);
             }
 
-            // Burst
-            if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_Phase) && HasStatusEffect(Buffs.StarryMuse))
-            {
-                // Check for CometInBlack
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_CometInBlack) && CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint)
-                    return CometinBlack;
+            #endregion
 
-                // Check for HammerTime
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_HammerCombo) && HammerStamp.LevelChecked() && HasStatusEffect(Buffs.HammerTime) && !HasStatusEffect(Buffs.Starstruck))
-                    return OriginalHook(HammerStamp);
+            #region GCDs
 
-                // Check for Starstruck
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_StarPrism))
-                {
-                    if (HasStatusEffect(Buffs.Starstruck) || (HasStatusEffect(Buffs.Starstruck) && GetStatusEffectRemainingTime(Buffs.Starstruck) < 3))
-                        return StarPrism;
-                }
+            //StarPrism
+            if (starPrismEnabled && HasStatusEffect(Buffs.Starstruck))
+                return StarPrism;
 
-                // Check for RainbowBright
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_RainbowDrip))
-                {
-                    if (HasStatusEffect(Buffs.RainbowBright) || (HasStatusEffect(Buffs.RainbowBright) && GetStatusEffectRemainingTime(Buffs.StarryMuse) < 3))
-                        return RainbowDrip;
-                }
-            }
-
-            if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_HolyinWhite) && !HasStatusEffect(Buffs.StarryMuse) && !HasStatusEffect(Buffs.MonochromeTones))
-            {
-                if (gauge.Paint > Config.PCT_AoE_AdvancedMode_HolyinWhiteOption ||
-                    (Config.PCT_AoE_AdvancedMode_HolyinWhiteOption == 5 && gauge.Paint == 5 && !HasStatusEffect(Buffs.HammerTime) &&
-                     (HasStatusEffect(Buffs.RainbowBright) || WasLastSpell(AeroIIinGreen) || WasLastSpell(StoneIIinYellow))))
-                    return OriginalHook(HolyInWhite);
-            }
-
-            if (HasStatusEffect(Buffs.RainbowBright) && !HasStatusEffect(Buffs.StarryMuse))
+            //RainbowDrip
+            if (rainbowDripEnabled && HasStatusEffect(Buffs.RainbowBright))
                 return RainbowDrip;
 
-            if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CometinBlack) && CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint && GetCooldownRemainingTime(StarryMuse) > 60)
+            //Comet in Black
+            if (cometEnabled && CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint)
                 return OriginalHook(CometinBlack);
 
-            if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_HammerStampCombo) && HammerStamp.LevelChecked() && HasStatusEffect(Buffs.HammerTime))
+            //Hammer Stamp Combo
+            if (hammerEnabled && ActionReady(OriginalHook(HammerStamp)) && ScenicCD > 10)
                 return OriginalHook(HammerStamp);
 
-            if (!HasStatusEffect(Buffs.StarryMuse))
-            {
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LandscapeMotif) && GetTargetHPPercent() > landscapeStop)
-                {
-                    if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetCooldownRemainingTime(ScenicMuse) <= 20)
-                        return OriginalHook(LandscapeMotif);
-                }
+            // LandscapeMotif
+            if (landscapeMotifEnabled && LandscapeMotifReady && GetTargetHPPercent() > landscapeStop &&
+                GetCooldownRemainingTime(ScenicMuse) <= 20)
+                return OriginalHook(LandscapeMotif);
 
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CreatureMotif) && GetTargetHPPercent() > creatureStop)
-                {
-                    if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
-                        return OriginalHook(CreatureMotif);
-                }
+            // CreatureMotif
+            if (creatureMotifEnabled && CreatureMotifReady && GetTargetHPPercent() > creatureStop &&
+                (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
+                return OriginalHook(CreatureMotif);
 
-                if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_WeaponMotif) && GetTargetHPPercent() > weaponStop)
-                {
-                    if (WeaponMotif.LevelChecked() && !HasStatusEffect(Buffs.HammerTime) && !gauge.WeaponMotifDrawn && (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
-                        return OriginalHook(WeaponMotif);
-                }
-            }
+            // WeaponMotif
+            if (weaponMotifEnabled && WeaponMotifReady && GetTargetHPPercent() > weaponStop &&
+                (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
+                return OriginalHook(WeaponMotif);
 
-            if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LucidDreaming) && Role.CanLucidDream(Config.PCT_ST_AdvancedMode_LucidOption))
-                return Role.LucidDreaming;
-
-            if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_BlizzardInCyan) && BlizzardIIinCyan.LevelChecked() && HasStatusEffect(Buffs.SubtractivePalette))
+            //Subtractive Combo
+            if (blizzardComboEnabled && BlizzardIIinCyan.LevelChecked() && HasStatusEffect(Buffs.SubtractivePalette))
                 return OriginalHook(BlizzardIIinCyan);
+
+            //Holy In White
+            if (holyInWhiteEnabled && !HasStatusEffect(Buffs.StarryMuse) && !HasStatusEffect(Buffs.MonochromeTones) && gauge.Paint > holdPaintCharges)
+                return OriginalHook(HolyInWhite);
+
             return actionID;
+
+            #endregion
         }
     }
+
+    #endregion
+
+    #region Smaller Features
 
     internal class CombinedAetherhues : CustomCombo
     {
@@ -917,4 +862,6 @@ internal partial class PCT : Caster
             return actionID;
         }
     }
+
+    #endregion
 }

--- a/WrathCombo/Combos/PvE/PCT/PCT_Config.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT_Config.cs
@@ -73,17 +73,6 @@ internal partial class PCT
                         $"Add {StarPrism.ActionName()} when under the effect of {Buffs.Starstruck.StatusName()}.");
                     break;
 
-                case CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HolyInWhite:
-                    UserConfig.DrawAdditionalBoolChoice(WhiteHyperphantasiaOption, "Hyperphantasia Priority Option",
-                        $"Prioritizes {HolyInWhite.ActionName()} if {Buffs.Inspiration.StatusName()} and {Buffs.Hyperphantasia.StatusName()} are active.");
-                    break;
-
-                case CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_CometinBlack:
-                    UserConfig.DrawAdditionalBoolChoice(BlackHyperphantasiaOption, "Hyperphantasia Priority Option",
-                        $"Prioritizes {CometinBlack.ActionName()} if {Buffs.Inspiration.StatusName()} and {Buffs.Hyperphantasia.StatusName()} are active.");
-                    break;
-
-
                 case CustomComboPreset.PCT_ST_AdvancedMode_LucidDreaming:
                     UserConfig.DrawSliderInt(0, 10000, PCT_ST_AdvancedMode_LucidOption,
                         "Add Lucid Dreaming when below this MP", sliderIncrement: SliderIncrements.Hundreds);

--- a/WrathCombo/Combos/PvE/PCT/PCT_Helper.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT_Helper.cs
@@ -1,15 +1,122 @@
-﻿using Dalamud.Game.ClientState.JobGauge.Types;
-using ECommons.DalamudServices;
+﻿#region Dependencies
+using Dalamud.Game.ClientState.JobGauge.Types;
 using System;
 using System.Collections.Generic;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
+using WrathCombo.Extensions;
+#endregion
 
 namespace WrathCombo.Combos.PvE;
 
 internal partial class PCT
 {
+    #region Variables
+
+    // Gauge Stuff
+    internal static PCTGauge gauge = GetJobGauge<PCTGauge>();
+
+
+    //Useful Bools
+    internal static bool ScenicMuseReady => gauge.LandscapeMotifDrawn && LevelChecked(ScenicMuse);
+    internal static bool LivingMuseReady => LevelChecked(LivingMuse) && gauge.CreatureMotifDrawn;
+    internal static bool SteelMuseReady => LevelChecked(SteelMuse) && !HasStatusEffect(Buffs.HammerTime) && gauge.WeaponMotifDrawn;
+    internal static bool PortraitReady => MogoftheAges.LevelChecked() && (gauge.MooglePortraitReady || gauge.MadeenPortraitReady);
+    internal static bool CreatureMotifReady => !gauge.CreatureMotifDrawn && LevelChecked(CreatureMotif) && !HasStatusEffect(Buffs.StarryMuse);
+    internal static bool WeaponMotifReady => !gauge.WeaponMotifDrawn && LevelChecked(WeaponMotif) && !HasStatusEffect(Buffs.StarryMuse) && !HasStatusEffect(Buffs.HammerTime);
+    internal static bool LandscapeMotifReady => !gauge.LandscapeMotifDrawn && LevelChecked(LandscapeMotif) && !HasStatusEffect(Buffs.StarryMuse);
+    internal static bool PaletteReady => SubtractivePalette.LevelChecked() && !HasStatusEffect(Buffs.SubtractivePalette) && !HasStatusEffect(Buffs.MonochromeTones) && 
+                                            (HasStatusEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50 && ScenicCD > 40 || gauge.PalleteGauge == 100);
+    internal static bool HasPaint => gauge.Paint > 0;
+  
+
+
+    //Buff Tracking
+    internal static float ScenicCD => GetCooldownRemainingTime(StarryMuse);
+    internal static float SteelCD => GetCooldownRemainingTime(StrikingMuse);
+
+
+    #endregion
+
+    #region Functions
+    internal static bool HyperPhantasiaMovementPaint()
+    //Increase priority for using casts as soon as possible to avoid losing DPS and ensure all abilities fit within buff windows
+    //previously, there were situations where Wrath prioritized using Hammer Combo over casts during hyperphantasia, which would prevent us from generating Rainbow Bright in time when movement is required
+    //so, if we have Hyperphantasia stacks and Inspiration is active from standing in PCT LeyLines, we burn it all down
+    {
+        if (GetStatusEffectStacks(Buffs.Hyperphantasia) > 0 && HasStatusEffect(Buffs.Inspiration) && HasPaint)
+        {
+            if ((IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HolyInWhite) || IsEnabled(CustomComboPreset.PCT_ST_SimpleMode)) 
+                && HolyInWhite.LevelChecked())
+                return true;
+
+            if ((IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_CometinBlack) || IsEnabled(CustomComboPreset.PCT_ST_SimpleMode)) 
+                && CometinBlack.LevelChecked())
+                return true;
+        }
+        return false;
+    }
+
+
+    internal static uint BurstWindow(uint actionId)
+    {
+        if (!HasStatusEffect(Buffs.StarryMuse))
+        {
+            if (SteelMuseReady)
+                return OriginalHook(SteelMuse);
+
+            if (ActionReady(HammerStamp) && !HasStatusEffect(Buffs.StarryMuse) && ScenicCD < 1 && !JustUsed(HammerStamp, 3f))
+                return HammerStamp;
+
+            if (CanWeave() && ActionReady(SubtractivePalette) && !HasStatusEffect(Buffs.SubtractivePalette) && 
+                !HasStatusEffect(Buffs.MonochromeTones) && IsOffCooldown(ScenicMuse) &&
+                (HasStatusEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50))
+                return SubtractivePalette;
+
+            if (ScenicMuseReady && CanDelayedWeave() && IsOffCooldown(ScenicMuse))
+                return OriginalHook(ScenicMuse);            
+        }
+
+        if (HasStatusEffect(Buffs.SubtractivePalette) && (GetStatusEffectRemainingTime(Buffs.StarryMuse) > 10 || !HasStatusEffect(Buffs.StarryMuse)))
+            return OriginalHook(BlizzardinCyan);
+
+        if (HasStatusEffect(Buffs.StarryMuse) && GetStatusEffectRemainingTime(Buffs.StarryMuse) < 15)
+        {
+            if (CanSpellWeave() && !HasStatusEffect(Buffs.MonochromeTones))
+            {                
+                if (ActionReady(SubtractivePalette) && !HasStatusEffect(Buffs.Starstruck) &&
+                    !HasStatusEffect(Buffs.SubtractivePalette) && (HasStatusEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50))
+                    return SubtractivePalette;
+               
+                if (PortraitReady && IsOffCooldown(OriginalHook(MogoftheAges)))
+                    return OriginalHook(MogoftheAges);
+
+                if (LivingMuseReady && !PortraitReady)
+                    return OriginalHook(LivingMuse);
+            }
+
+            if (LevelChecked(CometinBlack) && HasStatusEffect(Buffs.MonochromeTones) && HasPaint && HasStatusEffect(Buffs.HammerTime))
+                return OriginalHook(CometinBlack);  
+
+            if (ActionReady(OriginalHook(HammerStamp)))
+                return OriginalHook(HammerStamp);
+
+            if (HasStatusEffect(Buffs.Starstruck))
+                return StarPrism;
+
+            if (HasStatusEffect(Buffs.RainbowBright))
+                return RainbowDrip;
+
+            if (CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint && !HasStatusEffect(Buffs.RainbowBright))
+                return OriginalHook(CometinBlack);
+        }
+        return actionId;
+    }
+
+   
+    #endregion
+
     #region ID's
 
     public const byte JobID = 42;
@@ -76,6 +183,8 @@ internal partial class PCT
     }
 
     #endregion
+
+    #region Openers
 
     internal static PCTopenerMaxLevel1 Opener1 = new();
     internal static PCTopenerMaxLevel2 Opener2 = new();
@@ -235,5 +344,7 @@ internal partial class PCT
 
             return true;
         }
+        
     }
+#endregion
 }


### PR DESCRIPTION
What it needs at this point. Is just lots of live testing and logs. So I can minimize the drift and make sure it is consistent. But I don't raid with it or main it. 

- [x] Advanced st
- [x] Advanced aoe
- [x] Simple st
- [x] Simple aoe
- [x] CCP/UI Cleanup
- [x] All Regions set up

Updated Single Target Advanced to use the h2/h3 burst as well as clean some things up with adding some small pooling to make h2/3 work. As such, removed the choose your burst window spells options. Simply a choice on whether to use the optimized burst window. It won't function if you disabled half the spells.

Added Definitions to helperfile as well as burst window function and Hyperfantasia function.

Updated Aoe to match the single target setup retaining the holy in white option as it is a dps increase to not hold them
There is no optimized burst window option for aoe. 

Converted the advanced modes to simple modes. 

Cleaned up and reorganized the ccp and ui. Removed un-used options and reorganized in a logical manner. 

Hyperfantasia  movement "option" was not actually hooked up from the checkbox to the code. It doesnt really need to be. it is just using holy or comet before hammer in this very specific event. removed the unused checkboxes. The hyperfantasia priority still functions. Just baked into ccp description. 


