### PR TITLE
[UI] Fix Sheet Display Error for System Actions

### DIFF
--- a/WrathCombo/Window/Tabs/Debug.cs
+++ b/WrathCombo/Window/Tabs/Debug.cs
@@ -778,8 +778,9 @@ internal class Debug : ConfigWindow, IDisposable
                 CustomStyleText("Action Status:", $"{actionStatus} ({Svc.Data.GetExcelSheet<LogMessage>().GetRow(actionStatus).Text})");
                 CustomStyleText("Action Type:", _debugSpell.Value.ActionCategory.Value.Name);
 
-                if (_debugSpell.Value.UnlockLink.RowId != 0)
-                    CustomStyleText("Quest:", $"{Svc.Data.GetExcelSheet<Quest>().GetRow(_debugSpell.Value.UnlockLink.RowId).Name} ({(UIState.Instance()->IsUnlockLinkUnlockedOrQuestCompleted(_debugSpell.Value.UnlockLink.RowId) ? "Completed" : "Not Completed")})");
+                // Quest Check
+                if (_debugSpell.Value.UnlockLink.RowId != 0 && Svc.Data.GetExcelSheet<Quest>().TryGetRow(_debugSpell.Value.UnlockLink.RowId, out var unlockQuest))
+                    CustomStyleText("Quest:", $"{unlockQuest.Name} ({(UIState.Instance()->IsUnlockLinkUnlockedOrQuestCompleted(_debugSpell.Value.UnlockLink.RowId) ? "Completed" : "Not Completed")})");
 
                 CustomStyleText("Base Recast:", $"{_debugSpell.Value.Recast100ms / 10f}s");
                 CustomStyleText("Original Hook:", OriginalHook(_debugSpell.Value.RowId).ActionName());


### PR DESCRIPTION
- `System` actions have a `UnlockLink.RowId` value of `1` but no quest associated with them, resulting in an error.