### PR TITLE
[Core] Fix `OptionalTarget` for Healers

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -614,6 +614,7 @@ namespace WrathCombo.AutoRotation
                     var customCombo = Service.ActionReplacer.CustomCombos.FirstOrDefault(x => x.Preset == preset);
                     if (customCombo != null)
                     {
+                        customCombo.OptionalTarget = null;
                         if (customCombo.TryInvoke(actToCheck, out var changedAct, optionalTarget))
                         {
                             originalAct = actToCheck;

--- a/WrathCombo/CustomCombo/CustomCombo.cs
+++ b/WrathCombo/CustomCombo/CustomCombo.cs
@@ -23,7 +23,7 @@ namespace WrathCombo.CustomComboNS
             ClassID = JobIDs.JobToClass(JobID);
         }
 
-        protected IGameObject? OptionalTarget;
+        internal IGameObject? OptionalTarget;
 
         /// <summary> Gets the preset associated with this combo. </summary>
         protected internal abstract CustomComboPreset Preset { get; }
@@ -86,7 +86,7 @@ namespace WrathCombo.CustomComboNS
                 JobID != classJobID && ClassID != classJobID)
                 return false;
 
-            OptionalTarget = targetOverride;
+            OptionalTarget ??= targetOverride;
             uint resultingActionID = Invoke(actionID);
 
             var presetException = _presetsAllowedToReturnUnchanged


### PR DESCRIPTION
- [X] Fixes `OptionalTarget` to only be set by Auto Rotation Controller, and not by hotbar-walking\
      (which was making the value `null` before it ever got to the Healing code, you know, in that μs or two)

Thank you so much @edewen for helping resolve this