### PR TITLE
[WAR/Core] `Stationary Only` Delay Check + small `DrawSliderFloat` param for decimal places

### DIFF
--- a/WrathCombo/Combos/PvE/WAR/WAR.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR.cs
@@ -158,7 +158,8 @@ internal partial class WAR : Tank
                 return Upheaval;
             if (IsEnabled(CustomComboPreset.WAR_ST_PrimalWrath) && ShouldUsePrimalWrath)
                 return PrimalWrath;
-            if (IsEnabled(CustomComboPreset.WAR_ST_Onslaught) && ShouldUseOnslaught(Config.WAR_ST_Onslaught_Charges, Config.WAR_ST_Onslaught_Distance, Config.WAR_ST_Onslaught_Movement == 1 || (Config.WAR_ST_Onslaught_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(Config.WAR_ST_Onslaught_TimeStill))))
+            if (IsEnabled(CustomComboPreset.WAR_ST_Onslaught) && (!IsEnabled(CustomComboPreset.WAR_ST_InnerRelease) || (IsEnabled(CustomComboPreset.WAR_ST_InnerRelease) && IR.Cooldown > 40)) &&
+                ShouldUseOnslaught(Config.WAR_ST_Onslaught_Charges, Config.WAR_ST_Onslaught_Distance, Config.WAR_ST_Onslaught_Movement == 1 || (Config.WAR_ST_Onslaught_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(Config.WAR_ST_Onslaught_TimeStill))))
                 return Onslaught;
             if (IsEnabled(CustomComboPreset.WAR_ST_PrimalRend) &&
                 ShouldUsePrimalRend(Config.WAR_ST_PrimalRend_Distance, (Config.WAR_ST_PrimalRend_Movement == 1 || (Config.WAR_ST_PrimalRend_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(Config.WAR_ST_PrimalRend_TimeStill)))) &&
@@ -317,7 +318,8 @@ internal partial class WAR : Tank
                 return LevelChecked(Orogeny) ? Orogeny : Upheaval;
             if (IsEnabled(CustomComboPreset.WAR_AoE_PrimalWrath) && ShouldUsePrimalWrath)
                 return PrimalWrath;
-            if (IsEnabled(CustomComboPreset.WAR_AoE_Onslaught) && ShouldUseOnslaught(Config.WAR_AoE_Onslaught_Charges, Config.WAR_AoE_Onslaught_Distance, Config.WAR_AoE_Onslaught_Movement == 1 || (Config.WAR_AoE_Onslaught_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(Config.WAR_AoE_Onslaught_TimeStill))))
+            if (IsEnabled(CustomComboPreset.WAR_AoE_Onslaught) && (!IsEnabled(CustomComboPreset.WAR_AoE_InnerRelease) || (IsEnabled(CustomComboPreset.WAR_AoE_InnerRelease) && IR.Cooldown > 40)) &&
+                ShouldUseOnslaught(Config.WAR_AoE_Onslaught_Charges, Config.WAR_AoE_Onslaught_Distance, Config.WAR_AoE_Onslaught_Movement == 1 || (Config.WAR_AoE_Onslaught_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(Config.WAR_AoE_Onslaught_TimeStill))))
                 return Onslaught;
             if (IsEnabled(CustomComboPreset.WAR_AoE_PrimalRend) && ShouldUsePrimalRend(Config.WAR_AoE_PrimalRend_Distance, Config.WAR_AoE_PrimalRend_Movement == 1 || (Config.WAR_AoE_PrimalRend_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(Config.WAR_AoE_PrimalRend_TimeStill))) &&
                 (Config.WAR_AoE_PrimalRend_EarlyLate == 0 || (Config.WAR_AoE_PrimalRend_EarlyLate == 1 && (GetStatusEffectRemainingTime(Buffs.PrimalRendReady) <= 15 || (!HasIR.Stacks && !HasBF.Stacks && !HasWrath)))))
@@ -371,7 +373,8 @@ internal partial class WAR : Tank
                 return Upheaval;
             if (IsEnabled(CustomComboPreset.WAR_FC_PrimalWrath) && ShouldUsePrimalWrath)
                 return PrimalWrath;
-            if (IsEnabled(CustomComboPreset.WAR_FC_Onslaught) && ShouldUseOnslaught(Config.WAR_FC_Onslaught_Charges, Config.WAR_FC_Onslaught_Distance, Config.WAR_FC_Onslaught_Movement == 1 || (Config.WAR_FC_Onslaught_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(Config.WAR_FC_Onslaught_TimeStill))))
+            if (IsEnabled(CustomComboPreset.WAR_FC_Onslaught) && (!IsEnabled(CustomComboPreset.WAR_FC_InnerRelease) || (IsEnabled(CustomComboPreset.WAR_FC_InnerRelease) && IR.Cooldown > 40)) &&
+                ShouldUseOnslaught(Config.WAR_FC_Onslaught_Charges, Config.WAR_FC_Onslaught_Distance, Config.WAR_FC_Onslaught_Movement == 1 || (Config.WAR_FC_Onslaught_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(Config.WAR_FC_Onslaught_TimeStill))))
                 return Onslaught;
             if (IsEnabled(CustomComboPreset.WAR_FC_PrimalRend) &&
                 ShouldUsePrimalRend(Config.WAR_FC_PrimalRend_Distance, Config.WAR_FC_PrimalRend_Movement == 1 || (Config.WAR_FC_PrimalRend_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(Config.WAR_FC_PrimalRend_TimeStill))) &&

--- a/WrathCombo/Combos/PvE/WAR/WAR.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR.cs
@@ -371,10 +371,10 @@ internal partial class WAR : Tank
                 return Upheaval;
             if (IsEnabled(CustomComboPreset.WAR_FC_PrimalWrath) && ShouldUsePrimalWrath)
                 return PrimalWrath;
-            if (IsEnabled(CustomComboPreset.WAR_FC_Onslaught) && ShouldUseOnslaught(Config.WAR_FC_Onslaught_Charges, Config.WAR_FC_Onslaught_Distance, Config.WAR_FC_Onslaught_Movement == 1 || (Config.WAR_FC_Onslaught_Movement == 0 && !IsMoving())))
+            if (IsEnabled(CustomComboPreset.WAR_FC_Onslaught) && ShouldUseOnslaught(Config.WAR_FC_Onslaught_Charges, Config.WAR_FC_Onslaught_Distance, Config.WAR_FC_Onslaught_Movement == 1 || (Config.WAR_FC_Onslaught_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(Config.WAR_FC_Onslaught_TimeStill))))
                 return Onslaught;
             if (IsEnabled(CustomComboPreset.WAR_FC_PrimalRend) &&
-                ShouldUsePrimalRend(Config.WAR_FC_PrimalRend_Distance, Config.WAR_FC_PrimalRend_Movement == 1 || (Config.WAR_FC_PrimalRend_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(Config.WAR_AoE_PrimalRend_TimeStill))) &&
+                ShouldUsePrimalRend(Config.WAR_FC_PrimalRend_Distance, Config.WAR_FC_PrimalRend_Movement == 1 || (Config.WAR_FC_PrimalRend_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(Config.WAR_FC_PrimalRend_TimeStill))) &&
                 (Config.WAR_FC_PrimalRend_EarlyLate == 0 || (Config.WAR_FC_PrimalRend_EarlyLate == 1 && (GetStatusEffectRemainingTime(Buffs.PrimalRendReady) <= 15 || (!HasIR.Stacks && !HasBF.Stacks && !HasWrath)))))
                 return PrimalRend;
             if (IsEnabled(CustomComboPreset.WAR_FC_PrimalRuination) && ShouldUsePrimalRuination)

--- a/WrathCombo/Combos/PvE/WAR/WAR.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
@@ -157,10 +158,10 @@ internal partial class WAR : Tank
                 return Upheaval;
             if (IsEnabled(CustomComboPreset.WAR_ST_PrimalWrath) && ShouldUsePrimalWrath)
                 return PrimalWrath;
-            if (IsEnabled(CustomComboPreset.WAR_ST_Onslaught) && ShouldUseOnslaught(Config.WAR_ST_Onslaught_Charges, Config.WAR_ST_Onslaught_Distance, Config.WAR_ST_Onslaught_Movement == 1 || (Config.WAR_ST_Onslaught_Movement == 0 && !IsMoving())))
+            if (IsEnabled(CustomComboPreset.WAR_ST_Onslaught) && ShouldUseOnslaught(Config.WAR_ST_Onslaught_Charges, Config.WAR_ST_Onslaught_Distance, Config.WAR_ST_Onslaught_Movement == 1 || (Config.WAR_ST_Onslaught_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(Config.WAR_ST_Onslaught_TimeStill))))
                 return Onslaught;
             if (IsEnabled(CustomComboPreset.WAR_ST_PrimalRend) &&
-                ShouldUsePrimalRend(Config.WAR_ST_PrimalRend_Distance, Config.WAR_ST_PrimalRend_Movement == 1 || (Config.WAR_ST_PrimalRend_Movement == 0 && !IsMoving())) &&
+                ShouldUsePrimalRend(Config.WAR_ST_PrimalRend_Distance, (Config.WAR_ST_PrimalRend_Movement == 1 || (Config.WAR_ST_PrimalRend_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(Config.WAR_ST_PrimalRend_TimeStill)))) &&
                 (Config.WAR_ST_PrimalRend_EarlyLate == 0 || (Config.WAR_ST_PrimalRend_EarlyLate == 1 && (GetStatusEffectRemainingTime(Buffs.PrimalRendReady) <= 15 || (!HasIR.Stacks && !HasBF.Stacks && !HasWrath)))))
                 return PrimalRend;
             if (IsEnabled(CustomComboPreset.WAR_ST_PrimalRuination) && ShouldUsePrimalRuination)
@@ -316,9 +317,9 @@ internal partial class WAR : Tank
                 return LevelChecked(Orogeny) ? Orogeny : Upheaval;
             if (IsEnabled(CustomComboPreset.WAR_AoE_PrimalWrath) && ShouldUsePrimalWrath)
                 return PrimalWrath;
-            if (IsEnabled(CustomComboPreset.WAR_AoE_Onslaught) && ShouldUseOnslaught(Config.WAR_AoE_Onslaught_Charges, Config.WAR_AoE_Onslaught_Distance, Config.WAR_AoE_Onslaught_Movement == 1 || (Config.WAR_AoE_Onslaught_Movement == 0 && !IsMoving())))
+            if (IsEnabled(CustomComboPreset.WAR_AoE_Onslaught) && ShouldUseOnslaught(Config.WAR_AoE_Onslaught_Charges, Config.WAR_AoE_Onslaught_Distance, Config.WAR_AoE_Onslaught_Movement == 1 || (Config.WAR_AoE_Onslaught_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(Config.WAR_AoE_Onslaught_TimeStill))))
                 return Onslaught;
-            if (IsEnabled(CustomComboPreset.WAR_AoE_PrimalRend) && ShouldUsePrimalRend(Config.WAR_AoE_PrimalRend_Distance, Config.WAR_AoE_PrimalRend_Movement == 1 || (Config.WAR_AoE_PrimalRend_Movement == 0 && !IsMoving())) &&
+            if (IsEnabled(CustomComboPreset.WAR_AoE_PrimalRend) && ShouldUsePrimalRend(Config.WAR_AoE_PrimalRend_Distance, Config.WAR_AoE_PrimalRend_Movement == 1 || (Config.WAR_AoE_PrimalRend_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(Config.WAR_AoE_PrimalRend_TimeStill))) &&
                 (Config.WAR_AoE_PrimalRend_EarlyLate == 0 || (Config.WAR_AoE_PrimalRend_EarlyLate == 1 && (GetStatusEffectRemainingTime(Buffs.PrimalRendReady) <= 15 || (!HasIR.Stacks && !HasBF.Stacks && !HasWrath)))))
                 return PrimalRend;
             if (IsEnabled(CustomComboPreset.WAR_AoE_PrimalRuination) && ShouldUsePrimalRuination)
@@ -373,7 +374,7 @@ internal partial class WAR : Tank
             if (IsEnabled(CustomComboPreset.WAR_FC_Onslaught) && ShouldUseOnslaught(Config.WAR_FC_Onslaught_Charges, Config.WAR_FC_Onslaught_Distance, Config.WAR_FC_Onslaught_Movement == 1 || (Config.WAR_FC_Onslaught_Movement == 0 && !IsMoving())))
                 return Onslaught;
             if (IsEnabled(CustomComboPreset.WAR_FC_PrimalRend) &&
-                ShouldUsePrimalRend(Config.WAR_FC_PrimalRend_Distance, Config.WAR_FC_PrimalRend_Movement == 1 || (Config.WAR_FC_PrimalRend_Movement == 0 && !IsMoving())) &&
+                ShouldUsePrimalRend(Config.WAR_FC_PrimalRend_Distance, Config.WAR_FC_PrimalRend_Movement == 1 || (Config.WAR_FC_PrimalRend_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(Config.WAR_AoE_PrimalRend_TimeStill))) &&
                 (Config.WAR_FC_PrimalRend_EarlyLate == 0 || (Config.WAR_FC_PrimalRend_EarlyLate == 1 && (GetStatusEffectRemainingTime(Buffs.PrimalRendReady) <= 15 || (!HasIR.Stacks && !HasBF.Stacks && !HasWrath)))))
                 return PrimalRend;
             if (IsEnabled(CustomComboPreset.WAR_FC_PrimalRuination) && ShouldUsePrimalRuination)

--- a/WrathCombo/Combos/PvE/WAR/WAR_Config.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR_Config.cs
@@ -99,7 +99,13 @@ internal partial class WAR
             WAR_AoE_Onslaught_Distance = new("WAR_AoE_Ons_Distance", 3.0f),
             WAR_AoE_PrimalRend_Distance = new("WAR_AoE_PR_Distance", 3.0f),
             WAR_FC_Onslaught_Distance = new("WAR_FC_Ons_Distance", 3.0f),
-            WAR_FC_PrimalRend_Distance = new("WAR_FC_PR_Distance", 3.0f);
+            WAR_FC_PrimalRend_Distance = new("WAR_FC_PR_Distance", 3.0f),
+            WAR_ST_Onslaught_TimeStill = new("WAR_ST_Onslaught_TimeStill", 0),
+            WAR_ST_PrimalRend_TimeStill = new("WAR_ST_PrimalRend_TimeStill", 0),
+            WAR_AoE_Onslaught_TimeStill = new("WAR_AoE_Onslaught_TimeStill", 0),
+            WAR_AoE_PrimalRend_TimeStill = new("WAR_AoE_PrimalRend_TimeStill", 0),
+            WAR_FC_Onslaught_TimeStill = new("WAR_FC_Onslaught_TimeStill", 0),
+            WAR_FC_PrimalRend_TimeStill = new("WAR_FC_PrimalRend_TimeStill", 0);
 
         public static UserIntArray
             WAR_Mit_Priorities = new("WAR_Mit_Priorities");
@@ -136,11 +142,18 @@ internal partial class WAR
                     UserConfig.DrawHorizontalRadioButton(WAR_ST_Onslaught_Movement,
                             "Any Movement", "Uses Onslaught regardless of any movement conditions.\nNOTE: This could possibly get you killed", 1);
                     ImGui.Spacing();
+                    if (WAR_ST_Onslaught_Movement == 0)
+                    {
+                        ImGui.SetCursorPosX(48);
+                        UserConfig.DrawSliderFloat(0, 3, WAR_ST_Onslaught_TimeStill,
+                            " Stationary Delay Check (in seconds):", decimals: 1);
+                    }
+                    ImGui.SetCursorPosX(48);
                     UserConfig.DrawSliderInt(0, 2, WAR_ST_Onslaught_Charges,
                         " How many charges to keep ready?\n (0 = Use All)");
                     ImGui.SetCursorPosX(48);
                     UserConfig.DrawSliderFloat(1, 20, WAR_ST_Onslaught_Distance,
-                        " Use when Distance from target is less than or equal to:");
+                        " Use when Distance from target is less than or equal to:", decimals: 1);
                     break;
 
                 case CustomComboPreset.WAR_ST_Infuriate:
@@ -166,9 +179,15 @@ internal partial class WAR
                     UserConfig.DrawHorizontalRadioButton(WAR_ST_PrimalRend_Movement,
                         "Any Movement", "Uses Primal Rend regardless of any movement conditions.\nNOTE: This could possibly get you killed", 1);
                     ImGui.Spacing();
+                    if (WAR_ST_PrimalRend_Movement == 0)
+                    {
+                        ImGui.SetCursorPosX(48);
+                        UserConfig.DrawSliderFloat(0, 3, WAR_ST_PrimalRend_TimeStill,
+                            " Stationary Delay Check (in seconds):", decimals: 1);
+                    }
                     ImGui.SetCursorPosX(48);
                     UserConfig.DrawSliderFloat(1, 20, WAR_ST_PrimalRend_Distance,
-                        " Use when Distance from target is less than or equal to:");
+                        " Use when Distance from target is less than or equal to:", decimals: 1);
                     break;
                 #endregion
 
@@ -197,11 +216,17 @@ internal partial class WAR
                     UserConfig.DrawHorizontalRadioButton(WAR_AoE_Onslaught_Movement,
                             "Any Movement", "Uses Onslaught regardless of any movement conditions.\nNOTE: This could possibly get you killed", 1);
                     ImGui.Spacing();
+                    if (WAR_AoE_Onslaught_Movement == 0) 
+                    {
+                        ImGui.SetCursorPosX(48);
+                        UserConfig.DrawSliderFloat(0, 3, WAR_AoE_Onslaught_TimeStill,
+                            " Stationary Delay Check (in seconds):", decimals: 1);
+                    }
                     UserConfig.DrawSliderInt(0, 2, WAR_AoE_Onslaught_Charges,
                         " How many charges to keep ready?\n (0 = Use All)");
                     ImGui.SetCursorPosX(48);
                     UserConfig.DrawSliderFloat(1, 20, WAR_AoE_Onslaught_Distance,
-                        " Use when Distance from target is less than or equal to:");
+                        " Use when Distance from target is less than or equal to:", decimals: 1);
                     break;
 
                 case CustomComboPreset.WAR_AoE_PrimalRend:
