### PR TITLE
[SMN] Cleanup 2.0

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5750,9 +5750,10 @@ public enum CustomComboPreset
     [CustomComboInfo("Rekindle Combo Option", "Adds Rekindle to the single target combo.", SMN.JobID)]
     SMN_ST_Advanced_Combo_DemiSummons_Rekindle = 17028,
 
-    [ParentCombo(SMN_ST_Advanced_Combo_DemiSummons_Attacks)]
-    [CustomComboInfo("Lux Solaris Combo Option", "Adds Lux Solaris to the single target combo.", SMN.JobID)]
-    SMN_ST_Advanced_Combo_DemiSummons_LuxSolaris = 17029,
+    [ParentCombo(SMN_ST_Advanced_Combo_DemiSummons_Rekindle)]
+    [CustomComboInfo("Retarget Rekindle Combo Option", "Will Retarget Rekindle to a tank that needs it, then a party member that need healing, before Self.", SMN.JobID)]
+    [Retargeted]
+    SMN_ST_Advanced_Combo_DemiSummons_Rekindle_Retarget = 17080,    
 
     [ParentCombo(SMN_ST_Advanced_Combo)]
     [CustomComboInfo("Summon Titan", "Adds Titan to the Single Target Rotation", SMN.JobID)]
@@ -5786,33 +5787,27 @@ public enum CustomComboPreset
 
     [ParentCombo(SMN_ST_Advanced_Combo)]
     [CustomComboInfo("Energy Attacks Combo Option",
-        "Adds Energy Drain and Fester to the single target combo.\nWill be used on cooldown.", SMN.JobID)]
+        "Adds Energy Drain and Fester to the single target combo.", SMN.JobID)]
     SMN_ST_Advanced_Combo_EDFester = 17014,
 
     [ParentCombo(SMN_ST_Advanced_Combo_EDFester)]
     [CustomComboInfo("Pooled oGCDs Option",
-        "Pools damage oGCDs for use inside the selected Demi phase while under the Searing Light buff.\nBahamut Burst becomes Solar Bahamut Burst at Lv100.",
+        "Pools damage oGCDs for use while under the Searing Light buff.",
         SMN.JobID)]
-    SMN_ST_Advanced_Combo_DemiEgiMenu_oGCDPooling = 17025,
-
-    [ParentCombo(SMN_ST_Advanced_Combo_DemiEgiMenu_oGCDPooling)]
-    [CustomComboInfo("Any Searing Burst Option",
-        "Checks for any Searing Light for bursting rather than just your own.\nUse this option if partied with multiple SMN and are worried about your Searing Light being wasted.",
-        SMN.JobID)]
-    SMN_ST_Advanced_Combo_Burst_Any_Option = 17044,
+    SMN_ST_Advanced_Combo_oGCDPooling = 17025,
 
     [ParentCombo(SMN_ST_Advanced_Combo)]
     [CustomComboInfo("Searing Light Combo Option",
-       "Adds Searing Light to the single target combo.\nWill be used on cooldown.", SMN.JobID)]
+       "Adds Searing Light to the single target combo.", SMN.JobID)]
     SMN_ST_Advanced_Combo_SearingLight = 17017,
 
     [ParentCombo(SMN_ST_Advanced_Combo_SearingLight)]
     [CustomComboInfo("Searing Light Burst Option",
-        "Casts Searing Light only during Demi phases.\nReflects Demi choice selected under 'Pooled oGCDs Option'.\nNot recommended for SpS Builds.",
+        "Casts Searing Light only during Demi phases.\nSpellspeed builds would turn this off.",
         SMN.JobID)]
     SMN_ST_Advanced_Combo_SearingLight_Burst = 17018,
 
-    [ParentCombo(SMN_ST_Advanced_Combo_SearingLight)]
+    [ParentCombo(SMN_ST_Advanced_Combo)]
     [CustomComboInfo("Searing Flash Combo Option", "Adds Searing Flash to the single target combo.", SMN.JobID)]
     SMN_ST_Advanced_Combo_SearingFlash = 17019,
 
