### PR TITLE
[Core] Add build output directories specific to each OS

### DIFF
--- a/WrathCombo/WrathCombo.csproj
+++ b/WrathCombo/WrathCombo.csproj
@@ -8,35 +8,33 @@
         <!-- This is the version that will be used when pushing to the repo.-->
         <Description>XIVCombo for very lazy players</Description>
         <Copyright>Copyleft attick 2021 thanks attick UwU</Copyright>
-        <PackageProjectUrl></PackageProjectUrl>
+        <PackageProjectUrl>https://github.com/PunishXIV/WrathCombo</PackageProjectUrl>
         <TargetFramework>net9.0-windows</TargetFramework>
         <Configurations>Debug;Release</Configurations>
         <EnableWindowsTargeting>true</EnableWindowsTargeting>
     </PropertyGroup>
 
+    <ItemGroup>
+        <None Include="..\.editorconfig" Link=".editorconfig"/>
+    </ItemGroup>
+
     <PropertyGroup>
-        <DalamudLibPath Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
-        <DalamudLibPath Condition="$([MSBuild]::IsOSPlatform('Linux'))">$(HOME)/.xlcore/dalamud/Hooks/dev/</DalamudLibPath>
-        <DalamudLibPath Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(HOME)/Library/Application Support/XIV on Mac/dalamud/Hooks/dev/</DalamudLibPath>
-        <DalamudPluginPath>$(appdata)\XIVLauncher\installedPlugins\WrathCombo\$(version)</DalamudPluginPath>
-        <DalamudDevPlugins Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(appdata)\XIVLauncher\devPlugins\WrathCombo\</DalamudDevPlugins>
-        <DalamudDevPlugins Condition="$([MSBuild]::IsOSPlatform('Linux'))">$(HOME)/.xlcore/devPlugins/</DalamudDevPlugins>
-        <DalamudDevPlugins Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(HOME)/Library/Application Support/XIV on Mac/devPlugins/</DalamudDevPlugins>
         <AssemblyName>WrathCombo</AssemblyName>
         <PackageId>WrathCombo</PackageId>
         <Product>WrathCombo</Product>
+        <DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
+        <DalamudDevPlugins>$(appdata)\XIVLauncher\devPlugins\WrathCombo\</DalamudDevPlugins>
+        <DalamudPluginPath>$(appdata)\XIVLauncher\installedPlugins\WrathCombo\$(version)</DalamudPluginPath>
     </PropertyGroup>
-
-    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-        <Platforms>x64</Platforms>
-        <Nullable>enable</Nullable>
-        <LangVersion>preview</LangVersion>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
-        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-        <OutputPath>bin\Release</OutputPath>
-        <NoWarn>CS1591</NoWarn>
+    
+    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
+        <DalamudLibPath>$(HOME)/.xlcore/dalamud/Hooks/dev/</DalamudLibPath>
+        <DalamudDevPlugins>$(HOME)/.xlcore/devPlugins/</DalamudDevPlugins>
+    </PropertyGroup>
+    
+    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+        <DalamudLibPath>$(HOME)/Library/Application Support/XIV on Mac/dalamud/Hooks/dev/</DalamudLibPath>
+        <DalamudDevPlugins>$(HOME)/Library/Application Support/XIV on Mac/devPlugins/</DalamudDevPlugins>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
@@ -51,22 +49,24 @@
         <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
 
-    <PropertyGroup Label="Documentation">
-        <DocumentationFile></DocumentationFile>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+        <Platforms>x64</Platforms>
+        <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <OutputPath>bin\Release</OutputPath>
+        <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
-
-    <ItemGroup>
-        <Content Include="..\res\plugin\wrathcombo.png" Link="images\wrathcombo.png" CopyToOutputDirectory="PreserveNewest" Visible="false"/>
-    </ItemGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
         <Optimize>True</Optimize>
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\.editorconfig" Link=".editorconfig"/>
+        <Content Include="..\res\plugin\wrathcombo.png" Link="images\wrathcombo.png" CopyToOutputDirectory="PreserveNewest" Visible="false"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/WrathCombo/WrathCombo.csproj
+++ b/WrathCombo/WrathCombo.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <!-- Metadata -->
     <PropertyGroup>
         <Authors>Team Wrath</Authors>
         <Company>-</Company>
