### PR TITLE
[TANK] Retargetting Things

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -2746,8 +2746,21 @@ public enum CustomComboPreset
     #endregion
 
     #region Aurora Protection
+    [ReplaceSkill(GNB.Aurora)]
     [CustomComboInfo("Aurora Protection Feature", "Locks out Aurora if Aurora's effect is on the target by replacing it with Savage Blade.", GNB.JobID)]
     GNB_AuroraProtection = 7023,
+    
+    [ParentCombo(GNB_AuroraProtection)]
+    [CustomComboInfo("Aurora Mouseover Option", "Retargets Aurora to your mouseover target if they do not have the HoT", GNB.JobID)]
+    [Retargeted]
+    GNB_RetargetAurora_MO = 7087,
+    
+    [ParentCombo(GNB_AuroraProtection)]
+    [CustomComboInfo("Aurora Target's Target Option", "Retargets Aurora to the Target's Target if they do not have the HoT and you do not have Aggro", GNB.JobID)]
+    [Retargeted]
+    GNB_RetargetAurora_OtherTank = 7088,
+    
+    
     #endregion
 
     #region Variant Skills

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -2769,7 +2769,7 @@ public enum CustomComboPreset
     GNB_RetargetHeartofStone = 7089,
     
     [ParentCombo(GNB_RetargetHeartofStone)]
-    [CustomComboInfo("Heart of Stone Target's Target Option", "Retargets Heart of Stone/Corundum to the Target's Target you do not have Aggro, can bypass this by using mouseover at yourself", GNB.JobID)]
+    [CustomComboInfo("Heart of Stone Target's Target Option", "Retargets Heart of Stone/Corundum to the Target's Target you do not have Aggro, can still be overridden with mouseover.", GNB.JobID)]
     [Retargeted]
     GNB_RetargetHeartofStone_TT = 7090,
     #endregion

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -2758,9 +2758,20 @@ public enum CustomComboPreset
     [ParentCombo(GNB_AuroraProtection)]
     [CustomComboInfo("Aurora Target's Target Option", "Retargets Aurora to the Target's Target if they do not have the HoT and you do not have Aggro", GNB.JobID)]
     [Retargeted]
-    GNB_RetargetAurora_OtherTank = 7088,
+    GNB_RetargetAurora_TT = 7088,
     
+    #endregion
     
+    #region Heart Of Stone Retarget
+    [ReplaceSkill(GNB.HeartOfCorundum, GNB.HeartOfStone)]
+    [CustomComboInfo("Heart Of Stone Feature", "Will retarget Heart of Stone/Corundum to your mouseover target or hard target outside of other combos", GNB.JobID)]
+    [Retargeted]
+    GNB_RetargetHeartofStone = 7089,
+    
+    [ParentCombo(GNB_RetargetHeartofStone)]
+    [CustomComboInfo("Heart of Stone Target's Target Option", "Retargets Heart of Stone/Corundum to the Target's Target you do not have Aggro, can bypass this by using mouseover at yourself", GNB.JobID)]
+    [Retargeted]
+    GNB_RetargetHeartofStone_TT = 7090,
     #endregion
 
     #region Variant Skills
@@ -2947,7 +2958,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last Value = 7086
+    // Last Value = 7090
     #endregion
 
     #region MACHINIST

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6663,24 +6663,21 @@ public enum CustomComboPreset
     [ReplaceSkill(WAR.NascentFlash)]
     [CustomComboInfo("Nascent Flash Feature", "Replace Nascent Flash with Raw intuition when level synced below 76.", WAR.JobID)]
     WAR_NascentFlash = 18017,
+    
+    [ReplaceSkill(WAR.RawIntuition, WAR.Bloodwhetting)]
+    [CustomComboInfo("Raw Intuition to Nascent Flash Retargeting Feature", "If available, will replace the combo with Nascent Flash if you are hard targeting an ally.", WAR.JobID)]
+    [Retargeted]
+    WAR_RawIntuition_Targeting = 18119,
 