@@ -215,9 +240,15 @@ internal partial class WAR
                     UserConfig.DrawHorizontalRadioButton(WAR_AoE_PrimalRend_Movement,
                         "Any Movement", "Uses Primal Rend regardless of any movement conditions.\nNOTE: This could possibly get you killed", 1);
                     ImGui.Spacing();
+                    if (WAR_AoE_PrimalRend_Movement == 0)
+                    {
+                        ImGui.SetCursorPosX(48);
+                        UserConfig.DrawSliderFloat(0, 3, WAR_AoE_PrimalRend_TimeStill,
+                            " Stationary Delay Check (in seconds):", decimals: 1);
+                    }
                     ImGui.SetCursorPosX(48);
                     UserConfig.DrawSliderFloat(1, 20, WAR_AoE_PrimalRend_Distance,
-                        " Use when Distance from target is less than or equal to:");
+                        " Use when Distance from target is less than or equal to:", decimals: 1);
                     break;
 
                 case CustomComboPreset.WAR_AoE_Orogeny:
@@ -454,11 +485,17 @@ internal partial class WAR
                     UserConfig.DrawHorizontalRadioButton(WAR_FC_Onslaught_Movement,
                         "Any Movement", "Uses Onslaught regardless of any movement conditions.\nNOTE: This could possibly get you killed", 1);
                     ImGui.Spacing();
