### PR TITLE
[AST] Overwrite non dps cards fix

### DIFF
--- a/WrathCombo/Combos/PvE/AST/AST.cs
+++ b/WrathCombo/Combos/PvE/AST/AST.cs
@@ -58,7 +58,7 @@ internal partial class AST : Healer
                 if (IsEnabled(CustomComboPreset.AST_DPS_AutoDraw) &&
                     ActionReady(OriginalHook(AstralDraw)) &&
                     (Gauge.DrawnCards.All(x => x is CardType.None) ||
-                     (DrawnCard == CardType.None && Config.AST_ST_DPS_OverwriteCards)))
+                    (Gauge.DrawnCards[0] is CardType.None && Config.AST_ST_DPS_OverwriteCards)))
                     return OriginalHook(AstralDraw);
             }
 
@@ -113,7 +113,7 @@ internal partial class AST : Healer
                 if (IsEnabled(CustomComboPreset.AST_DPS_AutoDraw) &&
                     ActionReady(OriginalHook(AstralDraw)) &&
                     (Gauge.DrawnCards.All(x => x is CardType.None) ||
-                     (DrawnCard == CardType.None && Config.AST_ST_DPS_OverwriteCards)) &&
+                    (Gauge.DrawnCards[0] is CardType.None && Config.AST_ST_DPS_OverwriteCards)) &&
                     CanDelayedWeave())
                     return OriginalHook(AstralDraw);
 
@@ -220,7 +220,7 @@ internal partial class AST : Healer
             if (IsEnabled(CustomComboPreset.AST_AOE_AutoDraw) &&
                 ActionReady(OriginalHook(AstralDraw)) &&
                 (Gauge.DrawnCards.All(x => x is CardType.None) ||
-                 (DrawnCard == CardType.None && Config.AST_AOE_DPS_OverwriteCards)) &&
+                (Gauge.DrawnCards[0] is CardType.None && Config.AST_AOE_DPS_OverwriteCards)) &&
                 CanDelayedWeave())
                 return OriginalHook(AstralDraw);
 


### PR DESCRIPTION
Was overwriting dps cards as well. Fixed the drawncards code to check the dps card slot properly for out of combat, st, and aoe.