### PR TITLE
[IPC] Handle IPv6 better

### DIFF
--- a/WrathCombo/Services/IPC/Helper.cs
+++ b/WrathCombo/Services/IPC/Helper.cs
@@ -4,7 +4,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
+using Dalamud.Networking.Http;
 using ECommons;
 using ECommons.ExcelServices;
 using ECommons.EzIpcManager;
@@ -83,12 +85,11 @@ public partial class Helper(ref Leasing leasing)
             return null;
 
         // Detect the target type
-        var targetType = attr.CustomComboInfo.Name.Contains("single target", lower)
-            ? ComboTargetTypeKeys.SingleTarget
-            : (attr.CustomComboInfo.Name.Contains("- aoe", lower) ||
-               attr.CustomComboInfo.Name.Contains("aoe dps", lower))
-                ? ComboTargetTypeKeys.MultiTarget
-                : ComboTargetTypeKeys.Other;
+        var targetType = attr.CustomComboInfo.Name.Contains("single target", lower) ?
+            ComboTargetTypeKeys.SingleTarget :
+            (attr.CustomComboInfo.Name.Contains("- aoe", lower) ||
+             attr.CustomComboInfo.Name.Contains("aoe dps", lower)) ?
+                ComboTargetTypeKeys.MultiTarget : ComboTargetTypeKeys.Other;
 
         // Bail if it is not a Single-Target or Multi-Target primary preset
         if (targetType == ComboTargetTypeKeys.Other)
@@ -110,7 +111,7 @@ public partial class Helper(ref Leasing leasing)
             // Get the opposite mode
             var categorizedPreset =
                 P.IPCSearch.CurrentJobComboStatesCategorized
-                    [(Job)attr.CustomComboInfo.JobID]
+                        [(Job)attr.CustomComboInfo.JobID]
                     [targetType][simplicityLevelToSearchFor];
 
             // Return the opposite mode, as a proper preset
@@ -119,9 +120,10 @@ public partial class Helper(ref Leasing leasing)
                 Enum.Parse(typeof(CustomComboPreset), oppositeMode, true);
             return oppositeModePreset;
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
-            ex.LogWarning("No opposite combo found, this is probably correct if this is a healer.");
+            ex.LogWarning(
+                "No opposite combo found, this is probably correct if this is a healer.");
             return null;
         }
     }
@@ -153,9 +155,9 @@ public partial class Helper(ref Leasing leasing)
     /// <seealso cref="Provider.IsCurrentJobConfiguredOn" />
     /// <seealso cref="Provider.IsCurrentJobAutoModeOn" />
     internal ComboSimplicityLevelKeys? CheckCurrentJobModeIsEnabled
-            (ComboTargetTypeKeys mode,
-            ComboStateKeys enabledStateToCheck,
-            ComboSimplicityLevelKeys? previousMatch = null)
+    (ComboTargetTypeKeys mode,
+        ComboStateKeys enabledStateToCheck,
+        ComboSimplicityLevelKeys? previousMatch = null)
     {
         if (CustomComboFunctions.LocalPlayer is null)
             return null;
@@ -176,8 +178,12 @@ public partial class Helper(ref Leasing leasing)
             .TryGetValue(ComboSimplicityLevelKeys.Simple, out var simpleResults);
         var simpleHigher = simpleResults?.FirstOrDefault();
         var simple = simpleHigher?.Value;
+
         #region Override the Values with any IPC-control
-        CustomComboPreset? simpleComboPreset = simpleHigher is null ? null : (CustomComboPreset)
+
+        CustomComboPreset? simpleComboPreset = simpleHigher is null
+            ? null
+            : (CustomComboPreset)
             Enum.Parse(typeof(CustomComboPreset), simpleHigher.Value.Key, true);
         if (simpleComboPreset is not null)
         {
@@ -187,17 +193,22 @@ public partial class Helper(ref Leasing leasing)
                 P.IPCSearch.EnabledActions.Contains(
                     (CustomComboPreset)simpleComboPreset);
         }
+
         #endregion
 
         // Get the Advanced Mode settings
-        var (advancedKey, advancedValue) = comboStates[mode][ComboSimplicityLevelKeys.Advanced].First();
+        var (advancedKey, advancedValue) =
+            comboStates[mode][ComboSimplicityLevelKeys.Advanced].First();
+
         #region Override the Values with any IPC-control
+
         var advancedComboPreset = (CustomComboPreset)
             Enum.Parse(typeof(CustomComboPreset), advancedKey, true);
         advancedValue[ComboStateKeys.AutoMode] =
             P.IPCSearch.AutoActions[advancedComboPreset];
         advancedValue[ComboStateKeys.Enabled] =
             P.IPCSearch.EnabledActions.Contains(advancedComboPreset);
+
         #endregion
 
         // If the simplicity level is set, check that specifically instead of either
@@ -212,11 +223,10 @@ public partial class Helper(ref Leasing leasing)
         }
 
         // Check for either Simple or Advanced being ready