@@ -9,76 +10,84 @@
         <Description>XIVCombo for very lazy players</Description>
         <Copyright>Copyleft attick 2021 thanks attick UwU</Copyright>
         <PackageProjectUrl>https://github.com/PunishXIV/WrathCombo</PackageProjectUrl>
+        <PackageId>WrathCombo</PackageId>
+        <Product>WrathCombo</Product>
+    </PropertyGroup>
+
+    <!-- Build Parameters -->
+    <PropertyGroup>
+        <AssemblyName>WrathCombo</AssemblyName>
         <TargetFramework>net9.0-windows</TargetFramework>
         <Configurations>Debug;Release</Configurations>
         <EnableWindowsTargeting>true</EnableWindowsTargeting>
+        <NoWarn>CS1591</NoWarn>
+        <LangVersion>preview</LangVersion>
+        
+        <Platforms>x64</Platforms>
+        <Nullable>enable</Nullable>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+        <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     </PropertyGroup>
 
+    <!-- Build Parameter Overrides for Debug -->
+    <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+        <OutputPath>$(DalamudDevPlugins)</OutputPath>
+    </PropertyGroup>
+
+    <!-- Build Parameter Overrides for Release -->
+    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+        <OutputPath>bin\Release</OutputPath>
+    </PropertyGroup>
+
+    <!-- Build Parameter Overrides for Optimization even in Debug -->
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+        <Optimize>True</Optimize>
+    </PropertyGroup>
+
+    <!-- Styling Rules -->
     <ItemGroup>
         <None Include="..\.editorconfig" Link=".editorconfig"/>
     </ItemGroup>
-
+    
+    <!-- Required Paths -->
     <PropertyGroup>
-        <AssemblyName>WrathCombo</AssemblyName>
-        <PackageId>WrathCombo</PackageId>
-        <Product>WrathCombo</Product>
         <DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
         <DalamudDevPlugins>$(appdata)\XIVLauncher\devPlugins\WrathCombo\</DalamudDevPlugins>
         <DalamudPluginPath>$(appdata)\XIVLauncher\installedPlugins\WrathCombo\$(version)</DalamudPluginPath>
     </PropertyGroup>
-    
+
+    <!-- Path Overrides for Linux -->
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
         <DalamudLibPath>$(HOME)/.xlcore/dalamud/Hooks/dev/</DalamudLibPath>
         <DalamudDevPlugins>$(HOME)/.xlcore/devPlugins/</DalamudDevPlugins>
     </PropertyGroup>
-    
+
+    <!-- Path Overrides for Mac -->
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
         <DalamudLibPath>$(HOME)/Library/Application Support/XIV on Mac/dalamud/Hooks/dev/</DalamudLibPath>
         <DalamudDevPlugins>$(HOME)/Library/Application Support/XIV on Mac/devPlugins/</DalamudDevPlugins>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-        <Platforms>x64</Platforms>
-        <Nullable>enable</Nullable>
-        <LangVersion>latest</LangVersion>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
-        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-        <OutputPath>$(DalamudDevPlugins)</OutputPath>
-        <NoWarn>CS1591</NoWarn>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-        <Platforms>x64</Platforms>
-        <Nullable>enable</Nullable>
-        <LangVersion>preview</LangVersion>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
-        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-        <OutputPath>bin\Release</OutputPath>
-        <NoWarn>CS1591</NoWarn>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-        <Optimize>True</Optimize>
-    </PropertyGroup>
-
+    <!-- Logo -->
     <ItemGroup>
         <Content Include="..\res\plugin\wrathcombo.png" Link="images\wrathcombo.png" CopyToOutputDirectory="PreserveNewest" Visible="false"/>
     </ItemGroup>
 
+    <!-- Dalamud Packaging -->
     <ItemGroup>
         <PackageReference Include="DalamudPackager" Version="12.0.0" />
         <PackageReference Include="ILRepack" Version="2.0.18"/>
     </ItemGroup>
 
+    <!-- Dependencies -->
     <ItemGroup>
         <ProjectReference Include="..\ECommons\ECommons\ECommons.csproj"/>
         <ProjectReference Include="..\PunishLib\PunishLib\PunishLib.csproj"/>
     </ItemGroup>
 
