### PR TITLE
[PvP] Common Library Update

### DIFF
--- a/WrathCombo/Combos/PvP/ALL/ALL.cs
+++ b/WrathCombo/Combos/PvP/ALL/ALL.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Dalamud.Game.ClientState.Objects.Types;
-using ECommons.GameHelpers;
 using System.Collections.Generic;
 using System.Linq;
 using WrathCombo.Combos.PvE;
@@ -9,251 +8,251 @@ using WrathCombo.CustomComboNS.Functions;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 using static WrathCombo.Window.Functions.UserConfig;
 
-namespace WrathCombo.Combos.PvP
+namespace WrathCombo.Combos.PvP;
+
+internal static class PvPCommon
 {
-    internal static class PvPCommon
+    const uint RecuperateCost = 2500; // Recuperate MP Cost
+    const uint RecuperateAmount = 15000; // Recuperate Base Heal
+
+    public const uint
+        Teleport = 5,
+        Return = 6,
+        StandardElixir = 29055,
+        Recuperate = 29711,
+        Purify = 29056,
+        Guard = 29054,
+        Sprint = 29057,
+        PvPRoleAction = 43259;
+
+    internal class Debuffs
     {
-        public const uint
-            Teleport = 5,
-            Return = 6,
-            StandardElixir = 29055,
-            Recuperate = 29711,
-            Purify = 29056,
-            Guard = 29054,
-            Sprint = 29057;
+        public const ushort
+            Silence = 1347,
+            Bind = 1345,
+            Stun = 1343,
+            HalfAsleep = 3022, // Unused
+            Sleep = 1348, // Unused
+            DeepFreeze = 3219,
+            Heavy = 1344,
+            Unguarded = 3021,
+            MiracleOfNature = 3085;
+    }
 
-        internal class Config
+    internal class Buffs
+    {
+        public const ushort
+            Soaring = 1465, // Rival Wings
+            FlyingHigh = 1730, // Rival Wings
+            Sprint = 1342,
+            Guard = 3054,
+            WeakenedGuard = 3673,
+            RidingMecha = 1420;
+    }
+
+    internal class Config
+    {
+        public static UserInt
+            EmergencyHealThreshold = new("EmergencyHealThreshold"),
+            EmergencyGuardThreshold = new("EmergencyGuardThreshold");
+
+        public static UserBoolArray
+            QuickPurifyStatuses = new("QuickPurifyStatuses");
+
+        internal static void Draw(CustomComboPreset preset)
         {
-            public static UserInt
-                EmergencyHealThreshold = new("EmergencyHealThreshold"),
-                EmergencyGuardThreshold = new("EmergencyGuardThreshold");
-            public static UserBoolArray
-                QuickPurifyStatuses = new("QuickPurifyStatuses");
-
-            internal static void Draw(CustomComboPreset preset)
+            switch (preset)
             {
-                switch (preset)
-                {
-                    case CustomComboPreset.PvP_EmergencyHeals:
-                        if (Player.Object != null)
-                        {
-                            uint maxHP = Player.Object.MaxHp <= 15000 ? 0 : Player.Object.MaxHp - 15000;
+                case CustomComboPreset.PvP_EmergencyHeals:
+                    string baseMessage = $"Uses Recuperate when at or under the threshold.\n" +
+                         $"Calculated from (MaxHP - {RecuperateAmount:N0}) to prevent overhealing.";
 
-                            if (maxHP > 0)
-                            {
-                                int setting = EmergencyHealThreshold;
-                                float hpThreshold = (float)maxHP / 100 * setting;
-
-                                DrawSliderInt(1, 100, EmergencyHealThreshold, $"Set the percentage to be at or under for the feature to kick in.\n100% is considered to start at 15,000 less than your max HP to prevent wastage.\nHP Value to be at or under: {hpThreshold}");
-                            }
-
-                            else
-                            {
-                                DrawSliderInt(1, 100, EmergencyHealThreshold, "Set the percentage to be at or under for the feature to kick in.\n100% is considered to start at 15,000 less than your max HP to prevent wastage.");
-                            }
-                        }
-
-                        else
-                        {
-                            DrawSliderInt(1, 100, EmergencyHealThreshold, "Set the percentage to be at or under for the feature to kick in.\n100% is considered to start at 15,000 less than your max HP to prevent wastage.");
-                        }
-                        
-                        break;
-
-                    case CustomComboPreset.PvP_EmergencyGuard:
-                        DrawSliderInt(1, 100, EmergencyGuardThreshold, "Set the percentage to be at or under for the feature to kick in.");
-                        break;
-
-                    case CustomComboPreset.PvP_QuickPurify:
-                        DrawPvPStatusMultiChoice(QuickPurifyStatuses);
-                        break;
-                }
-            }
-        }
-
-        internal class Debuffs
-        {
-            public const ushort
-                Silence = 1347,
-                Bind = 1345,
-                Stun = 1343,
-                HalfAsleep = 3022,
-                Sleep = 1348,
-                DeepFreeze = 3219,
-                Heavy = 1344,
-                Unguarded = 3021,
-                MiracleOfNature = 3085;
-        }
-
-        internal class Buffs
-        {
-            public const ushort
-                Sprint = 1342,
-                Guard = 3054;
-        }
-
-        /// <summary> Checks if the target is immune to damage. Optionally, include buffs that provide significant damage reduction. </summary>
-        /// <param name="includeReductions"> Includes buffs that provide significant damage reduction. </param>
-        /// <param name="optionalTarget"> Optional target to check. </param>
-        public static bool TargetImmuneToDamage(bool includeReductions = true, IGameObject? optionalTarget = null)
-        {
-            var t = optionalTarget ?? CurrentTarget;
-            if (t is null || !InPvP()) return false;
-
-            bool targetHasReductions = HasStatusEffect(Buffs.Guard, t, true) || HasStatusEffect(VPRPvP.Buffs.HardenedScales, t, true);
-            bool targetHasImmunities = HasStatusEffect(DRKPvP.Buffs.UndeadRedemption, t, true) || HasStatusEffect(PLDPvP.Buffs.HallowedGround, t, true);
-
-            return includeReductions
-                ? targetHasReductions || targetHasImmunities
-                : targetHasImmunities;
-        }
-
-        // Lists of Excluded skills 
-        internal static readonly List<uint>
-            MovmentSkills = [WARPvP.Onslaught, VPRPvP.Slither, NINPvP.Shukuchi, DNCPvP.EnAvant, MNKPvP.ThunderClap, RDMPvP.CorpsACorps, RDMPvP.Displacement, SGEPvP.Icarus, RPRPvP.HellsIngress, RPRPvP.Regress, BRDPvP.RepellingShot, BLMPvP.AetherialManipulation, DRGPvP.ElusiveJump, GNBPvP.RoughDivide],
-            GlobalSkills = [Teleport, Guard, Recuperate, Purify, StandardElixir, Sprint];
-
-        internal class GlobalEmergencyHeals : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PvP_EmergencyHeals;
-
-            protected override uint Invoke(uint actionID)
-            {
-                if ((HasStatusEffect(Buffs.Guard) || JustUsed(Guard)) && IsEnabled(CustomComboPreset.PvP_MashCancel))
-                {
-                    if (actionID == Guard) return Guard;
-                    return All.SavageBlade;
-                }
-
-                if (Execute() &&
-                     InPvP() &&
-                    !GlobalSkills.Contains(actionID) &&
-                    !MovmentSkills.Contains(actionID))
-                    return OriginalHook(Recuperate);
-
-                return actionID;
-            }
-
-            public static bool Execute()
-            {
-                var jobMaxHp = LocalPlayer.MaxHp;
-                int threshold = Config.EmergencyHealThreshold;
-                var maxHPThreshold = jobMaxHp - 15000;
-                var remainingPercentage = (float)LocalPlayer.CurrentHp / (float)maxHPThreshold;
-
-
-                if (HasStatusEffect(3180)) return false; //DRG LB buff
-                if (HasStatusEffect(1420, anyOwner: true)) return false; //Rival Wings Mounted
-                if (HasStatusEffect(4096)) return false; //VPR Snakesbane
-                if (HasStatusEffect(DRKPvP.Buffs.UndeadRedemption)) return false;
-                if (LocalPlayer.CurrentMp < 2500) return false;
-                if (remainingPercentage * 100 > threshold) return false;
-
-                return true;
-
-            }
-        }
-
-        internal class GlobalEmergencyGuard : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PvP_EmergencyGuard;
-
-            protected override uint Invoke(uint actionID)
-            {
-                if ((HasStatusEffect(Buffs.Guard) || JustUsed(Guard)) && IsEnabled(CustomComboPreset.PvP_MashCancel))
-                {
-                    if (actionID == Guard)
+                    if (LocalPlayer is { } player && player.MaxHp > RecuperateAmount)
                     {
-                        if (IsEnabled(CustomComboPreset.PvP_MashCancelRecup) && !JustUsed(Guard, 2f) && LocalPlayer.CurrentMp >= 2500 && LocalPlayer.CurrentHp <= LocalPlayer.MaxHp - 15000) 
-                            return Recuperate;
-                        return Guard;
+                        var adjustedMaxHP = player.MaxHp - RecuperateAmount;
+                        var thresholdHP = adjustedMaxHP / 100f * EmergencyHealThreshold;
+
+                        DrawSliderInt(1, 100, EmergencyHealThreshold, $"{baseMessage}\nThreshold: {thresholdHP:N0} HP");
                     }
-                    return All.SavageBlade;
-                }
+                    else
+                    {
+                        DrawSliderInt(1, 100, EmergencyHealThreshold, baseMessage);
+                    }
+                    break;
 
-                if (Execute() &&
-                    InPvP() &&
-                    !GlobalSkills.Contains(actionID) &&
-                    !MovmentSkills.Contains(actionID))
-                    return OriginalHook(Guard);
+                case CustomComboPreset.PvP_EmergencyGuard:
+                    DrawSliderInt(1, 100, EmergencyGuardThreshold, "Uses Guard when at or under:");
+                    break;
 
-                return actionID;
-            }
-
-            public static bool Execute()
-            {
-                var jobMaxHp = LocalPlayer.MaxHp;
-                var threshold = Config.EmergencyGuardThreshold;
-                var remainingPercentage = (float)LocalPlayer.CurrentHp / (float)jobMaxHp;
-
-                if (HasStatusEffect(3180)) return false; //DRG LB buff
-                if (HasStatusEffect(4096)) return false; //VPR Snakesbane
-                if (HasStatusEffect(1420, anyOwner: true)) return false; //Rival Wings Mounted
-                if (HasStatusEffect(DRKPvP.Buffs.UndeadRedemption)) return false;
-                if (HasStatusEffect(Debuffs.Unguarded, anyOwner: true) || HasStatusEffect(WARPvP.Buffs.InnerRelease)) return false;
-                if (GetCooldown(Guard).IsCooldown) return false;
-                if (remainingPercentage * 100 > threshold) return false;
-
-                return true;
-
+                case CustomComboPreset.PvP_QuickPurify:
+                    DrawPvPStatusMultiChoice(QuickPurifyStatuses);
+                    break;
             }
         }
