### PR TITLE
[Retargeting] Fix crash

### DIFF
--- a/WrathCombo/Core/ActionRetargeting.cs
+++ b/WrathCombo/Core/ActionRetargeting.cs
@@ -167,7 +167,9 @@ public class ActionRetargeting : IDisposable
         replacedWith = action;
         // Find the Retarget object
         if (!Retargets.TryGetValue(action, out var retarget) ||
-            Service.ActionReplacer.LastActionInvokeFor[action] != retarget.Action)
+            !Service.ActionReplacer.LastActionInvokeFor
+                .TryGetValue(action, out var lastAction) ||
+            lastAction != retarget.Action)
             return false;
 
         replacedWith = retarget.Action;


### PR DESCRIPTION
- [X] Fixes crash (log related) when an action is Retargeted for the first time


```
2025-05-29 21:43:13.549 +02:00 [FTL] Unhandled exception on AppDomain
System.Collections.Generic.KeyNotFoundException: The given key '37026' was not present in the dictionary.
   at WrathCombo.Core.ActionRetargeting.TryGetTargetFor(UInt32 action, IGameObject& target, UInt32& replacedWith) in \WrathCombo\WrathCombo\Core\ActionRetargeting.cs:line 169
   at WrathCombo.Data.ActionWatching.UseActionDetour(ActionManager* actionManager, ActionType actionType, UInt32 actionId, UInt64 targetId, UInt32 extraParam, UseActionMode mode, UInt32 comboRouteId, Boolean* outOptAreaTargeted) in \WrathCombo\WrathCombo\Data\ActionWatching.cs:line 349
```
Just makes the `LastActionInvokeFor` accessing safer.

> @Taurenkey this may well need to be a hotfix.