### PR TITLE
[AST] Additions And Tweaks

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -225,6 +225,10 @@ public enum CustomComboPreset
     [CustomComboInfo("Lightspeed Weave Option", "Adds Lightspeed when moving", AST.JobID)]
     AST_DPS_LightSpeed = 1020,
 
+    [ParentCombo(AST_DPS_LightSpeed)]
+    [CustomComboInfo("Lightspeed Hold Option", "Retains 1 Lightspeed charge for use in the burst window", AST.JobID)]
+    AST_DPS_LightSpeedHold = 1061,
+
     [ParentCombo(AST_ST_DPS)]
     [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value", AST.JobID)]
     AST_DPS_Lucid = 1008,
@@ -232,6 +236,10 @@ public enum CustomComboPreset
     [ParentCombo(AST_ST_DPS)]
     [CustomComboInfo("Divination Weave Option", "Adds Divination", AST.JobID)]
     AST_DPS_Divination = 1016,
+
+    [ParentCombo(AST_DPS_Divination)]
+    [CustomComboInfo("Lightspeed Burst Option", "Add Lightspeed before Divination", AST.JobID)]
+    AST_DPS_LightspeedBurst = 1064,
 
     [ParentCombo(AST_ST_DPS)]
     [CustomComboInfo("Card Draw Weave Option", "Draws your cards", AST.JobID)]
@@ -278,6 +286,10 @@ public enum CustomComboPreset
     [CustomComboInfo("Lightspeed Weave Option", "Adds Lightspeed when moving", AST.JobID)]
     AST_AOE_LightSpeed = 1048,
 
+    [ParentCombo(AST_AOE_LightSpeed)]
+    [CustomComboInfo("Lightspeed Hold Option", "Retains 1 Lightspeed charge for use in the burst window", AST.JobID)]
+    AST_AOE_LightSpeedHold = 1062,
+
     [ParentCombo(AST_AOE_DPS)]
     [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value", AST.JobID
     )]
@@ -286,6 +298,10 @@ public enum CustomComboPreset
     [ParentCombo(AST_AOE_DPS)]
     [CustomComboInfo("Divination Weave Option", "Adds Divination", AST.JobID)]
     AST_AOE_Divination = 1043,
+
+    [ParentCombo(AST_AOE_Divination)]
+    [CustomComboInfo("Lightspeed Burst Option", "Add Lightspeed before Divination", AST.JobID)]
+    AST_AOE_LightspeedBurst = 1063,
 
     [ParentCombo(AST_AOE_DPS)]
     [CustomComboInfo("Card Draw Weave Option", "Draws your cards", AST.JobID)]

--- a/WrathCombo/Combos/PvE/AST/AST.cs
+++ b/WrathCombo/Combos/PvE/AST/AST.cs
@@ -152,7 +152,8 @@ internal partial class AST : Healer
                         float refreshTimer = Config.AST_ST_DPS_CombustUptime_Threshold;
                         int hpThreshold = Config.AST_ST_DPS_CombustSubOption == 1 || !InBossEncounter() ? Config.AST_DPS_CombustOption : 0;
                         if (GetStatusEffectRemainingTime(dotDebuffID, CurrentTarget) <= refreshTimer &&
-                            GetTargetHPPercent() > hpThreshold)
+                            GetTargetHPPercent() > hpThreshold &&
+                            CanApplyStatus(CurrentTarget,dotDebuffID))
                             return OriginalHook(Combust);
 
                         //Alternate Mode (idles as Malefic)

--- a/WrathCombo/Combos/PvE/AST/AST.cs
+++ b/WrathCombo/Combos/PvE/AST/AST.cs
@@ -80,8 +80,11 @@ internal partial class AST : Healer
                     ActionReady(Lightspeed) &&
                     GetTargetHPPercent() > Config.AST_DPS_LightSpeedOption &&
                     IsMoving() &&
-                    !HasStatusEffect(Buffs.Lightspeed))
-                    return Lightspeed;
+                    !HasStatusEffect(Buffs.Lightspeed) &&
+                    (IsNotEnabled(CustomComboPreset.AST_DPS_LightSpeedHold) ||
+                    GetCooldownChargeRemainingTime(Lightspeed) < GetCooldownRemainingTime(Divination) ||
+                    !LevelChecked(Divination)))
+                    return Lightspeed;                
 
                 if (IsEnabled(CustomComboPreset.AST_DPS_Lucid) &&
                     Role.CanLucidDream(Config.AST_LucidDreaming))
@@ -116,6 +119,14 @@ internal partial class AST : Healer
                      (DrawnDPSCard == CardType.None && Config.AST_ST_DPS_OverwriteCards)) &&
                     CanDelayedWeave())
                     return OriginalHook(AstralDraw);
+
+                //Lightspeed Burst
+                if (IsEnabled(CustomComboPreset.AST_DPS_LightspeedBurst) &&
+                    ActionReady(Lightspeed) &&
+                    !HasStatusEffect(Buffs.Lightspeed) &&
+                    GetCooldownRemainingTime(Divination) < 5 &&
+                    CanSpellWeave())
+                    return Lightspeed;
 
                 //Divination
                 if (IsEnabled(CustomComboPreset.AST_DPS_Divination) &&
@@ -188,8 +199,11 @@ internal partial class AST : Healer
                 ActionReady(Lightspeed) &&
                 GetTargetHPPercent() > Config.AST_AOE_LightSpeedOption &&
                 IsMoving() &&
-                !HasStatusEffect(Buffs.Lightspeed))
-                return Lightspeed;
+                !HasStatusEffect(Buffs.Lightspeed) &&
+                (IsNotEnabled(CustomComboPreset.AST_AOE_LightSpeedHold) ||
+                GetCooldownChargeRemainingTime(Lightspeed) < GetCooldownRemainingTime(Divination)  ||
+                !LevelChecked(Divination)))
+                return Lightspeed;            
 
             if (IsEnabled(CustomComboPreset.AST_AOE_Lucid) &&
                 Role.CanLucidDream(Config.AST_LucidDreaming))
@@ -224,6 +238,14 @@ internal partial class AST : Healer
                  (DrawnDPSCard == CardType.None && Config.AST_AOE_DPS_OverwriteCards)) &&
                 CanDelayedWeave())
                 return OriginalHook(AstralDraw);
+            
+            //Lightspeed Burst
+            if (IsEnabled(CustomComboPreset.AST_AOE_LightspeedBurst) &&
+                ActionReady(Lightspeed) &&
+                !HasStatusEffect(Buffs.Lightspeed) &&
+                GetCooldownRemainingTime(Divination) < 5 &&
+                CanSpellWeave())
+                return Lightspeed;
 
             //Divination
             if (IsEnabled(CustomComboPreset.AST_AOE_Divination) &&


### PR DESCRIPTION
- [ ] Added the status overcap code to combust list
- [ ] Added Lightspeed Holding Option to retain one Lightspeed charge for burst
- [ ] Added Lightspeed Burst Option to Use aforementioned Lightspeed charge up to 2 gcds before divination
- [ ] Add Neutral Sect, going for a copy of scholars interaction between fey illumination and Succor.
- [ ] Add Sun sign
- [ ] Add Macrocosmos to aoe non bosses vs boss content.
- [ ] Add Sliders for Aspected Benefire, top end and bottom end. 