### PR TITLE
[SCH] WellReadMage Overhaul

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6135,29 +6135,41 @@ public enum CustomComboPreset
     SCH_ST_Heal_Esuna = 16026,
 
     [ParentCombo(SCH_ST_Heal)]
-    [CustomComboInfo("Adloquium Option", "Use Adloquium when missing Galvanize or target HP%% below:", SCH.JobID)]
+    [CustomComboInfo("Adloquium Option", "Use Adloquium", SCH.JobID)]
     [PossiblyRetargeted]
     SCH_ST_Heal_Adloquium = 16027,
 
     [ParentCombo(SCH_ST_Heal)]
-    [CustomComboInfo("Lustrate Option", "Use Lustrate when target HP%% below:", SCH.JobID)]
+    [CustomComboInfo("Lustrate Option", "Use Lustrate", SCH.JobID)]
     [PossiblyRetargeted]
     SCH_ST_Heal_Lustrate = 16028,
 
     [ParentCombo(SCH_ST_Heal)]
-    [CustomComboInfo("Excogitation Option", "Use Excogitation when target HP%% below:", SCH.JobID)]
+    [CustomComboInfo("Excogitation Option", "Use Excogitation", SCH.JobID)]
     [PossiblyRetargeted]
     SCH_ST_Heal_Excogitation = 16038,
 
     [ParentCombo(SCH_ST_Heal)]
-    [CustomComboInfo("Protraction Option", "Use Protraction when target HP%% below:", SCH.JobID)]
+    [CustomComboInfo("Protraction Option", "Use Protraction", SCH.JobID)]
     [PossiblyRetargeted]
     SCH_ST_Heal_Protraction = 16039,
 
     [ParentCombo(SCH_ST_Heal)]
-    [CustomComboInfo("Aetherpact Option", "Use Aetherpact when target HP%% below:", SCH.JobID)]
+    [CustomComboInfo("Aetherpact Option", "Use Aetherpact", SCH.JobID)]
     [PossiblyRetargeted]
     SCH_ST_Heal_Aetherpact = 16047,
+    
+    [ParentCombo(SCH_ST_Heal)]
+    [CustomComboInfo("Whispering Dawn Option", "Use Whispering Dawn", SCH.JobID)]
+    SCH_ST_Heal_WhisperingDawn = 16067,
+    
+    [ParentCombo(SCH_ST_Heal)]
+    [CustomComboInfo("Fey Illumination Option", "Use Fey Illumination", SCH.JobID)]
+    SCH_ST_Heal_FeyIllumination = 16068,
+    
+    [ParentCombo(SCH_ST_Heal)]
+    [CustomComboInfo("Fey Blessing Option", "Use Fey Blessing", SCH.JobID)]
+    SCH_ST_Heal_FeyBlessing = 16069,
 
     [AutoAction(true, true)]
     [ReplaceSkill(SCH.Succor)]
@@ -6338,7 +6350,7 @@ public enum CustomComboPreset
     SCH_Hidden_Expedient = 16064,
     #endregion
 
-    // Last value = 16066
+    // Last value = 16069
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6291,7 +6291,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last value = 16052
+    // Last value = 16057
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6007,29 +6007,20 @@ public enum CustomComboPreset
 
     #region SCHOLAR
 
-    #region DPS
+    #region ST DPS
 
     [AutoAction(false, false)]
     [ReplaceSkill(SCH.Ruin, SCH.Broil, SCH.Broil2, SCH.Broil3, SCH.Broil4, SCH.Bio, SCH.Bio2, SCH.Biolysis)]
-    [CustomComboInfo("Single Target DPS Feature", "Replaces Ruin I / Broils with options below", SCH.JobID)]
+    [CustomComboInfo("Single Target DPS Feature", "Replaces Ruin I / Broils with options below.", SCH.JobID)]
     SCH_DPS = 16001,
 
     [ParentCombo(SCH_DPS)]
     [CustomComboInfo("Balance Opener (Level 100)", "Adds the Balance opener at level 100.", SCH.JobID)]
     SCH_DPS_Balance_Opener = 16009,
-
+    
     [ParentCombo(SCH_DPS)]
