### PR TITLE
[AutoRot][DNC][AST] Fix null error upon entering combat

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -38,7 +38,7 @@ namespace WrathCombo.AutoRotation
 
         static DateTime? TimeToHeal;
 
-        static Func<WrathPartyMember, bool> RezQuery => x => x.BattleChara.IsDead && !HasStatusEffect(2648, x.BattleChara, true) && !HasStatusEffect(148, x.BattleChara, true) && x.BattleChara.IsTargetable && TimeSpentDead(x.BattleChara.GameObjectId).TotalSeconds > 2 && GetTargetDistance(x.BattleChara) <= 30;
+        static Func<WrathPartyMember, bool> RezQuery => x => x.BattleChara is not null && x.BattleChara.IsDead && !HasStatusEffect(2648, x.BattleChara, true) && !HasStatusEffect(148, x.BattleChara, true) && x.BattleChara.IsTargetable && TimeSpentDead(x.BattleChara.GameObjectId).TotalSeconds > 2 && GetTargetDistance(x.BattleChara) <= 30;
 
         public static bool LockedST
         {

--- a/WrathCombo/Combos/PvE/AST/AST_Helper.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Helper.cs
@@ -105,7 +105,7 @@ internal partial class AST
             var card = Gauge.DrawnCards[0];
             var party = GetPartyMembers(false)
                 .Select(member => new { member.BattleChara, member.RealJob })
-                .Where(member => !member.BattleChara.IsDead && member.BattleChara.IsNotThePlayer())
+                .Where(member => member.BattleChara is not null && !member.BattleChara.IsDead && member.BattleChara.IsNotThePlayer())
                 .Where(x => InCardRange(x.BattleChara))
                 .Where(x => ExistingCardBuffFree(x.BattleChara))
                 .ToList();

--- a/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
@@ -259,7 +259,7 @@ internal partial class DNC
 
         var party = GetPartyMembers()
             .Where(member => member.GameObjectId != Player.Object.GameObjectId)
-            .Where(member => !member.BattleChara.IsDead)
+            .Where(member => member.BattleChara is not null && !member.BattleChara.IsDead)
             .Where(member => IsInRange(member.BattleChara, 30))
             .Where(member => !HasAnyPartner(member) || HasMyPartner(member))
             .Select(member => member.BattleChara)


### PR DESCRIPTION
- [X] Fixes null `BattleChara` errors upon entering combat for:
  - [X] Auto Rotation
  - [X] DNC
  - [X] AST