### PR TITLE
[Retargeting] Fix DNC+AST+WHM

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -7023,6 +7023,16 @@ SMN.JobID)]
     [Retargeted]
     WHM_AoEHeals_Asylum = 19028,
 
+    [ParentCombo(WHM_AoEHeals_Asylum)]
+    [CustomComboInfo("Enemy Placement Option", "Will add an enemy hard target as the top priority Retarget for Asylum.", WHM.JobID)]
+    [Retargeted]
+    WHM_AoEHeals_Asylum_Enemy = 19030,
+
+    [ParentCombo(WHM_AoEHeals_Asylum)]
+    [CustomComboInfo("Ally Placement Option", "Will add any ally UI MouseOver target, focus target, soft target, or hard target as the priority Retarget for Asylum.\nBeneath the Enemy placement option, but above yourself.", WHM.JobID)]
+    [Retargeted]
+    WHM_AoEHeals_Asylum_Allies = 19031,
+
     #endregion
 
     #region Heals Small Features

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -7014,7 +7014,7 @@ SMN.JobID)]
     WHM_AoEHeals_DivineCaress = 19207,
 
     [ParentCombo(WHM_AoEHeals)]
-    [CustomComboInfo("Asylum Option", "Adds Asylum placement, when standing still, to the rotation.\nWill Retarget it onto a friendly focus target, soft target, hard target, and fallback to placing it at your feet.", WHM.JobID)]
+    [CustomComboInfo("Asylum Option", "Adds Asylum placement, when standing still, to the rotation.\nWill Retarget it onto yourself.", WHM.JobID)]
     [Retargeted]
     WHM_AoEHeals_Asylum = 19028,
 

--- a/WrathCombo/Combos/PvE/AST/AST_Helper.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Helper.cs
@@ -101,7 +101,7 @@ internal partial class AST
             }
 
             var card = Gauge.DrawnCards[0];
-            var party = GetPartyMembers()
+            var party = GetPartyMembers(false)
                 .Select(member => member.BattleChara)
                 .Where(member => !member.IsDead && member.IsNotThePlayer())
                 .Where(InCardRange)

--- a/WrathCombo/Combos/PvE/AST/AST_Helper.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Helper.cs
@@ -104,11 +104,9 @@ internal partial class AST
                 return field;
 
             var card = Gauge.DrawnCards[0];
-            var playerID = LocalPlayer.GameObjectId;
             var party = GetPartyMembers()
-                .Where(member => member.GameObjectId != playerID)
-                .Where(member => !member.BattleChara.IsDead)
                 .Select(member => member.BattleChara)
+                .Where(member => !member.IsDead && member.IsNotThePlayer())
                 .Where(InCardRange)
                 .Where(ExistingCardBuffFree)
                 .ToList();

--- a/WrathCombo/Combos/PvE/AST/AST_Helper.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Helper.cs
@@ -100,9 +100,6 @@ internal partial class AST
                     return field = targetOverride;
             }
 
-            if (!EZ.Throttle("astCardPartyCheck", TS.FromSeconds(0.5)))
-                return field;
-
             var card = Gauge.DrawnCards[0];
             var party = GetPartyMembers()
                 .Select(member => member.BattleChara)

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -1,6 +1,5 @@
 ﻿#region
 
-using ECommons.Logging;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Data;
 using WrathCombo.Core;

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -1,5 +1,6 @@
 ﻿#region
 
+using ECommons.Logging;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Data;
 using WrathCombo.Core;
@@ -222,7 +223,7 @@ internal partial class DNC : PhysicalRanged
                 CurrentPartnerNonOptimal)
                 return HasStatusEffect(Buffs.ClosedPosition)
                     ? Ending
-                    : ClosedPosition.Retarget(Cascade, FeatureDancePartnerResolver);
+                    : ClosedPosition.Retarget(Cascade, DancePartnerResolver);
 
             // Variant Cure
             if (Variant.CanCure(CustomComboPreset.DNC_Variant_Cure, Config.DNCVariantCurePercent))
@@ -463,7 +464,7 @@ internal partial class DNC : PhysicalRanged
                 if (ActionReady(ClosedPosition) &&
                     !HasStatusEffect(Buffs.ClosedPosition) &&
                     (GetPartyMembers().Count > 1 || HasCompanionPresent()))