@@ -5821,6 +5816,10 @@ public enum CustomComboPreset
         "Adds Ruin IV to the single target combo.\nUses when moving during Garuda Phase and you have no attunement, when moving during Ifrit phase, or when you have no active Egi or Demi summon.",
         SMN.JobID)]
     SMN_ST_Advanced_Combo_Ruin4 = 17011,
+
+    [ParentCombo(SMN_ST_Advanced_Combo)]
+    [CustomComboInfo("Lux Solaris Combo Option", "Adds Lux Solaris to the single target combo.", SMN.JobID)]
+    SMN_ST_Advanced_Combo_DemiSummons_LuxSolaris = 17029,
 
     [ParentCombo(SMN_ST_Advanced_Combo)]
     [CustomComboInfo("Radiant Aegis Option", "Will use Radiant Aegis, 30 second self shield, when at 2 charges to prevent waste ", SMN.JobID)]
@@ -5855,9 +5854,10 @@ public enum CustomComboPreset
     [CustomComboInfo("Rekindle Combo Option", "Adds Rekindle to the AoE combo.", SMN.JobID)]
     SMN_AoE_Advanced_Combo_DemiSummons_Rekindle = 17056,
 
-    [ParentCombo(SMN_AoE_Advanced_Combo_DemiSummons_Attacks)]
-    [CustomComboInfo("Lux Solaris Combo Option", "Adds Lux Solaris to the AoE combo.", SMN.JobID)]
-    SMN_AoE_Advanced_Combo_DemiSummons_LuxSolaris = 17059,
+    [ParentCombo(SMN_AoE_Advanced_Combo_DemiSummons_Rekindle)]
+    [CustomComboInfo("Retarget Rekindle Combo Option", "Will Retarget Rekindle to a tank that needs it, then a party member that need healing, before Self.", SMN.JobID)]
+    [Retargeted]
+    SMN_AoE_Advanced_Combo_DemiSummons_Rekindle_Retarget = 17081,    
 
     [ParentCombo(SMN_AoE_Advanced_Combo)]
     [CustomComboInfo("Summon Titan", "Adds Titan to the AoE Rotation", SMN.JobID)]
@@ -5885,33 +5885,27 @@ public enum CustomComboPreset
 
     [ParentCombo(SMN_AoE_Advanced_Combo)]
     [CustomComboInfo("Energy Attacks Combo Option",
-        "Adds Energy Siphon and Painflare to the AoE combo.\nWill be used on cooldown.", SMN.JobID)]
+        "Adds Energy Siphon and Painflare to the AoE combo.", SMN.JobID)]
     SMN_AoE_Advanced_Combo_ESPainflare = 17051,
 
     [ParentCombo(SMN_AoE_Advanced_Combo_ESPainflare)]
     [CustomComboInfo("Pooled oGCDs Option",
-        "Pools damage oGCDs for use inside the selected Demi phase while under the Searing Light buff.\nBahamut Burst becomes Solar Bahamut Burst at Lv100.",
+        "Pools damage oGCDs for use inside the Searing Light buff",
         SMN.JobID)]
-    SMN_AoE_Advanced_Combo_DemiEgiMenu_oGCDPooling = 17050,
-
-    [ParentCombo(SMN_AoE_Advanced_Combo_DemiEgiMenu_oGCDPooling)]
-    [CustomComboInfo("Any Searing Burst Option",
-"Checks for any Searing Light for bursting rather than just your own.\nUse this option if partied with multiple SMN and are worried about your Searing Light being wasted.",
-SMN.JobID)]
-    SMN_AoE_Advanced_Combo_Burst_Any_Option = 17069,
+    SMN_AoE_Advanced_Combo_oGCDPooling = 17050,    
 
     [ParentCombo(SMN_AoE_Advanced_Combo)]