+                    if (WAR_FC_Onslaught_Movement == 0)
+                    {
+                        ImGui.SetCursorPosX(48);
+                        UserConfig.DrawSliderFloat(0, 3, WAR_FC_Onslaught_TimeStill,
+                            " Stationary Delay Check (in seconds):", decimals: 1);
+                    }
                     UserConfig.DrawSliderInt(0, 2, WAR_FC_Onslaught_Charges,
                         " How many charges to keep ready?\n (0 = Use All)");
                     ImGui.SetCursorPosX(48);
                     UserConfig.DrawSliderFloat(1, 20, WAR_FC_Onslaught_Distance,
-                        " Use when Distance from target is less than or equal to:");
+                        " Use when Distance from target is less than or equal to:", decimals: 1);
                     break;
 
                 case CustomComboPreset.WAR_FC_Infuriate:
@@ -479,9 +516,15 @@ internal partial class WAR
                     UserConfig.DrawHorizontalRadioButton(WAR_FC_PrimalRend_Movement,
                         "Any Movement", "Uses Primal Rend regardless of any movement conditions.\nNOTE: This could possibly get you killed", 1);
                     ImGui.Spacing();
+                    if (WAR_FC_PrimalRend_Movement == 0)
+                    {
+                        ImGui.SetCursorPosX(48);
+                        UserConfig.DrawSliderFloat(0, 3, WAR_FC_PrimalRend_TimeStill,
+                            " Stationary Delay Check (in seconds):", decimals: 1);
+                    }
                     ImGui.SetCursorPosX(48);
                     UserConfig.DrawSliderFloat(1, 20, WAR_FC_PrimalRend_Distance,
-                        " Use when Distance from target is less than or equal to:");
+                        " Use when Distance from target is less than or equal to:", decimals: 1);
                     break;
 
                 case CustomComboPreset.WAR_ST_Simple:

