### PR TITLE
[WHM] Status Effect Cap Code +Pom Visual fix

### DIFF
--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -70,7 +70,7 @@ internal partial class WHM : Healer
                     return Variant.Rampart;
 
                 if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_PresenceOfMind) &&
-                    ActionReady(PresenceOfMind) && OriginalHook(PresenceOfMind) is PresenceOfMind)
+                    ActionReady(PresenceOfMind) && !HasStatusEffect(Buffs.SacredSight))
                     return PresenceOfMind;
 
                 if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Assize) &&
@@ -152,7 +152,7 @@ internal partial class WHM : Healer
                     return Assize;
 
                 if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_PresenceOfMind) &&
-                    ActionReady(PresenceOfMind) && OriginalHook(PresenceOfMind) is PresenceOfMind)
+                    ActionReady(PresenceOfMind) && !HasStatusEffect(Buffs.SacredSight))
                     return PresenceOfMind;
 
                 if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_Lucid) &&

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -70,7 +70,7 @@ internal partial class WHM : Healer
                     return Variant.Rampart;
 
                 if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_PresenceOfMind) &&
-                    ActionReady(PresenceOfMind))
+                    ActionReady(PresenceOfMind) && OriginalHook(PresenceOfMind) is PresenceOfMind)
                     return PresenceOfMind;
 
                 if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Assize) &&
@@ -152,7 +152,7 @@ internal partial class WHM : Healer
                     return Assize;
 
                 if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_PresenceOfMind) &&
-                    ActionReady(PresenceOfMind))
+                    ActionReady(PresenceOfMind) && OriginalHook(PresenceOfMind) is PresenceOfMind)
                     return PresenceOfMind;
 
                 if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_Lucid) &&

--- a/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
@@ -35,6 +35,7 @@ internal partial class WHM
         var dotRemaining = GetStatusEffectRemainingTime(dotDebuffID, CurrentTarget);
 
         return ActionReady(dotAction) &&
+               CanApplyStatus(CurrentTarget, dotDebuffID) &&
                HasBattleTarget() &&
                GetTargetHPPercent() > hpThreshold &&
                dotRemaining <= Config.WHM_ST_MainCombo_DoT_Threshold;


### PR DESCRIPTION
When popping Presence of mind, The Actionready picks up the original hook ready from glare 4, and when weaving, it shows a greyed out Pom. 

This fixes that weird looking attempt at weave during the Pom Burst window. 

Added New status cap code to needsdot()