-    [CustomComboInfo("Fairy Reminder", "Adds Summon Eos whenever you've not summoned your fairy.", SCH.JobID)]
-    SCH_DPS_FairyReminder = 16048,
-
-    [ParentCombo(SCH_DPS)]
-    [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value:", SCH.JobID)]
-    SCH_DPS_Lucid = 16002,
-
-    [ParentCombo(SCH_DPS)]
-    [CustomComboInfo("Chain Stratagem / Baneful Impact Weave Option",
-        "Adds Chain Stratagem & Baneful Impact on cooldown with overlap protection", SCH.JobID)]
-    SCH_DPS_ChainStrat = 16003,
+    [CustomComboInfo("Bio / Biolysis Option", "Automatic DoT uptime.", SCH.JobID)]
+    SCH_DPS_Bio = 16008,
 
     [ParentCombo(SCH_DPS)]
     [CustomComboInfo("Aetherflow Weave Option", "Use Aetherflow when out of Aetherflow stacks.", SCH.JobID)]
@@ -6045,19 +6036,63 @@ public enum CustomComboPreset
     [CustomComboInfo("Energy Drain Burst Option",
         "Holds Energy Drain when Chain Stratagem is ready or has less than 10 seconds cooldown remaining.", SCH.JobID)]
     SCH_DPS_EnergyDrain_BurstSaver = 16006,
+    
+    [ParentCombo(SCH_DPS)]
+    [CustomComboInfo("Chain Stratagem",
+        "Adds Chain Stratagem on cooldown with overlap protection", SCH.JobID)]
+    SCH_DPS_ChainStrat = 16003,
+    
+    [ParentCombo(SCH_DPS)]
+    [CustomComboInfo("Baneful Impact",
+        "Adds Baneful Impact when available.", SCH.JobID)]
+    SCH_DPS_BanefulImpact = 16052,
 
     [ParentCombo(SCH_DPS)]
     [CustomComboInfo("Ruin II Moving Option", "Use Ruin II when you have to move.", SCH.JobID)]
     SCH_DPS_Ruin2Movement = 16007,
+    
+    [ParentCombo(SCH_DPS)]
+    [CustomComboInfo("Fairy Reminder", "Adds Summon Eos whenever you've not summoned your fairy.", SCH.JobID)]
+    SCH_DPS_FairyReminder = 16048,
 
     [ParentCombo(SCH_DPS)]
-    [CustomComboInfo("Bio / Biolysis Option", "Automatic DoT uptime.", SCH.JobID)]
-    SCH_DPS_Bio = 16008,
+    [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value:", SCH.JobID)]
+    SCH_DPS_Lucid = 16002,
+    
+    #endregion
+    
+    #region AoE DPS
 
     [AutoAction(true, false)]
     [ReplaceSkill(SCH.ArtOfWar, SCH.ArtOfWarII)]
     [CustomComboInfo("AoE DPS Feature", "Replaces Art of War with options below.", SCH.JobID)]
     SCH_AoE = 16010,
+    
+    [ParentCombo(SCH_AoE)]
+    [CustomComboInfo("Energy Drain Weave Option",
+        "Use Energy Drain to consume remaining Aetherflow stacks when Aetherflow is about to come off cooldown.",
+        SCH.JobID)]
+    SCH_AoE_EnergyDrain = 16056,
+
+    [ParentCombo(SCH_AoE_EnergyDrain)]
+    [CustomComboInfo("Energy Drain Burst Option",
+        "Holds Energy Drain when Chain Stratagem is ready or has less than 10 seconds cooldown remaining.", SCH.JobID)]
+    SCH_AoE_EnergyDrain_BurstSaver = 16055,
+    
+    [ParentCombo(SCH_AoE)]
+    [CustomComboInfo("Chain Stratagem",
+        "Adds Chain Stratagem on cooldown with overlap protection", SCH.JobID)]
+    SCH_AoE_ChainStrat = 16054,
+    
+    [ParentCombo(SCH_AoE_ChainStrat)]
+    [CustomComboInfo("Chain Stratagem",
+        "Will only use Chain Strategem when high enough level for Baneful Impaction and it is enabled.", SCH.JobID)]
+    SCH_AoE_ChainStrat_BanefulOnly = 16057,
+    
+    [ParentCombo(SCH_AoE)]
+    [CustomComboInfo("Baneful Impact",
+        "Adds Baneful Impact when available.", SCH.JobID)]
+    SCH_AoE_BanefulImpact = 16053,
 
     [ParentCombo(SCH_AoE)]
     [CustomComboInfo("Fairy Reminder", "Adds Summon Eos whenever you've not summoned your fairy.", SCH.JobID)]
@@ -6256,7 +6291,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last value = 16050
+    // Last value = 16052
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6191,33 +6191,6 @@ public enum CustomComboPreset
     [ParentCombo(SCH_AoE_Heal)]
     [CustomComboInfo("Consolation Option", "Use Consolation", SCH.JobID)]
     SCH_AoE_Heal_Consolation = 16046,
-    
-    [ParentCombo(SCH_AoE_Heal)]
-    [CustomComboInfo("RaidWide Succor Option", "Will try to cast Succor when a raidwide casting is detected", SCH.JobID)]
-    SCH_AoE_Heal_Succor_Raidwide = 16062,
-    
-    [ParentCombo(SCH_AoE_Heal_Succor_Raidwide)]
-    [CustomComboInfo("Recitation Option", "Use Recitation to buff before the Raidwide Succor.", SCH.JobID)]
-    SCH_AoE_Heal_Succor_Raidwide_Recitation = 16051,
-    
-    [ParentCombo(SCH_AoE_Heal)]
-    [CustomComboInfo("Sacred Soil Option", "Adds Sacred Soil placement, when standing still, to the rotation.\nWill Retarget it onto yourself.", SCH.JobID)]
-    [Retargeted]
-    SCH_AoE_Heal_SacredSoil = 16059,
-    
-    [ParentCombo(SCH_AoE_Heal_SacredSoil)]
-    [CustomComboInfo("Enemy Placement Option", "Will add an enemy hard target as the top priority Retarget for Asylum.", SCH.JobID)]
-    [Retargeted]
-    SCH_AoE_Heal_SacredSoil_Enemy = 16060,
-
-    [ParentCombo(SCH_AoE_Heal_SacredSoil)]
-    [CustomComboInfo("Ally Placement Option", "Will add any ally UI MouseOver target, focus target, soft target, or hard target as the priority Retarget for Asylum.\nBeneath the Enemy placement option, but above yourself.", SCH.JobID)]
-    [Retargeted]
-    SCH_AoE_Heal_SacredSoil_Allies = 16061,
-    
-    [ParentCombo(SCH_AoE_Heal)]
-    [CustomComboInfo("Expedient Raidwide Option", "Will try to use Expedient when a raidwide casting is detected", SCH.JobID)]
-    SCH_AoE_Heal_Expedient = 16064,
 
     [ParentCombo(SCH_AoE_Heal)]
     [CustomComboInfo("Aetherflow Option", "Use Aetherflow when out of Aetherflow stacks.", SCH.JobID)]
@@ -6263,6 +6236,21 @@ public enum CustomComboPreset
     [CustomComboInfo("Lustrate to Excogitation Feature",
         "Change Lustrate into Excogitation when Excogitation is ready.", SCH.JobID)]
     SCH_Lustrate = 16014,
+    
+    [ReplaceSkill(SCH.SacredSoil)]
+    [CustomComboInfo("Sacred Soil Retargetting", "Adds Self retargetting to Sacred Soil", SCH.JobID)]
+    [Retargeted]
+    SCH_SacredSoil = 16066,
+    
+    [ParentCombo(SCH_SacredSoil)]
+    [CustomComboInfo("Ally Placement Option", "Will add any ally UI MouseOver target, focus target, soft target, or hard target as the priority Retarget for Sacred Soil.\nBeneath the Enemy placement option, but above yourself.", SCH.JobID)]
+    [Retargeted]
+    SCH_SacredSoil_Allies = 16061,
+    
+    [ParentCombo(SCH_SacredSoil)]
+    [CustomComboInfo("Enemy Placement Option", "Will add an enemy hard target as the top priority Retarget for Sacred Soil", SCH.JobID)]
+    [Retargeted]
+    SCH_SacredSoil_Enemy = 16060,
     
     [ReplaceSkill(SCH.Recitation)]
     [CustomComboInfo("Recitation Combo Feature",
@@ -6322,8 +6310,35 @@ public enum CustomComboPreset
     SCH_DPS_Variant_Rampart = 16037,
 
     #endregion
+    
+    #region Hidden Features
+    [CustomComboInfo("Hidden Options", "Collection of cheeky or encounter-specific extra options only available to those in the know.\nDo not expect these options to be maintained, or even kept, after they are no longer Current.", SCH.JobID)]
+    [Hidden]
+    SCH_Hidden = 16065,
+    
+    [ParentCombo(SCH_Hidden)]
+    [CustomComboInfo("RaidWide Succor Option", "Will try to cast Succor when a raidwide casting is detected if shieldcheck from succor setting passes. \nWill be used in all 4 main combos.", SCH.JobID)]
+    [Hidden]
+    SCH_Hidden_Succor_Raidwide = 16062,
+    
+    [ParentCombo(SCH_Hidden_Succor_Raidwide)]
+    [CustomComboInfo("Recitation Option", "Use Recitation to buff before the Raidwide Succor.", SCH.JobID)]
+    [Hidden]
+    SCH_Hidden_Succor_Raidwide_Recitation = 16051,
+    
+    [ParentCombo(SCH_Hidden)]
+    [CustomComboInfo("Sacred Soil Option", "Will try to use Sacred Soil on self when a raidwide casting is detected..\nWill be used in all 4 main combos", SCH.JobID)]
+    [Hidden]
+    [Retargeted]
+    SCH_Hidden_SacredSoil = 16059,
+    
+    [ParentCombo(SCH_Hidden)]
+    [CustomComboInfo("Expedient Raidwide Option", "Will try to use Expedient when a raidwide casting is detected. \nWill be used in all 4 main combos.", SCH.JobID)]
+    [Hidden]
+    SCH_Hidden_Expedient = 16064,
+    #endregion
 
-    // Last value = 16064
+    // Last value = 16066
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6163,11 +6163,61 @@ public enum CustomComboPreset
     [ReplaceSkill(SCH.Succor)]
     [CustomComboInfo("Simple Heals - AoE", "Replaces Succor with options below:", SCH.JobID)]
     SCH_AoE_Heal = 16018,
+    
+    [ParentCombo(SCH_AoE_Heal)]
+    [CustomComboInfo("Indomitability Option", "Use Indomitabilty", SCH.JobID)]
+    SCH_AoE_Heal_Indomitability = 16022,
+    
+    [ParentCombo(SCH_AoE_Heal)]
+    [CustomComboInfo("Whispering Dawn Option", "Use Whispering Dawn", SCH.JobID)]
+    SCH_AoE_Heal_WhisperingDawn = 16043,
+    
+    [ParentCombo(SCH_AoE_Heal)]
+    [CustomComboInfo("Fey Illumination Option", "Use Fey Illumination", SCH.JobID)]
+    SCH_AoE_Heal_FeyIllumination = 16042,
+    
+    [ParentCombo(SCH_AoE_Heal)]
+    [CustomComboInfo("Fey Blessing Option", "Use Fey Blessing", SCH.JobID)]
+    SCH_AoE_Heal_FeyBlessing = 16045,
 
     [ParentCombo(SCH_AoE_Heal)]
-    [CustomComboInfo("Lucid Dreaming Option", "Adds Lucid Dreaming when MP isn't high enough to cast Succor.",
-        SCH.JobID)]
-    SCH_AoE_Heal_Lucid = 16019,
+    [CustomComboInfo("Seraphism Option", "Use Seraphism", SCH.JobID)]
+    SCH_AoE_Heal_Seraphism = 16044,
+
+    [ParentCombo(SCH_AoE_Heal)]
+    [CustomComboInfo("Summon Seraph Option", "Use Summon Seraph", SCH.JobID)]
+    SCH_AoE_Heal_SummonSeraph = 16063,
+    
+    [ParentCombo(SCH_AoE_Heal)]
+    [CustomComboInfo("Consolation Option", "Use Consolation", SCH.JobID)]
+    SCH_AoE_Heal_Consolation = 16046,
+    
+    [ParentCombo(SCH_AoE_Heal)]
+    [CustomComboInfo("RaidWide Succor Option", "Will try to cast Succor when a raidwide casting is detected", SCH.JobID)]
+    SCH_AoE_Heal_Succor_Raidwide = 16062,
+    
+    [ParentCombo(SCH_AoE_Heal_Succor_Raidwide)]
+    [CustomComboInfo("Recitation Option", "Use Recitation to buff before the Raidwide Succor.", SCH.JobID)]
+    SCH_AoE_Heal_Succor_Raidwide_Recitation = 16051,
+    
+    [ParentCombo(SCH_AoE_Heal)]
+    [CustomComboInfo("Sacred Soil Option", "Adds Sacred Soil placement, when standing still, to the rotation.\nWill Retarget it onto yourself.", SCH.JobID)]
+    [Retargeted]
+    SCH_AoE_Heal_SacredSoil = 16059,
+    
+    [ParentCombo(SCH_AoE_Heal_SacredSoil)]
+    [CustomComboInfo("Enemy Placement Option", "Will add an enemy hard target as the top priority Retarget for Asylum.", SCH.JobID)]
+    [Retargeted]
+    SCH_AoE_Heal_SacredSoil_Enemy = 16060,
+
+    [ParentCombo(SCH_AoE_Heal_SacredSoil)]
+    [CustomComboInfo("Ally Placement Option", "Will add any ally UI MouseOver target, focus target, soft target, or hard target as the priority Retarget for Asylum.\nBeneath the Enemy placement option, but above yourself.", SCH.JobID)]
+    [Retargeted]
+    SCH_AoE_Heal_SacredSoil_Allies = 16061,
+    
+    [ParentCombo(SCH_AoE_Heal)]
+    [CustomComboInfo("Expedient Raidwide Option", "Will try to use Expedient when a raidwide casting is detected", SCH.JobID)]
+    SCH_AoE_Heal_Expedient = 16064,
 
     [ParentCombo(SCH_AoE_Heal)]
     [CustomComboInfo("Aetherflow Option", "Use Aetherflow when out of Aetherflow stacks.", SCH.JobID)]
@@ -6188,35 +6238,10 @@ public enum CustomComboPreset
     SCH_AoE_Heal_Dissipation_Indomitability = 16058,
     
     [ParentCombo(SCH_AoE_Heal)]
-    [CustomComboInfo("Recitation Option", "Use Recitation to buff the selected heals", SCH.JobID)]
-    SCH_AoE_Heal_Recitation = 16051,
-
-    [ParentCombo(SCH_AoE_Heal)]
-    [CustomComboInfo("Indomitability Option", "Use Indomitability before using Succor.", SCH.JobID)]
-    SCH_AoE_Heal_Indomitability = 16022,
-
-    [ParentCombo(SCH_AoE_Heal)]
-    [CustomComboInfo("Fey Illumination Option", "Use Fey Illumination before using Succor.", SCH.JobID)]
-    SCH_AoE_Heal_FeyIllumination = 16042,
-
-    [ParentCombo(SCH_AoE_Heal)]
-    [CustomComboInfo("Whispering Dawn Option", "Use Whispering Dawn before using Succor.", SCH.JobID)]
-    SCH_AoE_Heal_WhisperingDawn = 16043,
-
-    [ParentCombo(SCH_AoE_Heal)]
-    [CustomComboInfo("Seraphism Option", "Use Seraphism before using Succor.", SCH.JobID)]
-    SCH_AoE_Heal_Seraphism = 16044,
-
-    [ParentCombo(SCH_AoE_Heal)]
-    [CustomComboInfo("Fey Blessing Option", "Use Fey Blessing before using Succor.", SCH.JobID)]
-    SCH_AoE_Heal_FeyBlessing = 16045,
-
-    [ParentCombo(SCH_AoE_Heal)]
-    [CustomComboInfo("Consolation", "Use Consolation before using Succor.", SCH.JobID)]
-    SCH_AoE_Heal_Consolation = 16046,
-
+    [CustomComboInfo("Lucid Dreaming Option", "Adds Lucid Dreaming when MP isn't high enough to cast Succor.",
+        SCH.JobID)]
+    SCH_AoE_Heal_Lucid = 16019,
     
-
     #endregion
 
     #region Utilities
@@ -6298,7 +6323,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last value = 16058
+    // Last value = 16064
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6110,29 +6110,54 @@ public enum CustomComboPreset
 
     #region Healing
 
-    [ReplaceSkill(SCH.FeyBlessing)]
-    [CustomComboInfo("Fey Blessing to Seraph's Consolation Feature",
-        "Change Fey Blessing into Consolation when Seraph is out.", SCH.JobID)]
-    SCH_Consolation = 16013,
+    [AutoAction(false, true)]
+    [ReplaceSkill(SCH.Physick)]
+    [CustomComboInfo("Simple Heals - Single Target",
+        "Change Physick into Adloquium, Lustrate, then Physick with below options:", SCH.JobID)]
+    [PossiblyRetargeted]
+    SCH_ST_Heal = 16023,
 
-    [ReplaceSkill(SCH.Lustrate)]
-    [CustomComboInfo("Lustrate to Excogitation Feature",
-        "Change Lustrate into Excogitation when Excogitation is ready.", SCH.JobID)]
-    SCH_Lustrate = 16014,
+    [ParentCombo(SCH_ST_Heal)]
+    [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value:", SCH.JobID)]
+    SCH_ST_Heal_Lucid = 16024,
 
-    [ReplaceSkill(SCH.Recitation)]
-    [CustomComboInfo("Recitation Combo Feature",
-        "Change Recitation into either Adloquium, Succor, Indomitability, or Excogitation when used.", SCH.JobID)]
-    SCH_Recitation = 16015,
+    [ParentCombo(SCH_ST_Heal)]
+    [CustomComboInfo("Aetherflow Weave Option", "Use Aetherflow when out of Aetherflow stacks.", SCH.JobID)]
+    SCH_ST_Heal_Aetherflow = 16025,
 
-    [ReplaceSkill(SCH.WhisperingDawn)]
-    [CustomComboInfo("Fairy Healing Combo Feature",
-        "Change Whispering Dawn into Fey Illumination, Fey Blessing, then Whispering Dawn when used.", SCH.JobID)]
-    SCH_Fairy_Combo = 16016,
+    [ParentCombo(SCH_ST_Heal)]
+    [CustomComboInfo("Disspation Option", "Use Dissipation when out of Aetherflow stacks.", SCH.JobID)]
+    SCH_ST_Heal_Dissipation = 16040,
 
-    [ParentCombo(SCH_Fairy_Combo)]
-    [CustomComboInfo("Consolation During Seraph Option", "Adds Consolation during Seraph.", SCH.JobID)]
-    SCH_Fairy_Combo_Consolation = 16017,
+    [ParentCombo(SCH_ST_Heal)]
+    [CustomComboInfo("Esuna Option", "Applies Esuna to your target if there is a cleansable debuff.", SCH.JobID)]
+    [PossiblyRetargeted]
+    SCH_ST_Heal_Esuna = 16026,
+
+    [ParentCombo(SCH_ST_Heal)]
+    [CustomComboInfo("Adloquium Option", "Use Adloquium when missing Galvanize or target HP%% below:", SCH.JobID)]
+    [PossiblyRetargeted]
+    SCH_ST_Heal_Adloquium = 16027,
+
+    [ParentCombo(SCH_ST_Heal)]
+    [CustomComboInfo("Lustrate Option", "Use Lustrate when target HP%% below:", SCH.JobID)]
+    [PossiblyRetargeted]
+    SCH_ST_Heal_Lustrate = 16028,
+
+    [ParentCombo(SCH_ST_Heal)]
+    [CustomComboInfo("Excogitation Option", "Use Excogitation when target HP%% below:", SCH.JobID)]
+    [PossiblyRetargeted]
+    SCH_ST_Heal_Excogitation = 16038,
+
+    [ParentCombo(SCH_ST_Heal)]
+    [CustomComboInfo("Protraction Option", "Use Protraction when target HP%% below:", SCH.JobID)]
+    [PossiblyRetargeted]
+    SCH_ST_Heal_Protraction = 16039,
+
+    [ParentCombo(SCH_ST_Heal)]
+    [CustomComboInfo("Aetherpact Option", "Use Aetherpact when target HP%% below:", SCH.JobID)]
+    [PossiblyRetargeted]
+    SCH_ST_Heal_Aetherpact = 16047,
 
     [AutoAction(true, true)]
     [ReplaceSkill(SCH.Succor)]
@@ -6190,71 +6215,64 @@ public enum CustomComboPreset
     [CustomComboInfo("Consolation", "Use Consolation before using Succor.", SCH.JobID)]
     SCH_AoE_Heal_Consolation = 16046,
 
-    [AutoAction(false, true)]
-    [ReplaceSkill(SCH.Physick)]
-    [CustomComboInfo("Simple Heals - Single Target",
-        "Change Physick into Adloquium, Lustrate, then Physick with below options:", SCH.JobID)]
-    [PossiblyRetargeted]
-    SCH_ST_Heal = 16023,
-
-    [ParentCombo(SCH_ST_Heal)]
-    [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value:", SCH.JobID)]
-    SCH_ST_Heal_Lucid = 16024,
-
-    [ParentCombo(SCH_ST_Heal)]
-    [CustomComboInfo("Aetherflow Weave Option", "Use Aetherflow when out of Aetherflow stacks.", SCH.JobID)]
-    SCH_ST_Heal_Aetherflow = 16025,
-
-    [ParentCombo(SCH_ST_Heal)]
-    [CustomComboInfo("Disspation Option", "Use Dissipation when out of Aetherflow stacks.", SCH.JobID)]
-    SCH_ST_Heal_Dissipation = 16040,
-
-    [ParentCombo(SCH_ST_Heal)]
-    [CustomComboInfo("Esuna Option", "Applies Esuna to your target if there is a cleansable debuff.", SCH.JobID)]
-    [PossiblyRetargeted]
-    SCH_ST_Heal_Esuna = 16026,
-
-    [ParentCombo(SCH_ST_Heal)]
-    [CustomComboInfo("Adloquium Option", "Use Adloquium when missing Galvanize or target HP%% below:", SCH.JobID)]
-    [PossiblyRetargeted]
-    SCH_ST_Heal_Adloquium = 16027,
-
-    [ParentCombo(SCH_ST_Heal)]
-    [CustomComboInfo("Lustrate Option", "Use Lustrate when target HP%% below:", SCH.JobID)]
-    [PossiblyRetargeted]
-    SCH_ST_Heal_Lustrate = 16028,
-
-    [ParentCombo(SCH_ST_Heal)]
-    [CustomComboInfo("Excogitation Option", "Use Excogitation when target HP%% below:", SCH.JobID)]
-    [PossiblyRetargeted]
-    SCH_ST_Heal_Excogitation = 16038,
-
-    [ParentCombo(SCH_ST_Heal)]
-    [CustomComboInfo("Protraction Option", "Use Protraction when target HP%% below:", SCH.JobID)]
-    [PossiblyRetargeted]
-    SCH_ST_Heal_Protraction = 16039,
-
-    [ParentCombo(SCH_ST_Heal)]
-    [CustomComboInfo("Aetherpact Option", "Use Aetherpact when target HP%% below:", SCH.JobID)]
-    [PossiblyRetargeted]
-    SCH_ST_Heal_Aetherpact = 16047,
+    
 
     #endregion
 
     #region Utilities
-
+    
     [ReplaceSkill(SCH.EnergyDrain, SCH.Lustrate, SCH.SacredSoil, SCH.Indomitability, SCH.Excogitation)]
     [CustomComboInfo("Aetherflow Helper Feature",
         "Change Aetherflow-using skills to Aetherflow, Recitation, or Dissipation as selected.", SCH.JobID)]
     SCH_Aetherflow = 16029,
-
-    [ParentCombo(SCH_Aetherflow)]
-    [CustomComboInfo("Recitation Option", "Prioritizes Recitation usage on Excogitation or Indomitability.", SCH.JobID)]
-    SCH_Aetherflow_Recite = 16030,
-
+    
     [ParentCombo(SCH_Aetherflow)]
     [CustomComboInfo("Dissipation Option", "If Aetherflow is on cooldown, show Dissipation instead.", SCH.JobID)]
     SCH_Aetherflow_Dissipation = 16031,
+    
+    [ParentCombo(SCH_Aetherflow)]
+    [CustomComboInfo("Recitation Option", "Prioritizes Recitation usage on Excogitation or Indomitability.", SCH.JobID)]
+    SCH_Aetherflow_Recite = 16030,
+    
+    [ReplaceSkill(SCH.Lustrate)]
+    [CustomComboInfo("Lustrate to Excogitation Feature",
+        "Change Lustrate into Excogitation when Excogitation is ready.", SCH.JobID)]
+    SCH_Lustrate = 16014,
+    
+    [ReplaceSkill(SCH.Recitation)]
+    [CustomComboInfo("Recitation Combo Feature",
+        "Change Recitation into either Adloquium, Succor, Indomitability, or Excogitation when used.", SCH.JobID)]
+    SCH_Recitation = 16015,
+    
+    [ReplaceSkill(SCH.DeploymentTactics)]
+    [CustomComboInfo("Deployment Tactics Feature",
+        "Changes Deployment Tactics to Adloquium until a party member has the Galvanize buff.", SCH.JobID)]
+    SCH_DeploymentTactics = 16034,
+
+    [ParentCombo(SCH_DeploymentTactics)]
+    [CustomComboInfo("Recitation Option",
+        "Adds Recitation when off cooldown to force a critical Galvanize buff on a party member.", SCH.JobID)]
+    SCH_DeploymentTactics_Recitation = 16035,
+    
+    [ReplaceSkill(SCH.WhisperingDawn, SCH.FeyIllumination, SCH.FeyBlessing, SCH.Aetherpact, SCH.Dissipation,
+        SCH.SummonSeraph)]
+    [CustomComboInfo("Fairy Feature", "Change all fairy actions into Summon Eos when the Fairy is not summoned.",
+        SCH.JobID)]
+    SCH_FairyReminder = 16033,
+    
+    [ReplaceSkill(SCH.FeyBlessing)]
+    [CustomComboInfo("Fey Blessing to Seraph's Consolation Feature",
+        "Change Fey Blessing into Consolation when Seraph is out.", SCH.JobID)]
+    SCH_Consolation = 16013,
+
+    [ReplaceSkill(SCH.WhisperingDawn)]
+    [CustomComboInfo("Fairy Healing Combo Feature",
+        "Change Whispering Dawn into Fey Illumination, Fey Blessing, then Whispering Dawn when used.", SCH.JobID)]
+    SCH_Fairy_Combo = 16016,
+
+    [ParentCombo(SCH_Fairy_Combo)]
+    [CustomComboInfo("Consolation During Seraph Option", "Adds Consolation during Seraph.", SCH.JobID)]
+    SCH_Fairy_Combo_Consolation = 16017,
 
     [ReplaceSkill(RoleActions.Magic.Swiftcast)]
     [ConflictingCombos(ALL_Healer_Raise)]
@@ -6266,23 +6284,7 @@ public enum CustomComboPreset
     [CustomComboInfo("Retarget Raise", "Will Retarget the Raise affected here to your Heal Stack.", SCH.JobID)]
     [Retargeted]
     SCH_Raise_Retarget = 16050,
-
-    [ReplaceSkill(SCH.WhisperingDawn, SCH.FeyIllumination, SCH.FeyBlessing, SCH.Aetherpact, SCH.Dissipation,
-        SCH.SummonSeraph)]
-    [CustomComboInfo("Fairy Feature", "Change all fairy actions into Summon Eos when the Fairy is not summoned.",
-        SCH.JobID)]
-    SCH_FairyReminder = 16033,
-
-    [ReplaceSkill(SCH.DeploymentTactics)]
-    [CustomComboInfo("Deployment Tactics Feature",
-        "Changes Deployment Tactics to Adloquium until a party member has the Galvanize buff.", SCH.JobID)]
-    SCH_DeploymentTactics = 16034,
-
-    [ParentCombo(SCH_DeploymentTactics)]
-    [CustomComboInfo("Recitation Option",
-        "Adds Recitation when off cooldown to force a critical Galvanize buff on a party member.", SCH.JobID)]
-    SCH_DeploymentTactics_Recitation = 16035,
-
+    
     [Variant]
     [VariantParent(SCH_DPS_Bio, SCH_AoE)]
     [CustomComboInfo("Spirit Dart Option",

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6149,13 +6149,18 @@ public enum CustomComboPreset
     SCH_AoE_Heal_Aetherflow = 16020,
 
     [ParentCombo(SCH_AoE_Heal_Aetherflow)]
-    [CustomComboInfo("Indomitability Ready Only Option", "Only uses Aetherflow is Indomitability is ready to use.",
+    [CustomComboInfo("Indomitability Ready Only Option", "Only uses Aetherflow if Indomitability is ready to use.",
         SCH.JobID)]
     SCH_AoE_Heal_Aetherflow_Indomitability = 16021,
 
     [ParentCombo(SCH_AoE_Heal)]
     [CustomComboInfo("Disspation Option", "Use Dissipation when out of Aetherflow stacks.", SCH.JobID)]
     SCH_AoE_Heal_Dissipation = 16041,
+    
+    [ParentCombo(SCH_AoE_Heal_Dissipation)]
+    [CustomComboInfo("Indomitability Ready Only Option", "Only uses Dissipation if Indomitability is ready to use.",
+        SCH.JobID)]
+    SCH_AoE_Heal_Dissipation_Indomitability = 16058,
     
     [ParentCombo(SCH_AoE_Heal)]
     [CustomComboInfo("Recitation Option", "Use Recitation to buff the selected heals", SCH.JobID)]
@@ -6291,7 +6296,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last value = 16057
+    // Last value = 16058
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using WrathCombo.Combos.PvE.Content;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Data;
@@ -8,189 +7,15 @@ namespace WrathCombo.Combos.PvE;
 
 internal partial class SCH : Healer
 {
-    /*
-     * SCH_Consolation
-     * Even though Summon Seraph becomes Consolation,
-     * This Feature also places Seraph's AoE heal+barrier ontop of the existing fairy AoE skill, Fey Blessing
-     */
-    internal class SCH_Consolation : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Consolation;
-        protected override uint Invoke(uint actionID)
-            => actionID is FeyBlessing && LevelChecked(SummonSeraph) && Gauge.SeraphTimer > 0 ? Consolation : actionID;
-    }
-
-    /*
-     * SCH_Lustrate
-     * Replaces Lustrate with Excogitation when Excogitation is ready.
-     */
-    internal class SCH_Lustrate : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Lustrate;
-        protected override uint Invoke(uint actionID) =>
-            actionID is Lustrate &&
-            LevelChecked(Excogitation) && IsOffCooldown(Excogitation)
-                ? Excogitation
-                : actionID;
-    }
-
-    /*
-     * SCH_Recitation
-     * Replaces Recitation with selected one of its combo skills.
-     */
-    internal class SCH_Recitation : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Recitation;
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not Recitation || !HasStatusEffect(Buffs.Recitation))
-                return actionID;
-
-            switch ((int)Config.SCH_Recitation_Mode)
-            {
-                case 0: return OriginalHook(Adloquium);
-                case 1: return OriginalHook(Succor);
-                case 2: return OriginalHook(Indomitability);
-                case 3: return OriginalHook(Excogitation);
-            }
-
-            return actionID;
-        }
-    }
-
-    /*
-     * SCH_Aetherflow
-     * Replaces all Energy Drain actions with Aetherflow when depleted, or just Energy Drain
-     * Dissipation option to show if Aetherflow is on Cooldown
-     * Recitation also an option
-     */
-    internal class SCH_Aetherflow : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Aetherflow;
-        protected override uint Invoke(uint actionID)
-        {
-            if (!AetherflowList.Contains(actionID) || !LevelChecked(Aetherflow))
-                return actionID;
-
-            bool hasAetherFlows = HasAetherflow(); //False if Zero stacks
-
-            if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Recite) &&
-                LevelChecked(Recitation) &&
-                (IsOffCooldown(Recitation) || HasStatusEffect(Buffs.Recitation)))
-            {
-                //Recitation Indominability and Excogitation, with optional check against AF zero stack count
-                bool alwaysShowReciteExcog = Config.SCH_Aetherflow_Recite_ExcogMode == 1;
-
-                if (Config.SCH_Aetherflow_Recite_Excog &&
-                    (alwaysShowReciteExcog ||
-                     !alwaysShowReciteExcog && !hasAetherFlows) && actionID is Excogitation)
-                {
-                    //Do not merge this nested if with above. Won't procede with next set
-                    return HasStatusEffect(Buffs.Recitation) && IsOffCooldown(Excogitation)
-                        ? Excogitation
-                        : Recitation;
-                }
-
-                bool alwaysShowReciteIndom = Config.SCH_Aetherflow_Recite_IndomMode == 1;
-
-                if (Config.SCH_Aetherflow_Recite_Indom &&
-                    (alwaysShowReciteIndom ||
-                     !alwaysShowReciteIndom && !hasAetherFlows) && actionID is Indomitability)
-                {
-                    //Same as above, do not nest with above. It won't procede with the next set
-                    return HasStatusEffect(Buffs.Recitation) && IsOffCooldown(Excogitation)
-                        ? Indomitability
-                        : Recitation;
-                }
-            }
-            if (!hasAetherFlows)
-            {
-                bool showAetherflowOnAll = Config.SCH_Aetherflow_Display == 1;
-
-                if ((actionID is EnergyDrain && !showAetherflowOnAll || showAetherflowOnAll) &&
-                    IsOffCooldown(actionID))
-                {
-                    if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Dissipation) &&
-                        ActionReady(Dissipation) && IsOnCooldown(Aetherflow) && HasPetPresent())
-                        //Dissipation requires fairy, can't seem to make it replace dissipation with fairy summon feature *shrug*
-                        return Dissipation;
-
-                    return Aetherflow;
-                }
-            }
-            return actionID;
-        }
-    }
-
-    /*
-     * SCH_Raise (Swiftcast Raise combo)
-     * Swiftcast changes to Raise when swiftcast is on cooldown
-     */
-    internal class SCH_Raise : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Raise;
-        protected override uint Invoke(uint actionID) =>
-            actionID == Role.Swiftcast && IsOnCooldown(Role.Swiftcast)
-                ? IsEnabled(CustomComboPreset.SCH_Raise_Retarget)
-                    ? Resurrection.Retarget(Role.Swiftcast,
-                        SimpleTarget.Stack.AllyToRaise)
-                    : Resurrection
-                : actionID;
-    }
-
-    // Replaces Fairy abilities with Fairy summoning with Eos
-    internal class SCH_FairyReminder : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_FairyReminder;
-        protected override uint Invoke(uint actionID)
-            => FairyList.Contains(actionID) && NeedToSummon ? SummonEos : actionID;
-    }
-
-    /*
-     * SCH_DeploymentTactics
-     * Combos Deployment Tactics with Adloquium by showing Adloquim when Deployment Tactics is ready,
-     * Recitation is optional, if one wishes to Crit the shield first
-     * Supports soft targetting and self as a fallback.
-     */
-    internal class SCH_DeploymentTactics : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_DeploymentTactics;
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not DeploymentTactics || !ActionReady(DeploymentTactics))
-                return actionID;
-
-            //Grab our target
-            var healTarget = OptionalTarget ?? SimpleTarget.Stack.AllyToHeal;
-
-            //Check for the Galvanize shield buff. Start applying if it doesn't exist
-            if (!HasStatusEffect(Buffs.Galvanize, healTarget)) 
-            {
-                if (IsEnabled(CustomComboPreset.SCH_DeploymentTactics_Recitation) && ActionReady(Recitation))
-                    return Recitation;
-
-                return OriginalHook(Adloquium);
-            }
-            return actionID;
-        }
-    }
-
-    /*
-     * SCH_DPS
-     * Overrides main DPS ability family, The Broils (and Ruin 1)
-     * Implements Ruin 2 as the movement option
-     * Chain Stratagem has overlap protection
-     */
+    #region ST DPS
     internal class SCH_DPS : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_DPS;