+    <!-- Dalamud Libraries -->
     <ItemGroup>
         <Reference Include="Dalamud">
             <HintPath>$(DalamudLibPath)Dalamud.dll</HintPath>
@@ -123,6 +132,7 @@
 
     </ItemGroup>
 
+    <!-- Release Manifest -->
     <ItemGroup>
         <None Update="WrathCombo.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/WrathCombo/WrathCombo.csproj
+++ b/WrathCombo/WrathCombo.csproj
@@ -19,7 +19,9 @@
         <DalamudLibPath Condition="$([MSBuild]::IsOSPlatform('Linux'))">$(HOME)/.xlcore/dalamud/Hooks/dev/</DalamudLibPath>
         <DalamudLibPath Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(HOME)/Library/Application Support/XIV on Mac/dalamud/Hooks/dev/</DalamudLibPath>
         <DalamudPluginPath>$(appdata)\XIVLauncher\installedPlugins\WrathCombo\$(version)</DalamudPluginPath>
-        <DalamudDevPlugins>$(appdata)\XIVLauncher\devPlugins\WrathCombo\</DalamudDevPlugins>
+        <DalamudDevPlugins Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(appdata)\XIVLauncher\devPlugins\WrathCombo\</DalamudDevPlugins>
+        <DalamudDevPlugins Condition="$([MSBuild]::IsOSPlatform('Linux'))">$(HOME)/.xlcore/devPlugins/</DalamudDevPlugins>
+        <DalamudDevPlugins Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(HOME)/Library/Application Support/XIV on Mac/devPlugins/</DalamudDevPlugins>
         <AssemblyName>WrathCombo</AssemblyName>
         <PackageId>WrathCombo</PackageId>
         <Product>WrathCombo</Product>

--- a/WrathCombo/WrathCombo.csproj
+++ b/WrathCombo/WrathCombo.csproj
@@ -31,26 +31,11 @@
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     </PropertyGroup>
 
-    <!-- Build Parameter Overrides for Debug -->
-    <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-        <OutputPath>$(DalamudDevPlugins)</OutputPath>
-    </PropertyGroup>
-
-    <!-- Build Parameter Overrides for Release -->
-    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-        <OutputPath>bin\Release</OutputPath>
-    </PropertyGroup>
-
-    <!-- Build Parameter Overrides for Optimization even in Debug -->
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-        <Optimize>True</Optimize>
-    </PropertyGroup>
-
     <!-- Styling Rules -->
     <ItemGroup>
         <None Include="..\.editorconfig" Link=".editorconfig"/>
     </ItemGroup>
-    
+
     <!-- Required Paths -->
     <PropertyGroup>
         <DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
@@ -68,6 +53,21 @@
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
         <DalamudLibPath>$(HOME)/Library/Application Support/XIV on Mac/dalamud/Hooks/dev/</DalamudLibPath>
         <DalamudDevPlugins>$(HOME)/Library/Application Support/XIV on Mac/devPlugins/</DalamudDevPlugins>
+    </PropertyGroup>
+
+    <!-- Build Parameter Overrides for Debug -->
+    <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+        <OutputPath>$(DalamudDevPlugins)</OutputPath>
+    </PropertyGroup>
+
+    <!-- Build Parameter Overrides for Release -->
+    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+        <OutputPath>bin\Release</OutputPath>
+    </PropertyGroup>
+
+    <!-- Build Parameter Overrides for Optimization even in Debug -->
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+        <Optimize>True</Optimize>
     </PropertyGroup>
 
     <!-- Logo -->


### PR DESCRIPTION
- [X] Made Linux and Mac overrides for `DalamudDevPlugins` (the actual fix here)
- [X] Add missing `PackageProjectUrl`
- [X] Made the Windows `DalamudLibPath` and `DalamudDevPlugins` default
- [X] Made new `PropertyGroup`s with `Condition`s for Linux and Mac
  - [X] Moved their respective `DalamudLibPath` and `DalamudDevPlugin` overrides there
- [X] Some basic reorganization and documentation of the rest of the `.csproj`
- [X] Removal of duplicate Properties
- [X] Removal of Documentation generation

> Preferably NightmareXIV/ECommons#118 is merged in time to be included in this, as that's most of the fix for building on Linux, but it's not required if you're not on Linux.