### PR TITLE
[DNC] Improve partner-priority-by-level sorting

### DIFF
--- a/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
@@ -364,6 +364,12 @@ internal partial class DNC
             // If it's the last step and there are no matches found, bail
             if (filter.Count == 0)
                 return false;
+            // If there's only one match, return it
+            if (filter.Count == 1)
+            {
+                newBestPartner = filter.First();
+                return true;
+            }
 
             var orderedFilter = filter
                 .OrderBy(x =>

--- a/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
@@ -365,21 +365,28 @@ internal partial class DNC
             if (filter.Count == 0)
                 return false;
 
-            filter = filter
+            var orderedFilter = filter
                 .OrderBy(x =>
                     PartnerPriority.RolePrio.GetValueOrDefault(
-                        x.ClassJob.RowId.Role(), int.MaxValue))
-                .ThenBy(x =>
-                    Player.Level >= 90
-                        ? PartnerPriority.Job090Prio.GetValueOrDefault(
-                            x.ClassJob.RowId, int.MaxValue)
-                        : int.MaxValue)
-                .ThenBy(x =>
-                    Player.Level >= 100
-                        ? PartnerPriority.Job100Prio.GetValueOrDefault(
-                            x.ClassJob.RowId, int.MaxValue)
-                        : int.MaxValue)
-                .ToList();
+                        x.ClassJob.RowId.Role(), int.MaxValue));
+
+            switch (Player.Level)
+            {
+                case < 100 and >= 90:
+                    orderedFilter = orderedFilter
+                        .ThenBy(x =>
+                            PartnerPriority.Job090Prio.GetValueOrDefault(
+                                x.ClassJob.RowId, int.MaxValue));
+                    break;
+                case >= 100:
+                    orderedFilter = orderedFilter
+                        .ThenBy(x =>
+                            PartnerPriority.Job100Prio.GetValueOrDefault(
+                                x.ClassJob.RowId, int.MaxValue));
+                    break;
+            }
+
+            filter = orderedFilter.ToList();
 
             newBestPartner = filter.First();
             return true;


### PR DESCRIPTION
- [X] Make the two sets of partner priorities not conflict
closes #619
- [X] Early-Return when there is only one partner (instead of sorting that one player)