### PR TITLE
[AST] Move `Earthly Star` Opener Retargeting

### DIFF
--- a/WrathCombo/Combos/PvE/AST/AST.cs
+++ b/WrathCombo/Combos/PvE/AST/AST.cs
@@ -65,11 +65,11 @@ internal partial class AST : Healer
             if (IsEnabled(CustomComboPreset.AST_ST_DPS_Opener) &&
                 Opener().FullOpener(ref actionID))
             {
-                if (actionID is (Balance or Spear) && IsEnabled(CustomComboPreset.AST_Cards_QuickTargetCards))
-                    return actionID.Retarget(replacedActions, CardResolver);
                 if (actionID is EarthlyStar && IsEnabled(CustomComboPreset.AST_ST_DPS_EarthlyStar))
                     return actionID.Retarget(replacedActions,
                         SimpleTarget.AnyEnemy ?? SimpleTarget.Stack.Allies);
+                if (actionID is (Balance or Spear) && IsEnabled(CustomComboPreset.AST_Cards_QuickTargetCards))
+                    return actionID.Retarget(replacedActions, CardResolver);
 
                 return actionID;
             }

--- a/WrathCombo/Combos/PvE/AST/AST.cs
+++ b/WrathCombo/Combos/PvE/AST/AST.cs
@@ -67,6 +67,9 @@ internal partial class AST : Healer
             {
                 if (actionID is (Balance or Spear) && IsEnabled(CustomComboPreset.AST_Cards_QuickTargetCards))
                     return actionID.Retarget(replacedActions, CardResolver);
+                if (actionID is EarthlyStar && IsEnabled(CustomComboPreset.AST_ST_DPS_EarthlyStar))
+                    return actionID.Retarget(replacedActions,
+                        SimpleTarget.AnyEnemy ?? SimpleTarget.Stack.Allies);
 
                 return actionID;
             }

--- a/WrathCombo/Combos/PvE/AST/AST_Helper.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Helper.cs
@@ -272,12 +272,6 @@ internal partial class AST
 
         public override bool HasCooldowns()
         {
-            if (ActionReady(EarthlyStar))
-                EarthlyStar.Retarget(Config.AST_DPS_AltMode > 0
-                        ? CombustList.Keys.ToArray()
-                        : MaleficList.ToArray(),
-                    SimpleTarget.Stack.Allies);
-
             if (GetCooldown(EarthlyStar).CooldownElapsed >= 4f)
                 return false;
 


### PR DESCRIPTION
- [X] Moves `Earthly Star` Retargeting for the Opener to where the Cards in the Opener are now properly Retargeted