-                    return ClosedPosition.Retarget(Cascade, FeatureDancePartnerResolver);
+                    return ClosedPosition.Retarget(Cascade, DancePartnerResolver);
 
                 if (TargetIsHostile())
                 {
@@ -547,7 +548,7 @@ internal partial class DNC : PhysicalRanged
                 CurrentPartnerNonOptimal)
                 return HasStatusEffect(Buffs.ClosedPosition)
                     ? Ending
-                    : ClosedPosition.Retarget(Cascade, FeatureDancePartnerResolver);
+                    : ClosedPosition.Retarget(Cascade, DancePartnerResolver);
 
             // Variant Cure
             if (Variant.CanCure(CustomComboPreset.DNC_Variant_Cure, 50))
@@ -745,7 +746,7 @@ internal partial class DNC : PhysicalRanged
                 (GetPartyMembers().Count > 1 || HasCompanionPresent()))
                 if (InAutoMode(false, false) ||
                     IsEnabled(CustomComboPreset.DNC_DesirablePartner))
-                    return ClosedPosition.Retarget(Cascade, FeatureDancePartnerResolver);
+                    return ClosedPosition.Retarget(Cascade, DancePartnerResolver);
                 else
                     return ClosedPosition;
 
@@ -1027,7 +1028,7 @@ internal partial class DNC : PhysicalRanged
                 (GetPartyMembers().Count > 1 || HasCompanionPresent()))
                 if (InAutoMode(false, true) ||
                     IsEnabled(CustomComboPreset.DNC_DesirablePartner))
-                    return ClosedPosition.Retarget(Cascade, FeatureDancePartnerResolver);
+                    return ClosedPosition.Retarget(Cascade, DancePartnerResolver);
                 else
                     return ClosedPosition;
 
@@ -1365,7 +1366,7 @@ internal partial class DNC : PhysicalRanged
                 //StatusManager.ExecuteStatusOff(Buffs.ClosedPosition);
 
                 return ClosedPosition.Retarget([ClosedPosition, Ending],
-                    FeatureDancePartnerResolver, dontCull: true);
+                    DancePartnerResolver, dontCull: true);
             }
 
             return (int)Config.DNC_Partner_ActionToShow switch

--- a/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
@@ -343,22 +343,35 @@ internal partial class DNC
             // If it's the last step and there are no matches found, bail
             if (filter.Count == 0)
                 return false;
+            // If there's only one match, return it
+            if (filter.Count == 1)
+            {
+                newBestPartner = filter.First();
+                return true;
+            }
 
-            filter = filter
+            var orderedFilter = filter
                 .OrderBy(x =>
                     PartnerPriority.RolePrio.GetValueOrDefault(
-                        x.ClassJob.RowId.Role(), int.MaxValue))
-                .ThenBy(x =>
-                    Player.Level >= 90
-                        ? PartnerPriority.Job090Prio.GetValueOrDefault(
-                            x.ClassJob.RowId, int.MaxValue)
-                        : int.MaxValue)
-                .ThenBy(x =>
-                    Player.Level >= 100
-                        ? PartnerPriority.Job100Prio.GetValueOrDefault(
-                            x.ClassJob.RowId, int.MaxValue)
-                        : int.MaxValue)
-                .ToList();
+                        x.ClassJob.RowId.Role(), int.MaxValue));
+
+            switch (Player.Level)
+            {
+                case < 100 and >= 90:
+                    orderedFilter = orderedFilter
+                        .ThenBy(x =>
+                            PartnerPriority.Job090Prio.GetValueOrDefault(
+                                x.ClassJob.RowId, int.MaxValue));
+                    break;
+                case >= 100:
+                    orderedFilter = orderedFilter
+                        .ThenBy(x =>
+                            PartnerPriority.Job100Prio.GetValueOrDefault(
+                                x.ClassJob.RowId, int.MaxValue));
+                    break;
+            }
+
+            filter = orderedFilter.ToList();
 
             newBestPartner = filter.First();
             return true;

--- a/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
@@ -206,27 +206,13 @@ internal partial class DNC
         }
     }
 
