### PR TITLE
[PCT] Fix for scuffed pulls

### DIFF
--- a/WrathCombo/Combos/PvE/PCT/PCT_Helper.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT_Helper.cs
@@ -61,6 +61,9 @@ internal partial class PCT
 
     internal static uint BurstWindow(uint actionId)
     {
+        if (LandscapeMotifReady)
+            return OriginalHook(LandscapeMotif);        
+
         if (!HasStatusEffect(Buffs.StarryMuse))
         {
             if (SteelMuseReady)
@@ -110,6 +113,9 @@ internal partial class PCT
 
             if (CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint && !HasStatusEffect(Buffs.RainbowBright))
                 return OriginalHook(CometinBlack);
+
+            if (HasStatusEffect(Buffs.SubtractivePalette))
+                return OriginalHook(BlizzardinCyan);
         }
         return actionId;
     }


### PR DESCRIPTION
Reported in discord. Someone didn't know to predraw motifs and led to weird issue. 

Opener wouldn't fire, burst window wouldn't draw the landscape to continue and got stuck in 123 limbo. 

Added an emergency landscape draw at beginning of burst window that wont interfere with normal operation, and an emergency blizzard in cyan at the end of burst window, to make sure you don't get locked out of 123 due to weird sub pallete stuff. 