--- a/WrathCombo/Combos/PvE/WAR/WAR_Helper.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR_Helper.cs
@@ -174,7 +174,7 @@ internal partial class WAR : Tank
     internal static bool ShouldUseInfuriate(int gauge = 40, int charges = 0) => CanInfuriate() && CanWeave() && !HasNC && !HasIR.Stacks && BeastGauge <= gauge && GetRemainingCharges(Infuriate) > charges && Minimal;
     internal static bool ShouldUseUpheaval => ActionReady(Upheaval) && CanWeave() && HasST && InMeleeRange() && Minimal;
     internal static bool ShouldUsePrimalWrath => LevelChecked(PrimalWrath) && CanWeave() && HasWrath && HasST && GetTargetDistance() <= 4.99f && Minimal;
-    internal static bool ShouldUseOnslaught(int charges = 0, float distance = 20, bool movement = true) => CanOnslaught(charges, distance, movement) && CanWeave() && HasST && (IR.Cooldown > 40 || GetRemainingCharges(Onslaught) == MaxDashCharges);
+    internal static bool ShouldUseOnslaught(int charges = 0, float distance = 20, bool movement = true) => CanOnslaught(charges, distance, movement) && CanWeave() && HasST;
     internal static bool ShouldUsePrimalRuination => LevelChecked(PrimalRuination) && HasStatusEffect(Buffs.PrimalRuinationReady) && HasST;
     internal static bool ShouldUsePrimalRend(float distance = 20, bool movement = true) => CanPRend(distance, movement) && !JustUsed(InnerRelease) && HasST;
     internal static bool ShouldUseFellCleave(int gauge = 90) => CanFC(gauge) && HasST && InMeleeRange() && Minimal;

