### PR TITLE
[Retargeting] Fix `AnyDeadNonPartyMember`

### DIFF
--- a/WrathCombo/CustomCombo/SimpleTarget.cs
+++ b/WrathCombo/CustomCombo/SimpleTarget.cs
@@ -376,9 +376,8 @@ internal static class SimpleTarget
 
     public static IGameObject? AnyDeadNonPartyMember =>
         Svc.Objects
-            .Where(x => x is IBattleChara &&
-                        x.IsFriendly() && !x.IsInParty() &&
-                        x.IsAPlayer() && x.IsTargetable)
+            .Where(x => x.IsAPlayer() && x.IsTargetable &&
+                        !x.IsInParty())
             .FirstOrDefault(x => x.IsDead());
 
     #region HP-Based Targets

--- a/WrathCombo/Extensions/GameObjectExtensions.cs
+++ b/WrathCombo/Extensions/GameObjectExtensions.cs
@@ -244,12 +244,12 @@ public static class GameObjectExtensions
     /// </summary>
     private static bool IsDeadEnoughToRaise(this IGameObject? obj)
     {
-        if (obj is not IBattleChara battleObj) return false;
-        return battleObj.IsDead &&
-               !CustomComboFunctions.HasStatusEffect(2648, battleObj, true) &&
-               !CustomComboFunctions.HasStatusEffect(148, battleObj, true) &&
-               battleObj.IsTargetable &&
-               (CustomComboFunctions.TimeSpentDead(battleObj.GameObjectId)
+        return obj.IsDead &&
+               obj.IsAPlayer() &&
+               !CustomComboFunctions.HasStatusEffect(2648, obj, true) &&
+               !CustomComboFunctions.HasStatusEffect(148, obj, true) &&
+               obj.IsTargetable &&
+               (CustomComboFunctions.TimeSpentDead(obj.GameObjectId)
                    .TotalSeconds > 2 || !obj.IsInParty());
     }
 }

--- a/WrathCombo/Extensions/GameObjectExtensions.cs
+++ b/WrathCombo/Extensions/GameObjectExtensions.cs
@@ -160,7 +160,7 @@ public static class GameObjectExtensions
     public static bool IsInParty(this IGameObject? obj) =>
         obj != null &&
         CustomComboFunctions.GetPartyMembers()
-            .Any(x => x.GameObjectId != obj.GameObjectId);
+            .Any(x => x.GameObjectId == obj.GameObjectId);
 
     // `IsHostile` already exists, and works the exact same as we would write here
 


### PR DESCRIPTION
- [X] Fixes the `IsInParty` `IGameObject` extension
- [X] Fixes the `AnyDeadNonPartyMember` `SimpleTarget` (non party members are not necessarily `IBattleChara`)
- [X] Fixes `IsDeadEnoughToRaise` (same as above)