+    }
 
-        internal class QuickPurify : CustomCombo
+    /// <summary> Checks if the target is immune to damage. Optionally, include buffs that provide significant damage reduction. </summary>
+    /// <param name="includeReductions"> Includes buffs that provide significant damage reduction. </param>
+    /// <param name="optionalTarget"> Optional target to check. </param>
+    public static bool TargetImmuneToDamage(bool includeReductions = true, IGameObject? optionalTarget = null)
+    {
+        var t = optionalTarget ?? CurrentTarget;
+        if (t is null || !InPvP()) return false;
+
+        bool targetHasReductions = HasStatusEffect(Buffs.Guard, t, true) || HasStatusEffect(Buffs.WeakenedGuard, t, true) || HasStatusEffect(VPRPvP.Buffs.HardenedScales, t, true);
+        bool targetHasImmunities = HasStatusEffect(DRKPvP.Buffs.UndeadRedemption, t, true) || HasStatusEffect(PLDPvP.Buffs.HallowedGround, t, true);
+
+        return includeReductions
+            ? targetHasReductions || targetHasImmunities
+            : targetHasImmunities;
+    }
+
+    // Lists of Excluded skills 
+    internal static readonly List<uint>
+        MovementSkills = [WARPvP.Onslaught, VPRPvP.Slither, NINPvP.Shukuchi, DNCPvP.EnAvant, MNKPvP.Thunderclap, RDMPvP.CorpsACorps, RDMPvP.Displacement, SGEPvP.Icarus, RPRPvP.HellsIngress, RPRPvP.Regress, BRDPvP.RepellingShot, BLMPvP.AetherialManipulation, DRGPvP.ElusiveJump, GNBPvP.RoughDivide],
+        GlobalSkills = [Teleport, Guard, Recuperate, Purify, StandardElixir, Sprint];
+
+    internal class GlobalEmergencyHeals : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PvP_EmergencyHeals;
+
+        protected override uint Invoke(uint actionID)
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PvP_QuickPurify;
-
-            public static (ushort debuff, string label)[] Statuses =
-            [
-                (Debuffs.Stun, "Stun"),
-                (Debuffs.DeepFreeze, "Deep Freeze"),
-                (Debuffs.HalfAsleep, "Half Asleep"), // todo: remove, reset cfg
-                (Debuffs.Sleep, "Sleep"), // todo: remove, reset cfg
-                (Debuffs.Bind, "Bind"),
-                (Debuffs.Heavy, "Heavy"),
-                (Debuffs.Silence, "Silence"),
-                (Debuffs.MiracleOfNature, "Miracle of Nature"),
-            ];
-
-            protected override uint Invoke(uint actionID)
+            if ((HasStatusEffect(Buffs.Guard) || JustUsed(Guard)) && IsEnabled(CustomComboPreset.PvP_MashCancel))
             {
-                if ((HasStatusEffect(Buffs.Guard) || JustUsed(Guard)) && IsEnabled(CustomComboPreset.PvP_MashCancel))
-                {
-                    if (actionID == Guard) return Guard;
-                    return All.SavageBlade;
-                }
+                if (actionID is Guard) return Guard;
 
-                if (Execute() &&
-                    InPvP() &&
-                    !GlobalSkills.Contains(actionID))
-                    return OriginalHook(Purify);
-
-                return actionID;
+                return All.SavageBlade;
             }
 
