### PR TITLE
[Meta] Add new Team Member ownership, adjust VPR ownership

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -5,7 +5,7 @@
 /WrathCombo/Combos/PvE/AST/                           @Taurenkey
 /WrathCombo/Combos/PvE/BLM/                           @Kagekazu
 /WrathCombo/Combos/PvE/BLU/                           @zbee
-/WrathCombo/Combos/PvE/BRD/                           @zbee
+/WrathCombo/Combos/PvE/BRD/                           @edewen
 /WrathCombo/Combos/PvE/DNC/                           @zbee
 /WrathCombo/Combos/PvE/DRG/                           @Kagekazu
 /WrathCombo/Combos/PvE/DRK/                           @zbee
@@ -26,7 +26,8 @@
 /WrathCombo/Combos/PvE/WHM/                           @zbee
 
 # PvP Combos
-/WrathCombo/Combos/PvP/                               @Nik-Potokar @Kaeris-Tempest
+/WrathCombo/Combos/PvP/                               @Nik-Potokar @Kaeris-Tempest @edewen
+/WrathCombo/Combos/PvP/BRDPVP.cs                      @edewen
 /WrathCombo/Combos/PvP/BLMPVP.cs                      @Kaeris-Tempest
 /WrathCombo/Combos/PvP/RDMPVP.cs                      @Kaeris-Tempest
 /WrathCombo/Combos/PvP/SAMPVP.cs                      @Kaeris-Tempest

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -21,7 +21,7 @@
 /WrathCombo/Combos/PvE/SCH/                           @Tartarga
 /WrathCombo/Combos/PvE/SGE/                           @Tartarga
 /WrathCombo/Combos/PvE/SMN/                           @Genesis-Nova
-/WrathCombo/Combos/PvE/VPR/                           @Akechi-kun @Kagekazu
+/WrathCombo/Combos/PvE/VPR/                           @Kagekazu
 /WrathCombo/Combos/PvE/WAR/                           @Akechi-kun
 /WrathCombo/Combos/PvE/WHM/                           @zbee
 

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -13,14 +13,14 @@
 /WrathCombo/Combos/PvE/MCH/                           @Kagekazu
 /WrathCombo/Combos/PvE/MNK/                           @Kagekazu
 /WrathCombo/Combos/PvE/NIN/                           @Taurenkey
-/WrathCombo/Combos/PvE/PCT/                           @Nik-Potokar
+/WrathCombo/Combos/PvE/PCT/                           @Nik-Potokar @edewen
 /WrathCombo/Combos/PvE/PLD/                           @Kaeris-Tempest
 /WrathCombo/Combos/PvE/RDM/                           @Tartarga
 /WrathCombo/Combos/PvE/RPR/                           @Kagekazu
 /WrathCombo/Combos/PvE/SAM/                           @Kagekazu
 /WrathCombo/Combos/PvE/SCH/                           @Tartarga
 /WrathCombo/Combos/PvE/SGE/                           @Tartarga
-/WrathCombo/Combos/PvE/SMN/                           @Genesis-Nova
+/WrathCombo/Combos/PvE/SMN/                           @Genesis-Nova @edewen
 /WrathCombo/Combos/PvE/VPR/                           @Kagekazu
 /WrathCombo/Combos/PvE/WAR/                           @Akechi-kun
 /WrathCombo/Combos/PvE/WHM/                           @zbee


### PR DESCRIPTION
- [X] Adds @edewen's sole ownership:
  - [X] BRD
  - [X] BRD (PvP)
- [X] Add @edewen's partial ownership:
  - [X] PvP (one of three)
  - [X] SMN (one of two)
  - [X] PCT (one of two)
- [X] Adjusts VPR to @Kagekazu's sole ownership

@Taurenkey this does require @edewen be on [the team](https://github.com/orgs/PunishXIV/teams/teamwrath)