### PR TITLE
[AST] Add MaxHP as secondary card priority

### DIFF
--- a/WrathCombo/Combos/PvE/AST/AST_Helper.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Helper.cs
@@ -183,6 +183,7 @@ internal partial class AST
                     .OrderBy(x =>
                         _cardPriorities.GetValueOrDefault(
                             (byte)x.ClassJob.RowId, byte.MaxValue))
+                    .ThenByDescending(x => x.MaxHp)
                     .ToList();
 
                 bestTarget = filter.First();


### PR DESCRIPTION
Add a secondary sort for Ast card priority to choose the highest max HP option when there are duplicate jobs present