-    internal static ulong? FeatureDesiredDancePartner
-    {
-        get
-        {
-            if (!EZ.Throttle("dncFeatPartnerDesiredCheck", TS.FromSeconds(7)))
-                return field;
-
-            field = TryGetDancePartner(out var partner, true)
-                ? partner.GameObjectId
-                : null;
-            return field;
-        }
-    }
-
     private static bool CurrentPartnerNonOptimal =>
-        FeatureDesiredDancePartner is not null &&
+        DesiredDancePartner is not null &&
         (!HasStatusEffect(Buffs.ClosedPosition) &&
          (IsInParty() ||
           HasCompanionPresent())) ||
         (CurrentDancePartner is not null &&
-         FeatureDesiredDancePartner != CurrentDancePartner);
+         DesiredDancePartner != CurrentDancePartner);
 
     #region Resolver Delegates
 
@@ -235,15 +221,9 @@ internal partial class DNC
         Svc.Objects.FirstOrDefault(x =>
             x.GameObjectId == DesiredDancePartner);
 
-    [ActionRetargeting.TargetResolver]
-    internal static IGameObject? FeatureDancePartnerResolver() =>
-        Svc.Objects.FirstOrDefault(x =>
-            x.GameObjectId == FeatureDesiredDancePartner);
-
     #endregion
 
-    private static bool TryGetDancePartner
-        (out IGameObject? partner, bool? callingFromFeature = null)
+    private static bool TryGetDancePartner (out IGameObject? partner)
     {
         partner = null;
 
@@ -265,8 +245,7 @@ internal partial class DNC
 
         // Check if we have a target overriding any searching
         var focusTarget = SimpleTarget.FocusTarget;
-        if (callingFromFeature is true &&
-            Config.DNC_Partner_FocusOverride &&
+        if (Config.DNC_Partner_FocusOverride &&
             focusTarget is IBattleChara &&
             !focusTarget.IsDead &&
             focusTarget.IsInParty() &&

--- a/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
@@ -196,7 +196,8 @@ internal partial class DNC
     {
         get
         {
-            if (!EZ.Throttle("dncPartnerDesiredCheck", TS.FromSeconds(2)))
+            if (!EZ.Throttle("dncPartnerDesiredCheck", TS.FromSeconds(2)) &&
+                field is not null)
                 return field;
 
             field = TryGetDancePartner(out var partner)
@@ -214,20 +215,19 @@ internal partial class DNC
         (CurrentDancePartner is not null &&
          DesiredDancePartner != CurrentDancePartner);
 
-    #region Resolver Delegates
-
     [ActionRetargeting.TargetResolver]
     internal static IGameObject? DancePartnerResolver () =>
         Svc.Objects.FirstOrDefault(x =>
-            x.GameObjectId == DesiredDancePartner);
-
-    #endregion
+            x.GameObjectId == DesiredDancePartner) ??
+        (!HasStatusEffect(Buffs.ClosedPosition)
+            ? SimpleTarget.AnySelfishDPS ?? SimpleTarget.AnyMeleeDPS ?? SimpleTarget.AnyDPS
+            : null);
 
     private static bool TryGetDancePartner (out IGameObject? partner)
     {
         partner = null;
 
-        if (!Player.Available || Player.IsBusy)
+        if (!Player.Available)
             return false;
 
         #region Skip a new check, if the current partner is just out of range

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -335,11 +335,19 @@ internal partial class WHM : Healer
                 ActionReady(DivineCaress))
                 return OriginalHook(DivineCaress);
 
+            var asylumTarget =
+                (IsEnabled(CustomComboPreset.WHM_AoEHeals_Asylum_Enemy)
+                    ? SimpleTarget.HardTarget
+                    : null) ??
+                (IsEnabled(CustomComboPreset.WHM_AoEHeals_Asylum_Allies)
+                    ? SimpleTarget.Stack.OverridesAllies
+                    : null) ??
+                SimpleTarget.Self;
             if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Asylum) &&
                 ActionReady(Asylum) &&
                 !IsMoving() &&
                 (!Config.WHM_AoEHeals_AsylumRaidwideOnly || RaidWideCasting()))
-                return Asylum.Retarget(Medica1, SimpleTarget.Self);
+                return Asylum.Retarget(Medica1, asylumTarget);
 
             if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Lucid) &&
                 CanSpellWeave() &&

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -339,7 +339,7 @@ internal partial class WHM : Healer
                 ActionReady(Asylum) &&
                 !IsMoving() &&
                 (!Config.WHM_AoEHeals_AsylumRaidwideOnly || RaidWideCasting()))