-
         internal static int BroilCount => ActionWatching.CombatActions.Count(x => x == OriginalHook(Broil));
-
         protected override uint Invoke(uint actionID)
         {
+            #region Determine Replaced Action
             bool actionFound;
-
             if (Config.SCH_ST_DPS_Adv && Config.SCH_ST_DPS_Adv_Actions.Count > 0)
             {
                 bool onBroils = Config.SCH_ST_DPS_Adv_Actions[0] && BroilList.Contains(actionID);
@@ -200,102 +25,70 @@ internal partial class SCH : Healer
             }
             else
                 actionFound = BroilList.Contains(actionID); //default handling
-
-            // Return if action not found
+            #endregion
+            
             if (!actionFound)
                 return actionID;
 
-            if (IsEnabled(CustomComboPreset.SCH_DPS_FairyReminder) &&
-                NeedToSummon)
+            if (IsEnabled(CustomComboPreset.SCH_DPS_FairyReminder) && NeedToSummon)
                 return SummonEos;
 
+            #region Variant
             if (Variant.CanRampart(CustomComboPreset.SCH_DPS_Variant_Rampart))
                 return Variant.Rampart;
+            
+            if (Variant.CanSpiritDart(CustomComboPreset.SCH_DPS_Variant_SpiritDart))
+                return Variant.SpiritDart;
 
             if (OccultCrescent.ShouldUsePhantomActions())
                 return OccultCrescent.BestPhantomAction();
+            #endregion
 
             //Opener
-            if (IsEnabled(CustomComboPreset.SCH_DPS_Balance_Opener) &&
-                Opener().FullOpener(ref actionID))
+            if (IsEnabled(CustomComboPreset.SCH_DPS_Balance_Opener) && Opener().FullOpener(ref actionID))
                 return actionID;
 
-            // Aetherflow
-            if (IsEnabled(CustomComboPreset.SCH_DPS_Aetherflow) &&
-                !WasLastAction(Dissipation) && ActionReady(Aetherflow) &&
-                !HasAetherflow() && InCombat() && CanSpellWeave())
-                return Aetherflow;
-
-            // Lucid Dreaming
-            if (IsEnabled(CustomComboPreset.SCH_DPS_Lucid) &&
-                Role.CanLucidDream(Config.SCH_ST_DPS_LucidOption))
-                return Role.LucidDreaming;
-
-            //Target based options
-            if (HasBattleTarget())
+            if (InCombat() && CanSpellWeave())
             {
-                // Energy Drain
-                if (IsEnabled(CustomComboPreset.SCH_DPS_EnergyDrain))
-                {
-                    float edTime = Config.SCH_ST_DPS_EnergyDrain_Adv ? Config.SCH_ST_DPS_EnergyDrain : 10f;
-
-                    if (LevelChecked(EnergyDrain) && InCombat() && CanSpellWeave() &&
-                        HasAetherflow() && GetCooldownRemainingTime(Aetherflow) <= edTime &&
-                        (!IsEnabled(CustomComboPreset.SCH_DPS_EnergyDrain_BurstSaver) ||
-                         LevelChecked(ChainStratagem) && GetCooldownRemainingTime(ChainStratagem) > 10 ||
-                         !ChainStratagem.LevelChecked()))
-                        return EnergyDrain;
-                }
-
-                // Chain Stratagem
-                if (IsEnabled(CustomComboPreset.SCH_DPS_ChainStrat) &&
-                    (Config.SCH_ST_DPS_ChainStratagemSubOption == 0 ||
-                     Config.SCH_ST_DPS_ChainStratagemSubOption == 1 && InBossEncounter()))
-                {
-                    // If CS is available and usable, or if the Impact Buff is on Player
-                    if (ActionReady(ChainStratagem) && CanApplyStatus(CurrentTarget, Debuffs.ChainStratagem) &&
-                        !HasStatusEffect(Debuffs.ChainStratagem, CurrentTarget, true) &&
-                        GetTargetHPPercent() > Config.SCH_ST_DPS_ChainStratagemOption &&
-                        InCombat() &&
-                        CanSpellWeave())
-                        return ChainStratagem;
-
-                    if (LevelChecked(BanefulImpaction) &&
-                        HasStatusEffect(Buffs.ImpactImminent) &&
-                        InCombat() &&
-                        CanSpellWeave())
-                        return BanefulImpaction;
-                    // Don't use OriginalHook(ChainStratagem), because player can disable ingame action replacement
-                }
-
-                //Bio/Biolysis
-                if (IsEnabled(CustomComboPreset.SCH_DPS_Bio) && LevelChecked(Bio) && InCombat() &&
-                    BioList.TryGetValue(OriginalHook(Bio), out ushort dotDebuffID))
-                {
-                    if (Variant.CanSpiritDart(CustomComboPreset.SCH_DPS_Variant_SpiritDart))
-                        return Variant.SpiritDart;
-
-                    float refreshTimer = Config.SCH_DPS_BioUptime_Threshold;
-                    int hpThreshold = Config.SCH_DPS_BioSubOption == 1 || !InBossEncounter() ? Config.SCH_DPS_BioOption : 0;
-                    if (GetStatusEffectRemainingTime(dotDebuffID, CurrentTarget) <= refreshTimer && CanApplyStatus(CurrentTarget, dotDebuffID) &&
-                        GetTargetHPPercent() > hpThreshold)
-                        return OriginalHook(Bio);
-                }
-
-                //Ruin 2 Movement
-                if (IsEnabled(CustomComboPreset.SCH_DPS_Ruin2Movement) &&
-                    LevelChecked(Ruin2) && IsMoving())
-                    return OriginalHook(Ruin2);
+                // Aetherflow
+                if (IsEnabled(CustomComboPreset.SCH_DPS_Aetherflow) && !WasLastAction(Dissipation) && ActionReady(Aetherflow) && !HasAetherflow)
+                    return Aetherflow;
+                
+                if (IsEnabled(CustomComboPreset.SCH_DPS_BanefulImpact) && HasStatusEffect(Buffs.ImpactImminent) && !JustUsed(ChainStratagem))
+                    return BanefulImpaction;
+                
+                if (IsEnabled(CustomComboPreset.SCH_DPS_ChainStrat) && ActionWatching.NumberOfGcdsUsed > 3 && ActionReady(ChainStratagem) && 
+                    CanApplyStatus(CurrentTarget, Debuffs.ChainStratagem) &&
+                    !HasStatusEffect(Debuffs.ChainStratagem, CurrentTarget, true) &&
+                    GetTargetHPPercent() > Config.SCH_ST_DPS_ChainStratagemOption &&
+                    (Config.SCH_ST_DPS_ChainStratagemSubOption == 0 || Config.SCH_ST_DPS_ChainStratagemSubOption == 1 && InBossEncounter()))
+                    return ChainStratagem;
+                    
+                if (IsEnabled(CustomComboPreset.SCH_DPS_EnergyDrain) && ActionReady(EnergyDrain) && 
+                    GetCooldownRemainingTime(Aetherflow) <= Config.SCH_ST_DPS_EnergyDrain &&
+                    (!IsEnabled(CustomComboPreset.SCH_DPS_EnergyDrain_BurstSaver) ||
+                     GetCooldownRemainingTime(ChainStratagem) > 10 ||
+                     !LevelChecked(ChainStratagem)))
+                    return EnergyDrain;
+                
+                if (IsEnabled(CustomComboPreset.SCH_DPS_Lucid) && Role.CanLucidDream(Config.SCH_ST_DPS_LucidOption))
+                    return Role.LucidDreaming;
             }
+            
+            //Bio/Biolysis
+            if (IsEnabled(CustomComboPreset.SCH_DPS_Bio) && NeedsDoT() && InCombat())
+                return OriginalHook(Bio);
+
+            //Ruin 2 Movement
+            if (IsEnabled(CustomComboPreset.SCH_DPS_Ruin2Movement) && ActionReady(Ruin2) && IsMoving() && InCombat())
+                return OriginalHook(Ruin2);
+            
             return actionID;
         }
     }