-    [ReplaceSkill(WAR.Bloodwhetting)]
-    [CustomComboInfo("Bloodwhetting Feature", "Replaces Bloodwhetting with Raw Intuition, when level synced below 82.", WAR.JobID)]
-    WAR_Bloodwhetting = 18118,
-
-    [ParentCombo(WAR_Bloodwhetting)]
-    [CustomComboInfo("Nascent When Targeting Option", "If available, will replace the combo with Nascent Flash if you are hard targeting an ally.", WAR.JobID)]
-    WAR_Bloodwhetting_Targeting = 18119,
-
-    [ParentCombo(WAR_Bloodwhetting_Targeting)]
+    [ParentCombo(WAR_RawIntuition_Targeting)]
     [CustomComboInfo("Include MouseOver Target", "If mousing over an ally in the UI, will Retarget Nascent Flash onto them.", WAR.JobID)]
     [Retargeted]
-    WAR_Bloodwhetting_Targeting_MO = 18120,
+    WAR_RawIntuition_Targeting_MO = 18120,
 
-    [ParentCombo(WAR_Bloodwhetting_Targeting)]
+    [ParentCombo(WAR_RawIntuition_Targeting)]
     [CustomComboInfo("Include Target's Target", "If your target's target is not you, will Retarget Nascent Flash onto them.\n(if you're not top aggro, and not mousing over or hard targeting an ally)", WAR.JobID)]
     [Retargeted]
-    WAR_Bloodwhetting_Targeting_TT = 18121,
+    WAR_RawIntuition_Targeting_TT = 18121,
 
     [ReplaceSkill(WAR.Holmgang)]
     [CustomComboInfo("Retarget Holmgang Feature", "Will Retarget Holmgang to yourself, instead of letting it go on enemies.", WAR.JobID)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -4298,6 +4298,11 @@ public enum CustomComboPreset
         "Replaces Shield Lob with Holy Spirit when available.\n- Must be under the effect of Divine Might or not moving.",
         PLD.JobID)]
     PLD_ShieldLob_Feature = 11027,
+    
+    [ReplaceSkill(PLD.Clemency)]
+    [CustomComboInfo("Retarget Clemency Feature", "Will retarget Clemency to lowest hp ally unless you fall below set threshold.", PLD.JobID)]
+    [Retargeted]
+    PLD_RetargetClemency = 11067,
 
     // Variant Features
 
@@ -4321,7 +4326,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    //// Last value = 11064
+    //// Last value = 11067
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -4303,6 +4303,22 @@ public enum CustomComboPreset
     [CustomComboInfo("Retarget Clemency Feature", "Will retarget Clemency to lowest hp ally unless you fall below set threshold.", PLD.JobID)]
     [Retargeted]
     PLD_RetargetClemency = 11067,
+    
+    [ReplaceSkill(PLD.Sheltron)]
+    [CustomComboInfo("Sheltron to Invervention Feature", "Will use intervention on your Hard Target if target is a friendly party member, if not then Sheltron." +
+                                                         "\n- UI Mousover > Hard target > Target's target > Self Sheltron", PLD.JobID)]
+    [Retargeted]
+    PLD_RetargetSheltron = 11068,
+    
+    [ParentCombo(PLD_RetargetSheltron)]
+    [CustomComboInfo("Mouseover Invervention Option", "Adds UI mouseover to the priority.", PLD.JobID)]
+    [Retargeted]
+    PLD_RetargetSheltron_MO = 11069,
+    
+    [ParentCombo(PLD_RetargetSheltron)]
+    [CustomComboInfo("Target's Target Invervention Option", "Adds Target's Target to the priority when you do not have agro.", PLD.JobID)]
+    [Retargeted]
+    PLD_RetargetSheltron_TT = 11070,
 
     // Variant Features
 
@@ -4326,7 +4342,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    //// Last value = 11067
+    //// Last value = 11070
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -65,7 +65,6 @@ public enum CustomComboPreset
     ALL_Tank_ShirkRetargeting = 100002,
 
     [Role(JobRole.Tank)]
-    [ReplaceSkill(RoleActions.Tank.Shirk)]
     [ParentCombo(ALL_Tank_ShirkRetargeting)]
     [CustomComboInfo("Use Healers instead",
         "Will Retarget Shirk to healers, instead of the other tank.\nOnly recommended during some specific enrages.", ADV.JobID)]
@@ -73,7 +72,6 @@ public enum CustomComboPreset
     ALL_Tank_ShirkRetargeting_Healer = 100003,
 
     [Role(JobRole.Tank)]
