### PR TITLE
[BLM] Polyglot usage tweaks

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -489,10 +489,6 @@ public enum CustomComboPreset
     [CustomComboInfo("Foul/Xenoglossy Option", "Add Foul/Xenoglossy to the rotation.", BLM.JobID)]
     BLM_ST_UsePolyglot = 2104,
 
-    [ParentCombo(BLM_ST_UsePolyglot)]
-    [CustomComboInfo("Spend ASAP", "Use Foul/Xenoglossy whenever available.\nWill NOT save a proc for Movement!", BLM.JobID)]
-    BLM_ST_UsePolyglotAsap = 2117,
-
     [ParentCombo(BLM_ST_AdvancedMode)]
     [CustomComboInfo("Movement Option", "Add chosen options for movement.", BLM.JobID)]
     BLM_ST_Movement = 2113,

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -258,13 +258,8 @@ internal partial class BLM : Caster
             if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot))
             {
                 //Overcap protection
-                if (HasMaxPolyglotStacks && PolyglotTimer <= 5000)
-                    return LevelChecked(Xenoglossy)
-                        ? Xenoglossy
-                        : Foul;
-
-                if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglotAsap) &&
-                    HasPolyglotStacks())
+                if (HasMaxPolyglotStacks && PolyglotTimer <= 5000 || 
+                    PolyglotStacks > BLM_ST_Polyglot_Save)
                     return LevelChecked(Xenoglossy)
                         ? Xenoglossy
                         : Foul;
@@ -324,8 +319,7 @@ internal partial class BLM : Caster
             {
                 // TODO: Revisit when Raid Buff checks are in place
                 if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot) &&
-                    ((BLM_ST_MovementOption[3] && PolyglotStacks > BLM_ST_Polyglot_Movement) ||
-                     (!BLM_ST_MovementOption[3] && HasPolyglotStacks())))
+                    BLM_ST_MovementOption[3] && PolyglotStacks > BLM_ST_Polyglot_Movement)
                     return LevelChecked(Xenoglossy)
                         ? Xenoglossy
                         : Foul;

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -257,7 +257,7 @@ internal partial class BLM : Caster
                 return Scathe;
 
             //Overcap protection
-            if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot) && 
+            if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot) &&
                 HasMaxPolyglotStacks && PolyglotTimer <= 5000)
                 return LevelChecked(Xenoglossy)
                     ? Xenoglossy
@@ -297,10 +297,11 @@ internal partial class BLM : Caster
             {
                 // TODO: Revisit when Raid Buff checks are in place
                 if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot) &&
-                    BLM_ST_MovementOption[3] &&
-                    PolyglotStacks > BLM_ST_Polyglot_Movement ||
-                    !BLM_ST_MovementOption[3] &&
-                    PolyglotStacks > BLM_ST_Polyglot_Save)
+                    ((BLM_ST_MovementOption[3] &&
+                      PolyglotStacks > BLM_ST_Polyglot_Movement &&
+                      PolyglotStacks > BLM_ST_Polyglot_Save) ||
+                     (!BLM_ST_MovementOption[3] &&
+                      PolyglotStacks > BLM_ST_Polyglot_Save)))
                     return LevelChecked(Xenoglossy)
                         ? Xenoglossy
                         : Foul;

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using WrathCombo.CustomComboNS;
 using static WrathCombo.Combos.PvE.BLM.Config;
 using static WrathCombo.Data.ActionWatching;
@@ -255,15 +256,13 @@ internal partial class BLM : Caster
                 IsMoving() && !LevelChecked(Triplecast))
                 return Scathe;
 
