### PR TITLE
[Core] Occult Crescent: Add Swiftcasting of `Comet`, and various improvements

### DIFF
--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent.cs
@@ -201,12 +201,32 @@ internal partial class OccultCrescent
         {
             if (IsEnabledAndUsable(CustomComboPreset.Phantom_TimeMage_OccultQuick, OccultQuick) && !HasStatusEffect(Buffs.OccultQuick))
                 return OccultQuick; //damage buff
+            
             if (IsEnabledAndUsable(CustomComboPreset.Phantom_TimeMage_OccultDispel, OccultDispel) && TargetIsHostile() && HasPhantomDispelStatus(CurrentTarget))
                 return OccultDispel; //cleanse
+            
             if (IsEnabledAndUsable(CustomComboPreset.Phantom_TimeMage_OccultMageMasher, OccultMageMasher) && !HasStatusEffect(Debuffs.OccultMageMasher, CurrentTarget))
                 return OccultMageMasher; //weaken target's magic attack
+            
             if (IsEnabledAndUsable(CustomComboPreset.Phantom_TimeMage_OccultComet, OccultComet))
-                return OccultComet; //damage
+            {
+                // Make comet fast
+                if (Config.Phantom_TimeMage_Comet_RequireSpeed &&
+                    !HasStatusEffect(Buffs.OccultQuick) &&
+                    !JustUsed(OccultQuick) && 
+                    !HasStatusEffect(RoleActions.Magic.Buffs.Swiftcast) &&
+                    !JustUsed(RoleActions.Magic.Swiftcast))
+                    if (HasActionEquipped(OccultQuick) && ActionReady(OccultQuick))
+                        return OccultQuick;
+                    else if (ActionReady(RoleActions.Magic.Swiftcast))
+                        return RoleActions.Magic.Swiftcast;
+                
+                if (!Config.Phantom_TimeMage_Comet_RequireSpeed ||
+                    (HasStatusEffect(Buffs.OccultQuick) ||
+                     HasStatusEffect(RoleActions.Magic.Buffs.Swiftcast)))
+                    return OccultComet; // damage
+            }
+            
             if (IsEnabledAndUsable(CustomComboPreset.Phantom_TimeMage_OccultSlowga, OccultSlowga) && !HasStatusEffect(Debuffs.Slow, CurrentTarget) &&
                 (IsNotEnabled(CustomComboPreset.Phantom_TimeMage_OccultSlowga_Wait) || (ICDTracker.TimeUntilExpired(Debuffs.Slow, CurrentTarget.GameObjectId) < TimeSpan.FromSeconds(1.5) || ICDTracker.NumberOfTimesApplied(Debuffs.Slow, CurrentTarget.GameObjectId) < 3)))
                 return OccultSlowga; //aoe slow

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent.cs
@@ -212,6 +212,7 @@ internal partial class OccultCrescent
             {
                 // Make comet fast
                 if (Config.Phantom_TimeMage_Comet_RequireSpeed &&
+                    Config.Phantom_TimeMage_Comet_UseSpeed &&
                     !HasStatusEffect(Buffs.OccultQuick) &&
                     !JustUsed(OccultQuick) && 
                     !HasStatusEffect(RoleActions.Magic.Buffs.Swiftcast) &&

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Config.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Config.cs
@@ -35,7 +35,8 @@ internal partial class OccultCrescent
         
         public static UserBool
             Phantom_Chemist_OccultElixir_RequireParty = new("Phantom_Chemist_OccultElixir_RequireParty", true),
-            Phantom_TimeMage_Comet_RequireSpeed = new("Phantom_TimeMage_Comet_RequireSpeed", true);
+            Phantom_TimeMage_Comet_RequireSpeed = new("Phantom_TimeMage_Comet_RequireSpeed", true),
+            Phantom_TimeMage_Comet_UseSpeed = new("Phantom_TimeMage_Comet_UseSpeed", true);
 
         internal static void Draw(CustomComboPreset preset)
         {
@@ -128,7 +129,15 @@ internal partial class OccultCrescent
                 
                 case CustomComboPreset.Phantom_TimeMage_OccultComet:
                     UserConfig.DrawAdditionalBoolChoice(Phantom_TimeMage_Comet_RequireSpeed,
-                        "Require Swiftcast or Occult Quick", "");
+                        "Require Swiftcast or Occult Quick to use Comet", "");
+                    if (Phantom_TimeMage_Comet_RequireSpeed)
+                    {
+                        ImGui.Indent();
+                        UserConfig.DrawAdditionalBoolChoice(
+                            Phantom_TimeMage_Comet_UseSpeed,
+                            "Add Swiftcast or Occult Quick prior to using Comet", "");
+                        ImGui.Unindent();
+                    }
                     break;
             }
         }

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Config.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Config.cs
@@ -33,7 +33,9 @@ internal partial class OccultCrescent
             Phantom_Ranger_PhantomAim_Stop = new("Phantom_Ranger_PhantomAim_Stop", 30),
             Phantom_Thief_Steal_Health = new("Phantom_Thief_Steal_Health", 10);
         
-        public static UserBool Phantom_Chemist_OccultElixir_RequireParty = new("Phantom_Chemist_OccultElixir_RequireParty", true);
+        public static UserBool
+            Phantom_Chemist_OccultElixir_RequireParty = new("Phantom_Chemist_OccultElixir_RequireParty", true),
+            Phantom_TimeMage_Comet_RequireSpeed = new("Phantom_TimeMage_Comet_RequireSpeed", true);
 
         internal static void Draw(CustomComboPreset preset)
         {
@@ -122,6 +124,11 @@ internal partial class OccultCrescent
                     ImGuiEx.TextWrapped(ImGuiColors.DalamudYellow, "Not advisable in most situations!");
                     ImGuiEx.TextWrapped(ImGuiColors.DalamudYellow, "The slider value should be rather low, if you do use it!");
                     ImGui.Unindent();
+                    break;
+                
+                case CustomComboPreset.Phantom_TimeMage_OccultComet:
+                    UserConfig.DrawAdditionalBoolChoice(Phantom_TimeMage_Comet_RequireSpeed,
+                        "Require Swiftcast or Occult Quick", "");
                     break;
             }
         }

