### PR TITLE
[Core] Add null checking to the last `SimpleTarget`s

### DIFF
--- a/WrathCombo/CustomCombo/SimpleTarget.cs
+++ b/WrathCombo/CustomCombo/SimpleTarget.cs
@@ -404,7 +404,7 @@ internal static class SimpleTarget
         CustomComboFunctions
             .GetPartyMembers()
             .Select(x => x.BattleChara)
-            .Where(x => x.IsDead() == false)
+            .Where(x => x is not null && x.IsDead() == false)
             .OrderBy(x => x.CurrentHp)
             .FirstOrDefault();
 
@@ -415,7 +415,7 @@ internal static class SimpleTarget
         CustomComboFunctions
             .GetPartyMembers()
             .Select(x => x.BattleChara)
-            .Where(x => x.IsDead() == false)
+            .Where(x => x is not null && x.IsDead() == false)
             .OrderBy(x => x.CurrentHp / x.MaxHp * 100)
             .FirstOrDefault();
 


### PR DESCRIPTION
- [X] Adds null checking to the last `SimpleTarget`s that use anything beyond my `IGameObject` Extensions, or Real Job checking