-    [CustomComboInfo("Searing Light Combo Option", "Adds Searing Light to the AoE combo.\nWill be used on cooldown.",
+    [CustomComboInfo("Searing Light Combo Option", "Adds Searing Light to the AoE combo.",
         SMN.JobID)]
     SMN_AoE_Advanced_Combo_SearingLight = 17053,
 
     [ParentCombo(SMN_AoE_Advanced_Combo_SearingLight)]
     [CustomComboInfo("Searing Light Burst Option",
-        "Casts Searing Light only during Demi phases.\nReflects Demi choice selected under 'Pooled oGCDs Option'.\nNot recommended for SpS Builds.",
+        "Casts Searing Light only during Demi phases.\nSpellspeed Builds would turn this off.",
         SMN.JobID)]
     SMN_AoE_Advanced_Combo_SearingLight_Burst = 17054,
 
-    [ParentCombo(SMN_AoE_Advanced_Combo_SearingLight)]
+    [ParentCombo(SMN_AoE_Advanced_Combo)]
     [CustomComboInfo("Searing Flash Combo Option", "Adds Searing Flash to the AoE combo.", SMN.JobID)]
     SMN_AoE_Advanced_Combo_SearingFlash = 17058,
 
@@ -5922,28 +5916,17 @@ SMN.JobID)]
     SMN_AoE_Advanced_Combo_Ruin4 = 17062,
 
     [ParentCombo(SMN_AoE_Advanced_Combo)]
+    [CustomComboInfo("Lux Solaris Combo Option", "Adds Lux Solaris to the AoE combo.", SMN.JobID)]
+    SMN_AoE_Advanced_Combo_DemiSummons_LuxSolaris = 17059,
+
+    [ParentCombo(SMN_AoE_Advanced_Combo)]
     [CustomComboInfo("Radiant Aegis Option", "Will use Radiant Aegis, 30 second self shield, when at 2 charges to prevent waste ", SMN.JobID)]
     SMN_AoE_Advanced_Combo_Radiant = 17070,
 
     [ParentCombo(SMN_AoE_Advanced_Combo)]
     [CustomComboInfo("Lucid Dreaming Option", "Adds Lucid Dreaming to the AoE combo when MP falls below the set value.",
         SMN.JobID)]
-    SMN_AoE_Advanced_Combo_Lucid = 17060,
-
-    
-
-
-   
-
-   
-
-     
-
-    
-
-    
-
-    
+    SMN_AoE_Advanced_Combo_Lucid = 17060,    
     #endregion
 
     #region Standalone Features

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5709,7 +5709,7 @@ public enum CustomComboPreset
 
     [AutoAction(false, false)]
     [ConflictingCombos(SMN_ST_Advanced_Combo)]
-    [ReplaceSkill(SMN.Ruin, SMN.Ruin2)]
+    [ReplaceSkill(SMN.Ruin, SMN.Ruin2, SMN.Ruin3)]
     [CustomComboInfo("Simple Mode - Single Target",
         "Replaces Ruin with a full one-button single target rotation.\nThis is the ideal option for newcomers to the job.",
         SMN.JobID)]
@@ -5727,7 +5727,7 @@ public enum CustomComboPreset
 
     #region Advanced ST
     [AutoAction(false, false)]
-    [ReplaceSkill(SMN.Ruin, SMN.Ruin2)]
+    [ReplaceSkill(SMN.Ruin, SMN.Ruin2, SMN.Ruin3)]
     [ConflictingCombos(SMN_ST_Simple_Combo)]
     [CustomComboInfo("Advanced Mode - Single Target",
         "Replaces Ruin with a full one-button single target rotation.\nThese features are ideal if you want to customize the rotation.",

--- a/WrathCombo/Combos/PvE/SMN/SMN.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN.cs
@@ -185,7 +185,7 @@ internal partial class SMN : Caster
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is not (Ruin or Ruin2))
+            if (actionID is not (Ruin or Ruin2 or Ruin3))
                 return actionID;
                         
             #region Variants
@@ -464,8 +464,11 @@ internal partial class SMN : Caster
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is not (Ruin or Ruin2))
-                return actionID;
+            bool allRuins = Config.SMN_ST_Advanced_Combo_AltMode == 0;
+            bool actionFound = allRuins && AllRuinsList.Contains(actionID) ||
+                               !allRuins && NotRuin3List.Contains(actionID);   
+            if (!actionFound)
+                return actionID;          
 
             if (NeedToSummon && ActionReady(SummonCarbuncle))
                 return SummonCarbuncle;