-            public static bool Execute()
-            {
-                bool[] selectedStatuses = Config.QuickPurifyStatuses;
+            if (Execute() && InPvP() &&
+                !GlobalSkills.Contains(actionID) &&
+                !MovementSkills.Contains(actionID))
+                return OriginalHook(Recuperate);
 
-                // Bail if nothing is enabled
-                if (selectedStatuses.Length == 0) return false;
-                // Make sure new statuses are supported
-                Array.Resize(ref selectedStatuses, Statuses.Length);
-                // Bail if Purify is not available
-                if (GetCooldown(Purify).IsCooldown) return false;
-
-                // Don't purify if under some buffs
-                if (HasStatusEffect(3180) || //DRG LB buff
-                    HasStatusEffect(4096) || //VPR Snake's Bane
-                    HasStatusEffect(1420, anyOwner: true)) //Rival Wings Mounted
-                    return false;
-
-                // Check if the status is present and one the user wants purified
-                return selectedStatuses.Where((t, i) =>
-                    t && HasStatusEffect(Statuses[i].debuff, anyOwner: true)).Any();
-            }
+            return actionID;
         }
 
+        public static bool Execute()
+        {
+            if (LocalPlayer is not { } player || player.IsDead) return false;
+
+            // Special States
+            if (HasStatusEffect(DRGPvP.Buffs.SkyHigh) ||
+                HasStatusEffect(VPRPvP.Buffs.HardenedScales) ||
+                HasStatusEffect(DRKPvP.Buffs.UndeadRedemption) ||
+                HasStatusEffect(Buffs.RidingMecha, anyOwner: true))
+                return false;
+
+            var adjustedCurrentHP = player.CurrentHp * 100;
+            var adjustedMaxHP = player.MaxHp - RecuperateAmount;
+
+            return player.CurrentMp >= RecuperateCost && adjustedCurrentHP <= Config.EmergencyHealThreshold * adjustedMaxHP;
+        }
+    }
+
+    internal class GlobalEmergencyGuard : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PvP_EmergencyGuard;
+
+        protected override uint Invoke(uint actionID)
+        {
+            var player = LocalPlayer;
+
+            if ((HasStatusEffect(Buffs.Guard) || JustUsed(Guard)) && IsEnabled(CustomComboPreset.PvP_MashCancel))
+            {
+                if (actionID is Guard)
+                {
+                    if (IsEnabled(CustomComboPreset.PvP_MashCancelRecup) && !JustUsed(Guard, 2f) &&
+                        player.CurrentMp >= RecuperateCost && player.CurrentHp <= player.MaxHp - RecuperateAmount) 
+                        return Recuperate;
+
+                    return Guard;
+                }
+
+                return All.SavageBlade;
+            }
+
+            if (Execute() && InPvP() &&
+                !GlobalSkills.Contains(actionID) &&
+                !MovementSkills.Contains(actionID))
+                return OriginalHook(Guard);
+
+            return actionID;
+        }
+
+        public static bool Execute()
+        {
+            if (LocalPlayer is not { } player || player.IsDead || IsOnCooldown(Guard)) return false;
+
+            // Special States
+            if (HasStatusEffect(DRGPvP.Buffs.SkyHigh) ||
+                HasStatusEffect(WARPvP.Buffs.InnerRelease) ||
+                HasStatusEffect(VPRPvP.Buffs.HardenedScales) ||
+                HasStatusEffect(DRKPvP.Buffs.UndeadRedemption) ||
+                HasStatusEffect(Debuffs.Unguarded, anyOwner: true) ||
+                HasStatusEffect(Buffs.RidingMecha, anyOwner: true))
+                return false;
+
+            var adjustedCurrentHP = player.CurrentHp * 100;
+            var adjustedThreshold = Config.EmergencyGuardThreshold * player.MaxHp;
+
+            return adjustedCurrentHP <= adjustedThreshold;
+        }
+    }
+
+    internal class QuickPurify : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PvP_QuickPurify;
+
+        public static (ushort debuff, string label)[] Statuses =
+        [
+            (Debuffs.Stun, "Stun"),
+            (Debuffs.DeepFreeze, "Deep Freeze"),
+            (Debuffs.HalfAsleep, "Half Asleep"), // todo: remove, reset cfg
+            (Debuffs.Sleep, "Sleep"), // todo: remove, reset cfg
+            (Debuffs.Bind, "Bind"),
+            (Debuffs.Heavy, "Heavy"),
+            (Debuffs.Silence, "Silence"),
+            (Debuffs.MiracleOfNature, "Miracle of Nature"),
+        ];
+
+        protected override uint Invoke(uint actionID)
+        {
+            if ((HasStatusEffect(Buffs.Guard) || JustUsed(Guard)) && IsEnabled(CustomComboPreset.PvP_MashCancel))
+            {
+                if (actionID == Guard) return Guard;
+                return All.SavageBlade;
+            }
+
+            if (Execute() && InPvP() &&
+                !GlobalSkills.Contains(actionID))
+                return OriginalHook(Purify);
+
+            return actionID;
+        }
+
+        public static bool Execute()
+        {
+            if (LocalPlayer is not { } player || player.IsDead || IsOnCooldown(Purify)) return false;
+
+            bool[] selectedStatuses = Config.QuickPurifyStatuses;
+
+            // Bail if nothing is enabled
+            if (selectedStatuses.Length == 0) return false;
+
+            // Make sure new statuses are supported
+            Array.Resize(ref selectedStatuses, Statuses.Length);
+
+            // Don't purify if under some buffs
+            if (HasStatusEffect(DRGPvP.Buffs.SkyHigh) ||
+                HasStatusEffect(VPRPvP.Buffs.HardenedScales) ||
+                HasStatusEffect(Buffs.RidingMecha, anyOwner: true))
+                return false;
+
+            // Check if the status is present and one the user wants purified
+            return selectedStatuses.Where((t, i) => t && HasStatusEffect(Statuses[i].debuff, anyOwner: true)).Any();
+        }
     }
 
 }