-    [ReplaceSkill(RoleActions.Tank.Shirk)]
     [ParentCombo(ALL_Tank_ShirkRetargeting)]
     [CustomComboInfo("Fallback to Any Support",
         "Will Retarget Shirk to tanks or healers, per your setting above, but will include a fallback to any tank OR healer if none of your setting is found.\nUseful to help your Shirk always go to *someone* even if your chosen players are not alive.", ADV.JobID)]
@@ -2011,6 +2009,7 @@ public enum CustomComboPreset
 
     [ParentCombo(DRK_Retarget_TBN)]
     [CustomComboInfo("Include Target's Target", "If your target's target is not you, will Retarget The Blackest Night onto them.\n(if you're not top aggro, and not mousing over or hard targeting an ally)", DRK.JobID)]
+    [Retargeted]
     DRK_Retarget_TBN_TT = 5131,
 
     [ReplaceSkill(DRK.Oblation)]
@@ -2020,13 +2019,18 @@ public enum CustomComboPreset
 
     [ParentCombo(DRK_Retarget_Oblation)]
     [CustomComboInfo("Include Target's Target", "If your target's target is not you, will Retarget Oblation onto them.\n(if you're not top aggro, and not mousing over or hard targeting an ally)", DRK.JobID)]
+    [Retargeted]
     DRK_Retarget_Oblation_TT = 5133,
 
-    #endregion
-    // Last value = 5133
+    [ParentCombo(DRK_Retarget_Oblation)]
+    [CustomComboInfo("Prevent Double Oblations", "Will change Oblation to Savage Blade when your target already has Oblation on them.", DRK.JobID)]
+    DRK_Retarget_Oblation_DoubleProtection = 5134,
 
     #endregion
-    // Last value = 5133
+    // Last value = 5134
+
+    #endregion
+    // Last value = 5134
 
     #region Variant
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6699,7 +6699,7 @@ public enum CustomComboPreset
     WAR_NascentFlash = 18017,
     
     [ReplaceSkill(WAR.RawIntuition, WAR.Bloodwhetting)]
-    [CustomComboInfo("Raw Intuition to Nascent Flash Retargeting Feature", "If available, will replace the combo with Nascent Flash if you are hard targeting an ally.", WAR.JobID)]
+    [CustomComboInfo("Raw Intuition to Nascent Flash Retargeting Feature", "If available, will replace the Raw Intuition/Bloodwhetting with Nascent Flash if you are hard targeting an ally.", WAR.JobID)]
     [Retargeted]
     WAR_RawIntuition_Targeting = 18119,
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -4304,9 +4304,19 @@ public enum CustomComboPreset
     PLD_ShieldLob_Feature = 11027,
     
     [ReplaceSkill(PLD.Clemency)]
-    [CustomComboInfo("Retarget Clemency Feature", "Will retarget Clemency to lowest hp ally unless you fall below set threshold.", PLD.JobID)]
+    [CustomComboInfo("Retarget Clemency Feature", "Will retarget Clemency according to following Suboptions", PLD.JobID)]
     [Retargeted]
     PLD_RetargetClemency = 11067,