@@ -478,8 +481,9 @@ internal partial class SMN : Caster
             bool IfritAstralFlowStrike = IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_Egi_AstralFlow) && Config.SMN_ST_Egi_AstralFlow[3];
             bool GarudaAstralFlow = IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_Egi_AstralFlow) && Config.SMN_ST_Egi_AstralFlow[2];
             var waitForSearing = GetCooldownRemainingTime(SearingLight) > (Gauge.SummonTimerRemaining / 1000f) + GCDTotal;
+            var replacedActions = allRuins ? AllRuinsList.ToArray() : NotRuin3List.ToArray();
             #endregion
-           
+
             #region Opener    
             if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_Balance_Opener) &&
                 Opener().FullOpener(ref actionID))
@@ -542,7 +546,7 @@ internal partial class SMN : Caster
                             return OriginalHook(AstralFlow);
 
                         if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_DemiSummons_Rekindle) && DemiPheonix)
-                            return OriginalHook(AstralFlow).Retarget([Ruin, Ruin2], SimpleTarget.TargetsTarget.IfInParty() ?? SimpleTarget.AnyTank.IfMissingHP() ?? SimpleTarget.LowestHPPAlly.IfMissingHP() ?? SimpleTarget.Self);
+                            return OriginalHook(AstralFlow).Retarget(replacedActions, SimpleTarget.TargetsTarget.IfInParty() ?? SimpleTarget.AnyTank.IfMissingHP() ?? SimpleTarget.LowestHPPAlly.IfMissingHP() ?? SimpleTarget.Self);
                     }
                 }
 

--- a/WrathCombo/Combos/PvE/SMN/SMN_Config.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN_Config.cs
@@ -84,39 +84,7 @@ internal partial class SMN
                 case CustomComboPreset.SMN_AoE_Advanced_Combo_Ifrit:
                     UserConfig.DrawPriorityInput(SMN_AoE_Egi_Priority, 3, 2,
                         $"{SummonRuby.ActionName()} Priority: ");
-                    break;
-
-                case CustomComboPreset.SMN_ST_Advanced_Combo_DemiEgiMenu_oGCDPooling:
-                    UserConfig.DrawHorizontalRadioButton(SMN_ST_BurstPhase, "Solar Bahamut/Pre 100 Bahamut",
-                        "Bursts during Bahamut phase before 100.\nBahamut burst phase becomes Solar Bahamut at Lv100.", 1);
-                    UserConfig.DrawHorizontalRadioButton(SMN_ST_BurstPhase, "Phoenix/Post 100 Bahamut", "Bursts during Phoenix phase. Also adds Regular Bahamut at 100. ", 2);
-
-                    UserConfig.DrawHorizontalRadioButton(SMN_ST_BurstPhase, "Any Demi Phase",
-                        "Bursts during any Demi Summon phase.", 3);
-
-                    UserConfig.DrawHorizontalRadioButton(SMN_ST_BurstPhase, "Flexible (SpS) Option",
-                        "Bursts when Searing Light is ready, regardless of phase.", 4);
-
-                    UserConfig.DrawSliderInt(0, 3, SMN_ST_Burst_Delay,
-                        "Sets the amount of GCDs under Demi summon to wait for oGCD use.");
-
-                    break;
-
-                case CustomComboPreset.SMN_AoE_Advanced_Combo_DemiEgiMenu_oGCDPooling:
-                    UserConfig.DrawHorizontalRadioButton(SMN_AoE_BurstPhase, "Solar Bahamut/Pre 100 Bahamut",
-                        "Bursts during Bahamut phase below 100.\nBahamut burst phase becomes Solar Bahamut at Lv100.", 1);
-                    UserConfig.DrawHorizontalRadioButton(SMN_AoE_BurstPhase, "Phoenix/Post 100 Bahamut", "Bursts during Phoenix phase. Also adds Regular Bahamut at 100.", 2);
-
-                    UserConfig.DrawHorizontalRadioButton(SMN_AoE_BurstPhase, "Any Demi Phase",
-                        "Bursts during any Demi Summon phase.", 3);
-
-                    UserConfig.DrawHorizontalRadioButton(SMN_AoE_BurstPhase, "Flexible (SpS) Option",
-                        "Bursts when Searing Light is ready, regardless of phase.", 4);
-
-                    UserConfig.DrawSliderInt(0, 3, SMN_AoE_Burst_Delay,
-                        "Sets the amount of GCDs under Demi summon to wait for oGCD use.");
-
-                    break;
+                    break;              
 
                 case CustomComboPreset.SMN_ST_Advanced_Combo_DemiEgiMenu_SwiftcastEgi:
                     UserConfig.DrawHorizontalRadioButton(SMN_ST_SwiftcastPhase, "Garuda", "Swiftcasts Slipstream", 1);