--- a/WrathCombo/Combos/PvP/BRDPVP.cs
+++ b/WrathCombo/Combos/PvP/BRDPVP.cs
@@ -34,18 +34,6 @@ namespace WrathCombo.Combos.PvP
                 EncoreofLightReady = 4312,
                 FrontlineMarch = 3139;
         }
-        internal class Debuffs
-        {
-            public const ushort
-                Silence = 1347,
-                Bind = 1345,
-                Stun = 1343,
-                HalfAsleep = 3022,
-                Sleep = 1348,
-                DeepFreeze = 3219,
-                Heavy = 1344,
-                Unguarded = 3021;
-        }
         #endregion
 
         #region Config
@@ -95,7 +83,7 @@ namespace WrathCombo.Combos.PvP
                     if (!PvPCommon.TargetImmuneToDamage())
                     {
                         if (IsEnabled(CustomComboPreset.BRDPvP_Wardens) && InPvP() &&  //Autowardens set up only for soft ccs, it cant be used while cced like purify
-                            (HasStatusEffect(Debuffs.Bind, anyOwner: true) || HasStatusEffect(Debuffs.Heavy, anyOwner: true) || HasStatusEffect(Debuffs.HalfAsleep, anyOwner: true)))
+                            (HasStatusEffect(PvPCommon.Debuffs.Bind, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.Heavy, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.HalfAsleep, anyOwner: true)))
                             return OriginalHook(WardensPaean);
 
                         if (canWeave)