+    
+    [ParentCombo(PLD_RetargetClemency)]
+    [CustomComboInfo("Mouseover Clemency Option", "Adds UI mouseover to the priority. Above LowHP option.", PLD.JobID)]
+    [Retargeted]
+    PLD_RetargetClemency_MO = 11071,
+    
+    [ParentCombo(PLD_RetargetClemency)]
+    [CustomComboInfo("Low hp Clemency Option", "Will Heal Lowest Health Party member until you fall below set threshold", PLD.JobID)]
+    [Retargeted]
+    PLD_RetargetClemency_LowHP = 11072,
     
     [ReplaceSkill(PLD.Sheltron)]
     [CustomComboInfo("Sheltron to Intervention Feature", "Will use intervention on your Hard Target if target is a friendly party member, if not then Sheltron." +
@@ -4346,7 +4356,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    //// Last value = 11070
+    //// Last value = 11071
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -4309,18 +4309,18 @@ public enum CustomComboPreset
     PLD_RetargetClemency = 11067,
     
     [ReplaceSkill(PLD.Sheltron)]
-    [CustomComboInfo("Sheltron to Invervention Feature", "Will use intervention on your Hard Target if target is a friendly party member, if not then Sheltron." +
+    [CustomComboInfo("Sheltron to Intervention Feature", "Will use intervention on your Hard Target if target is a friendly party member, if not then Sheltron." +
                                                          "\n- UI Mousover > Hard target > Target's target > Self Sheltron", PLD.JobID)]
     [Retargeted]
     PLD_RetargetSheltron = 11068,
     
     [ParentCombo(PLD_RetargetSheltron)]
-    [CustomComboInfo("Mouseover Invervention Option", "Adds UI mouseover to the priority.", PLD.JobID)]
+    [CustomComboInfo("Mouseover Intervention Option", "Adds UI mouseover to the priority.", PLD.JobID)]
     [Retargeted]
     PLD_RetargetSheltron_MO = 11069,
     
     [ParentCombo(PLD_RetargetSheltron)]
-    [CustomComboInfo("Target's Target Invervention Option", "Adds Target's Target to the priority when you do not have agro.", PLD.JobID)]
+    [CustomComboInfo("Target's Target Intervention Option", "Adds Target's Target to the priority when you do not have agro.", PLD.JobID)]
     [Retargeted]
     PLD_RetargetSheltron_TT = 11070,
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -4380,7 +4380,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    //// Last value = 11071
+    //// Last value = 11072
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/DRK/DRK.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK.cs
@@ -393,6 +393,12 @@ internal partial class DRK : Tank
                     ? SimpleTarget.TargetsTarget.IfFriendly().IfNotThePlayer()
                     : null);
 
+            var checkTarget = target ?? SimpleTarget.Self;
+            if (IsEnabled(Preset.DRK_Retarget_Oblation_DoubleProtection) &&
+                (HasStatusEffect(Buffs.Oblation, checkTarget, anyOwner: true) ||
+                 JustUsedOn(Oblation, checkTarget)))
+                return All.SavageBlade;
+
             if (target is not null)
                 return actionID.Retarget(target, dontCull: true);
 

--- a/WrathCombo/Combos/PvE/PLD/PLD.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD.cs
@@ -849,7 +849,7 @@ internal partial class PLD : Tank
                     : null) ??
                 
                 //Hard target retarget
-                SimpleTarget.HardTarget.IfInParty() ??
+                SimpleTarget.HardTarget.IfInParty().IfNotThePlayer() ??
                 
                 //Targets target retarget option
                 (IsEnabled(CustomComboPreset.PLD_RetargetSheltron_TT)

--- a/WrathCombo/Combos/PvE/PLD/PLD.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD.cs
@@ -825,12 +825,25 @@ internal partial class PLD : Tank
                 return actionID;
 
             int healthThreshold = Config.PLD_RetargetClemency_Health;
+            
+            var target =
+                //Mouseover retarget option
+                (IsEnabled(CustomComboPreset.PLD_RetargetClemency_MO) 
+                    ? SimpleTarget.UIMouseOverTarget.IfNotThePlayer().IfInParty()
+                    : null) ??
+                
+                //Hard target
+                SimpleTarget.HardTarget ??
+                
+                //Lowest HP option
+                (IsEnabled(CustomComboPreset.PLD_RetargetClemency_LowHP)
+                 && PlayerHealthPercentageHp() > healthThreshold
+                    ? SimpleTarget.LowestHPAlly.IfNotThePlayer().IfAlive()
+                    : null);
 
-            if (PlayerHealthPercentageHp() > healthThreshold)
-                return actionID.Retarget(
-                    SimpleTarget.LowestHPPAlly.IfMissingHP() ??
-                    SimpleTarget.Self);
-            return actionID;
+            return target != null
+                ? actionID.Retarget(target)
+                : actionID;
         }
     }
     internal class PLD_RetargetSheltron : CustomCombo

--- a/WrathCombo/Combos/PvE/PLD/PLD.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD.cs
@@ -1,6 +1,9 @@
 ﻿using System.Linq;
+using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Data;
+using WrathCombo.Extensions;
+
 namespace WrathCombo.Combos.PvE;
 
 internal partial class PLD : Tank
@@ -812,6 +815,24 @@ internal partial class PLD : Tank
         }
     }
 
+    internal class PLD_RetargetClemency : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PLD_RetargetClemency;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID != Clemency)
+                return actionID;
+
+            int healthThreshold = Config.PLD_RetargetClemency_Health;
+
+            if (PlayerHealthPercentageHp() > healthThreshold)
+                return actionID.Retarget(
+                    SimpleTarget.LowestHPPAlly.IfMissingHP() ??
+                    SimpleTarget.Self);
+            return actionID;
+        }
+    }
     #region One-Button Mitigation
 
     internal class PLD_Mit_OneButton : CustomCombo