-            if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot))
-            {
-                //Overcap protection
-                if (HasMaxPolyglotStacks && PolyglotTimer <= 5000 || 
-                    PolyglotStacks > BLM_ST_Polyglot_Save)
-                    return LevelChecked(Xenoglossy)
-                        ? Xenoglossy
-                        : Foul;
-            }
+            //Overcap protection
+            if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot) && 
+                (HasMaxPolyglotStacks && PolyglotTimer <= 5000 ||
+                 PolyglotStacks > BLM_ST_Polyglot_Save))
+                return LevelChecked(Xenoglossy)
+                    ? Xenoglossy
+                    : Foul;
 
             if (IsEnabled(CustomComboPreset.BLM_ST_Thunder) &&
                 LevelChecked(Thunder) && HasStatusEffect(Buffs.Thunderhead))
@@ -287,32 +286,12 @@ internal partial class BLM : Caster
 
             if (IsMoving() && InCombat())
             {
-                if (BLM_ST_MovementOption[0] &&
-                    ActionReady(Triplecast) &&
-                    !HasStatusEffect(Buffs.Triplecast) &&
-                    !HasStatusEffect(Role.Buffs.Swiftcast) &&
-                    !HasStatusEffect(Buffs.LeyLines))
-                    return Triplecast;
-
-                if (BLM_ST_MovementOption[1] &&
-                    ActionReady(Paradox) &&
-                    FirePhase && ActiveParadox &&
-                    !HasStatusEffect(Buffs.Firestarter) &&
-                    !HasStatusEffect(Buffs.Triplecast) &&
-                    !HasStatusEffect(Role.Buffs.Swiftcast))
-                    return OriginalHook(Paradox);
-
-                if (BLM_ST_MovementOption[2] &&
-                    ActionReady(Role.Swiftcast) && !HasStatusEffect(Buffs.Triplecast))
-                    return Role.Swiftcast;
-
-                if (BLM_ST_MovementOption[3] &&
-                    HasPolyglotStacks() &&
-                    !HasStatusEffect(Buffs.Triplecast) &&
-                    !HasStatusEffect(Role.Buffs.Swiftcast))
-                    return LevelChecked(Xenoglossy)
-                        ? Xenoglossy
-                        : Foul;
+                foreach(int priority in BLM_ST_Movement_Priority.Items.OrderBy(x => x))
+                {
+                    int index = BLM_ST_Movement_Priority.IndexOf(priority);
+                    if (CheckMovementConfigMeetsRequirements(index, out uint action))
+                        return action;
+                }
             }
 
             if (FirePhase)
@@ -429,7 +408,7 @@ internal partial class BLM : Caster
                 return Foul;
 
             if (HasStatusEffect(Buffs.Thunderhead) && LevelChecked(Thunder2) &&
-                (GetTargetHPPercent() > 1) &&
+                GetTargetHPPercent() > 1 &&
                 (ThunderDebuffAoE is null && ThunderDebuffST is null ||
                  ThunderDebuffAoE?.RemainingTime <= 3 ||
                  ThunderDebuffST?.RemainingTime <= 3) &&

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -258,8 +258,7 @@ internal partial class BLM : Caster
 
             //Overcap protection
             if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot) && 
-                (HasMaxPolyglotStacks && PolyglotTimer <= 5000 ||
-                 PolyglotStacks > BLM_ST_Polyglot_Save))
+                HasMaxPolyglotStacks && PolyglotTimer <= 5000)
                 return LevelChecked(Xenoglossy)
                     ? Xenoglossy
                     : Foul;
@@ -298,7 +297,10 @@ internal partial class BLM : Caster
             {
                 // TODO: Revisit when Raid Buff checks are in place
                 if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot) &&
-                    BLM_ST_MovementOption[3] && PolyglotStacks > BLM_ST_Polyglot_Movement)
+                    BLM_ST_MovementOption[3] &&
+                    PolyglotStacks > BLM_ST_Polyglot_Movement ||
+                    !BLM_ST_MovementOption[3] &&
+                    PolyglotStacks > BLM_ST_Polyglot_Save)
                     return LevelChecked(Xenoglossy)
                         ? Xenoglossy
                         : Foul;