--- a/WrathCombo/Combos/PvP/DRGPVP.cs
+++ b/WrathCombo/Combos/PvP/DRGPVP.cs
@@ -36,12 +36,11 @@ namespace WrathCombo.Combos.PvP
         public static class Buffs
         {
             public const ushort
-            FirstmindsFocus = 3178,
-            LifeOfTheDragon = 3177,
-            Heavensent = 3176,
-            StarCrossReady = 4302;
-
-
+                SkyHigh = 3180,
+                FirstmindsFocus = 3178,
+                LifeOfTheDragon = 3177,
+                Heavensent = 3176,
+                StarCrossReady = 4302;
         }
         #endregion
 

--- a/WrathCombo/Combos/PvP/MNKPVP.cs
+++ b/WrathCombo/Combos/PvP/MNKPVP.cs
@@ -20,7 +20,7 @@ namespace WrathCombo.Combos.PvP
             PhantomRush = 29478,
             RisingPhoenix = 29481,
             RiddleOfEarth = 29482,
-            ThunderClap = 29484,
+            Thunderclap = 29484,
             EarthsReply = 29483,
             Meteordrive = 29485,
             WindsReply = 41509,
@@ -94,8 +94,8 @@ namespace WrathCombo.Combos.PvP
                         if (IsEnabled(CustomComboPreset.MNKPvP_Burst_RiddleOfEarth) && IsOffCooldown(RiddleOfEarth) && PlayerHealthPercentageHp() <= 95)
                             return OriginalHook(RiddleOfEarth);
 