@@ -185,16 +153,7 @@ internal partial class SMN
                                 "Enforced Crimson Cyclone Melee Check", "Only uses Crimson Cyclone within melee range.");
 
                         break;
-                    }
-
-                case CustomComboPreset.SMN_ST_Advanced_Combo_SearingLight:
-                    UserConfig.DrawAdditionalBoolChoice(SMN_ST_Searing_Any, $"Do not user when under another {Job.SMN.GetData().Abbreviation}'s {Buffs.SearingLight.StatusName()} buff.", $"Saves your {SearingLight.ActionName()} if you already have the buff from another {Job.SMN.GetData().Abbreviation}.");
-                    break;
-
-                case CustomComboPreset.SMN_AoE_Advanced_Combo_SearingLight:
-                    UserConfig.DrawAdditionalBoolChoice(SMN_AoE_Searing_Any, $"Do not user when under another {Job.SMN.GetData().Abbreviation}'s {Buffs.SearingLight.StatusName()} buff.", $"Saves your {SearingLight.ActionName()} if you already have the buff from another {Job.SMN.GetData().Abbreviation}.");
-                    break;
-                
+                    }  
             }
         }
     }

--- a/WrathCombo/Combos/PvE/SMN/SMN_Config.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN_Config.cs
@@ -3,6 +3,8 @@ using ImGuiNET;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Extensions;
 using WrathCombo.Window.Functions;
+using static WrathCombo.Extensions.UIntExtensions;
+using static WrathCombo.Window.Functions.UserConfig;
 
 namespace WrathCombo.Combos.PvE;
 
