### PR TITLE
[Retargeting] Add Dead Non-Party target, various improvements

### DIFF
--- a/WrathCombo/CustomCombo/SimpleTarget.cs
+++ b/WrathCombo/CustomCombo/SimpleTarget.cs
@@ -369,6 +369,13 @@ internal static class SimpleTarget
             .Select(x => x.BattleChara)
             .FirstOrDefault(x => x?.IsDead() == true);
 
+    public static IGameObject? AnyDeadNonPartyMember =>
+        Svc.Objects
+            .OfType<IBattleChara>()
+            .Where(x => x.IsFriendly() && !x.IsInParty() &&
+                        x.IsTargetable)
+            .FirstOrDefault(x => !x.IsDead);
+
     #region HP-Based Targets
 
     public static IGameObject? LowestHPAlly =>

--- a/WrathCombo/CustomCombo/SimpleTarget.cs
+++ b/WrathCombo/CustomCombo/SimpleTarget.cs
@@ -162,7 +162,7 @@ internal static class SimpleTarget
                 {
                     var resolved = GetSimpleTargetValueFromName(name);
                     var target =
-                        CustomLogic(resolved.IfFriendly().IfWithinRange());
+                        CustomLogic(resolved.IfFriendly().IfTargetable().IfWithinRange());
 
                     // Only include Missing-HP options if they are missing HP
                     if (name.Contains("Missing"))
@@ -195,7 +195,8 @@ internal static class SimpleTarget
                 {
                     var resolved = GetSimpleTargetValueFromName(name);
                     var target =
-                        CustomLogic(resolved.IfFriendly().IfDead().IfWithinRange(30));
+                        CustomLogic(resolved.IfFriendly().IfTargetable()
+                            .IfDead().IfWithinRange(30));
 
                     if (logging)
                         PluginLog.Verbose(

--- a/WrathCombo/Extensions/GameObjectExtensions.cs
+++ b/WrathCombo/Extensions/GameObjectExtensions.cs
@@ -127,6 +127,14 @@ public static class GameObjectExtensions
     public static IGameObject? IfDead (this IGameObject? obj) =>
         obj != null && IsDeadEnoughToRaise(obj) ? obj : null;
 
+    /// <summary>
+    ///     Can be chained onto a <see cref="IGameObject" /> to make it return
+    ///     <see langword="null" /> if the target is not targetable.
+    /// </summary>
+    /// <seealso cref="IsDeadEnoughToRaise"/>
+    public static IGameObject? IfTargetable (this IGameObject? obj) =>
+        obj != null && obj.IsTargetable ? obj : null;
+
     #endregion
 
     #region Target Checking (same as above, but returns a boolean)


### PR DESCRIPTION
- [X] Adds a new `SimpleTarget` for `AnyDeadNonPartyMember`
- [X] Require Raise Stack targets be targetable