-
-    /*
-     * SCH_AoE
-     * Overrides main AoE DPS ability, Art of War
-     * Lucid Dreaming and Aetherflow weave options
-     */
+    #endregion
+    
+    #region AoE DPS
     internal class SCH_AoE : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AoE;
@@ -307,7 +100,8 @@ internal partial class SCH : Healer
             if (IsEnabled(CustomComboPreset.SCH_AoE_FairyReminder) &&
                 NeedToSummon)
                 return SummonEos;
-
+            
+            #region Variant
             if (Variant.CanRampart(CustomComboPreset.SCH_DPS_Variant_Rampart))
                 return Variant.Rampart;
 
@@ -316,112 +110,41 @@ internal partial class SCH : Healer
 
             if (OccultCrescent.ShouldUsePhantomActions())
                 return OccultCrescent.BestPhantomAction();
-
-            // Aetherflow
-            if (IsEnabled(CustomComboPreset.SCH_AoE_Aetherflow) &&
-                ActionReady(Aetherflow) && !HasAetherflow() &&
-                InCombat())
+            #endregion
+            
+            if (!InCombat() || !CanSpellWeave()) return actionID;
+            
+            if (IsEnabled(CustomComboPreset.SCH_AoE_Aetherflow) && !WasLastAction(Dissipation) && ActionReady(Aetherflow) && !HasAetherflow)
                 return Aetherflow;
-
-            // Lucid Dreaming
-            if (IsEnabled(CustomComboPreset.SCH_AoE_Lucid) &&
-                Role.CanLucidDream(Config.SCH_AoE_LucidOption))
+                
+            if (IsEnabled(CustomComboPreset.SCH_AoE_BanefulImpact) && HasStatusEffect(Buffs.ImpactImminent) && !JustUsed(ChainStratagem))
+                return BanefulImpaction;
+                
+            if (IsEnabled(CustomComboPreset.SCH_AoE_ChainStrat) && ActionWatching.NumberOfGcdsUsed > 3 && ActionReady(ChainStratagem) && 
+                (LevelChecked(BanefulImpaction) && IsEnabled(CustomComboPreset.SCH_AoE_BanefulImpact) || !IsEnabled(CustomComboPreset.SCH_AoE_ChainStrat_BanefulOnly)) &&
+                CanApplyStatus(CurrentTarget, Debuffs.ChainStratagem) && 
+                !HasStatusEffect(Debuffs.ChainStratagem, CurrentTarget, true) &&
+                GetTargetHPPercent() > Config.SCH_AoE_DPS_ChainStratagemOption &&
+                (Config.SCH_AoE_DPS_ChainStratagemSubOption == 0 || Config.SCH_AoE_DPS_ChainStratagemSubOption == 1 && InBossEncounter()))
+                return ChainStratagem;
+                    
+            if (IsEnabled(CustomComboPreset.SCH_AoE_EnergyDrain) && ActionReady(EnergyDrain) && 
+                GetCooldownRemainingTime(Aetherflow) <= Config.SCH_AoE_DPS_EnergyDrain &&
+                (!IsEnabled(CustomComboPreset.SCH_AoE_EnergyDrain_BurstSaver) ||
+                 GetCooldownRemainingTime(ChainStratagem) > 10 ||
+                 !LevelChecked(ChainStratagem)))
+                return EnergyDrain;
+                
+            if (IsEnabled(CustomComboPreset.SCH_AoE_Lucid) && Role.CanLucidDream(Config.SCH_AoE_DPS_LucidOption))
                 return Role.LucidDreaming;
 
             return actionID;
         }
     }
 
-    /*
-     * SCH_AoE_Heal
-     * Overrides main AoE Healing abiility, Succor
-     * Lucid Dreaming and Atherflow weave options
-     */
-    internal class SCH_AoE_Heal : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AoE_Heal;
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not Succor)
-                return actionID;
-
-            // Aetherflow
-            if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Aetherflow) &&
-                ActionReady(Aetherflow) && !HasAetherflow() &&
-                !(IsEnabled(CustomComboPreset.SCH_AoE_Heal_Aetherflow_Indomitability) && GetCooldownRemainingTime(Indomitability) <= 0.6f) &&
-                InCombat())
-                return Aetherflow;
-
-            if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Dissipation)
-                && ActionReady(Dissipation)
-                && !HasAetherflow()
-                && InCombat())
-                return Dissipation;
-
-            // Lucid Dreaming
-            if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Lucid)
-                && Role.CanLucidDream(Config.SCH_AoE_Heal_LucidOption))
-                return Role.LucidDreaming;
-
-            float averagePartyHP = GetPartyAvgHPPercent();
-            for(int i = 0; i < Config.SCH_AoE_Heals_Priority.Count; i++)
-            {
-                int index = Config.SCH_AoE_Heals_Priority.IndexOf(i + 1);
-                int config = GetMatchingConfigAoE(index, out uint spell, out bool enabled);
-                bool onIdom = IsEnabled(CustomComboPreset.SCH_AoE_Heal_Recitation) && 
-                              Config.SCH_AoE_Heal_Recitation_Actions[0] && spell is Indomitability;
-                bool onSuccor = IsEnabled(CustomComboPreset.SCH_AoE_Heal_Recitation) && 
-                                Config.SCH_AoE_Heal_Recitation_Actions[1] && spell is Succor or Concitation;
-
-                if (enabled && averagePartyHP <= config && ActionReady(spell))
-                     return ActionReady(Recitation) && (onIdom || onSuccor) ? 
-                        Recitation :
-                        spell;
-
-            }
-
-            return actionID;
-        }
-    }
-
-    /*
-     * SCH_Fairy_Combo
-     * Overrides Whispering Dawn
-     */
-    internal class SCH_Fairy_Combo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Fairy_Combo;
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not WhisperingDawn)
-                return actionID;
-
-            if (HasPetPresent())
-            {
-                // FeyIllumination
-                if (ActionReady(FeyIllumination))
-                    return OriginalHook(FeyIllumination);
-
-                // FeyBlessing
-                if (ActionReady(FeyBlessing) && !(Gauge.SeraphTimer > 0))
-                    return OriginalHook(FeyBlessing);
-
-                if (IsEnabled(CustomComboPreset.SCH_Fairy_Combo_Consolation) && ActionReady(WhisperingDawn))
-                    return OriginalHook(actionID);
-
-                if (IsEnabled(CustomComboPreset.SCH_Fairy_Combo_Consolation) && Gauge.SeraphTimer > 0 && GetRemainingCharges(Consolation) > 0)
-                    return OriginalHook(Consolation);
-            }
-
-            return actionID;
-        }
-    }
-
-    /*
-     * SCH_ST_Heal
-     * Overrides main AoE Healing abiility, Succor
-     * Lucid Dreaming and Atherflow weave options
-     */
+    #endregion
+    
+    #region ST Heal
     internal class SCH_ST_Heal : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_ST_Heal;
@@ -432,13 +155,13 @@ internal partial class SCH : Healer
 
             // Aetherflow
             if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Aetherflow) &&
-                ActionReady(Aetherflow) && !HasAetherflow() &&
+                ActionReady(Aetherflow) && !HasAetherflow &&
                 InCombat() && CanSpellWeave())
                 return Aetherflow;
 
             if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Dissipation)
                 && ActionReady(Dissipation)
-                && !HasAetherflow()
+                && !HasAetherflow
                 && InCombat())
                 return Dissipation;
 
@@ -497,4 +220,293 @@ internal partial class SCH : Healer
                 .RetargetIfEnabled(OptionalTarget, Physick);
         }
     }