--- a/WrathCombo/Combos/PvE/PLD/PLD.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD.cs
@@ -833,7 +833,7 @@ internal partial class PLD : Tank
                     : null) ??
                 
                 //Hard target
-                SimpleTarget.HardTarget ??
+                SimpleTarget.HardTarget.IfFriendly() ??
                 
                 //Lowest HP option
                 (IsEnabled(CustomComboPreset.PLD_RetargetClemency_LowHP)

--- a/WrathCombo/Combos/PvE/PLD/PLD.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD.cs
@@ -833,6 +833,38 @@ internal partial class PLD : Tank
             return actionID;
         }
     }
+    internal class PLD_RetargetSheltron : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PLD_RetargetSheltron;
+
+        protected override uint Invoke(uint action)
+        {
+            if (action != OriginalHook(Sheltron))
+                return action;
+            
+            var target =
+                //Mouseover retarget option
+                (IsEnabled(CustomComboPreset.PLD_RetargetSheltron_MO) 
+                    ? SimpleTarget.UIMouseOverTarget.IfNotThePlayer().IfInParty()
+                    : null) ??
+                
+                //Hard target retarget
+                SimpleTarget.HardTarget.IfInParty() ??
+                
+                //Targets target retarget option
+                (IsEnabled(CustomComboPreset.PLD_RetargetSheltron_TT)
+                    && !PlayerHasAggro
+                    ? SimpleTarget.TargetsTarget.IfNotThePlayer().IfInParty()
+                    : null);
+
+            // Intervention if trying to Buff an ally
+            if (ActionReady(Intervention) && 
+                target != null)
+                return Intervention.Retarget(OriginalHook(Sheltron), target);
+
+            return action;
+        }
+    }
     #region One-Button Mitigation
 
     internal class PLD_Mit_OneButton : CustomCombo

--- a/WrathCombo/Combos/PvE/PLD/PLD.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD.cs
@@ -839,7 +839,7 @@ internal partial class PLD : Tank
 
         protected override uint Invoke(uint action)
         {
-            if (action != OriginalHook(Sheltron))
+            if (action is not (Sheltron or HolySheltron))
                 return action;
             
             var target =
@@ -860,7 +860,7 @@ internal partial class PLD : Tank
             // Intervention if trying to Buff an ally
             if (ActionReady(Intervention) && 
                 target != null)
-                return Intervention.Retarget(OriginalHook(Sheltron), target);
+                return Intervention.Retarget([Sheltron, HolySheltron], target);
 
             return action;
         }

--- a/WrathCombo/Combos/PvE/PLD/PLD_Config.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD_Config.cs
@@ -1,5 +1,7 @@
 using ImGuiNET;
 using System.Numerics;
+using Dalamud.Interface.Colors;
+using ECommons.ImGuiMethods;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
 using WrathCombo.Window.Functions;
@@ -281,6 +283,16 @@ internal partial class PLD
                     UserConfig.DrawHorizontalRadioButton(PLD_AoE_MitsOptions,
                         "Exclude Mitigations",
                         "Disables the use of mitigations in Simple Mode.", 1);
+                    break;
+                
+                case CustomComboPreset.PLD_RetargetSheltron_TT:
+                    ImGui.Indent();
+                    ImGuiEx.TextWrapped(ImGuiColors.DalamudGrey,
+                        "Note: If you are Off-Tanking, and want to use Sheltron on yourself, the expectation would be that you do so via the One-Button Mitigation Feature or the Mitigation options in your rotation.\n" +
+                        "You could also mouseover yourself in the party to use Sheltron in this case.\n" +
+                        "If you don't, intervention would replace the combo, and it would go to the main tank.\n" +
+                        "If you don't use those Features for your personal mitigation, you may not want to enable this.");
+                    ImGui.Unindent();
                     break;
                
                 #region One-Button Mitigation

--- a/WrathCombo/Combos/PvE/PLD/PLD_Config.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD_Config.cs
@@ -42,6 +42,7 @@ internal partial class PLD
             PLD_ShieldLob_SubOption = new("PLD_ShieldLob_SubOption", 1),
             PLD_Requiescat_SubOption = new("PLD_Requiescat_SubOption", 1),
             PLD_SpiritsWithin_SubOption = new("PLD_SpiritsWithin_SubOption", 1),