--- a/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
@@ -31,6 +31,9 @@ internal partial class BLM
         public static UserBoolArray
             BLM_ST_MovementOption = new("BLM_ST_MovementOption");
 
+        public static UserIntArray
+            BLM_ST_Movement_Priority = new("BLM_ST_Movement_Priority");
+
         internal static void Draw(CustomComboPreset preset)
         {
             switch (preset)
@@ -54,19 +57,26 @@ internal partial class BLM
                     break;
 
                 case CustomComboPreset.BLM_ST_Movement:
-
                     DrawHorizontalMultiChoice(BLM_ST_MovementOption, $"Use {Triplecast.ActionName()}", "", 4, 0);
+                    DrawPriorityInput(BLM_ST_Movement_Priority, 4, 0, $"{Triplecast.ActionName()} Priority: ");
                     DrawHorizontalMultiChoice(BLM_ST_MovementOption, $"Use {Paradox.ActionName()}", "", 4, 1);
+                    DrawPriorityInput(BLM_ST_Movement_Priority, 4, 1, $"{Paradox.ActionName()} Priority: ");
                     DrawHorizontalMultiChoice(BLM_ST_MovementOption, $"Use {Role.Swiftcast.ActionName()}", "", 4, 2);
+                    DrawPriorityInput(BLM_ST_Movement_Priority, 4, 2, $"{Role.Swiftcast.ActionName()} Priority: ");
                     DrawHorizontalMultiChoice(BLM_ST_MovementOption, $"Use {Foul.ActionName()} / {Xenoglossy.ActionName()}", "", 4, 3);
+                    DrawPriorityInput(BLM_ST_Movement_Priority, 4, 3, $"{Xenoglossy.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.BLM_ST_UsePolyglot:
                     DrawSliderInt(0, 3, BLM_ST_Polyglot_Save,
                         "How many charges to save for manual use?");
-                    if (BLM_ST_MovementOption[3])
-                        DrawSliderInt(1, 3, BLM_ST_Polyglot_Movement,
-                            "How many charges to save for movement?");
+
+                    DrawSliderInt(0, 3 - BLM_ST_Polyglot_Save, BLM_ST_Polyglot_Movement,
+                        "How many charges to save for movement?");
+
+                    if (BLM_ST_Polyglot_Movement > 3 - BLM_ST_Polyglot_Save)
+                        BLM_ST_Polyglot_Movement.Value = 3 - BLM_ST_Polyglot_Save;
+
                     break;
 
                 case CustomComboPreset.BLM_ST_Triplecast:

--- a/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
@@ -68,14 +68,15 @@ internal partial class BLM
                     break;
 
                 case CustomComboPreset.BLM_ST_UsePolyglot:
-                    DrawSliderInt(0, 3, BLM_ST_Polyglot_Save,
-                        "How many charges to save for manual use?");
+                    if (DrawSliderInt(0, 3, BLM_ST_Polyglot_Save,
+                        "How many charges to save for manual use?"))
+                        if (BLM_ST_Polyglot_Movement > 3 - BLM_ST_Polyglot_Save)
+                            BLM_ST_Polyglot_Movement.Value = 3 - BLM_ST_Polyglot_Save;
 
-                    DrawSliderInt(0, 3 - BLM_ST_Polyglot_Save, BLM_ST_Polyglot_Movement,
-                        "How many charges to save for movement?");
-
-                    if (BLM_ST_Polyglot_Movement > 3 - BLM_ST_Polyglot_Save)
-                        BLM_ST_Polyglot_Movement.Value = 3 - BLM_ST_Polyglot_Save;
+                    if (DrawSliderInt(0, 3, BLM_ST_Polyglot_Movement,
+                        "How many charges to save for movement?"))
+                        if (BLM_ST_Polyglot_Save > 3 - BLM_ST_Polyglot_Movement)
+                            BLM_ST_Polyglot_Save.Value = 3 - BLM_ST_Polyglot_Movement;
 
                     break;
 

--- a/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
@@ -17,6 +17,7 @@ internal partial class BLM
             BLM_ST_Thunder_SubOption = new("BLM_ST_Thunder_SubOption", 1),
             BLM_ST_Triplecast_Movement = new("BLM_ST_Triplecast_Movement", 1),
             BLM_ST_Polyglot_Movement = new("BLM_ST_Polyglot_Movement", 1),
+            BLM_ST_Polyglot_Save = new("BLM_ST_Polyglot_Save", 0),
             BLM_ST_Manaward_Threshold = new("BLM_ST_Manaward_Threshold", 25),
             BLM_AoE_Triplecast_HoldCharges = new("BLM_AoE_Triplecast_HoldCharges", 0),
             BLM_AoE_LeyLinesCharges = new("BLM_AoE_LeyLinesCharges", 1),
@@ -61,6 +62,8 @@ internal partial class BLM
                     break;
 
                 case CustomComboPreset.BLM_ST_UsePolyglot:
+                    DrawSliderInt(0, 3, BLM_ST_Polyglot_Save,
+                        "How many charges to save for manual use?");
                     if (BLM_ST_MovementOption[3])
                         DrawSliderInt(1, 3, BLM_ST_Polyglot_Movement,
                             "How many charges to save for movement?");

--- a/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
@@ -53,6 +53,50 @@ internal partial class BLM
 
     internal static bool HasPolyglotStacks() => PolyglotStacks > 0;
 
+    #region Movement Prio
+
+    private static (uint Action, CustomComboPreset Preset, System.Func<bool> Logic)[]
+        PrioritizedMovement =>
+    [
+        //Triplecast
+        (Triplecast, CustomComboPreset.BLM_ST_Movement,
+            () => Config.BLM_ST_MovementOption[0] &&
+                  ActionReady(Triplecast) &&
+                  !HasStatusEffect(Buffs.Triplecast) &&
+                  !HasStatusEffect(Role.Buffs.Swiftcast) &&
+                  !HasStatusEffect(Buffs.LeyLines)),
+        // Paradox
+        (OriginalHook(Paradox), CustomComboPreset.BLM_ST_Movement,
+            () => Config.BLM_ST_MovementOption[1] &&
+                  ActionReady(Paradox) &&
+                  FirePhase && ActiveParadox &&
+                  !HasStatusEffect(Buffs.Firestarter) &&
+                  !HasStatusEffect(Buffs.Triplecast) &&
+                  !HasStatusEffect(Role.Buffs.Swiftcast)),
+        //Swiftcast
+        (Role.Swiftcast, CustomComboPreset.BLM_ST_Movement,
+            () => Config.BLM_ST_MovementOption[2] &&
+                  ActionReady(Role.Swiftcast) &&
+                  !HasStatusEffect(Buffs.Triplecast)),
+        //Xeno
+        (Xenoglossy, CustomComboPreset.BLM_ST_Movement,
+            () => Config.BLM_ST_MovementOption[3] &&
+                  HasPolyglotStacks() &&
+                  !HasStatusEffect(Buffs.Triplecast) &&
+                  !HasStatusEffect(Role.Buffs.Swiftcast))
+    ];
+
+    private static bool CheckMovementConfigMeetsRequirements
+        (int index, out uint action)
+    {
+        action = PrioritizedMovement[index].Action;
+        return ActionReady(action) && LevelChecked(action) &&
+               PrioritizedMovement[index].Logic() &&
+               IsEnabled(PrioritizedMovement[index].Preset);
+    }
+
+    #endregion
+
     #region Openers
 
     internal static WrathOpener Opener()


### PR DESCRIPTION
Initial work on making polyglot usage a bit more flexible.

- Added a slider that allows user to select how many chargers to keep for manual use, seperate from the movement option slider
- Removed the "USE ASAP" option as slider can be set to "0" to recreate the same behavior
- Make the movement slider and manual usage slider not conflict with each other.
- Added priority movement options