### PR TITLE
[Core/Presets] Added Attribute to always show the User Options for a preset

### DIFF
--- a/WrathCombo/Attributes/AlwaysShowUserOptionsAttribute.cs
+++ b/WrathCombo/Attributes/AlwaysShowUserOptionsAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace WrathCombo.Attributes
+{
+    /// <summary> Attribute forcing User Options to always show, regardless of preset being enabled </summary>
+    [AttributeUsage(AttributeTargets.Field)]
+    internal class AlwaysShowUserOptsAttribute : Attribute
+    {
+    }
+}

--- a/WrathCombo/Window/Functions/Presets.cs
+++ b/WrathCombo/Window/Functions/Presets.cs
@@ -48,6 +48,7 @@ namespace WrathCombo.Window.Functions
             public AutoActionAttribute? AutoAction;
             public RoleAttribute? RoleAttribute;
             public HiddenAttribute? Hidden;
+            public AlwaysShowUserOptsAttribute? AlwaysShowUserOpts;
 
             public PresetAttributes(CustomComboPreset preset)
             {
@@ -67,6 +68,7 @@ namespace WrathCombo.Window.Functions
                 AutoAction = preset.GetAttribute<AutoActionAttribute>();
                 RoleAttribute = preset.GetAttribute<RoleAttribute>();
                 Hidden = preset.GetAttribute<HiddenAttribute>();
+                AlwaysShowUserOpts = preset.GetAttribute<AlwaysShowUserOptsAttribute>();
             }
         }
 
@@ -90,6 +92,7 @@ namespace WrathCombo.Window.Functions
             var eurekaParents = Attributes[preset].EurekaParent;
             var auto = Attributes[preset].AutoAction;
             var hidden = Attributes[preset].Hidden;
+            bool showUserOpts = Attributes[preset].AlwaysShowUserOpts != null;
 
             ImGui.Spacing();
 
@@ -296,7 +299,7 @@ namespace WrathCombo.Window.Functions
                 }
                 ImGui.PopStyleColor();
             }
-            if (enabled)
+            if (enabled || showUserOpts)
             {
                 if (!pvp)
                 {


### PR DESCRIPTION
Current Behavior, user options are hidden when preset is not enabled
![image](https://github.com/user-attachments/assets/4b7f1fba-1039-45d2-a5de-156b95bc9758)

Depending on the situation (RDM / RPR Soulsow Reminder), it might be nice to go ahead and show the options regardless. Pictures taken with RDM PR. 

![image](https://github.com/user-attachments/assets/31b5404f-788e-4373-b10b-d684cac4b94e)
![image](https://github.com/user-attachments/assets/65d92b54-cc35-45bd-a21d-c98fd8b93c4a)
![image](https://github.com/user-attachments/assets/1856ed7a-27c8-4b38-9904-c3cf3eb30566)

Using the attribute tag on Reaper's Soulsow Reminder would be another example
![image](https://github.com/user-attachments/assets/ad8b1754-7858-4471-b1c0-c2cbfd0d1f86)
![image](https://github.com/user-attachments/assets/53103067-6f02-46c3-818c-0453220fa893)