+            PLD_RetargetClemency_Health = new("PLD_RetargetClemency_Health", 30),
             PLD_VariantCure = new("PLD_VariantCure"),
             PLD_Balance_Content = new("PLD_Balance_Content", 1),
             PLD_ST_MitsOptions = new("PLD_ST_MitsOptions", 0),
@@ -245,6 +246,12 @@ internal partial class PLD
 
                     UserConfig.DrawHorizontalRadioButton(PLD_SpiritsWithin_SubOption, "Add Drift Prevention",
                         "Prevents Spirits Within and Circle of Scorn from drifting.\n- Actions must be used within 5 seconds of each other.", 2);
+
+                    break;
+                
+                // Retarget Clemency Feature
+                case CustomComboPreset.PLD_RetargetClemency:
+                    UserConfig.DrawSliderInt(1, 100, PLD_RetargetClemency_Health, "Player HP%", 200);
 
                     break;
 

--- a/WrathCombo/Combos/PvE/PLD/PLD_Config.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD_Config.cs
@@ -252,7 +252,7 @@ internal partial class PLD
                     break;
                 
                 // Retarget Clemency Feature
-                case CustomComboPreset.PLD_RetargetClemency:
+                case CustomComboPreset.PLD_RetargetClemency_LowHP:
                     UserConfig.DrawSliderInt(1, 100, PLD_RetargetClemency_Health, "Player HP%", 200);
 
                     break;

--- a/WrathCombo/Combos/PvE/PLD/PLD_Helper.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD_Helper.cs
@@ -194,6 +194,7 @@ internal partial class PLD
         Intervene = 16461,
         BladeOfHonor = 36922,
         Sheltron = 3542,
+        HolySheltron = 25746,
         Clemency = 3541;
 
     public static class Buffs

--- a/WrathCombo/Combos/PvE/WAR/WAR_Config.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR_Config.cs
@@ -515,10 +515,11 @@ internal partial class WAR
                         " Player HP% to be less than or equal to:", 200);
                     break;
 
-                case CustomComboPreset.WAR_Bloodwhetting_Targeting_TT:
+                case CustomComboPreset.WAR_RawIntuition_Targeting_TT:
                     ImGui.Indent();
                     ImGuiEx.TextWrapped(ImGuiColors.DalamudGrey,
                         "Note: If you are Off-Tanking, and want to use Bloodwhetting on yourself, the expectation would be that you do so via the One-Button Mitigation Feature or the Mitigation options in your rotation.\n" +
+                        "You could also mouseover yourself in the party to use Bloodwhetting or raw Intuition in this case.\n" +
                         "If you don't, Nascent Flash would replace the combo, and it would go to the main tank.\n" +
                         "If you don't use those Features for your personal mitigation, you may not want to enable this.");
                     ImGui.Unindent();

--- a/WrathCombo/Core/ActionRetargeting.cs
+++ b/WrathCombo/Core/ActionRetargeting.cs
@@ -315,6 +315,9 @@ public class ActionRetargeting : IDisposable
         AST.EssentialDignity,
         DRK.BlackestNight,
         DRK.Oblation,
+        GNB.HeartOfStone,
+        GNB.HeartOfCorundum,
+        PLD.Clemency,
 
         // Resurrection abilities from the "All" feature
         WHM.Raise,


### PR DESCRIPTION
- [x] PLD Retarget Clemency Feature. Mouseover > hard target > lowest hp
- [x] PLD Sheltron => Intervention Retarget Feature
- [x] Fix Warrior Bloodwhetting feature to be Raw intuition/Bloodwhetting to Nascent Flash Feature, Correct logic. 
- [x] zbee added oblation logic for waste prevention
- [x] GNB Upgraded Aurora protection to include retargeting choices which also have the same built in protection. 
- [x] GNB Retarget Heart of Corundum


![image](https://github.com/user-attachments/assets/a691dba9-adf3-4594-b775-8bdd62277f03)
![image](https://github.com/user-attachments/assets/41159b6f-9370-4c03-8afe-bcc960699c1b)
![image](https://github.com/user-attachments/assets/166afdfc-f032-4e88-9d74-90152dcfc7e5)
![image](https://github.com/user-attachments/assets/f1aef747-86f9-4761-bcda-5313a83cfaf2)

closes #47