@@ -11,6 +13,7 @@ internal partial class SMN
     internal static class Config
     {
         public static UserInt
+            SMN_ST_Advanced_Combo_AltMode = new("SMN_ST_Advanced_Combo_AltMode"),
             SMN_ST_Lucid = new("SMN_ST_Lucid", 8000),
             SMN_ST_BurstPhase = new("SMN_ST_BurstPhase", 1),
             SMN_ST_SwiftcastPhase = new("SMN_SwiftcastPhase", 1),
@@ -43,6 +46,11 @@ internal partial class SMN
         {
             switch (preset)
             {
+                case CustomComboPreset.SMN_ST_Advanced_Combo:
+                    DrawRadioButton(SMN_ST_Advanced_Combo_AltMode, $"On Ruin 1, 2, and 3", "", 0);
+                    DrawRadioButton(SMN_ST_Advanced_Combo_AltMode, $"On Ruin 1 and 2 Only", $"Alternative DPS Mode. Leaves Ruin 3 alone for pure DPS.", 1);
+                    break;
+
                 case CustomComboPreset.SMN_ST_Advanced_Combo_Balance_Opener:
                     
                     UserConfig.DrawBossOnlyChoice(SMN_Balance_Content);

--- a/WrathCombo/Combos/PvE/SMN/SMN_Config.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN_Config.cs
@@ -1,4 +1,3 @@
-using ECommons.ExcelServices;
 using ImGuiNET;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Extensions;

--- a/WrathCombo/Combos/PvE/SMN/SMN_Helper.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN_Helper.cs
@@ -152,6 +152,10 @@ internal partial class SMN
     #endregion
 
     #region Variables
+    internal static readonly List<uint>
+        AllRuinsList = [Ruin, Ruin2, Ruin3],
+        NotRuin3List = [Ruin, Ruin2];
+
     internal static SMNGauge Gauge => GetJobGauge<SMNGauge>();
 
     internal static bool IsIfritAttuned => Gauge.AttunementType is SummonAttunement.Ifrit;

--- a/WrathCombo/Combos/PvE/SMN/SMN_Helper.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN_Helper.cs
@@ -7,6 +7,8 @@ using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 using Dalamud.Game.ClientState.Objects.Types;
+using WrathCombo.Data;
+using System.Diagnostics.Metrics;
 
 namespace WrathCombo.Combos.PvE;
 
@@ -168,8 +170,13 @@ internal partial class SMN
     internal static bool IsPhoenixReady => Gauge.AetherFlags.HasFlag((AetherFlags)4) && !Gauge.AetherFlags.HasFlag((AetherFlags)8);
     internal static bool IsSolarBahamutReady => Gauge.AetherFlags.HasFlag((AetherFlags)8) || Gauge.AetherFlags.HasFlag((AetherFlags)12);
     internal static bool DemiExists => CurrentDemiSummon is not DemiSummon.None;
+    internal static bool DemiNone => CurrentDemiSummon is DemiSummon.None;
     internal static bool DemiNotPheonix => CurrentDemiSummon is not DemiSummon.Phoenix;
     internal static bool DemiPheonix => CurrentDemiSummon is DemiSummon.Phoenix;
+    internal static bool SearingBurstDriftCheck => SearingCD >=3 && SearingCD <=8;
+    internal static bool SummonerWeave => CanSpellWeave() && !ActionWatching.HasDoubleWeaved();
+    internal static float SearingCD => GetCooldownRemainingTime(SearingLight);
+   
     #endregion
 
     #region Carbuncle Summoner
@@ -280,6 +287,18 @@ internal partial class SMN
     }
 
     #endregion
+
+    internal static uint EmergencyDemiAttacks(uint actionId)
+    {
+        if (Gauge.SummonTimerRemaining <= 2500)
+        {
+            if (ActionReady(OriginalHook(EnkindleBahamut)))
+                return OriginalHook(EnkindleBahamut);
+            if (ActionReady(AstralFlow) && DemiNotPheonix)
+                return OriginalHook(AstralFlow);
+        }
+        return actionId;
+    }
 
     #region Opener
 

--- a/WrathCombo/Combos/PvE/SMN/SMN_Helper.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN_Helper.cs
@@ -286,19 +286,7 @@ internal partial class SMN
         return 0;
     }
 
-    #endregion
-
-    internal static uint EmergencyDemiAttacks(uint actionId)
-    {
-        if (Gauge.SummonTimerRemaining <= 2500)
-        {
-            if (ActionReady(OriginalHook(EnkindleBahamut)))
-                return OriginalHook(EnkindleBahamut);
-            if (ActionReady(AstralFlow) && DemiNotPheonix)
-                return OriginalHook(AstralFlow);
-        }
-        return actionId;
-    }
+    #endregion   
 
     #region Opener
 

--- a/WrathCombo/Combos/PvE/SMN/SMN_Helper.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN_Helper.cs
@@ -162,7 +162,10 @@ internal partial class SMN
     internal static bool IsDreadwyrmTranceReady => !LevelChecked(SummonBahamut) && IsBahamutReady;
     internal static bool IsBahamutReady => !IsPhoenixReady && !IsSolarBahamutReady;
     internal static bool IsPhoenixReady => Gauge.AetherFlags.HasFlag((AetherFlags)4) && !Gauge.AetherFlags.HasFlag((AetherFlags)8);
-    internal static bool IsSolarBahamutReady => Gauge.AetherFlags.HasFlag((AetherFlags)8) || Gauge.AetherFlags.HasFlag((AetherFlags)12);    
+    internal static bool IsSolarBahamutReady => Gauge.AetherFlags.HasFlag((AetherFlags)8) || Gauge.AetherFlags.HasFlag((AetherFlags)12);
+    internal static bool DemiExists => CurrentDemiSummon is not DemiSummon.None;
+    internal static bool DemiNotPheonix => CurrentDemiSummon is not DemiSummon.Phoenix;
+    internal static bool DemiPheonix => CurrentDemiSummon is DemiSummon.Phoenix;
 
     private static DateTime SummonTime
     {

--- a/WrathCombo/Combos/PvE/SMN/SMN_Helper.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN_Helper.cs
@@ -170,7 +170,9 @@ internal partial class SMN
     internal static bool DemiExists => CurrentDemiSummon is not DemiSummon.None;
     internal static bool DemiNotPheonix => CurrentDemiSummon is not DemiSummon.Phoenix;
     internal static bool DemiPheonix => CurrentDemiSummon is DemiSummon.Phoenix;
+    #endregion
 
+    #region Carbuncle Summoner
     private static DateTime SummonTime
     {
         get
@@ -181,8 +183,10 @@ internal partial class SMN
             return field;
         }
     }
+    public static bool NeedToSummon => DateTime.Now > SummonTime && !HasPetPresent() && ActionReady(SummonCarbuncle);
+    #endregion
 
-    public static bool NeedToSummon => DateTime.Now > SummonTime && !HasPetPresent();
+    #region Demi Summon Detector
 
     internal static DemiSummon CurrentDemiSummon
     {


### PR DESCRIPTION
More adjustments for Summoner in line with Dawntrail Changes.

1. Removed the Burst Delay Option. This was needed when the 2 minute buff was 30 seconds long and popped on pull before the Demi. Now that it is 20 seconds and popped during demi. Setting it to 3 GCDS can very easily push OGCDS out of the demi summon window when pooling. Resulting in a need for the Emergency Demi Dump. Leaving that there for now.

2. Removed the any searing burst option checkbox. The code still looks for any searing, Just removed it as a choice. No other classes are concerned with 2 of the same class in a raid and set up several lines of code around it.Because it accounts for any burst. If another summoner IS with you, and you have demi only burst selected it will on its own start running with the next demi phase. 

3. Because it is Automatic, removed the selector for choosing which demi phase to burst with. This led to issues searing could get misaligned due to death or dungeon and be held off cooldown for over a minute. 

4. Added retargetting option to rekindle in advanced modes. 

5. Tired of users asking why summoner doesn't work just to find out it is the wrong ruin. No longer. It now applies to all 3 ruins. But wait there's more, For one small click they can use a radio button to choose the option from ruin1/2 only like before, set up just like astro. 

6. Added Drift adjustment for Searing light at slightly higher spellspeeds. Due to autorotation not using the queue, extra spellspeed/performance mode/ lower throttle is needed to ensure 6/6 Demi attacks in the window. This added spellspeed leads to lower cd on Demi which misaligns the Searing cd from the slightly short cd Demi. WIll automatically Fire an extra Ruin 3 to realign if the misalignment falls between 3 and 8 seconds. 

https://xivanalysis.com/fflogs/8XAhtWPT2Z3rpGwj/4/3

Overall adjustments to simplify the user end of Summoner as well as the code by removing unnecessary things that were based off 30 second buff in endwalker. 

- [x] Advanced ST
- [x] Advance AoE
- [x] Menu Cleanup
- [x] Ruin Choice
- [x] Playtesting and Analyzing
- [x] Covert Simple modes