--- a/WrathCombo/Combos/PvE/PLD/PLD.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD.cs
@@ -424,6 +424,9 @@ internal partial class PLD : Tank
 
             #endregion
 
+            if (OccultCrescent.ShouldUsePhantomActions())
+                return OccultCrescent.BestPhantomAction();
+
             // Interrupt
             if (IsEnabled(CustomComboPreset.PLD_ST_Interrupt)
                 && Role.CanInterject())

--- a/WrathCombo/CustomCombo/Functions/Status.cs
+++ b/WrathCombo/CustomCombo/Functions/Status.cs
@@ -129,7 +129,7 @@ namespace WrathCombo.CustomComboNS.Functions
         /// <returns></returns>
         public static bool HasBeneficialStatus(IGameObject? target) => StatusCache.HasBeneficialStatus(target);
 
-        public static bool HasPhantomDispelStatus(IGameObject? target) => StatusCache.HasDamageUp(target) || StatusCache.HasEvasionUp(target) || HasStatusEffect(4355, target);
+        public static bool HasPhantomDispelStatus(IGameObject? target) => StatusCache.HasDamageUp(target) || StatusCache.HasEvasionUp(target) || HasStatusEffect(4355, target) || StatusCache.TargetIsInvincible(target);
 
         /// <summary>
         /// Checks if the target is invincible due to status effects or encounter-specific mechanics.

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -215,6 +215,9 @@ namespace WrathCombo.Data
                 target is null)
                 return false;
 
+            if (actionId == OccultCrescent.Revive)
+                target = SimpleTarget.Stack.AllyToRaise;
+
             targetObjectId = target.GameObjectId;
             return true;
         }


### PR DESCRIPTION
- [X] `Occult Dispel` will now target `Invulnerable` on enemies
- [X] `Occult Revive` will now be Retargeted to the Raise Stack
- [X] `Occult Comet` now has an option to be swiftcasted, and an option to use swifcast/quick
      (closes #657)
- [X] Adds Occult Actions to PLD