-                        if (IsEnabled(CustomComboPreset.MNKPvP_Burst_Thunderclap) && GetRemainingCharges(ThunderClap) > 0 && !InMeleeRange())
-                            return OriginalHook(ThunderClap);
+                        if (IsEnabled(CustomComboPreset.MNKPvP_Burst_Thunderclap) && GetRemainingCharges(Thunderclap) > 0 && !InMeleeRange())
+                            return OriginalHook(Thunderclap);
 
                         if (IsEnabled(CustomComboPreset.MNKPvP_Burst_WindsReply) && InActionRange(WindsReply) && IsOffCooldown(WindsReply))
                             return WindsReply;

--- a/WrathCombo/Combos/PvP/PLDPVP.cs
+++ b/WrathCombo/Combos/PvP/PLDPVP.cs
@@ -27,17 +27,16 @@ namespace WrathCombo.Combos.PvP
             BladeOfTruth = 29072,
             BladeOfValor = 29073;
 
-
         internal class Buffs
         {
             internal const ushort
+                Covered = 1301,
                 ConfiteorReady = 3028,
                 HallowedGround = 1302,
                 AttonementReady = 2015,
                 SupplicationReady = 4281,
                 SepulchreReady = 4282,
                 BladeOfFaithReady = 3250;
-
         }
 
         internal class Debuffs


### PR DESCRIPTION
- Added missing common and class-specific IDs.
- Added class-level constants for easier maintenance.
- Reduced amount of `LocalPlayer` calls across functions `(11 → 5)`.
- Condensed several conditional statements, moved some to early-exits.
- Refactored `CustomComboPreset.PvP_EmergencyHeals`, functionality unchanged.
- Plugged several status checks into their respective, job-specific IDs instead of using magic numbers.