--- a/WrathCombo/Window/Functions/UserConfig.cs
+++ b/WrathCombo/Window/Functions/UserConfig.cs
@@ -152,8 +152,7 @@ namespace WrathCombo.Window.Functions
         /// <param name="hasAdditionalChoice"></param>
         /// <param name="additonalChoiceCondition"></param>
         /// <param name="decimals">Number of decimal places shown in the slider and input box (e.g. 1 = 0.0f, 3 = 0.000f)</param>
-        public static void DrawSliderFloat(float minValue, float maxValue, string config, string sliderDescription, float itemWidth = 150, bool hasAdditionalChoice = false, string additonalChoiceCondition = "", int decimals = 3
-        )
+        public static void DrawSliderFloat(float minValue, float maxValue, string config, string sliderDescription, float itemWidth = 150, bool hasAdditionalChoice = false, string additonalChoiceCondition = "", int decimals = 3)
         {
             float output = PluginConfiguration.GetCustomFloatValue(config, minValue);
             if (output < minValue)

--- a/WrathCombo/Window/Functions/UserConfig.cs
+++ b/WrathCombo/Window/Functions/UserConfig.cs
@@ -151,7 +151,9 @@ namespace WrathCombo.Window.Functions
         /// <param name="itemWidth"> How long the slider should be. </param>
         /// <param name="hasAdditionalChoice"></param>
         /// <param name="additonalChoiceCondition"></param>
-        public static void DrawSliderFloat(float minValue, float maxValue, string config, string sliderDescription, float itemWidth = 150, bool hasAdditionalChoice = false, string additonalChoiceCondition = "")
+        /// <param name="decimals">Number of decimal places shown in the slider and input box (e.g. 1 = 0.0f, 3 = 0.000f)</param>
+        public static void DrawSliderFloat(float minValue, float maxValue, string config, string sliderDescription, float itemWidth = 150, bool hasAdditionalChoice = false, string additonalChoiceCondition = "", int decimals = 3
+        )
         {
             float output = PluginConfiguration.GetCustomFloatValue(config, minValue);
             if (output < minValue)
@@ -164,7 +166,7 @@ namespace WrathCombo.Window.Functions
             sliderDescription = sliderDescription.Replace("%", "%%");
             float contentRegionMin = ImGui.GetItemRectMax().Y - ImGui.GetItemRectMin().Y;
             float wrapPos = ImGui.GetContentRegionMax().X - 35f;
-
+            string format = $"%.{decimals}f";
 
             InfoBox box = new()
             {
@@ -196,7 +198,6 @@ namespace WrathCombo.Window.Functions
                         {
                             newLines += "\n\n";
                         }
-
                     }
 
                     if (hasAdditionalChoice)
@@ -222,7 +223,7 @@ namespace WrathCombo.Window.Functions
                     ImGui.SameLine();
                     ImGui.SetCursorPosX(currentPos.X);
                     ImGui.PushItemWidth(itemWidth);
-                    inputChanged |= ImGui.SliderFloat($"{newLines}###{config}", ref output, minValue, maxValue);
+                    inputChanged |= ImGui.SliderFloat($"{newLines}###{config}", ref output, minValue, maxValue, format);
 
                     if (inputChanged)
                     {


### PR DESCRIPTION
Since the values we're working with typically don't require precision beyond the first decimal place, supporting flexibility from one to three should be okay here and for other use-cases with other jobs. 

The default param set (3) will keep behavior as is for the other references, and now devs can set `decimals: 1` to reflect this behavior here in the screenshots with the slider moving in increments of `0.1` instead of `0.001`. 

![image](https://github.com/user-attachments/assets/89657c1d-0ef0-4b6a-bb0b-0303efc7df45)
![image](https://github.com/user-attachments/assets/9274eb40-074d-40a3-80a3-6b6e85abfdb7)

I will admit this feels kind of lazy, or is this just really that simple? idk, but this works fine from testing😄

Let me know if there's a better way you'd like this done.