### PR TITLE
[PCT] Tweaks and Hammer fix

### DIFF
--- a/WrathCombo/Combos/PvE/PCT/PCT.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT.cs
@@ -40,7 +40,7 @@ internal partial class PCT : Caster
             #endregion
 
             #region Burst Window lvl 100 only
-            if (LevelChecked(StarPrism) &&InCombat() && (ScenicCD <= 5 || HasStatusEffect(Buffs.StarryMuse)))
+            if (BurstPhaseReady)
                 return BurstWindow(actionID);
 
             #endregion
@@ -254,7 +254,7 @@ internal partial class PCT : Caster
             #endregion
 
             #region Burst Window
-            if (burstPhaseEnabled && LevelChecked(StarPrism) && InCombat() && (ScenicCD <= 5 || HasStatusEffect(Buffs.StarryMuse)))
+            if (burstPhaseEnabled && BurstPhaseReady)
                 return BurstWindow(actionID);
 
             #endregion

--- a/WrathCombo/Combos/PvE/PCT/PCT_Helper.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT_Helper.cs
@@ -29,7 +29,8 @@ internal partial class PCT
     internal static bool PaletteReady => SubtractivePalette.LevelChecked() && !HasStatusEffect(Buffs.SubtractivePalette) && !HasStatusEffect(Buffs.MonochromeTones) && 
                                             (HasStatusEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50 && ScenicCD > 40 || gauge.PalleteGauge == 100);
     internal static bool HasPaint => gauge.Paint > 0;
-  
+    internal static bool BurstPhaseReady => LevelChecked(StarPrism) && InCombat() && (ScenicCD <= 5 || HasStatusEffect(Buffs.StarryMuse) && gauge.PalleteGauge >= 50);
+
 
 
     //Buff Tracking
@@ -61,15 +62,15 @@ internal partial class PCT
 
     internal static uint BurstWindow(uint actionId)
     {
-        if (LandscapeMotifReady)
+        if (LandscapeMotifReady) //Emergency Landscape Paint if someone started a fight with no motifs.
             return OriginalHook(LandscapeMotif);        
 
         if (!HasStatusEffect(Buffs.StarryMuse))
         {
-            if (SteelMuseReady)
+            if (SteelMuseReady && HasCharges(SteelMuse))
                 return OriginalHook(SteelMuse);
 
-            if (ActionReady(HammerStamp) && !HasStatusEffect(Buffs.StarryMuse) && ScenicCD < 1 && !JustUsed(HammerStamp, 3f))
+            if (ActionReady(HammerStamp) && !HasStatusEffect(Buffs.StarryMuse) && ScenicCD < 1 && !JustUsed(HammerStamp, 3f) && GetStatusEffectStacks(Buffs.HammerTime) == 3)
                 return HammerStamp;
 
             if (CanWeave() && ActionReady(SubtractivePalette) && !HasStatusEffect(Buffs.SubtractivePalette) && 
@@ -77,7 +78,7 @@ internal partial class PCT
                 (HasStatusEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50))
                 return SubtractivePalette;
 
-            if (ScenicMuseReady && CanDelayedWeave() && IsOffCooldown(ScenicMuse))
+            if (ScenicMuseReady && (CanDelayedWeave() || !CanWeave()) && IsOffCooldown(ScenicMuse)) // The !canweave option is specifically so that it can minimize drift IF it does not catch the delayed weave in time.
                 return OriginalHook(ScenicMuse);            
         }
 


### PR DESCRIPTION
Hammer was getting stuck in the burst window when someone would skip starry muse locking it up on hammer stamp 1 even though it was already cast. 

Added a buff check on top of the existing justused ( still needed for propagation purposes) to push it into next gcd

added a || !canweave to starry muse so that if the delayed weave is missed due to the slighest lag, it still pushes the 2 min instead of adding s more seconds of drift. (lesser of 2 evils)

Added charge check on steelmuse because if run without the opener, the first windows starry is too close to steel in cooldown, leading to it hanging on steel muse for couple second at 2 min window before fixing itself for the 4 min. 
