### PR TITLE
[BRD] Retargetted Warden's Paeon

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -900,6 +900,10 @@ public enum CustomComboPreset
     [CustomComboInfo("Self Cleanse Option", "Uses Wardens Paeon when you have a cleansable debuff.", BRD.JobID)]
     BRD_ST_Wardens = 3047,
 
+    [ParentCombo(BRD_ST_Wardens)]
+    [CustomComboInfo("Party Cleanse Option", "Uses Wardens Paeon when someone in the party has a cleansable debuff using the Retargeting Function", BRD.JobID)]
+    BRD_ST_WardensAuto = 3064,
+
     [AutoAction(true, false)]
     [ConflictingCombos(BRD_AoE_Combo, BRD_AoE_SimpleMode)]
     [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
@@ -968,6 +972,10 @@ public enum CustomComboPreset
     [ParentCombo(BRD_AoE_AdvMode)]
     [CustomComboInfo("Self Cleanse Option", "Uses Wardens Paeon when you have a cleansable debuff.", BRD.JobID)]
     BRD_AoE_Wardens = 3046,
+
+    [ParentCombo(BRD_AoE_Wardens)]
+    [CustomComboInfo("Party Cleanse Option", "Uses Wardens Paeon when someone in the party has a cleansable debuff using the Retargeting Function.", BRD.JobID)]
+    BRD_AoE_WardensAuto = 3063,
 
     #endregion
 
@@ -1062,7 +1070,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last value = 3058
+    // Last value = 3063
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -1,4 +1,5 @@
 using Dalamud.Game.ClientState.JobGauge.Enums;
+using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Data;
 using static WrathCombo.Combos.PvE.BRD.Config;
@@ -363,12 +364,17 @@ internal partial class BRD : PhysicalRanged
 
             if (CanBardWeave)
             {
-                if (IsEnabled(CustomComboPreset.BRD_ST_SecondWind) && Role.CanSecondWind(Config.BRD_STSecondWindThreshold))
+                if (IsEnabled(CustomComboPreset.BRD_AoE_SecondWind) && Role.CanSecondWind(Config.BRD_STSecondWindThreshold))
                     return Role.SecondWind;
+               
+                if (IsEnabled(CustomComboPreset.BRD_AoE_Wardens) && ActionReady(TheWardensPaeon))
+                {
+                    if (HasCleansableDebuff(LocalPlayer))
+                        return TheWardensPaeon;
 
-                // Could be upgraded with a targetting system in the future
-                if (IsEnabled(CustomComboPreset.BRD_ST_Wardens) && ActionReady(TheWardensPaeon) && HasCleansableDebuff(LocalPlayer))
-                    return OriginalHook(TheWardensPaeon);
+                    else if (IsEnabled(CustomComboPreset.BRD_AoE_WardensAuto) && WardenResolver() is not null)
+                        return TheWardensPaeon.Retarget([Ladonsbite, QuickNock], WardenResolver);
+                }                   
             }
 
             #endregion
@@ -438,7 +444,7 @@ internal partial class BRD : PhysicalRanged
 
             #region Opener
 
-            if (IsEnabled(CustomComboPreset.BRD_ST_Adv_Balance_Standard) &&
+            if (IsEnabled(CustomComboPreset.BRD_ST_Adv_Balance_Standard) && HasBattleTarget() &&
                 Opener().FullOpener(ref actionID))
             {
                 if (ActionWatching.GetAttackType(Opener().CurrentOpenerAction) != ActionWatching.ActionAttackType.Ability && CanBardWeave)
@@ -540,13 +546,19 @@ internal partial class BRD : PhysicalRanged
 
             #region Self Care
 
-            if (CanBardWeave)
+            if (CanBardWeave || !InCombat())
             {
                 if (IsEnabled(CustomComboPreset.BRD_ST_SecondWind) && Role.CanSecondWind(Config.BRD_STSecondWindThreshold))
                     return Role.SecondWind;
 
-                if (IsEnabled(CustomComboPreset.BRD_ST_Wardens) && ActionReady(TheWardensPaeon) && HasCleansableDebuff(LocalPlayer))
-                    return OriginalHook(TheWardensPaeon);
+                if (IsEnabled(CustomComboPreset.BRD_ST_Wardens) && ActionReady(TheWardensPaeon))
+                {
+                    if (HasCleansableDebuff(LocalPlayer))
+                        return TheWardensPaeon;
+
+                    else if (IsEnabled(CustomComboPreset.BRD_ST_WardensAuto) && WardenResolver() is not null)
+                        return TheWardensPaeon.Retarget([HeavyShot, BurstShot], WardenResolver);
+                }
             }
 
             #endregion
@@ -711,8 +723,14 @@ internal partial class BRD : PhysicalRanged
                 if (Role.CanSecondWind(40))
                     return Role.SecondWind;
 
-                if (ActionReady(TheWardensPaeon) && HasCleansableDebuff(LocalPlayer))
-                    return OriginalHook(TheWardensPaeon);
+                if (ActionReady(TheWardensPaeon))
+                {
+                    if (HasCleansableDebuff(LocalPlayer))
+                        return TheWardensPaeon;
+
+                    else if (WardenResolver() is not null)
+                        return TheWardensPaeon.Retarget([Ladonsbite, QuickNock], WardenResolver);
+                }
             }
 
             #endregion
@@ -844,8 +862,13 @@ internal partial class BRD : PhysicalRanged
                 if (Role.CanSecondWind(40))
                     return Role.SecondWind;
 
-                if (ActionReady(TheWardensPaeon) && HasCleansableDebuff(LocalPlayer))
-                    return OriginalHook(TheWardensPaeon);
+                if (ActionReady(TheWardensPaeon))
+                {
+                    if (HasCleansableDebuff(LocalPlayer))
+                        return TheWardensPaeon;
+                    else if (WardenResolver() is not null)
+                        return TheWardensPaeon.Retarget([HeavyShot, BurstShot], WardenResolver);
+                }
             }
 
             #endregion

--- a/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
@@ -2,13 +2,20 @@
 
 using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
+using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Game.ClientState.Statuses;
+using ECommons.DalamudServices;
+using ECommons.GameHelpers;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
+using WrathCombo.Extensions;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
+
 
 #endregion
 
@@ -231,6 +238,17 @@ internal partial class BRD
         return false;
     }
     #endregion
+
+        #region Warden Resolver
+        [ActionRetargeting.TargetResolver]
+        private static IGameObject? WardenResolver() =>
+         GetPartyMembers()
+              .Select(member => member.BattleChara)
+              .Where(member => member.IsNotThePlayer() && !member.IsDead && member.IsCleansable() && InActionRange(TheWardensPaeon, member))          
+              .FirstOrDefault();
+        #endregion
+
+
 
     #endregion
 


### PR DESCRIPTION
Expanded on already existing self cleanse setup with Warden's Paeon to use the retargeting system to detect and cleanse party as well. Optional in Advanced. 

Tested in Sohm Al. Cleansed Ysayle of her unwanted DD

![image](https://github.com/user-attachments/assets/fd951156-5e27-4653-87dc-b4b04ae6f311)


