### PR TITLE
[WHM] Finish rename that was lost in the merge

### DIFF
--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -221,9 +221,8 @@ internal partial class WHM : Healer
                              !HasStatusEffect(Buffs.ThinAir) &&
                              GetRemainingCharges(ThinAir) >
                              Config.WHM_STHeals_ThinAir;
-
-
-            var regenReady = ActionReady(Regen) &&
+            
+            var canRegen = ActionReady(Regen) &&
                              !JustUsedOn(Regen, healTarget) &&
                              GetStatusEffectRemainingTime(Buffs.Regen, healTarget)
                              <= Config.WHM_STHeals_RegenTimer && //Refresh Time Threshold
@@ -272,7 +271,7 @@ internal partial class WHM : Healer
 
             #region GCD Tools
 
-            if (IsEnabled(CustomComboPreset.WHM_STHeals_Regen) && regenReady)
+            if (IsEnabled(CustomComboPreset.WHM_STHeals_Regen) && canRegen)
                 return Regen
                     .RetargetIfEnabled(OptionalTarget, Cure);
 


### PR DESCRIPTION
- [X] Re-applies the rename that was lost in the merge
      (5e5bc7a may have made the code compile again, but it does not reflect the changes that were intentionally made)