+    #endregion
+    
+    #region Aoe Heal 
+    /*
+     * SCH_AoE_Heal
+     * Overrides main AoE Healing abiility, Succor
+     * Lucid Dreaming and Atherflow weave options
+     */
+    internal class SCH_AoE_Heal : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AoE_Heal;
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not Succor)
+                return actionID;
+
+            // Aetherflow
+            if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Aetherflow) &&
+                ActionReady(Aetherflow) && !HasAetherflow &&
+                !(IsEnabled(CustomComboPreset.SCH_AoE_Heal_Aetherflow_Indomitability) && GetCooldownRemainingTime(Indomitability) <= 0.6f) &&
+                InCombat())
+                return Aetherflow;
+
+            if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Dissipation)
+                && ActionReady(Dissipation)
+                && !HasAetherflow
+                && InCombat())
+                return Dissipation;
+
+            // Lucid Dreaming
+            if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Lucid)
+                && Role.CanLucidDream(Config.SCH_AoE_Heal_LucidOption))
+                return Role.LucidDreaming;
+
+            float averagePartyHP = GetPartyAvgHPPercent();
+            for(int i = 0; i < Config.SCH_AoE_Heals_Priority.Count; i++)
+            {
+                int index = Config.SCH_AoE_Heals_Priority.IndexOf(i + 1);
+                int config = GetMatchingConfigAoE(index, out uint spell, out bool enabled);
+                bool onIdom = IsEnabled(CustomComboPreset.SCH_AoE_Heal_Recitation) && 
+                              Config.SCH_AoE_Heal_Recitation_Actions[0] && spell is Indomitability;
+                bool onSuccor = IsEnabled(CustomComboPreset.SCH_AoE_Heal_Recitation) && 
+                                Config.SCH_AoE_Heal_Recitation_Actions[1] && spell is Succor or Concitation;
+
+                if (enabled && averagePartyHP <= config && ActionReady(spell))
+                     return ActionReady(Recitation) && (onIdom || onSuccor) ? 
+                        Recitation :
+                        spell;
+
+            }
+
+            return actionID;
+        }
+    }
+    
+    #endregion
+    
+    #region Standalone Features
+    
+    #region Consolation
+    /*
+     * SCH_Consolation
+     * Even though Summon Seraph becomes Consolation,
+     * This Feature also places Seraph's AoE heal+barrier ontop of the existing fairy AoE skill, Fey Blessing
+     */
+    internal class SCH_Consolation : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Consolation;
+        protected override uint Invoke(uint actionID)
+            => actionID is FeyBlessing && LevelChecked(SummonSeraph) && Gauge.SeraphTimer > 0 ? Consolation : actionID;
+    }
+    
+    #endregion
+    
+    #region Lustrate
+
+    /*
+     * SCH_Lustrate
+     * Replaces Lustrate with Excogitation when Excogitation is ready.
+     */
+    internal class SCH_Lustrate : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Lustrate;
+        protected override uint Invoke(uint actionID) =>
+            actionID is Lustrate &&
+            LevelChecked(Excogitation) && IsOffCooldown(Excogitation)
+                ? Excogitation
+                : actionID;
+    }
+    
+    #endregion
+    
+    #region Recitation
+
+    /*
+     * SCH_Recitation
+     * Replaces Recitation with selected one of its combo skills.
+     */
+    internal class SCH_Recitation : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Recitation;
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not Recitation || !HasStatusEffect(Buffs.Recitation))
+                return actionID;
+
+            switch ((int)Config.SCH_Recitation_Mode)
+            {
+                case 0: return OriginalHook(Adloquium);
+                case 1: return OriginalHook(Succor);
+                case 2: return OriginalHook(Indomitability);
+                case 3: return OriginalHook(Excogitation);
+            }
+
+            return actionID;
+        }
+    }
+    
+    #endregion
+
+    #region Aetherflow
+    /*
+     * SCH_Aetherflow
+     * Replaces all Energy Drain actions with Aetherflow when depleted, or just Energy Drain
+     * Dissipation option to show if Aetherflow is on Cooldown
+     * Recitation also an option
+     */
+    internal class SCH_Aetherflow : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Aetherflow;
+        protected override uint Invoke(uint actionID)
+        {
+            if (!AetherflowList.Contains(actionID) || !LevelChecked(Aetherflow))
+                return actionID;
+
+            bool hasAetherFlows = HasAetherflow; //False if Zero stacks
+
+            if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Recite) &&
+                LevelChecked(Recitation) &&
+                (IsOffCooldown(Recitation) || HasStatusEffect(Buffs.Recitation)))
+            {
+                //Recitation Indominability and Excogitation, with optional check against AF zero stack count
+                bool alwaysShowReciteExcog = Config.SCH_Aetherflow_Recite_ExcogMode == 1;
+
+                if (Config.SCH_Aetherflow_Recite_Excog &&
+                    (alwaysShowReciteExcog ||
+                     !alwaysShowReciteExcog && !hasAetherFlows) && actionID is Excogitation)
+                {
+                    //Do not merge this nested if with above. Won't procede with next set
+                    return HasStatusEffect(Buffs.Recitation) && IsOffCooldown(Excogitation)
+                        ? Excogitation
+                        : Recitation;
+                }
+
+                bool alwaysShowReciteIndom = Config.SCH_Aetherflow_Recite_IndomMode == 1;
+
+                if (Config.SCH_Aetherflow_Recite_Indom &&
+                    (alwaysShowReciteIndom ||
+                     !alwaysShowReciteIndom && !hasAetherFlows) && actionID is Indomitability)
+                {
+                    //Same as above, do not nest with above. It won't procede with the next set
+                    return HasStatusEffect(Buffs.Recitation) && IsOffCooldown(Excogitation)
+                        ? Indomitability
+                        : Recitation;
+                }
+            }
+            if (!hasAetherFlows)
+            {
+                bool showAetherflowOnAll = Config.SCH_Aetherflow_Display == 1;
+
+                if ((actionID is EnergyDrain && !showAetherflowOnAll || showAetherflowOnAll) &&
+                    IsOffCooldown(actionID))
+                {
+                    if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Dissipation) &&
+                        ActionReady(Dissipation) && IsOnCooldown(Aetherflow) && HasPetPresent())
+                        //Dissipation requires fairy, can't seem to make it replace dissipation with fairy summon feature *shrug*
+                        return Dissipation;
+
+                    return Aetherflow;
+                }
+            }
+            return actionID;
+        }
+    }
+
+    #endregion
+    
+    #region Raise
+    /*
+     * SCH_Raise (Swiftcast Raise combo)
+     * Swiftcast changes to Raise when swiftcast is on cooldown
+     */
+    internal class SCH_Raise : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Raise;
+        protected override uint Invoke(uint actionID) =>
+            actionID == Role.Swiftcast && IsOnCooldown(Role.Swiftcast)
+                ? IsEnabled(CustomComboPreset.SCH_Raise_Retarget)
+                    ? Resurrection.Retarget(Role.Swiftcast,
+                        SimpleTarget.Stack.AllyToRaise)
+                    : Resurrection
+                : actionID;
+    }
+    
+    #endregion
+    
+    #region Fairy Reminder
+
+    // Replaces Fairy abilities with Fairy summoning with Eos
+    internal class SCH_FairyReminder : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_FairyReminder;
+        protected override uint Invoke(uint actionID)
+            => FairyList.Contains(actionID) && NeedToSummon ? SummonEos : actionID;
+    }
+    
+    #endregion
+    
+    #region Deployment Tactics
+
+    /*
+     * SCH_DeploymentTactics
+     * Combos Deployment Tactics with Adloquium by showing Adloquim when Deployment Tactics is ready,
+     * Recitation is optional, if one wishes to Crit the shield first
+     * Supports soft targetting and self as a fallback.
+     */
+    internal class SCH_DeploymentTactics : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_DeploymentTactics;
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not DeploymentTactics || !ActionReady(DeploymentTactics))
+                return actionID;
+
+            //Grab our target
+            var healTarget = OptionalTarget ?? SimpleTarget.Stack.AllyToHeal;
+
+            //Check for the Galvanize shield buff. Start applying if it doesn't exist
+            if (!HasStatusEffect(Buffs.Galvanize, healTarget)) 
+            {
+                if (IsEnabled(CustomComboPreset.SCH_DeploymentTactics_Recitation) && ActionReady(Recitation))
+                    return Recitation;
+
+                return OriginalHook(Adloquium);
+            }
+            return actionID;
+        }
+    }
+    
+    #endregion
+    
+    #region Fairy Combo
+
+    /*
+     * SCH_Fairy_Combo
+     * Overrides Whispering Dawn
+     */
+    internal class SCH_Fairy_Combo : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Fairy_Combo;
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not WhisperingDawn)
+                return actionID;
+
+            if (HasPetPresent())
+            {
+                // FeyIllumination
+                if (ActionReady(FeyIllumination))
+                    return OriginalHook(FeyIllumination);
+
+                // FeyBlessing
+                if (ActionReady(FeyBlessing) && !(Gauge.SeraphTimer > 0))
+                    return OriginalHook(FeyBlessing);
+
+                if (IsEnabled(CustomComboPreset.SCH_Fairy_Combo_Consolation) && ActionReady(WhisperingDawn))
+                    return OriginalHook(actionID);
+
+                if (IsEnabled(CustomComboPreset.SCH_Fairy_Combo_Consolation) && Gauge.SeraphTimer > 0 && GetRemainingCharges(Consolation) > 0)
+                    return OriginalHook(Consolation);
+            }
+
+            return actionID;
+        }
+    }
+    
+    #endregion
+    
+    #endregion
 }

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -166,8 +166,7 @@ internal partial class SCH : Healer
                     .RetargetIfEnabled(OptionalTarget, Physick);
 
             #endregion
-
-            #region OGCD Tools
+            
             // Aetherflow
             if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Aetherflow) &&
                 ActionReady(Aetherflow) && !HasAetherflow &&
@@ -197,39 +196,23 @@ internal partial class SCH : Healer
             for(int i = 0; i < Config.SCH_ST_Heals_Priority.Count; i++)
             {
                 int index = Config.SCH_ST_Heals_Priority.IndexOf(i + 1);
-                int config = GetMatchingConfigST(index, out uint spell, out bool enabled);
+                int config = GetMatchingConfigST(index, OptionalTarget, out uint spell, out bool enabled);
 
                 if (enabled)
                 {
+                    if (Config.SCH_ST_Heal_AldoquimOpts[2] && ActionReady(EmergencyTactics) &&
+                        spell is Adloquium && 
+                        GetTargetHPPercent(healTarget, Config.SCH_ST_Heal_IncludeShields) <=
+                        Config.SCH_ST_Heal_AdloquiumOption_Emergency)
+                        return EmergencyTactics;
+                    
                     if (GetTargetHPPercent(healTarget, Config.SCH_ST_Heal_IncludeShields) <= config &&
                         ActionReady(spell))
-                        return spell
-                            .RetargetIfEnabled(OptionalTarget, Physick);
+                        return spell.RetargetIfEnabled(OptionalTarget, Physick);
                 }
             }
-
-            #endregion
-            
-            #region GCD Tools
-            //Check for the Galvanize shield buff. Start applying if it doesn't exist or Target HP is below %
-            if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Adloquium) &&
-                ActionReady(Adloquium) &&
-                GetTargetHPPercent(healTarget, Config.SCH_ST_Heal_IncludeShields) <= Config.SCH_ST_Heal_AdloquiumOption)
-            {
-                if (Config.SCH_ST_Heal_AldoquimOpts[2] && ActionReady(EmergencyTactics))
-                    return EmergencyTactics;
-
-                if ((Config.SCH_ST_Heal_AldoquimOpts[0] || !HasStatusEffect(Buffs.Galvanize, healTarget, true)) && //Ignore existing shield check
-                    (!Config.SCH_ST_Heal_AldoquimOpts[1] ||
-                     !HasStatusEffect(SGE.Buffs.EukrasianDiagnosis, healTarget, true) && !HasStatusEffect(SGE.Buffs.EukrasianPrognosis, healTarget, true)
-                    )) //Eukrasia Shield Check
-                    return OriginalHook(Adloquium)
-                        .RetargetIfEnabled(OptionalTarget, Physick);
-            }
-
             return actionID
                 .RetargetIfEnabled(OptionalTarget, Physick);
-            #endregion
         }
     }
     #endregion

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -235,11 +235,6 @@ internal partial class SCH : Healer
     #endregion
     
     #region Aoe Heal 
-    /*
-     * SCH_AoE_Heal
-     * Overrides main AoE Healing abiility, Succor
-     * Lucid Dreaming and Atherflow weave options
-     */
     internal class SCH_AoE_Heal : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AoE_Heal;
@@ -248,24 +243,20 @@ internal partial class SCH : Healer
             if (actionID is not Succor)
                 return actionID;
 
-            // Aetherflow
-            if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Aetherflow) &&
-                ActionReady(Aetherflow) && !HasAetherflow &&
-                !(IsEnabled(CustomComboPreset.SCH_AoE_Heal_Aetherflow_Indomitability) && GetCooldownRemainingTime(Indomitability) <= 0.6f) &&
-                InCombat())
-                return Aetherflow;
+            if (!HasAetherflow && InCombat())
+            {
+                if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Aetherflow) && ActionReady(Aetherflow) && 
+                    (!IsEnabled(CustomComboPreset.SCH_AoE_Heal_Aetherflow_Indomitability) || GetCooldownRemainingTime(Indomitability) <= 1))
+                    return Aetherflow;
 
-            if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Dissipation)
-                && ActionReady(Dissipation)
-                && !HasAetherflow
-                && InCombat())
-                return Dissipation;
-
-            // Lucid Dreaming
-            if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Lucid)
-                && Role.CanLucidDream(Config.SCH_AoE_Heal_LucidOption))
+                if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Dissipation) && ActionReady(Dissipation) &&
+                    (!IsEnabled(CustomComboPreset.SCH_AoE_Heal_Dissipation_Indomitability) || GetCooldownRemainingTime(Indomitability) <= 1))
+                    return Dissipation;
+            }
+            if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Lucid) && Role.CanLucidDream(Config.SCH_AoE_Heal_LucidOption))
                 return Role.LucidDreaming;
 
+            //Priority List
             float averagePartyHP = GetPartyAvgHPPercent();
             for(int i = 0; i < Config.SCH_AoE_Heals_Priority.Count; i++)
             {
@@ -280,9 +271,7 @@ internal partial class SCH : Healer
                      return ActionReady(Recitation) && (onIdom || onSuccor) ? 
                         Recitation :
                         spell;
-
             }
-
             return actionID;
         }
     }

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -32,7 +32,10 @@ internal partial class SCH : Healer
 
             if (IsEnabled(CustomComboPreset.SCH_DPS_FairyReminder) && NeedToSummon)
                 return SummonEos;
-
+            //Opener
+            if (IsEnabled(CustomComboPreset.SCH_DPS_Balance_Opener) && Opener().FullOpener(ref actionID))
+                return actionID;
+            
             #region Variant
             if (Variant.CanRampart(CustomComboPreset.SCH_DPS_Variant_Rampart))
                 return Variant.Rampart;
@@ -43,10 +46,11 @@ internal partial class SCH : Healer
             if (OccultCrescent.ShouldUsePhantomActions())
                 return OccultCrescent.BestPhantomAction();
             #endregion
-
-            //Opener
-            if (IsEnabled(CustomComboPreset.SCH_DPS_Balance_Opener) && Opener().FullOpener(ref actionID))
-                return actionID;
+            
+            #region Dissolve Union
+            if (EndAetherpact)
+                return DissolveUnion;
+            #endregion
 
             if (InCombat() && CanSpellWeave())
             {
@@ -112,6 +116,11 @@ internal partial class SCH : Healer
                 return OccultCrescent.BestPhantomAction();
             #endregion
             
+            #region Dissolve Union
+            if (EndAetherpact)
+                return DissolveUnion;
+            #endregion
+            
             if (!InCombat() || !CanSpellWeave()) return actionID;
             
             if (IsEnabled(CustomComboPreset.SCH_AoE_Aetherflow) && !WasLastAction(Dissipation) && ActionReady(Aetherflow) && !HasAetherflow)
@@ -167,6 +176,11 @@ internal partial class SCH : Healer
 
             #endregion
             
+            #region Dissolve Union
+            if (EndAetherpact)
+                return DissolveUnion;
+            #endregion
+            
             // Aetherflow
             if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Aetherflow) &&
                 ActionReady(Aetherflow) && !HasAetherflow &&
@@ -184,13 +198,6 @@ internal partial class SCH : Healer
             if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Lucid) &&
                 Role.CanLucidDream(Config.SCH_ST_Heal_LucidOption))
                 return Role.LucidDreaming;
-
-            // Dissolve Union if needed
-            if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Aetherpact)
-                && OriginalHook(Aetherpact) is DissolveUnion //Quick check to see if Fairy Aetherpact is Active
-                && AetherPactTarget is not null //Null checking so GetTargetHPPercent doesn't fall back to CurrentTarget
-                && GetTargetHPPercent(AetherPactTarget) >= Config.SCH_ST_Heal_AetherpactDissolveOption)
-                return DissolveUnion;
 
             //Priority List
             for(int i = 0; i < Config.SCH_ST_Heals_Priority.Count; i++)
@@ -235,6 +242,11 @@ internal partial class SCH : Healer
                     ? SimpleTarget.Stack.OverridesAllies
                     : null) ??
                 SimpleTarget.Self;
+            #endregion
+            
+            #region Dissolve Union
+            if (EndAetherpact)
+                return DissolveUnion;
             #endregion
 
             if (!HasAetherflow && InCombat())

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -298,7 +298,9 @@ internal partial class SCH : Healer
             if (Config.SCH_AoE_Heal_Succor_Options[0] && ActionReady(EmergencyTactics))
                 return OriginalHook(EmergencyTactics);
             
-            return actionID;
+            return !LevelChecked(Succor)?
+                WhisperingDawn:
+                actionID;
         }
     }
     

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -152,13 +152,29 @@ internal partial class SCH : Healer
         {
             if (actionID is not Physick)
                 return actionID;
+            
+            #region Variables
+            var healTarget = OptionalTarget ?? SimpleTarget.Stack.AllyToHeal;
+            #endregion
+            
+            #region Priority Cleansing
+            
+            if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Esuna) && 
+                ActionReady(Role.Esuna) && HasCleansableDebuff(healTarget) &&
+                GetTargetHPPercent(healTarget, Config.SCH_ST_Heal_IncludeShields) >= Config.SCH_ST_Heal_EsunaOption)
+                return Role.Esuna
+                    .RetargetIfEnabled(OptionalTarget, Physick);
 
+            #endregion
+
+            #region OGCD Tools
             // Aetherflow
             if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Aetherflow) &&
                 ActionReady(Aetherflow) && !HasAetherflow &&
                 InCombat() && CanSpellWeave())
                 return Aetherflow;
 
+            // Dissipation
             if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Dissipation)
                 && ActionReady(Dissipation)
                 && !HasAetherflow
@@ -177,15 +193,7 @@ internal partial class SCH : Healer
                 && GetTargetHPPercent(AetherPactTarget) >= Config.SCH_ST_Heal_AetherpactDissolveOption)
                 return DissolveUnion;
 
-            //Grab our target
-            var healTarget = OptionalTarget ?? SimpleTarget.Stack.AllyToHeal;
-
-            if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Esuna) && ActionReady(Role.Esuna) &&
-                GetTargetHPPercent(healTarget, Config.SCH_ST_Heal_IncludeShields) >= Config.SCH_ST_Heal_EsunaOption &&
-                HasCleansableDebuff(healTarget))
-                return Role.Esuna
-                    .RetargetIfEnabled(OptionalTarget, Physick);
-
+            //Priority List
             for(int i = 0; i < Config.SCH_ST_Heals_Priority.Count; i++)
             {
                 int index = Config.SCH_ST_Heals_Priority.IndexOf(i + 1);
@@ -200,6 +208,9 @@ internal partial class SCH : Healer
                 }
             }
 
