### PR TITLE
ShouldSkipAutorotation Update

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -73,7 +73,8 @@ namespace WrathCombo.AutoRotation
             return !cfg.Enabled
                 || !Player.Available
                 || Player.Object.IsDead
-                || Svc.Condition[ConditionFlag.Mounted]
+                || GenericHelpers.IsOccupied()
+                || Player.Mounted
                 || !EzThrottler.Throttle("Autorot", cfg.Throttler);
         }
 


### PR DESCRIPTION
Stop Autorot running during various busy things (ie cutscenes). Solves small errors with Healers and post dungeon boss cutscene with Trusts. Yes I could null check CanAoEHeal but why do autorot stuff during busy moments? This seems like a better solution overall

Fixes #563