### PR TITLE
[Core] Make `IsEnabledWith(preset, func, func)` non-blocking

### DIFF
--- a/WrathCombo/Combos/PvE/DRK/DRK_ActionLogic.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_ActionLogic.cs
@@ -180,7 +180,7 @@ internal partial class DRK
             if ((flags.HasFlag(Combo.Simple) ||
                  IsSTEnabled(flags, Preset.DRK_ST_CD_Interrupt) ||
                  IsAoEEnabled(flags, Preset.DRK_AoE_Interrupt)) &&
-                HiddenFeaturesData.IsEnabledWith(
+                HiddenFeaturesData.NonBlockingIsEnabledWith(
                     Preset.DRK_Hid_R7SCircleCastOnly,
                     () => HiddenFeaturesData.Content.InR7S,
                     () => HiddenFeaturesData.Targeting.R7SCircleCastingAdd) &&
@@ -193,7 +193,7 @@ internal partial class DRK
                 !TargetIsBoss() &&
                 !JustUsed(Role.Interject) &&
                 Role.CanLowBlow() &&
-                HiddenFeaturesData.IsEnabledWith(
+                HiddenFeaturesData.NonBlockingIsEnabledWith(
                     Preset.DRK_Hid_R6SStunJabberOnly,
                     () => HiddenFeaturesData.Content.InR6S,
                     () => HiddenFeaturesData.Targeting.R6SJabber) &&

--- a/WrathCombo/Combos/PvE/WAR/WAR.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR.cs
@@ -89,7 +89,7 @@ internal partial class WAR : Tank
                 return OtherAction;
             #region Stuns
             if (IsEnabled(CustomComboPreset.WAR_ST_Interrupt)
-                && HiddenFeaturesData.IsEnabledWith( // Only interrupt circle adds in 7
+                && HiddenFeaturesData.NonBlockingIsEnabledWith( // Only interrupt circle adds in 7
                     CustomComboPreset.WAR_Hid_R7SCircleCastOnly,
                     () => HiddenFeaturesData.Content.InR7S,
                     () => HiddenFeaturesData.Targeting.R7SCircleCastingAdd)
@@ -259,7 +259,7 @@ internal partial class WAR : Tank
 
             if (IsEnabled(CustomComboPreset.WAR_AoE_Interrupt) && Role.CanInterject())
                 return Role.Interject;
-            if (IsEnabled(CustomComboPreset.WAR_AoE_Stun) && !JustUsed(Role.Interject) && Role.CanLowBlow() && HiddenFeaturesData.IsEnabledWith( // Only stun the jabber, if in 6
+            if (IsEnabled(CustomComboPreset.WAR_AoE_Stun) && !JustUsed(Role.Interject) && Role.CanLowBlow() && HiddenFeaturesData.NonBlockingIsEnabledWith( // Only stun the jabber, if in 6
                     CustomComboPreset.WAR_Hid_R6SStunJabberOnly,
                     () => HiddenFeaturesData.Content.InR6S,
                     () => HiddenFeaturesData.Targeting.R6SJabber))

--- a/WrathCombo/Data/HiddenFeaturesData.cs
+++ b/WrathCombo/Data/HiddenFeaturesData.cs
@@ -33,7 +33,8 @@ internal static class HiddenFeaturesData
 
     /// <summary>
     ///     Check if a Hidden Feature Preset is enabled, and meets your conditions,
-    ///     and then passes your logic for that feature.<br />
+    ///     and then passes your logic for that feature; only False if the Feature
+    ///     is fully enabled and the condition is met, but the logic fails.<br />
     ///     Use when you have a Hidden Feature Preset logic to employ, but it should
     ///     only be employed under certain circumstances; i.e. when you want to check
     ///     logic for a certain fight, but if not in that fight it should let the
@@ -50,14 +51,16 @@ internal static class HiddenFeaturesData
     ///     The logic that must be met to enable the feature.
     /// </param>
     /// <returns>
-    ///     If Hidden Features are enabled and the preset is enabled,
-    ///     and if the condition is met, and the logic is true (or if the condition
-    ///     is not met).
+    ///     True if Hidden Features or the preset are disabled, or if the condition
+    ///     is not met; so that it can just be included in existing action logic.
+    ///     <br />
+    ///     Otherwise, returns: If Hidden Features and the preset are enabled,
+    ///     and if the condition is met, and the logic is true.
     /// </returns>
-    public static bool IsEnabledWith
+    public static bool NonBlockingIsEnabledWith
         (CustomComboPreset preset, Func<bool> condition, Func<bool> logic) =>
-        FeaturesEnabled && IsEnabled(preset) &&
-        ((condition() && logic()) || !condition());
+        (!FeaturesEnabled || !IsEnabled(preset) || !condition()) ||
+        (FeaturesEnabled && IsEnabled(preset) && condition() && logic());
 
     /// <summary>
     ///     Check if a Hidden Feature Preset is enabled, and meets your conditions,


### PR DESCRIPTION
- [X] This method is supposed to be able to be used in existing action logic blocks, but currently it returns False if the feature or hidden features in general are not enabled.\
      Now it only returns False if hidden features, the preset, and the condition are met.