### PR TITLE
[SMN PVP] Tweaks for burst, and prevent r4 waste

### DIFF
--- a/WrathCombo/Combos/PvP/SMNPvP.cs
+++ b/WrathCombo/Combos/PvP/SMNPvP.cs
@@ -1,3 +1,4 @@
+using WrathCombo.Combos.PvE;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
@@ -84,6 +85,9 @@ namespace WrathCombo.Combos.PvP
                     int radiantThreshold = PluginConfiguration.GetCustomIntValue(Config.SMNPvP_RadiantAegisThreshold);
                     #endregion
 
+                    if (PvPCommon.TargetImmuneToDamage() && HasStatusEffect(Buffs.FurtherRuin)) // Block for ruin 4 because it is on action ID
+                        return All.SavageBlade;
+                    
                     if (!PvPCommon.TargetImmuneToDamage())
                     {
                         if (canWeave)
@@ -102,6 +106,9 @@ namespace WrathCombo.Combos.PvP
 
                         if (IsEnabled(CustomComboPreset.SMNPvP_BurstMode_DeathFlare) && bahamutBurst && IsOffCooldown(DeathFlare))
                             return DeathFlare;
+
+                        if (HasStatusEffect(Buffs.FurtherRuin))
+                            return actionID;
 
                         if (IsEnabled(CustomComboPreset.SMNPvP_BurstMode_Necrotize) && GetRemainingCharges(Necrotize) > 0 && !HasStatusEffect(Buffs.FurtherRuin))
                             return Necrotize;


### PR DESCRIPTION
Shifted a couple things around to allow for a more frontloaded burst. And less chance to waste an r4 proc. 

Start with 2 Ogcds which sucks but then it will knock out 30k in 2 gcds followed by another 32k in 3 gcds. 

Added a line to throw up savage blade if target is immune during an r4 proc. It replaces ruin 3, so it is the only way to prevent a wasted proc. 