### PR TITLE
[Core] Fix `StatusList` crashes

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -754,8 +754,21 @@ namespace WrathCombo.AutoRotation
 
             internal static bool CanAoEHeal(uint outAct = 0)
             {
-                var members = GetPartyMembers().Where(x => !x.BattleChara.IsDead && x.BattleChara.IsTargetable && (outAct == 0 ? GetTargetDistance(x.BattleChara) <= 15 : InActionRange(outAct, x.BattleChara)) && ((float)x.CurrentHP / x.BattleChara.MaxHp * 100) <= cfg.HealerSettings.AoETargetHPP);
-                if (members.Count() < cfg.HealerSettings.AoEHealTargetCount)
+                int memberCount;
+                try
+                {
+                    var members = GetPartyMembers()
+                        .Where(x => x.BattleChara is not null &&
+                            !x.BattleChara.IsDead && x.BattleChara.IsTargetable &&
+                            (outAct == 0
+                                ? GetTargetDistance(x.BattleChara) <= 15
+                                : InActionRange(outAct, x.BattleChara)) &&
+                            ((float)x.CurrentHP / x.BattleChara.MaxHp * 100) <= cfg.HealerSettings.AoETargetHPP);
+                    memberCount = members.Count();
+                }
+                catch { memberCount = 0; }
+
+                if (memberCount < cfg.HealerSettings.AoEHealTargetCount)
                     return false;
 
                 return true;

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -614,7 +614,6 @@ namespace WrathCombo.AutoRotation
                     var customCombo = Service.ActionReplacer.CustomCombos.FirstOrDefault(x => x.Preset == preset);
                     if (customCombo != null)
                     {
-                        customCombo.OptionalTarget = null;
                         if (customCombo.TryInvoke(actToCheck, out var changedAct, optionalTarget))
                         {
                             originalAct = actToCheck;

--- a/WrathCombo/Combos/PvE/ALL/HealRetargeting.cs
+++ b/WrathCombo/Combos/PvE/ALL/HealRetargeting.cs
@@ -3,7 +3,6 @@
 using Dalamud.Game.ClientState.Objects.Types;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
-using WrathCombo.Extensions;
 using WrathCombo.Services;
 using EZ = ECommons.Throttlers.EzThrottler;
 using TS = System.TimeSpan;
@@ -15,7 +14,7 @@ using TS = System.TimeSpan;
 namespace WrathCombo.Combos.PvE;
 
 /// <summary>
-///     Should be the same as <see cref="Core.UIntExtensions" />, but with checking
+///     Should be the same as <see cref="UIntExtensions" />, but with checking
 ///     the <see cref="PluginConfiguration.RetargetHealingActionsToStack" /> setting,
 ///     and automatically setting the target to the
 ///     <see cref="SimpleTarget.Stack.AllyToHeal">Heal Stack</see>.
@@ -54,12 +53,12 @@ public static class HealRetargeting
     ///     </see>
     ///     is enabled, and there is no target override.
     /// </summary>
-    /// <seealso cref="Core.UIntExtensions.Retarget(uint,IGameObject?,bool)" />
+    /// <seealso cref="UIntExtensions.Retarget(uint,IGameObject?,bool)" />
     public static uint RetargetIfEnabled
     (this uint actionID,
         IGameObject? optionalTarget,
         bool dontCull = false) =>
-        RetargetSettingOn && optionalTarget.IfStillInParty() is null
+        RetargetSettingOn && optionalTarget is null
             ? actionID.Retarget(
                 actionID == RoleActions.Healer.Esuna ? EsunaStack : HealStack,
                 dontCull)
@@ -72,13 +71,13 @@ public static class HealRetargeting
     ///     </see>
     ///     is enabled, and there is no target override.
     /// </summary>
-    /// <seealso cref="Core.UIntExtensions.Retarget(uint,uint,IGameObject?,bool)" />
+    /// <seealso cref="UIntExtensions.Retarget(uint,uint,IGameObject?,bool)" />
     public static uint RetargetIfEnabled
     (this uint actionID,
         IGameObject? optionalTarget,
         uint replaced,
         bool dontCull = false) =>
-        RetargetSettingOn && optionalTarget.IfStillInParty() is null
+        RetargetSettingOn && optionalTarget is null
             ? actionID.Retarget(replaced,
                 actionID == RoleActions.Healer.Esuna ? EsunaStack : HealStack,
                 dontCull)
@@ -91,13 +90,13 @@ public static class HealRetargeting
     ///     </see>
     ///     is enabled, and there is no target override.
     /// </summary>
-    /// <seealso cref="Core.UIntExtensions.Retarget(uint,uint[],IGameObject?,bool)" />
+    /// <seealso cref="UIntExtensions.Retarget(uint,uint[],IGameObject?,bool)" />
     public static uint RetargetIfEnabled
     (this uint actionID,
         IGameObject? optionalTarget,
         uint[] replaced,
         bool dontCull = false) =>
-        RetargetSettingOn && optionalTarget.IfStillInParty() is null
+        RetargetSettingOn && optionalTarget is null
             ? actionID.Retarget(replaced,
                 actionID == RoleActions.Healer.Esuna ? EsunaStack : HealStack,
                 dontCull)

--- a/WrathCombo/Combos/PvE/ALL/HealRetargeting.cs
+++ b/WrathCombo/Combos/PvE/ALL/HealRetargeting.cs
@@ -3,6 +3,7 @@
 using Dalamud.Game.ClientState.Objects.Types;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
+using WrathCombo.Extensions;
 using WrathCombo.Services;
 using EZ = ECommons.Throttlers.EzThrottler;
 using TS = System.TimeSpan;
@@ -14,7 +15,7 @@ using TS = System.TimeSpan;
 namespace WrathCombo.Combos.PvE;
 
 /// <summary>
-///     Should be the same as <see cref="UIntExtensions" />, but with checking
+///     Should be the same as <see cref="Core.UIntExtensions" />, but with checking
 ///     the <see cref="PluginConfiguration.RetargetHealingActionsToStack" /> setting,
 ///     and automatically setting the target to the
 ///     <see cref="SimpleTarget.Stack.AllyToHeal">Heal Stack</see>.
@@ -53,12 +54,12 @@ public static class HealRetargeting
     ///     </see>
     ///     is enabled, and there is no target override.
     /// </summary>
-    /// <seealso cref="UIntExtensions.Retarget(uint,IGameObject?,bool)" />
+    /// <seealso cref="Core.UIntExtensions.Retarget(uint,IGameObject?,bool)" />
     public static uint RetargetIfEnabled
-        (this uint actionID,
-            IGameObject? optionalTarget,
-            bool dontCull = false) =>
-        RetargetSettingOn && optionalTarget is null
+    (this uint actionID,
+        IGameObject? optionalTarget,
+        bool dontCull = false) =>
+        RetargetSettingOn && optionalTarget.IfStillInParty() is null
             ? actionID.Retarget(
                 actionID == RoleActions.Healer.Esuna ? EsunaStack : HealStack,
                 dontCull)
@@ -71,13 +72,13 @@ public static class HealRetargeting
     ///     </see>
     ///     is enabled, and there is no target override.
     /// </summary>
-    /// <seealso cref="UIntExtensions.Retarget(uint,uint,IGameObject?,bool)" />
+    /// <seealso cref="Core.UIntExtensions.Retarget(uint,uint,IGameObject?,bool)" />
     public static uint RetargetIfEnabled
     (this uint actionID,
         IGameObject? optionalTarget,
         uint replaced,
         bool dontCull = false) =>
-        RetargetSettingOn && optionalTarget is null
+        RetargetSettingOn && optionalTarget.IfStillInParty() is null
             ? actionID.Retarget(replaced,
                 actionID == RoleActions.Healer.Esuna ? EsunaStack : HealStack,
                 dontCull)
@@ -90,13 +91,13 @@ public static class HealRetargeting
     ///     </see>
     ///     is enabled, and there is no target override.
     /// </summary>
-    /// <seealso cref="UIntExtensions.Retarget(uint,uint[],IGameObject?,bool)" />
+    /// <seealso cref="Core.UIntExtensions.Retarget(uint,uint[],IGameObject?,bool)" />
     public static uint RetargetIfEnabled
     (this uint actionID,
         IGameObject? optionalTarget,
         uint[] replaced,
         bool dontCull = false) =>
-        RetargetSettingOn && optionalTarget is null
+        RetargetSettingOn && optionalTarget.IfStillInParty() is null
             ? actionID.Retarget(replaced,
                 actionID == RoleActions.Healer.Esuna ? EsunaStack : HealStack,
                 dontCull)

--- a/WrathCombo/CustomCombo/CustomCombo.cs
+++ b/WrathCombo/CustomCombo/CustomCombo.cs
@@ -23,7 +23,7 @@ namespace WrathCombo.CustomComboNS
             ClassID = JobIDs.JobToClass(JobID);
         }
 
-        internal IGameObject? OptionalTarget;
+        protected IGameObject? OptionalTarget;
 
         /// <summary> Gets the preset associated with this combo. </summary>
         protected internal abstract CustomComboPreset Preset { get; }
@@ -86,8 +86,9 @@ namespace WrathCombo.CustomComboNS
                 JobID != classJobID && ClassID != classJobID)
                 return false;
 
-            OptionalTarget ??= targetOverride;
+            OptionalTarget = targetOverride;
             uint resultingActionID = Invoke(actionID);
+            OptionalTarget = null;
 
             var presetException = _presetsAllowedToReturnUnchanged
                 .TryGetValue(Preset, out var actionException);

--- a/WrathCombo/Data/StatusCache.cs
+++ b/WrathCombo/Data/StatusCache.cs
@@ -25,7 +25,7 @@ namespace WrathCombo.Data
         /// <returns> Status object or null. </returns>
         internal Status? GetStatus(uint statusID, IGameObject? obj, ulong? sourceID)
         {
-            if (obj is null || !obj.IsStillAround())
+            if (obj is null)
                 return null;
 
             var key = (statusID, obj.GameObjectId, sourceID);

--- a/WrathCombo/Data/StatusCache.cs
+++ b/WrathCombo/Data/StatusCache.cs
@@ -36,18 +36,7 @@ namespace WrathCombo.Data
             if (obj is not IBattleChara chara)
                 return statusCache[key] = null;
 
-            StatusList? statuses;
-            try
-            {
-                statuses = Svc.Objects
-                    .Select(x => x as IBattleChara)
-                    .FirstOrDefault(x => x.GameObjectId == chara.GameObjectId)?
-                    .StatusList;
-                if (statuses is null)
-                    throw new NullReferenceException("StatusList is null for the given character.");
-            }
-            catch { return statusCache[key] = null; }
-
+            var statuses = chara.StatusList;
             foreach (var status in statuses)
             {
                 if (status.StatusId == InvalidStatusID)
@@ -223,18 +212,7 @@ namespace WrathCombo.Data
             if (gameObject is not IBattleChara chara)
                 return false;
 
-            StatusList? statuses;
-            try
-            {
-                statuses = Svc.Objects
-                    .Select(x => x as IBattleChara)
-                    .FirstOrDefault(x => x.GameObjectId == chara.GameObjectId)?
-                    .StatusList;
-                if (statuses is null)
-                    throw new NullReferenceException("StatusList is null for the given character.");
-            }
-            catch { return false; }
-
+            var statuses = chara.StatusList;
             var targetStatuses = statuses.Select(s => s.StatusId).ToHashSet();
             return statusList.Count switch
             {

--- a/WrathCombo/Data/StatusCache.cs
+++ b/WrathCombo/Data/StatusCache.cs
@@ -37,7 +37,15 @@ namespace WrathCombo.Data
                 return statusCache[key] = null;
 
             StatusList? statuses;
-            try { statuses = chara.StatusList; }
+            try
+            {
+                statuses = Svc.Objects
+                    .Select(x => x as IBattleChara)
+                    .FirstOrDefault(x => x.GameObjectId == chara.GameObjectId)?
+                    .StatusList;
+                if (statuses is null)
+                    throw new NullReferenceException("StatusList is null for the given character.");
+            }
             catch { return statusCache[key] = null; }
 
             foreach (var status in statuses)
@@ -107,12 +115,9 @@ namespace WrathCombo.Data
         {
             if (target is not IBattleChara tar)
                 return false;
-            StatusList? statuses;
-            try { statuses = tar.StatusList; }
-            catch { return false; }
 
             // Turn Target's status to uint hashset
-            var targetStatuses = statuses.Select(s => s.StatusId).ToHashSet();
+            var targetStatuses = tar.StatusList.Select(s => s.StatusId).ToHashSet();
             uint targetID = tar.DataId;
 
             switch (Svc.ClientState.TerritoryType)
@@ -215,11 +220,19 @@ namespace WrathCombo.Data
         /// <returns></returns>
         internal static bool HasStatusInCacheList(HashSet<uint> statusList, IGameObject? gameObject = null)
         {
-            if (gameObject is not IBattleChara chara || !gameObject.IsStillAround())
+            if (gameObject is not IBattleChara chara)
                 return false;
 
             StatusList? statuses;
-            try { statuses = chara.StatusList; }
+            try
+            {
+                statuses = Svc.Objects
+                    .Select(x => x as IBattleChara)
+                    .FirstOrDefault(x => x.GameObjectId == chara.GameObjectId)?
+                    .StatusList;
+                if (statuses is null)
+                    throw new NullReferenceException("StatusList is null for the given character.");
+            }
             catch { return false; }
 
             var targetStatuses = statuses.Select(s => s.StatusId).ToHashSet();

--- a/WrathCombo/Data/StatusCache.cs
+++ b/WrathCombo/Data/StatusCache.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using WrathCombo.Extensions;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 using Status = Dalamud.Game.ClientState.Statuses.Status; // conflicts with structs if not defined
 
@@ -24,7 +25,7 @@ namespace WrathCombo.Data
         /// <returns> Status object or null. </returns>
         internal Status? GetStatus(uint statusID, IGameObject? obj, ulong? sourceID)
         {
-            if (obj is null)
+            if (obj is null || !obj.IsStillAround())
                 return null;
 
             var key = (statusID, obj.GameObjectId, sourceID);
@@ -214,7 +215,7 @@ namespace WrathCombo.Data
         /// <returns></returns>
         internal static bool HasStatusInCacheList(HashSet<uint> statusList, IGameObject? gameObject = null)
         {
-            if (gameObject is not IBattleChara chara)
+            if (gameObject is not IBattleChara chara || !gameObject.IsStillAround())
                 return false;
 
             StatusList? statuses;

--- a/WrathCombo/Extensions/GameObjectExtensions.cs
+++ b/WrathCombo/Extensions/GameObjectExtensions.cs
@@ -45,24 +45,6 @@ public static class GameObjectExtensions
 
     /// <summary>
     ///     Can be chained onto a <see cref="IGameObject" /> to make it return
-    ///     <see langword="null" /> if the target is not in the player's party
-    ///     currently.<br/>
-    ///     Faster and more up-to-date than <see cref="IfInParty"/>, but less
-    ///     sanity-checked.
-    /// </summary>
-    public static IGameObject? IfStillInParty(this IGameObject? obj)
-    {
-        if (obj == null) return null;
-
-        var party = new ulong?[9];
-        for (var i = 1; i <= 8; i++)
-            party[i] = SimpleTarget.GetPartyMemberInSlotSlot(i)?.GameObjectId;
-
-        return party.Contains(obj.GameObjectId) ? obj : null;
-    }
-
-    /// <summary>
-    ///     Can be chained onto a <see cref="IGameObject" /> to make it return
     ///     <see langword="null" /> if the target is not hostile.
     /// </summary>
     public static IGameObject? IfHostile (this IGameObject? obj) =>
@@ -189,23 +171,6 @@ public static class GameObjectExtensions
         obj != null &&
         CustomComboFunctions.GetPartyMembers()
             .Any(x => x.GameObjectId == obj.GameObjectId);
-
-    /// <summary>
-    ///     Can be chained onto a <see cref="IGameObject" /> to make it a quick
-    ///     boolean check for if the target is in the player's party.<br />
-    ///     Faster and more up-to-date than <see cref="IfInParty"/>, but less
-    ///     sanity-checked.
-    /// </summary>
-    public static bool IsStillInParty(this IGameObject? obj)
-    {
-        if (obj == null) return false;
-
-        ulong?[] party = [];
-        for (var i = 1; i <= 8; i++)
-            party[i] = SimpleTarget.GetPartyMemberInSlotSlot(i)?.GameObjectId;
-
-        return party.Contains(obj.GameObjectId);
-    }
 
     // `IsHostile` already exists, and works the exact same as we would write here
 

--- a/WrathCombo/Extensions/GameObjectExtensions.cs
+++ b/WrathCombo/Extensions/GameObjectExtensions.cs
@@ -45,6 +45,24 @@ public static class GameObjectExtensions
 
     /// <summary>
     ///     Can be chained onto a <see cref="IGameObject" /> to make it return
+    ///     <see langword="null" /> if the target is not in the player's party
+    ///     currently.<br/>
+    ///     Faster and more up-to-date than <see cref="IfInParty"/>, but less
+    ///     sanity-checked.
+    /// </summary>
+    public static IGameObject? IfStillInParty(this IGameObject? obj)
+    {
+        if (obj == null) return null;
+
+        var party = new ulong?[9];
+        for (var i = 1; i <= 8; i++)
+            party[i] = SimpleTarget.GetPartyMemberInSlotSlot(i)?.GameObjectId;
+
+        return party.Contains(obj.GameObjectId) ? obj : null;
+    }
+
+    /// <summary>
+    ///     Can be chained onto a <see cref="IGameObject" /> to make it return
     ///     <see langword="null" /> if the target is not hostile.
     /// </summary>
     public static IGameObject? IfHostile (this IGameObject? obj) =>
@@ -142,6 +160,16 @@ public static class GameObjectExtensions
     public static IGameObject? IfAPlayer (this IGameObject? obj) =>
         obj != null && obj is IPlayerCharacter ? obj : null;
 
+    /// <summary>
+    ///     Can be chained onto a <see cref="IGameObject" /> to make it return
+    ///     <see langword="null" /> if the target is not still loaded in the player's
+    ///     game.
+    /// </summary>
+    public static IGameObject? IfStillAround (this IGameObject? obj) =>
+        obj != null &&
+        Svc.Objects
+            .Any(x => x.GameObjectId != obj.GameObjectId) ? obj : null;
+
     #endregion
 
     #region Target Checking (same as above, but returns a boolean)
@@ -161,6 +189,23 @@ public static class GameObjectExtensions
         obj != null &&
         CustomComboFunctions.GetPartyMembers()
             .Any(x => x.GameObjectId == obj.GameObjectId);
+
+    /// <summary>
+    ///     Can be chained onto a <see cref="IGameObject" /> to make it a quick
+    ///     boolean check for if the target is in the player's party.<br />
+    ///     Faster and more up-to-date than <see cref="IfInParty"/>, but less
+    ///     sanity-checked.
+    /// </summary>
+    public static bool IsStillInParty(this IGameObject? obj)
+    {
+        if (obj == null) return false;
+
+        ulong?[] party = [];
+        for (var i = 1; i <= 8; i++)
+            party[i] = SimpleTarget.GetPartyMemberInSlotSlot(i)?.GameObjectId;
+
+        return party.Contains(obj.GameObjectId);
+    }
 
     // `IsHostile` already exists, and works the exact same as we would write here
 
@@ -234,6 +279,15 @@ public static class GameObjectExtensions
     /// </summary>
     public static bool IsAPlayer(this IGameObject? obj) =>
         obj != null && obj is IPlayerCharacter;
+
+    /// <summary>
+    ///     Can be chained onto a <see cref="IGameObject" /> to make it a quick
+    ///     boolean check for if the object is still loaded in the player's game.
+    /// </summary>
+    public static bool IsStillAround(this IGameObject? obj) =>
+        obj != null &&
+        Svc.Objects
+            .Any(x => x.GameObjectId == obj.GameObjectId);
 
     #endregion
 


### PR DESCRIPTION
- [X] Reset Auto Rotation's `OptionalTarget` immediately after use, not letting it get stale in the first place.
- [X] Remove accesses of `StatusList` at the same time an object is determined not to be an `IBattleChara`.
- [X] Check for `0` Statuses, which is how they are marked as `<nothing>`, not with a `null`.\
  (they're not even null-able)