-        return simple is not null && simple[enabledStateToCheck]
-            ? ComboSimplicityLevelKeys.Simple
-            : advancedValue[enabledStateToCheck]
-                ? ComboSimplicityLevelKeys.Advanced
-                : null;
+        return simple is not null && simple[enabledStateToCheck] ?
+            ComboSimplicityLevelKeys.Simple :
+            advancedValue[enabledStateToCheck] ? ComboSimplicityLevelKeys.Advanced :
+                null;
     }
 
     /// <summary>
@@ -361,7 +371,17 @@ public partial class Helper(ref Leasing leasing)
 
     #region Checking the repo for live IPC status
 
-    private readonly HttpClient _httpClient = new();
+    /// Dalamud's happy eyeballs handler, which handles IPv6, among other things.
+    // ReSharper disable once InconsistentNaming
+    private static readonly SocketsHttpHandler _httpHandler = new()
+    {
+        AutomaticDecompression = DecompressionMethods.All,
+        ConnectCallback = new HappyEyeballsCallback().ConnectCallback,
+    };
+
+    /// The HTTP client, setup with a short timeout and Dalamud's happy handler.
+    private readonly HttpClient _httpClient = new(_httpHandler)
+        { Timeout = TS.FromSeconds(5) };
 
     /// <summary>
     ///     The endpoint for checking the IPC status straight from the repo,

--- a/WrathCombo/Services/IPC/Helper.cs
+++ b/WrathCombo/Services/IPC/Helper.cs
@@ -407,10 +407,10 @@ public partial class Helper(ref Leasing leasing)
     {
         get
         {
-            // If the IPC status was checked within the last 5 minutes:
+            // If the IPC status was checked within the last 20 minutes:
             // return the cached value
             if (_ipcEnabled is not null &&
-                !EZ.Throttle("ipcLastStatusChecked", TS.FromMinutes(5)))
+                !EZ.Throttle("ipcLastStatusChecked", TS.FromMinutes(20)))
                 return _ipcEnabled!.Value;
 
             // Otherwise, check the status and cache the result

--- a/WrathCombo/Services/IPC/Provider.cs
+++ b/WrathCombo/Services/IPC/Provider.cs
@@ -125,6 +125,7 @@ public partial class Provider : IDisposable
             return;
         }
 
+        // Getting the IPC status early
         _ = P.IPC.Helper.IPCEnabled;
 
         // Build job-specific combo state caches

--- a/WrathCombo/Services/IPC/Provider.cs
+++ b/WrathCombo/Services/IPC/Provider.cs
@@ -125,6 +125,8 @@ public partial class Provider : IDisposable
             return;
         }
 
+        _ = P.IPC.Helper.IPCEnabled;
+
         // Build job-specific combo state caches
         // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
         P.IPCSearch.ComboStatesByJob.TryGetValue(Player.Job, out _);

--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -16,8 +16,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Dalamud.Networking.Http;
 using ECommons.Logging;
 using WrathCombo.Attributes;
 using WrathCombo.AutoRotation;
@@ -45,7 +47,12 @@ public sealed partial class WrathCombo : IDalamudPlugin
     internal static DateTime LastPresetDeconflictTime = DateTime.MinValue;
     internal static WrathCombo? P;
     private readonly WindowSystem ws;
-    private readonly HttpClient httpClient = new();
+    private static readonly SocketsHttpHandler httpHandler = new()
+    {
+        AutomaticDecompression = DecompressionMethods.All,
+        ConnectCallback = new HappyEyeballsCallback().ConnectCallback,
+    };
+    private readonly HttpClient httpClient = new(httpHandler) { Timeout = TimeSpan.FromSeconds(5) };
     private readonly IDtrBarEntry DtrBarEntry;
     internal Provider IPC;
     internal Search IPCSearch = null!;


### PR DESCRIPTION
- [X] Uses Dalamud's `Happy Eyeballs` handler for the HTTP client used to check the status of the IPC
- [X] Adds a short timeout, if that still doesn't handle some peoples' network setups
- [X] Applies the same to the MotD http client