+            #endregion
+            
+            #region GCD Tools
             //Check for the Galvanize shield buff. Start applying if it doesn't exist or Target HP is below %
             if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Adloquium) &&
                 ActionReady(Adloquium) &&
@@ -218,6 +229,7 @@ internal partial class SCH : Healer
 
             return actionID
                 .RetargetIfEnabled(OptionalTarget, Physick);
+            #endregion
         }
     }
     #endregion

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -212,7 +212,8 @@ internal partial class SCH : Healer
             if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Dissipation)
                 && ActionReady(Dissipation)
                 && !HasAetherflow
-                && InCombat())
+                && InCombat()
+                && !FairyBusy)
                 return Dissipation;
 
             // Lucid Dreaming
@@ -251,7 +252,7 @@ internal partial class SCH : Healer
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AoE_Heal;
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is not Succor)
+            if (actionID is not (Succor or Concitation or Accession))
                 return actionID;
             
             #region Dissolve Union
@@ -272,7 +273,7 @@ internal partial class SCH : Healer
                     (!IsEnabled(CustomComboPreset.SCH_AoE_Heal_Aetherflow_Indomitability) || GetCooldownRemainingTime(Indomitability) <= 1))
                     return Aetherflow;
 
-                if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Dissipation) && ActionReady(Dissipation) &&
+                if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Dissipation) && ActionReady(Dissipation) && !FairyBusy &&
                     (!IsEnabled(CustomComboPreset.SCH_AoE_Heal_Dissipation_Indomitability) || GetCooldownRemainingTime(Indomitability) <= 1))
                     return Dissipation;
             }

--- a/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
@@ -202,12 +202,6 @@ internal partial class SCH
                     DrawPriorityInput(SCH_AoE_Heals_Priority, 8, 5, $"{Indomitability.ActionName()} Priority: ");
                     break;
                 
-                
-                case CustomComboPreset.SCH_AoE_Heal_SacredSoil:
-                    DrawAdditionalBoolChoice(SCH_AoE_Heal_SacredSoil_RaidwideOnly,
-                        "Only use when a Raidwide is casting",
-                        "Will not use Sacred Soil in the rotation unless we detect a Raidwide is casting.");
-                    break;
                 #endregion
                 
                 #region Standalones
@@ -302,11 +296,11 @@ internal partial class SCH
         public static UserIntArray
             SCH_ST_Heals_Priority = new("SCH_ST_Heals_Priority"),
             SCH_AoE_Heals_Priority = new("SCH_AoE_Heals_Priority");
+
         public static UserBool
             SCH_ST_Heal_Adv = new("SCH_ST_Heal_Adv"),
             SCH_ST_Heal_IncludeShields = new("SCH_ST_Heal_IncludeShields"),
-            SCH_AoE_Heal_Indomitability_Recitation = new("SCH_AoE_Heal_Indomitability_Recitation"),
-            SCH_AoE_Heal_SacredSoil_RaidwideOnly = new("SCH_AoE_Heal_SacredSoil_RaidwideOnly");
+            SCH_AoE_Heal_Indomitability_Recitation = new("SCH_AoE_Heal_Indomitability_Recitation");
 
         public static UserBoolArray
             SCH_ST_Heal_AldoquimOpts = new("SCH_ST_Heal_AldoquimOpts"),

--- a/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
@@ -15,6 +15,7 @@ internal partial class SCH
         {
             switch (preset)
             {
+                #region DPS
                 case CustomComboPreset.SCH_DPS_Balance_Opener:
                     DrawHorizontalRadioButton(SCH_ST_DPS_OpenerOption, "Dissipation First", "Uses Dissipation first, then Aetherflow", 0);
                     DrawHorizontalRadioButton(SCH_ST_DPS_OpenerOption, "Aetherflow First", "Uses Aetherflow first, then Dissipation", 1);
@@ -32,11 +33,6 @@ internal partial class SCH
                         DrawHorizontalMultiChoice(SCH_ST_DPS_Adv_Actions, "On Ruin II", "Apply options to Ruin II.", 3, 2);
                         ImGui.Unindent();
                     }
-                    break;
-                
-                case CustomComboPreset.SCH_AoE_Heal_Recitation:
-                    DrawHorizontalMultiChoice(SCH_AoE_Heal_Recitation_Actions, "On Indomitability", "", 2, 0);
-                    DrawHorizontalMultiChoice(SCH_AoE_Heal_Recitation_Actions, "On Succor/Concitation", "", 2, 1);
                     break;
                 
                 case CustomComboPreset.SCH_DPS_Lucid:
@@ -57,9 +53,6 @@ internal partial class SCH
                     DrawHorizontalRadioButton(SCH_DPS_BioSubOption,
                         "All Enemies", "Applies the HP check above to all enemies.", 1);
 
-                    
-                    
-
                     DrawRoundedSliderFloat(0, 4, SCH_DPS_BioUptime_Threshold, "Seconds remaining before reapplying the DoT. Set to Zero to disable this check.", digits: 1);
 
                     ImGui.Unindent();
@@ -79,15 +72,31 @@ internal partial class SCH
                     break;
 
                 case CustomComboPreset.SCH_DPS_EnergyDrain:
-                    DrawAdditionalBoolChoice(SCH_ST_DPS_EnergyDrain_Adv, "Advanced Options", "", isConditionalChoice: true);
-                    if (SCH_ST_DPS_EnergyDrain_Adv)
-                    {
-                        ImGui.Indent();
-                        DrawRoundedSliderFloat(0, 60, SCH_ST_DPS_EnergyDrain, "Aetherflow remaining cooldown:", digits: 1);
-                        ImGui.Unindent();
-                    }
+                    DrawSliderInt(0, 60, SCH_ST_DPS_EnergyDrain, "Aetherflow remaining cooldown");
+                    break;
+                
+                case CustomComboPreset.SCH_AoE_Lucid:
+                    DrawSliderInt(4000, 9500, SCH_AoE_DPS_LucidOption, "MP Threshold", 150, Hundreds);
+                    break;
+                
+                case CustomComboPreset.SCH_AoE_ChainStrat:
+                    DrawHorizontalRadioButton(SCH_AoE_DPS_ChainStratagemSubOption,
+                        "All content",
+                        $"Uses {ActionWatching.GetActionName(ChainStratagem)} regardless of content.", 0);
+
+                    DrawHorizontalRadioButton(SCH_AoE_DPS_ChainStratagemSubOption,
+                        "Boss encounters Only",
+                        $"Only uses {ActionWatching.GetActionName(ChainStratagem)} when in Boss encounters.", 1);
+
+                    DrawSliderInt(0, 100, SCH_AoE_DPS_ChainStratagemOption, "Stop using at Enemy HP%. Set to Zero to disable this check.");
                     break;
 
+                case CustomComboPreset.SCH_AoE_EnergyDrain:
+                    DrawSliderInt(0, 60, SCH_AoE_DPS_EnergyDrain, "Aetherflow remaining cooldown");
+                    break;
+                #endregion
+                
+                #region Healing
                 case CustomComboPreset.SCH_ST_Heal:
                     DrawAdditionalBoolChoice(SCH_ST_Heal_Adv, "Advanced Options", "", isConditionalChoice: true);
                     if (SCH_ST_Heal_Adv)
@@ -134,11 +143,7 @@ internal partial class SCH
                 case CustomComboPreset.SCH_ST_Heal_Esuna:
                     DrawSliderInt(0, 100, SCH_ST_Heal_EsunaOption, "Stop using when below HP %. Set to Zero to disable this check");
                     break;
-
-                case CustomComboPreset.SCH_AoE_Lucid:
-                    DrawSliderInt(4000, 9500, SCH_AoE_LucidOption, "MP Threshold", 150, Hundreds);
-                    break;
-
+                
                 case CustomComboPreset.SCH_AoE_Heal_Lucid:
                     DrawSliderInt(4000, 9500, SCH_AoE_Heal_LucidOption, "MP Threshold", 150, Hundreds);
                     break;
@@ -178,7 +183,14 @@ internal partial class SCH
                     DrawSliderInt(0, 100, SCH_AoE_Heal_IndomitabilityOption, "Start using when below party average HP %. Set to 100 to disable this check");
                     DrawPriorityInput(SCH_AoE_Heals_Priority, 7, 5, $"{Indomitability.ActionName()} Priority: ");
                     break;
-
+                
+                case CustomComboPreset.SCH_AoE_Heal_Recitation:
+                    DrawHorizontalMultiChoice(SCH_AoE_Heal_Recitation_Actions, "On Indomitability", "", 2, 0);
+                    DrawHorizontalMultiChoice(SCH_AoE_Heal_Recitation_Actions, "On Succor/Concitation", "", 2, 1);
+                    break;
+                #endregion
+                
+                #region Standalones
                 case CustomComboPreset.SCH_Aetherflow:
                     DrawRadioButton(SCH_Aetherflow_Display, "Show Aetherflow On Energy Drain Only", "", 0);
                     DrawRadioButton(SCH_Aetherflow_Display, "Show Aetherflow On All Aetherflow Skills", "", 1);
@@ -211,27 +223,34 @@ internal partial class SCH
                     DrawRadioButton(SCH_Recitation_Mode, "Succor", "", 1);
                     DrawRadioButton(SCH_Recitation_Mode, "Indomitability", "", 2);
                     DrawRadioButton(SCH_Recitation_Mode, "Excogitation", "", 3);
-                    break;               
+                    break; 
+                #endregion
             }
         }
-          #region DPS
+        
+    #region Options
+    
+        #region DPS
 
         public static UserInt
-            SCH_ST_DPS_AltMode = new("SCH_ST_DPS_AltMode"),
             SCH_ST_DPS_LucidOption = new("SCH_ST_DPS_LucidOption", 6500),
-            SCH_ST_DPS_BioOption = new("SCH_ST_DPS_BioOption", 10),
+            SCH_AoE_DPS_LucidOption = new("SCH_AoE_LucidOption", 6500),
             SCH_ST_DPS_OpenerOption = new("SCH_ST_DPS_OpenerOption"),
             SCH_ST_DPS_OpenerContent = new("SCH_ST_DPS_OpenerContent", 1),
             SCH_ST_DPS_ChainStratagemOption = new("SCH_ST_DPS_ChainStratagemOption", 10),
+            SCH_AoE_DPS_ChainStratagemOption = new("SCH_ST_DPS_ChainStratagemOption", 10),
             SCH_DPS_BioOption = new("SCH_DPS_BioOption"),
             SCH_DPS_BioSubOption = new("SCH_DPS_BioSubOption", 0),
-            SCH_ST_DPS_ChainStratagemSubOption = new("SCH_ST_DPS_ChainStratagemSubOption", 1);
+            SCH_ST_DPS_EnergyDrain = new("SCH_ST_DPS_EnergyDrain", 3),
+            SCH_ST_DPS_ChainStratagemSubOption = new("SCH_ST_DPS_ChainStratagemSubOption", 1),
+            SCH_AoE_DPS_EnergyDrain = new("SCH_ST_DPS_EnergyDrain", 3),
+            SCH_AoE_DPS_ChainStratagemSubOption = new("SCH_ST_DPS_ChainStratagemSubOption", 1);
         public static UserBool
-            SCH_ST_DPS_Adv = new("SCH_ST_DPS_Adv"),
-            SCH_ST_DPS_EnergyDrain_Adv = new("SCH_ST_DPS_EnergyDrain_Adv");
+            SCH_ST_DPS_Adv = new("SCH_ST_DPS_Adv");
+
         public static UserFloat
-            SCH_DPS_BioUptime_Threshold = new("SCH_DPS_BioUptime_Threshold", 3.0f),
-            SCH_ST_DPS_EnergyDrain = new("SCH_ST_DPS_EnergyDrain", 3.0f);
+            SCH_DPS_BioUptime_Threshold = new("SCH_DPS_BioUptime_Threshold", 3.0f);
+            
         public static UserBoolArray
             SCH_ST_DPS_Adv_Actions = new("SCH_ST_DPS_Adv_Actions");
 
@@ -240,7 +259,7 @@ internal partial class SCH
         #region Healing
 
         public static UserInt
-            SCH_AoE_LucidOption = new("SCH_AoE_LucidOption", 6500),
+            
             SCH_AoE_Heal_LucidOption = new("SCH_AoE_Heal_LucidOption", 6500),
             SCH_AoE_Heal_SuccorShieldOption = new("SCH_AoE_Heal_SuccorShieldCount"),
             SCH_AoE_Heal_WhisperingDawnOption = new("SCH_AoE_Heal_WhisperingDawnOption", 70),
@@ -270,7 +289,7 @@ internal partial class SCH
 
         #endregion
 
-        #region Utility
+        #region Standalones
 
         internal static UserBool
             SCH_Aetherflow_Recite_Indom = new("SCH_Aetherflow_Recite_Indom"),
@@ -282,5 +301,8 @@ internal partial class SCH
             SCH_Recitation_Mode = new("SCH_Recitation_Mode");
 
         #endregion
+        
+    #endregion
+    
     }
 }