-                return Asylum.Retarget(Medica1, SimpleTarget.Stack.Allies);
+                return Asylum.Retarget(Medica1, SimpleTarget.Self);
 
             if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Lucid) &&
                 CanSpellWeave() &&

--- a/WrathCombo/CustomCombo/Functions/Party.cs
+++ b/WrathCombo/CustomCombo/Functions/Party.cs
@@ -24,10 +24,10 @@ namespace WrathCombo.CustomComboNS.Functions
 
         /// <summary> Gets the party list </summary>
         /// <returns> Current party list. </returns>
-        public static unsafe List<WrathPartyMember> GetPartyMembers()
+        public static unsafe List<WrathPartyMember> GetPartyMembers(bool allowCache = true)
         {
             if (!Player.Available) return [];
-            if (!EzThrottler.Throttle("PartyUpdateThrottle", 2000))
+            if (allowCache && !EzThrottler.Throttle("PartyUpdateThrottle", 2000))
                 return _partyList;
 
             var existingIds = _partyList.Select(x => x.GameObjectId).ToHashSet();

--- a/WrathCombo/CustomCombo/SimpleTarget.cs
+++ b/WrathCombo/CustomCombo/SimpleTarget.cs
@@ -50,7 +50,7 @@ internal static class SimpleTarget
         /// </remarks>
         public static IGameObject? OverridesAllies =>
             UIMouseOverTarget ?? FocusTarget.IfFriendly() ??
-            SoftTarget.IfFriendly()  ?? HardTarget .IfFriendly() ??
+            SoftTarget.IfFriendly() ?? HardTarget.IfFriendly() ??
             Self;
 
         /// A very common stack that targets the player, if there are no manual

--- a/WrathCombo/CustomCombo/SimpleTarget.cs
+++ b/WrathCombo/CustomCombo/SimpleTarget.cs
@@ -65,7 +65,7 @@ internal static class SimpleTarget
         /// A very common stack that targets an ally or self.
         public static IGameObject? Allies =>
             FocusTarget.IfFriendly() ?? SoftTarget.IfFriendly() ??
-            HardTarget .IfFriendly() ?? Self;
+            HardTarget.IfFriendly() ?? Self;
 
         /// A little mask for Plugin Configuration to make the string a bit shorter.
         private static PluginConfiguration cfg =>

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -351,7 +351,9 @@ namespace WrathCombo.Data
             var changed = CheckForChangedTarget(original, ref targetId,
                 out var replacedWith); //Passes the original action to the retargeting framework, outputs a targetId and a replaced action
 
-            if (changed) //Check if the action can be used on the target, and if not revert to original
+            var areaTargeted = Svc.Data.GetExcelSheet<Lumina.Excel.Sheets.Action>().GetRow(replacedWith).TargetArea;
+
+            if (changed && !areaTargeted) //Check if the action can be used on the target, and if not revert to original
                 if (!ActionManager.CanUseActionOnTarget(replacedWith,
                     Svc.Objects
                         .FirstOrDefault(x => x.GameObjectId == targetId)

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -355,17 +355,9 @@ namespace WrathCombo.Data
                     var changed = CheckForChangedTarget(original, ref targetId,
                         out var replacedWith); //Passes the original action to the retargeting framework, outputs a targetId and a replaced action
 
-                    bool areaTargeted;
-                    try
-                    {
-                        areaTargeted = Svc.Data
-                            .GetExcelSheet<Lumina.Excel.Sheets.Action>()
-                            .GetRow(replacedWith).TargetArea;
-                    }
-                    catch
-                    {
-                        areaTargeted = false;
-                    }
+                    var areaTargeted = Svc.Data
+                        .GetExcelSheet<Lumina.Excel.Sheets.Action>()
+                        .GetRow(replacedWith).TargetArea;
 
                     if (changed && !areaTargeted) //Check if the action can be used on the target, and if not revert to original
                         if (!ActionManager.CanUseActionOnTarget(replacedWith,

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -332,31 +332,34 @@ namespace WrathCombo.Data
 
         private unsafe static bool UseActionDetour(ActionManager* actionManager, ActionType actionType, uint actionId, ulong targetId, uint extraParam, ActionManager.UseActionMode mode, uint comboRouteId, bool* outOptAreaTargeted)
         {
-            if (Service.Configuration.PerformanceMode)
+            var original = actionId; //Save the original action, do not modify
+            var originalTargetId = targetId; //Save the original target, do not modify
+
+            if (Service.Configuration.PerformanceMode) //Performance mode only logic, to modify the actionId
             {
                 var result = actionId;
                 foreach (var combo in ActionReplacer.FilteredCombos)
                 {
                     if (combo.TryInvoke(actionId, out result))
                     {
-                        actionId = Service.ActionReplacer.LastActionInvokeFor[actionId] = result;
+                        actionId = Service.ActionReplacer.LastActionInvokeFor[actionId] = result; //Sets actionId and the LastActionInvokeFor dictionary entry to the result of the combo
                         break;
                     }
                 }
             }
-            
-            var originalTargetId = targetId;
-            var changed = CheckForChangedTarget(actionId, ref targetId,
-                out var replacedWith);
+           
+            var changed = CheckForChangedTarget(original, ref targetId,
+                out var replacedWith); //Passes the original action to the retargeting framework, outputs a targetId and a replaced action
 
-            if (changed)
+            if (changed) //Check if the action can be used on the target, and if not revert to original
                 if (!ActionManager.CanUseActionOnTarget(replacedWith,
                     Svc.Objects
                         .FirstOrDefault(x => x.GameObjectId == targetId)
                         .Struct()))
-                    targetId = originalTargetId;
+                    targetId = originalTargetId; 
 
-            var hookResult = UseActionHook.Original(actionManager, actionType, replacedWith, targetId, extraParam, mode, comboRouteId, outOptAreaTargeted);
+            //Important to pass actionId here and not replaced. Performance mode = result from earlier, which could be modified. Non-performance mode = original action, which gets modified by the hook. Same result.
+            var hookResult = UseActionHook.Original(actionManager, actionType, actionId, targetId, extraParam, mode, comboRouteId, outOptAreaTargeted);
 
             // If the target was changed, support changing the target for ground actions, too
             if (changed)

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -332,43 +332,57 @@ namespace WrathCombo.Data
 
         private unsafe static bool UseActionDetour(ActionManager* actionManager, ActionType actionType, uint actionId, ulong targetId, uint extraParam, ActionManager.UseActionMode mode, uint comboRouteId, bool* outOptAreaTargeted)
         {
-            var original = actionId; //Save the original action, do not modify
-            var originalTargetId = targetId; //Save the original target, do not modify
-
-            if (Service.Configuration.PerformanceMode) //Performance mode only logic, to modify the actionId
+            try
             {
-                var result = actionId;
-                foreach (var combo in ActionReplacer.FilteredCombos)
+                if (actionType is FFXIVClientStructs.FFXIV.Client.Game.ActionType.Action or FFXIVClientStructs.FFXIV.Client.Game.ActionType.Ability)
                 {
-                    if (combo.TryInvoke(actionId, out result))
+                    var original = actionId; //Save the original action, do not modify
+                    var originalTargetId = targetId; //Save the original target, do not modify
+
+                    if (Service.Configuration.PerformanceMode) //Performance mode only logic, to modify the actionId
                     {
-                        actionId = Service.ActionReplacer.LastActionInvokeFor[actionId] = result; //Sets actionId and the LastActionInvokeFor dictionary entry to the result of the combo
-                        break;
+                        var result = actionId;
+                        foreach (var combo in ActionReplacer.FilteredCombos)
+                        {
+                            if (combo.TryInvoke(actionId, out result))
+                            {
+                                actionId = Service.ActionReplacer.LastActionInvokeFor[actionId] = result; //Sets actionId and the LastActionInvokeFor dictionary entry to the result of the combo
+                                break;
+                            }
+                        }
                     }
+
+                    var changed = CheckForChangedTarget(original, ref targetId,
+                        out var replacedWith); //Passes the original action to the retargeting framework, outputs a targetId and a replaced action
+
+                    var areaTargeted = Svc.Data.GetExcelSheet<Lumina.Excel.Sheets.Action>().GetRow(replacedWith).TargetArea;
+
+                    if (changed && !areaTargeted) //Check if the action can be used on the target, and if not revert to original
+                        if (!ActionManager.CanUseActionOnTarget(replacedWith,
+                            Svc.Objects
+                                .FirstOrDefault(x => x.GameObjectId == targetId)
+                                .Struct()))
+                            targetId = originalTargetId;
+
+                    //Important to pass actionId here and not replaced. Performance mode = result from earlier, which could be modified. Non-performance mode = original action, which gets modified by the hook. Same result.
+                    var hookResult = UseActionHook.Original(actionManager, actionType, actionId, targetId, extraParam, mode, comboRouteId, outOptAreaTargeted);
+
+                    // If the target was changed, support changing the target for ground actions, too
+                    if (changed)
+                        ActionManager.Instance()->AreaTargetingExecuteAtObject =
+                            targetId;
+
+                    return hookResult;
+                }
+                else
+                {
+                    return UseActionHook.Original(actionManager, actionType, actionId, targetId, extraParam, mode, comboRouteId, outOptAreaTargeted);
                 }
             }
-           
-            var changed = CheckForChangedTarget(original, ref targetId,
-                out var replacedWith); //Passes the original action to the retargeting framework, outputs a targetId and a replaced action
-
-            var areaTargeted = Svc.Data.GetExcelSheet<Lumina.Excel.Sheets.Action>().GetRow(replacedWith).TargetArea;
-
-            if (changed && !areaTargeted) //Check if the action can be used on the target, and if not revert to original
-                if (!ActionManager.CanUseActionOnTarget(replacedWith,
-                    Svc.Objects
-                        .FirstOrDefault(x => x.GameObjectId == targetId)
-                        .Struct()))
-                    targetId = originalTargetId; 
-
-            //Important to pass actionId here and not replaced. Performance mode = result from earlier, which could be modified. Non-performance mode = original action, which gets modified by the hook. Same result.
-            var hookResult = UseActionHook.Original(actionManager, actionType, actionId, targetId, extraParam, mode, comboRouteId, outOptAreaTargeted);
-
-            // If the target was changed, support changing the target for ground actions, too
-            if (changed)
-                ActionManager.Instance()->AreaTargetingExecuteAtObject =
-                    targetId;
-
-            return hookResult;
+            catch
+            {
+                return UseActionHook.Original(actionManager, actionType, actionId, targetId, extraParam, mode, comboRouteId, outOptAreaTargeted);
+            }
         }
 
         public static void Enable()

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -355,7 +355,17 @@ namespace WrathCombo.Data
                     var changed = CheckForChangedTarget(original, ref targetId,
                         out var replacedWith); //Passes the original action to the retargeting framework, outputs a targetId and a replaced action
 
-                    var areaTargeted = Svc.Data.GetExcelSheet<Lumina.Excel.Sheets.Action>().GetRow(replacedWith).TargetArea;
+                    bool areaTargeted;
+                    try
+                    {
+                        areaTargeted = Svc.Data
+                            .GetExcelSheet<Lumina.Excel.Sheets.Action>()
+                            .GetRow(replacedWith).TargetArea;
+                    }
+                    catch
+                    {
+                        areaTargeted = false;
+                    }
 
                     if (changed && !areaTargeted) //Check if the action can be used on the target, and if not revert to original
                         if (!ActionManager.CanUseActionOnTarget(replacedWith,

--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -296,6 +296,9 @@ public sealed partial class WrathCombo : IDalamudPlugin
 
         Service.Configuration.SetActionChanging();
 
+        if (Player.Available && Player.IsDead)
+            ActionRetargeting.Retargets.Clear();
+
         // Skip the IPC checking if hidden
         if (DtrBarEntry.UserHidden) return;
 


### PR DESCRIPTION
- [X] Fixes DNC's bad Partner logic
- [X] Early-Returns DNC's Partner if only one valid one was found
      (from #621)
- [X] Separates DNC's level-based partner priority sorting, to prevent any conflicts between the sorts
      (from #621)
- [X] Removes AST's Card Resolver throttle
- [X] Clears Retargets when you die
- [X] Fixes to Retargeting to use the Retarget for ground-targeted abilities
- [X] Added options for whom to target with WHM's Asylum