--- a/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
@@ -113,24 +113,42 @@ internal partial class SCH
 
                 case CustomComboPreset.SCH_ST_Heal_Lustrate:
                     DrawSliderInt(0, 100, SCH_ST_Heal_LustrateOption, "Start using when below HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SCH_ST_Heals_Priority, 5, 0, $"{Lustrate.ActionName()} Priority: ");
+                    DrawPriorityInput(SCH_ST_Heals_Priority, 8, 0, $"{Lustrate.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SCH_ST_Heal_Excogitation:
                     DrawSliderInt(0, 100, SCH_ST_Heal_ExcogitationOption, "Start using when below HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SCH_ST_Heals_Priority, 5, 1, $"{Excogitation.ActionName()} Priority: ");
+                    DrawPriorityInput(SCH_ST_Heals_Priority, 8, 1, $"{Excogitation.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SCH_ST_Heal_Protraction:
                     DrawSliderInt(0, 100, SCH_ST_Heal_ProtractionOption, "Start using when below HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SCH_ST_Heals_Priority, 5, 2, $"{Protraction.ActionName()} Priority: ");
+                    DrawPriorityInput(SCH_ST_Heals_Priority, 8, 2, $"{Protraction.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SCH_ST_Heal_Aetherpact:
                     DrawSliderInt(0, 100, SCH_ST_Heal_AetherpactOption, "Start using when below HP %. Set to 100 to disable this check");
                     DrawSliderInt(0, 100, SCH_ST_Heal_AetherpactDissolveOption, "Stop using when above HP %.");
                     DrawSliderInt(10, 100, SCH_ST_Heal_AetherpactFairyGauge, "Minimal Fairy Gauge to start using Aetherpact", sliderIncrement: Tens);
-                    DrawPriorityInput(SCH_ST_Heals_Priority, 5, 3, $"{Aetherpact.ActionName()} Priority: ");
+                    DrawPriorityInput(SCH_ST_Heals_Priority, 8, 3, $"{Aetherpact.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.SCH_ST_Heal_WhisperingDawn:
+                    DrawSliderInt(0, 100, SCH_ST_Heal_WhisperingDawnOption, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(SCH_ST_Heal_WhisperingDawnBossOption, "Not on Bosses", "Will not use on ST in Boss encounters.");
+                    DrawPriorityInput(SCH_ST_Heals_Priority, 8, 5, $"{WhisperingDawn.ActionName()} Priority: ");
+                    break;
+
+                case CustomComboPreset.SCH_ST_Heal_FeyIllumination:
+                    DrawSliderInt(0, 100, SCH_ST_Heal_FeyIlluminationOption, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(SCH_ST_Heal_FeyIlluminationBossOption, "Not on Bosses", "Will not use on ST in Boss encounters.");
+                    DrawPriorityInput(SCH_ST_Heals_Priority, 8, 6, $"{FeyIllumination.ActionName()} Priority: ");
+                    break;
+
+                case CustomComboPreset.SCH_ST_Heal_FeyBlessing:
+                    DrawSliderInt(0, 100, SCH_ST_Heal_FeyBlessingOption, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(SCH_ST_Heal_FeyBlessingBossOption, "Not on Bosses", "Will not use on ST in Boss encounters.");
+                    DrawPriorityInput(SCH_ST_Heals_Priority, 8, 7, $"{FeyBlessing.ActionName()} Priority: ");
                     break;
                 
                 case CustomComboPreset.SCH_ST_Heal_Adloquium:
@@ -146,7 +164,7 @@ internal partial class SCH
                         ImGui.Unindent();
                     }
                     
-                    DrawPriorityInput(SCH_ST_Heals_Priority, 5, 4, $"{Adloquium.ActionName()} Priority: ");
+                    DrawPriorityInput(SCH_ST_Heals_Priority, 8, 4, $"{Adloquium.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SCH_ST_Heal_Esuna:
@@ -292,6 +310,9 @@ internal partial class SCH
             SCH_ST_Heal_AetherpactOption = new("SCH_ST_Heal_AetherpactOption", 60),
             SCH_ST_Heal_AetherpactDissolveOption = new("SCH_ST_Heal_AetherpactDissolveOption", 90),
             SCH_ST_Heal_AetherpactFairyGauge = new("SCH_ST_Heal_AetherpactFairyGauge", 50),
+            SCH_ST_Heal_WhisperingDawnOption = new("SCH_ST_Heal_WhisperingDawnOption", 70),
+            SCH_ST_Heal_FeyIlluminationOption = new("SCH_ST_Heal_FeyIlluminationOption", 70),
+            SCH_ST_Heal_FeyBlessingOption = new("SCH_ST_Heal_FeyBlessingOption", 70),
             SCH_ST_Heal_EsunaOption = new("SCH_ST_Heal_EsunaOption", 30);
         public static UserIntArray
             SCH_ST_Heals_Priority = new("SCH_ST_Heals_Priority"),
@@ -300,6 +321,9 @@ internal partial class SCH
         public static UserBool
             SCH_ST_Heal_Adv = new("SCH_ST_Heal_Adv"),
             SCH_ST_Heal_IncludeShields = new("SCH_ST_Heal_IncludeShields"),
+            SCH_ST_Heal_WhisperingDawnBossOption = new("SCH_ST_Heal_WhisperingDawnBossOption"),
+            SCH_ST_Heal_FeyIlluminationBossOption = new("SCH_ST_Heal_FeyIlluminationBossOption"),
+            SCH_ST_Heal_FeyBlessingBossOption = new("SCH_ST_Heal_FeyBlessingBossOption"),
             SCH_AoE_Heal_Indomitability_Recitation = new("SCH_AoE_Heal_Indomitability_Recitation");
 
         public static UserBoolArray

--- a/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
@@ -158,44 +158,55 @@ internal partial class SCH
                     break;
 
                 case CustomComboPreset.SCH_AoE_Heal:
-                    ImGui.TextUnformatted("Note: Succor will always be available. These options are to provide optional priority to Succor.");
-                    DrawSliderInt(0, 100, SCH_AoE_Heal_SuccorShieldOption, "Shield Check: Percentage of Party Members without shields to check for.", sliderIncrement: 25);
-                    DrawPriorityInput(SCH_AoE_Heals_Priority, 7, 6, $"{Succor.ActionName()} Priority: ");
+                    ImGui.TextUnformatted("Note: Succor will always be available.");
+                    ImGui.TextUnformatted("These options are to provide optional priority to Succor or to set up Emergency tactics option.");
+                    DrawSliderInt(0, 100, SCH_AoE_Heal_SuccorShieldOption, "Shield Check: Will use when less than set percentage of party have shields.", sliderIncrement: 25);
+                    DrawPriorityInput(SCH_AoE_Heals_Priority, 8, 7, $"{Succor.ActionName()} Priority: ");
+                    DrawHorizontalMultiChoice(SCH_AoE_Heal_Succor_Options,"Emergency Tactics","If more than the set percentage of the party has shields, will use Emergency Tactics before Succor", 2, 0);
+                    DrawHorizontalMultiChoice(SCH_AoE_Heal_Succor_Options,"Recitation","Will use Recitation to buff Succor", 2, 1);
                     break;
 
                 case CustomComboPreset.SCH_AoE_Heal_WhisperingDawn:
                     DrawSliderInt(0, 100, SCH_AoE_Heal_WhisperingDawnOption, "Start using when below party average HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SCH_AoE_Heals_Priority, 7, 0, $"{WhisperingDawn.ActionName()} Priority: ");
+                    DrawPriorityInput(SCH_AoE_Heals_Priority, 8, 0, $"{WhisperingDawn.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SCH_AoE_Heal_FeyIllumination:
                     DrawSliderInt(0, 100, SCH_AoE_Heal_FeyIlluminationOption, "Start using when below party average HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SCH_AoE_Heals_Priority, 7, 1, $"{FeyIllumination.ActionName()} Priority: ");
+                    DrawPriorityInput(SCH_AoE_Heals_Priority, 8, 1, $"{FeyIllumination.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SCH_AoE_Heal_FeyBlessing:
                     DrawSliderInt(0, 100, SCH_AoE_Heal_FeyBlessingOption, "Start using when below party average HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SCH_AoE_Heals_Priority, 7, 2, $"{FeyBlessing.ActionName()} Priority: ");
+                    DrawPriorityInput(SCH_AoE_Heals_Priority, 8, 2, $"{FeyBlessing.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SCH_AoE_Heal_Consolation:
                     DrawSliderInt(0, 100, SCH_AoE_Heal_ConsolationOption, "Start using when below party average HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SCH_AoE_Heals_Priority, 7, 3, $"{Consolation.ActionName()} Priority: ");
+                    DrawPriorityInput(SCH_AoE_Heals_Priority, 8, 3, $"{Consolation.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.SCH_AoE_Heal_SummonSeraph:
+                    DrawSliderInt(0, 100, SCH_AoE_Heal_SummonSeraph, "Start using when below party average HP %. Set to 100 to disable this check");
+                    DrawPriorityInput(SCH_AoE_Heals_Priority, 8, 6, $"{SummonSeraph.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SCH_AoE_Heal_Seraphism:
                     DrawSliderInt(0, 100, SCH_AoE_Heal_SeraphismOption, "Start using when below party average HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SCH_AoE_Heals_Priority, 7, 4, $"{Seraphism.ActionName()} Priority: ");
+                    DrawPriorityInput(SCH_AoE_Heals_Priority, 8, 4, $"{Seraphism.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SCH_AoE_Heal_Indomitability:
                     DrawSliderInt(0, 100, SCH_AoE_Heal_IndomitabilityOption, "Start using when below party average HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SCH_AoE_Heals_Priority, 7, 5, $"{Indomitability.ActionName()} Priority: ");
+                    DrawAdditionalBoolChoice(SCH_AoE_Heal_Indomitability_Recitation, "Recitation Option", "Will use Recitation to buff Indomitability.");
+                    DrawPriorityInput(SCH_AoE_Heals_Priority, 8, 5, $"{Indomitability.ActionName()} Priority: ");
                     break;
                 
-                case CustomComboPreset.SCH_AoE_Heal_Recitation:
-                    DrawHorizontalMultiChoice(SCH_AoE_Heal_Recitation_Actions, "On Indomitability", "", 2, 0);
-                    DrawHorizontalMultiChoice(SCH_AoE_Heal_Recitation_Actions, "On Succor/Concitation", "", 2, 1);
+                
+                case CustomComboPreset.SCH_AoE_Heal_SacredSoil:
+                    DrawAdditionalBoolChoice(SCH_AoE_Heal_SacredSoil_RaidwideOnly,
+                        "Only use when a Raidwide is casting",
+                        "Will not use Sacred Soil in the rotation unless we detect a Raidwide is casting.");
                     break;
                 #endregion
                 
@@ -272,11 +283,12 @@ internal partial class SCH
             SCH_AoE_Heal_LucidOption = new("SCH_AoE_Heal_LucidOption", 8000),
             SCH_AoE_Heal_SuccorShieldOption = new("SCH_AoE_Heal_SuccorShieldCount", 50),
             SCH_AoE_Heal_WhisperingDawnOption = new("SCH_AoE_Heal_WhisperingDawnOption", 70),
-            SCH_AoE_Heal_FeyIlluminationOption = new("SCH_AoE_Heal_FeyIlluminationOption", 70),
-            SCH_AoE_Heal_ConsolationOption = new("SCH_AoE_Heal_ConsolationOption", 70),
-            SCH_AoE_Heal_FeyBlessingOption = new("SCH_AoE_Heal_FeyBlessingOption", 70),
-            SCH_AoE_Heal_SeraphismOption = new("SCH_AoE_Heal_SeraphismOption", 70),
+            SCH_AoE_Heal_FeyIlluminationOption = new("SCH_AoE_Heal_FeyIlluminationOption", 50),
+            SCH_AoE_Heal_ConsolationOption = new("SCH_AoE_Heal_ConsolationOption", 60),
+            SCH_AoE_Heal_FeyBlessingOption = new("SCH_AoE_Heal_FeyBlessingOption", 60),
+            SCH_AoE_Heal_SeraphismOption = new("SCH_AoE_Heal_SeraphismOption", 30),
             SCH_AoE_Heal_IndomitabilityOption = new("SCH_AoE_Heal_IndomitabilityOption", 70),
+            SCH_AoE_Heal_SummonSeraph = new("SCH_AoE_Heal_SummonSeraph", 40),
             SCH_ST_Heal_LucidOption = new("SCH_ST_Heal_LucidOption", 8000),
             SCH_ST_Heal_AdloquiumOption = new("SCH_ST_Heal_AdloquiumOption", 70),
             SCH_ST_Heal_AdloquiumOption_Emergency= new("SCH_ST_Heal_AdloquiumOption_Emergency", 30),
@@ -292,10 +304,13 @@ internal partial class SCH
             SCH_AoE_Heals_Priority = new("SCH_AoE_Heals_Priority");
         public static UserBool
             SCH_ST_Heal_Adv = new("SCH_ST_Heal_Adv"),
-            SCH_ST_Heal_IncludeShields = new("SCH_ST_Heal_IncludeShields");
+            SCH_ST_Heal_IncludeShields = new("SCH_ST_Heal_IncludeShields"),
+            SCH_AoE_Heal_Indomitability_Recitation = new("SCH_AoE_Heal_Indomitability_Recitation"),
+            SCH_AoE_Heal_SacredSoil_RaidwideOnly = new("SCH_AoE_Heal_SacredSoil_RaidwideOnly");
+
         public static UserBoolArray
             SCH_ST_Heal_AldoquimOpts = new("SCH_ST_Heal_AldoquimOpts"),
-            SCH_AoE_Heal_Recitation_Actions = new ("SCH_AoE_Heal_Recitation_Actions");
+            SCH_AoE_Heal_Succor_Options = new("SCH_AoE_Heal_Succor_Options");
 
         #endregion
 

--- a/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
@@ -111,33 +111,42 @@ internal partial class SCH
                     DrawSliderInt(4000, 9500, SCH_ST_Heal_LucidOption, "MP Threshold", 150, Hundreds);
                     break;
 
-                case CustomComboPreset.SCH_ST_Heal_Adloquium:
-                    DrawSliderInt(0, 100, SCH_ST_Heal_AdloquiumOption, "Start using when below HP %. Set to 100 to disable this check.");
-                    DrawHorizontalMultiChoice(SCH_ST_Heal_AldoquimOpts, "Ignore Shield Check", $"Warning, will force the use of {Adloquium.ActionName()}, and normal {Physick.ActionName()} maybe unavailable.", 3, 0);
-                    DrawHorizontalMultiChoice(SCH_ST_Heal_AldoquimOpts, "Sage Shield Check", "Enable to not override an existing Sage's shield.", 3, 1);
-                    DrawHorizontalMultiChoice(SCH_ST_Heal_AldoquimOpts, $"{EmergencyTactics.ActionName()}", $"Use {EmergencyTactics.ActionName()} before {Adloquium.ActionName()}", 3, 2);
-                    break;
-
                 case CustomComboPreset.SCH_ST_Heal_Lustrate:
                     DrawSliderInt(0, 100, SCH_ST_Heal_LustrateOption, "Start using when below HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SCH_ST_Heals_Priority, 4, 0, $"{Lustrate.ActionName()} Priority: ");
+                    DrawPriorityInput(SCH_ST_Heals_Priority, 5, 0, $"{Lustrate.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SCH_ST_Heal_Excogitation:
                     DrawSliderInt(0, 100, SCH_ST_Heal_ExcogitationOption, "Start using when below HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SCH_ST_Heals_Priority, 4, 1, $"{Excogitation.ActionName()} Priority: ");
+                    DrawPriorityInput(SCH_ST_Heals_Priority, 5, 1, $"{Excogitation.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SCH_ST_Heal_Protraction:
                     DrawSliderInt(0, 100, SCH_ST_Heal_ProtractionOption, "Start using when below HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(SCH_ST_Heals_Priority, 4, 2, $"{Protraction.ActionName()} Priority: ");
+                    DrawPriorityInput(SCH_ST_Heals_Priority, 5, 2, $"{Protraction.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SCH_ST_Heal_Aetherpact:
                     DrawSliderInt(0, 100, SCH_ST_Heal_AetherpactOption, "Start using when below HP %. Set to 100 to disable this check");
                     DrawSliderInt(0, 100, SCH_ST_Heal_AetherpactDissolveOption, "Stop using when above HP %.");
                     DrawSliderInt(10, 100, SCH_ST_Heal_AetherpactFairyGauge, "Minimal Fairy Gauge to start using Aetherpact", sliderIncrement: Tens);
-                    DrawPriorityInput(SCH_ST_Heals_Priority, 4, 3, $"{Aetherpact.ActionName()} Priority: ");
+                    DrawPriorityInput(SCH_ST_Heals_Priority, 5, 3, $"{Aetherpact.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.SCH_ST_Heal_Adloquium:
+                    DrawSliderInt(0, 100, SCH_ST_Heal_AdloquiumOption,"Start using when below HP %. Set to 100 to disable this check.");
+                    DrawHorizontalMultiChoice(SCH_ST_Heal_AldoquimOpts,"Scholar Shield Check", "Enable to not override an existing Scholar's shield.", 3, 0);
+                    DrawHorizontalMultiChoice(SCH_ST_Heal_AldoquimOpts,"Sage Shield Check", "Enable to not override an existing Sage's shield.", 3, 1);
+                    DrawHorizontalMultiChoice(SCH_ST_Heal_AldoquimOpts,"Emergency Tactics","Will use Emergency tactics before Adloquim when below set threshold", 3, 2);
+                    
+                    if (SCH_ST_Heal_AldoquimOpts[2])
+                    {
+                        ImGui.Indent();
+                        DrawSliderInt(0, 100, SCH_ST_Heal_AdloquiumOption_Emergency,"Start using when below HP %. Set to 100 to disable this check.");
+                        ImGui.Unindent();
+                    }
+                    
+                    DrawPriorityInput(SCH_ST_Heals_Priority, 5, 4, $"{Adloquium.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SCH_ST_Heal_Esuna:
@@ -260,23 +269,24 @@ internal partial class SCH
 
         public static UserInt
             
-            SCH_AoE_Heal_LucidOption = new("SCH_AoE_Heal_LucidOption", 6500),
-            SCH_AoE_Heal_SuccorShieldOption = new("SCH_AoE_Heal_SuccorShieldCount"),
+            SCH_AoE_Heal_LucidOption = new("SCH_AoE_Heal_LucidOption", 8000),
+            SCH_AoE_Heal_SuccorShieldOption = new("SCH_AoE_Heal_SuccorShieldCount", 50),
             SCH_AoE_Heal_WhisperingDawnOption = new("SCH_AoE_Heal_WhisperingDawnOption", 70),
             SCH_AoE_Heal_FeyIlluminationOption = new("SCH_AoE_Heal_FeyIlluminationOption", 70),
             SCH_AoE_Heal_ConsolationOption = new("SCH_AoE_Heal_ConsolationOption", 70),
             SCH_AoE_Heal_FeyBlessingOption = new("SCH_AoE_Heal_FeyBlessingOption", 70),
             SCH_AoE_Heal_SeraphismOption = new("SCH_AoE_Heal_SeraphismOption", 70),
             SCH_AoE_Heal_IndomitabilityOption = new("SCH_AoE_Heal_IndomitabilityOption", 70),
-            SCH_ST_Heal_LucidOption = new("SCH_ST_Heal_LucidOption", 6500),
-            SCH_ST_Heal_AdloquiumOption = new("SCH_ST_Heal_AdloquiumOption", 99),
-            SCH_ST_Heal_LustrateOption = new("SCH_ST_Heal_LustrateOption", 99),
-            SCH_ST_Heal_ExcogitationOption = new("SCH_ST_Heal_ExcogitationOption", 99),
-            SCH_ST_Heal_ProtractionOption = new("SCH_ST_Heal_ProtractionOption", 99),
-            SCH_ST_Heal_AetherpactOption = new("SCH_ST_Heal_AetherpactOption", 99),
-            SCH_ST_Heal_AetherpactDissolveOption = new("SCH_ST_Heal_AetherpactDissolveOption", 99),
-            SCH_ST_Heal_AetherpactFairyGauge = new("SCH_ST_Heal_AetherpactFairyGauge", 99),
-            SCH_ST_Heal_EsunaOption = new("SCH_ST_Heal_EsunaOption", 100);
+            SCH_ST_Heal_LucidOption = new("SCH_ST_Heal_LucidOption", 8000),
+            SCH_ST_Heal_AdloquiumOption = new("SCH_ST_Heal_AdloquiumOption", 70),
+            SCH_ST_Heal_AdloquiumOption_Emergency= new("SCH_ST_Heal_AdloquiumOption_Emergency", 30),
+            SCH_ST_Heal_LustrateOption = new("SCH_ST_Heal_LustrateOption", 70),
+            SCH_ST_Heal_ExcogitationOption = new("SCH_ST_Heal_ExcogitationOption", 50),
+            SCH_ST_Heal_ProtractionOption = new("SCH_ST_Heal_ProtractionOption", 30),
+            SCH_ST_Heal_AetherpactOption = new("SCH_ST_Heal_AetherpactOption", 60),
+            SCH_ST_Heal_AetherpactDissolveOption = new("SCH_ST_Heal_AetherpactDissolveOption", 90),
+            SCH_ST_Heal_AetherpactFairyGauge = new("SCH_ST_Heal_AetherpactFairyGauge", 50),
+            SCH_ST_Heal_EsunaOption = new("SCH_ST_Heal_EsunaOption", 30);
         public static UserIntArray
             SCH_ST_Heals_Priority = new("SCH_ST_Heals_Priority"),
             SCH_AoE_Heals_Priority = new("SCH_AoE_Heals_Priority");

--- a/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
@@ -238,13 +238,13 @@ internal partial class SCH
             SCH_ST_DPS_OpenerOption = new("SCH_ST_DPS_OpenerOption"),
             SCH_ST_DPS_OpenerContent = new("SCH_ST_DPS_OpenerContent", 1),
             SCH_ST_DPS_ChainStratagemOption = new("SCH_ST_DPS_ChainStratagemOption", 10),
-            SCH_AoE_DPS_ChainStratagemOption = new("SCH_ST_DPS_ChainStratagemOption", 10),
+            SCH_AoE_DPS_ChainStratagemOption = new("SCH_AoE_DPS_ChainStratagemOption", 10),
             SCH_DPS_BioOption = new("SCH_DPS_BioOption"),
             SCH_DPS_BioSubOption = new("SCH_DPS_BioSubOption", 0),
             SCH_ST_DPS_EnergyDrain = new("SCH_ST_DPS_EnergyDrain", 3),
             SCH_ST_DPS_ChainStratagemSubOption = new("SCH_ST_DPS_ChainStratagemSubOption", 1),
-            SCH_AoE_DPS_EnergyDrain = new("SCH_ST_DPS_EnergyDrain", 3),
-            SCH_AoE_DPS_ChainStratagemSubOption = new("SCH_ST_DPS_ChainStratagemSubOption", 1);
+            SCH_AoE_DPS_EnergyDrain = new("SCH_AoE_DPS_EnergyDrain", 3),
+            SCH_AoE_DPS_ChainStratagemSubOption = new("SCH_AoE_DPS_ChainStratagemSubOption", 1);
         public static UserBool
             SCH_ST_DPS_Adv = new("SCH_ST_DPS_Adv");
 

--- a/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
@@ -198,7 +198,7 @@ internal partial class SCH
             
             case 7:
                 action = OriginalHook(Succor);
-                enabled = IsEnabled(CustomComboPreset.SCH_AoE_Heal) && ShieldCheck;
+                enabled = IsEnabled(CustomComboPreset.SCH_AoE_Heal) && ShieldCheck && LevelChecked(Succor);
                 return 100; //Don't HP Check
         }
 

--- a/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
@@ -136,6 +136,21 @@ internal partial class SCH
                           GetTargetHPPercent(healTarget, Config.SCH_ST_Heal_IncludeShields) <= Config.SCH_ST_Heal_AdloquiumOption &&
                           (EmergencyAdlo || ShieldCheck && SageShieldCheck);
                 return Config.SCH_ST_Heal_AdloquiumOption;
+            case 5:
+                action = OriginalHook(WhisperingDawn);
+                enabled = IsEnabled(CustomComboPreset.SCH_ST_Heal_WhisperingDawn) && HasPetPresent() && 
+                          (!Config.SCH_ST_Heal_WhisperingDawnBossOption || !InBossEncounter());
+                return Config.SCH_ST_Heal_WhisperingDawnOption;
+            case 6:
+                action = OriginalHook(FeyIllumination);
+                enabled = IsEnabled(CustomComboPreset.SCH_ST_Heal_FeyIllumination) && HasPetPresent() && 
+                          (!Config.SCH_ST_Heal_FeyIlluminationBossOption || !InBossEncounter());
+                return Config.SCH_ST_Heal_FeyIlluminationOption;
+            case 7:
+                action = FeyBlessing;
+                enabled = IsEnabled(CustomComboPreset.SCH_ST_Heal_FeyBlessing) && HasPetPresent() && 
+                          (!Config.SCH_ST_Heal_FeyBlessingBossOption || !InBossEncounter());
+                return Config.SCH_ST_Heal_FeyBlessingOption;
         }
 
         enabled = false;

--- a/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
@@ -49,6 +49,7 @@ internal partial class SCH
     
     #endregion
     
+    #region Dot Checker
     internal static bool NeedsDoT()
     {
         var dotAction = OriginalHook(Bio);
@@ -66,6 +67,7 @@ internal partial class SCH
                GetTargetHPPercent() > hpThreshold &&
                dotRemaining <= Config.SCH_DPS_BioUptime_Threshold;
     }
+    #endregion
     
     #region Get ST Heals
     public static int GetMatchingConfigST(int i, out uint action, out bool enabled)

--- a/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
@@ -33,6 +33,11 @@ internal partial class SCH
     internal static IBattleChara? AetherPactTarget => Svc.Objects.Where(x => x is IBattleChara chara && chara.StatusList.Any(y => y.StatusId == 1223 && y.SourceObject.GameObjectId == Svc.Buddies.PetBuddy.ObjectId)).Cast<IBattleChara>().FirstOrDefault();
     internal static bool HasAetherflow => Gauge.Aetherflow > 0;
     internal static bool FairyDismissed => Gauge.DismissedFairy > 0;
+    internal static bool EndAetherpact => IsEnabled(CustomComboPreset.SCH_ST_Heal_Aetherpact) && IsEnabled(CustomComboPreset.SCH_ST_Heal)
+                                            && OriginalHook(Aetherpact) is DissolveUnion //Quick check to see if Fairy Aetherpact is Active
+                                            && AetherPactTarget is not null //Null checking so GetTargetHPPercent doesn't fall back to CurrentTarget
+                                            && GetTargetHPPercent(AetherPactTarget) >= Config.SCH_ST_Heal_AetherpactDissolveOption;
+    
     
     
     #region Eos Summoner

--- a/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
@@ -104,9 +104,9 @@ internal partial class SCH
                 enabled = IsEnabled(CustomComboPreset.SCH_ST_Heal_Aetherpact) && Gauge.FairyGauge >= Config.SCH_ST_Heal_AetherpactFairyGauge && IsOriginal(Aetherpact);
                 return Config.SCH_ST_Heal_AetherpactOption;
             case 4:
-                action = Adloquium;
+                action = OriginalHook(Adloquium);
                 enabled = IsEnabled(CustomComboPreset.SCH_ST_Heal_Adloquium) &&
-                          ActionReady(Adloquium) &&
+                          ActionReady(OriginalHook(Adloquium)) &&
                           GetTargetHPPercent(healTarget, Config.SCH_ST_Heal_IncludeShields) <= Config.SCH_ST_Heal_AdloquiumOption &&
                           (EmergencyAdlo || ShieldCheck && SageShieldCheck);
                 return Config.SCH_ST_Heal_AdloquiumOption;
@@ -121,6 +121,8 @@ internal partial class SCH
     #region Get Aoe Heals
     public static int GetMatchingConfigAoE(int i, out uint action, out bool enabled)
     {
+        bool shieldCheck = GetPartyBuffPercent(Buffs.Galvanize) <= Config.SCH_AoE_Heal_SuccorShieldOption &&
+                           GetPartyBuffPercent(SGE.Buffs.EukrasianPrognosis) <= Config.SCH_AoE_Heal_SuccorShieldOption;
         switch (i)
         {
             case 0:
@@ -148,8 +150,13 @@ internal partial class SCH
                 enabled = IsEnabled(CustomComboPreset.SCH_AoE_Heal_Indomitability) && HasAetherflow;
                 return Config.SCH_AoE_Heal_IndomitabilityOption;
             case 6:
+                action = SummonSeraph;
+                enabled = IsEnabled(CustomComboPreset.SCH_AoE_Heal_SummonSeraph) && HasPetPresent();
+                return Config.SCH_AoE_Heal_SummonSeraph;
+            
+            case 7:
                 action = OriginalHook(Succor);
-                enabled = IsEnabled(CustomComboPreset.SCH_AoE_Heal) && GetPartyBuffPercent(Buffs.Galvanize) <= Config.SCH_AoE_Heal_SuccorShieldOption;
+                enabled = IsEnabled(CustomComboPreset.SCH_AoE_Heal) && shieldCheck;
                 return 100; //Don't HP Check
         }
 
@@ -245,6 +252,8 @@ internal partial class SCH
         Resurrection = 173,
         Protraction = 25867,
         Seraphism = 37014,
+        Manifestation = 37015,
+        Accession = 37016,
 
         // Offense
         Bio = 17864,
@@ -276,6 +285,7 @@ internal partial class SCH
         Recitation = 16542,
         ChainStratagem = 7436,
         DeploymentTactics = 3585,
+        Expedient = 25868,
         EmergencyTactics = 3586;
 
     //Action Groups

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -18,7 +18,7 @@
 #/WrathCombo/Combos/PvE/RDM/                           
 /WrathCombo/Combos/PvE/RPR/                           @Kagekazu
 /WrathCombo/Combos/PvE/SAM/                           @Kagekazu
-#/WrathCombo/Combos/PvE/SCH/                           
+/WrathCombo/Combos/PvE/SCH/                           @edewen
 /WrathCombo/Combos/PvE/SGE/                           @Kagekazu
 /WrathCombo/Combos/PvE/SMN/                           @Genesis-Nova @edewen
 /WrathCombo/Combos/PvE/VPR/                           @Kagekazu


### PR DESCRIPTION
- General
  - Cleanup and regions for all sch stuff
  - Removed redundant options
  - Reorganized CCP to be more logical
 
- ST
  - Rewrote Dots in whm style
  - Split Chain Stratagem and Baneful Impaction into 2 options
 
- AoE
  - Added Chain Stratagem with a optional Level Check for Baneful Impaction
  - Added Baneful Impaction
  - Added Energy Drain
 
- ST Heals
  - Added Adloquim to the ST priority System
  - Added Emergency Tactics as a option on Adloquim with a separate health slider
  - Added Fey Blessing, Illumination, and Whispering dawn to ST with Non Boss Option for dungeon trash (single target options   were lacking there and was using gcds to heal too often with autorotation)
  - Added the Dissolve union to all 4 combos. Will not affect dps, but it is needed for auto rotation to turn off Aetherpact when the target reaching the desired health level. This is a bug fix for already existing code. 
 
- AoE Heals
  - Fix Dissipation Logic, if Aetherflow was held for Indomitably, Dissipation would just fire instead.
  - Added hold for Indomitably option to Dissipation as well.
  - Added Summon Seraph to the priority List
  - Added Emergency tactics option to Succor, similar to ST. It will use ET if the Shield check fails and no other priorities exist 
  - Fixed issue for 20-35. Succor level check, whispering dawn only option at that level range.
 
- Standalone Features
  - Added Sacred Soil Retarget Standalone
 
- Hidden Features
  - Added Hidden Raid Wide Features for Expedient, Sacred Soil, and Succor as raidwide still needs a lot more testing before public access. 