### PR TITLE
[AST] Priority Treatment

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -821,8 +821,11 @@ public enum CustomComboPreset
     [ParentCombo(AST_AoE_SimpleHeals)]
     [CustomComboInfo("Stellar Detonation Option", "Adds Stellar Detonation when under the effect of Giant Dominance", AST.JobID)]
     AST_AoE_SimpleHeals_StellarDetonation = 1072,
-
     
+    [ParentCombo(AST_AoE_SimpleHeals)]
+    [CustomComboInfo("Collective Unconscious Option", "Adds Collective Unconscious for to regen, it will not hold it.", AST.JobID)]
+    [PossiblyRetargeted]
+    AST_AoE_SimpleHeals_CollectiveUnconscious = 1074,
 
     [ReplaceSkill(AST.Benefic2)]
     [CustomComboInfo("Benefic 2 Downgrade", "Changes Benefic 2 to Benefic when Benefic 2 is not unlocked or available.",
@@ -875,7 +878,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last value = 1072
+    // Last value = 1074
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -719,6 +719,16 @@ public enum CustomComboPreset
         AST.JobID)]
     [PossiblyRetargeted]
     AST_ST_SimpleHeals = 1023,
+    
+    [ParentCombo(AST_ST_SimpleHeals)]
+    [CustomComboInfo("Esuna Option", "Applies Esuna to your target if there is a cleansable debuff.", AST.JobID)]
+    [PossiblyRetargeted]
+    AST_ST_SimpleHeals_Esuna = 1039,
+    
+    [ParentCombo(AST_ST_SimpleHeals)]
+    [CustomComboInfo("Aspected Benefic Option", "Adds Aspected Benefic & refreshes it if needed.", AST.JobID)]
+    [PossiblyRetargeted]
+    AST_ST_SimpleHeals_AspectedBenefic = 1027,
 
     [ParentCombo(AST_ST_SimpleHeals)]
     [CustomComboInfo("Essential Dignity Option",
@@ -730,16 +740,6 @@ public enum CustomComboPreset
     [CustomComboInfo("Celestial Intersection Option", "Adds Celestial Intersection.", AST.JobID)]
     [PossiblyRetargeted]
     AST_ST_SimpleHeals_CelestialIntersection = 1025,
-
-    [ParentCombo(AST_ST_SimpleHeals)]
-    [CustomComboInfo("Aspected Benefic Option", "Adds Aspected Benefic & refreshes it if needed.", AST.JobID)]
-    [PossiblyRetargeted]
-    AST_ST_SimpleHeals_AspectedBenefic = 1027,
-
-    [ParentCombo(AST_ST_SimpleHeals)]
-    [CustomComboInfo("Esuna Option", "Applies Esuna to your target if there is a cleansable debuff.", AST.JobID)]
-    [PossiblyRetargeted]
-    AST_ST_SimpleHeals_Esuna = 1039,
 
     [ParentCombo(AST_ST_SimpleHeals)]
     [CustomComboInfo("Exaltation Option", "Adds Exaltation.", AST.JobID)]
@@ -765,34 +765,64 @@ public enum CustomComboPreset
     [CustomComboInfo("The Bole Option", "Adds The Bole (Reduced Damage) when the card has been drawn", AST.JobID)]
     [PossiblyRetargeted]
     AST_ST_SimpleHeals_Bole = 1050,
+    
+    [ParentCombo(AST_ST_SimpleHeals)]
+    [CustomComboInfo("Celestial Opposition Option", "Adds Celestial Opposition", AST.JobID)]
+    [PossiblyRetargeted]
+    AST_ST_SimpleHeals_CelestialOpposition = 1068,
+    
+    [ParentCombo(AST_ST_SimpleHeals)]
+    [CustomComboInfo("Collective Unconscious Option", "Adds Collective Unconscious for to regen, it will not hold it.", AST.JobID)]
+    [PossiblyRetargeted]
+    AST_ST_SimpleHeals_CollectiveUnconscious = 1069,
+    
+    [ParentCombo(AST_ST_SimpleHeals)]
+    [CustomComboInfo("Lady Option", "Adds Lady of Crowns, if the card is drawn.", AST.JobID)]
+    [PossiblyRetargeted]
+    AST_ST_SimpleHeals_SoloLady = 1070,
+    
+    
 
     [AutoAction(true, true)]
     [ReplaceSkill(AST.Helios, AST.AspectedHelios, AST.HeliosConjuction)]
     [CustomComboInfo("Simple Heals - AoE",
-        "Replaces Aspected Helios/Helios Conjunction or Helios with a one button healing replacement.", AST.JobID)]
-    AST_AoE_SimpleHeals_AspectedHelios = 1010,
+        "Replaces Aspected Helios/Helios Conjunction or Helios with a one button healing replacement."
+        + "This Spell will be consider the bottom priority with no checks regardless of below settings.", AST.JobID)]
+    AST_AoE_SimpleHeals = 1010,
+    
+    [ParentCombo(AST_AoE_SimpleHeals)]
+    [CustomComboInfo("Aspected Helios Option", "Adds Aspected Helios/Helios Conjunction", AST.JobID)]
+    AST_AoE_SimpleHeals_Aspected = 1053,
+    
+    [ParentCombo(AST_AoE_SimpleHeals)]
+    [CustomComboInfo("Helios Option", "Adds Helios", AST.JobID)]
+    AST_AoE_SimpleHeals_Helios = 1073,
 
-    [ParentCombo(AST_AoE_SimpleHeals_AspectedHelios)]
+    [ParentCombo(AST_AoE_SimpleHeals)]
     [CustomComboInfo("Celestial Opposition Option", "Adds Celestial Opposition", AST.JobID)]
     AST_AoE_SimpleHeals_CelestialOpposition = 1021,
 
-    [ParentCombo(AST_AoE_SimpleHeals_AspectedHelios)]
+    [ParentCombo(AST_AoE_SimpleHeals)]
     [CustomComboInfo("Lazy Lady Option", "Adds Lady of Crowns, if the card is drawn", AST.JobID)]
     AST_AoE_SimpleHeals_LazyLady = 1022,
 
-    [ParentCombo(AST_AoE_SimpleHeals_AspectedHelios)]
-    [CustomComboInfo("Horoscope Option", "Adds Horoscope.", AST.JobID)]
+    [ParentCombo(AST_AoE_SimpleHeals)]
+    [CustomComboInfo("Horoscope Option", "Adds Horoscope followed by Aspected Helios or Helios.", AST.JobID)]
     AST_AoE_SimpleHeals_Horoscope = 1026,
+    
+    [ParentCombo(AST_AoE_SimpleHeals)]
+    [CustomComboInfo("Horoscope Helios Option", "Adds Horoscope Helios.", AST.JobID)]
+    AST_AoE_SimpleHeals_HoroscopeHeal = 1071,
 
-    [ParentCombo(AST_AoE_SimpleHeals_AspectedHelios)]
+    [ParentCombo(AST_AoE_SimpleHeals)]
     [CustomComboInfo("Neutral Sect Option", "Adds Neutral Sect and its followup Sun Sign.", AST.JobID)]
     AST_AoE_SimpleHeals_NeutralSect = 1067,
+    
+    [ParentCombo(AST_AoE_SimpleHeals)]
+    [CustomComboInfo("Stellar Detonation Option", "Adds Stellar Detonation when under the effect of Giant Dominance", AST.JobID)]
+    AST_AoE_SimpleHeals_StellarDetonation = 1072,
 
-    [ParentCombo(AST_AoE_SimpleHeals_AspectedHelios)]
-    [CustomComboInfo("Aspected Helios Option",
-        "In Helios mode: Will Cast Aspected Helios/Helios Conjunction when the HoT is missing on yourself."
-        + "\nIn Aspected Helios mode: Is considered enabled regardless.", AST.JobID)]
-    AST_AoE_SimpleHeals_Aspected = 1053,
+    
 
     [ReplaceSkill(AST.Benefic2)]
     [CustomComboInfo("Benefic 2 Downgrade", "Changes Benefic 2 to Benefic when Benefic 2 is not unlocked or available.",
@@ -845,7 +875,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last value = 1067
+    // Last value = 1072
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/AST/AST.cs
+++ b/WrathCombo/Combos/PvE/AST/AST.cs
@@ -1,5 +1,4 @@
-﻿using Dalamud.Game.ClientState.JobGauge.Enums;
-using Dalamud.Game.ClientState.Statuses;
+﻿using Dalamud.Game.ClientState.Statuses;
 using System.Linq;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;

--- a/WrathCombo/Combos/PvE/AST/AST.cs
+++ b/WrathCombo/Combos/PvE/AST/AST.cs
@@ -318,7 +318,7 @@ internal partial class AST : Healer
         }
     }
 
-    internal class AST_AoE_SimpleHeals_AspectedHelios : CustomCombo
+    internal class AST_AoE_SimpleHeals : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AST_AoE_SimpleHeals;
 

--- a/WrathCombo/Combos/PvE/AST/AST_Config.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Config.cs
@@ -55,8 +55,8 @@ internal partial class AST
             AST_AoE_SimpleHeals_Opposition = new("AST_AoE_SimpleHeals_Opposition"),
             AST_AoE_SimpleHeals_Horoscope = new("AST_AoE_SimpleHeals_Horoscope"),
             AST_AoE_SimpleHeals_NeutralSectWeave = new("AST_AoE_SimpleHeals_NeutralSectWeave"),
-            AST_ST_DPS_OverwriteCards = new("AST_ST_DPS_OverwriteCards"),
-            AST_AOE_DPS_OverwriteCards = new("AST_AOE_DPS_OverwriteCards");
+            AST_ST_DPS_OverwriteHealCards = new("AST_ST_DPS_OverwriteHealCards"),
+            AST_AOE_DPS_OverwriteHealCards = new("AST_AOE_DPS_OverwriteHealCards");
         public static UserFloat
             AST_ST_DPS_CombustUptime_Threshold = new("AST_ST_DPS_CombustUptime_Threshold");
 
@@ -122,7 +122,7 @@ internal partial class AST
                     break;
 
                 case CustomComboPreset.AST_AOE_AutoDraw:
-                    DrawAdditionalBoolChoice(AST_AOE_DPS_OverwriteCards, "Overwrite Non-DPS Cards", "Will draw even if you have healing cards remaining.");
+                    DrawAdditionalBoolChoice(AST_AOE_DPS_OverwriteHealCards, "Overwrite Non-DPS Cards", "Will draw even if you have healing cards remaining.");
                     break;
 
                 case CustomComboPreset.AST_AOE_DPS_MacroCosmos:
@@ -236,7 +236,7 @@ internal partial class AST
                     break;
 
                 case CustomComboPreset.AST_DPS_AutoDraw:
-                    DrawAdditionalBoolChoice(AST_ST_DPS_OverwriteCards, "Overwrite Non-DPS Cards", "Will draw even if you have healing cards remaining.");
+                    DrawAdditionalBoolChoice(AST_ST_DPS_OverwriteHealCards, "Overwrite Non-DPS Cards", "Will draw even if you have healing cards remaining.");
                     break;
 
                

--- a/WrathCombo/Combos/PvE/AST/AST_Config.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Config.cs
@@ -1,8 +1,6 @@
 ﻿using Dalamud.Interface.Colors;
 using ImGuiNET;
 using WrathCombo.CustomComboNS.Functions;
-using WrathCombo.Window.Functions;
-using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 using static WrathCombo.Extensions.UIntExtensions;
 using static WrathCombo.Window.Functions.SliderIncrements;
 using static WrathCombo.Window.Functions.UserConfig;
@@ -12,36 +10,51 @@ internal partial class AST
 {
     public static class Config
     {
+        public static UserIntArray
+            AST_ST_SimpleHeals_Priority = new("AST_ST_SimpleHeals_Priority"),
+            AST_AoE_SimpleHeals_Priority = new("AST_AoE_SimpleHeals_Priority");
+        
         public static UserInt
-            AST_LucidDreaming = new("ASTLucidDreamingFeature", 8000),
-            AST_AOE_LucidDreaming = new("AST_AOE_LucidDreaming", 8000),
-            AST_EssentialDignity = new("ASTCustomEssentialDignity", 50),
-            AST_Spire = new("AST_Spire", 80),
-            AST_Ewer = new("AST_Ewer", 80),
-            AST_Arrow = new("AST_Arrow", 80),
-            AST_Bole = new("AST_Bole", 80),
-            AST_AoE_SimpleHeals_LazyLadyThreshold = new("AST_AoE_SimpleHeals_LazyLadyThreshold", 80),
-            AST_AoE_SimpleHeals_HoroscopeThreshold = new("AST_AoE_SimpleHeals_HoroscopeThreshold", 80),
-            AST_AoE_SimpleHeals_CelestialOppositionThreshold = new("AST_AoE_SimpleHeals_CelestialOppositionThreshold", 80),
-            AST_AoE_SimpleHeals_NeutralSectThreshold = new("AST_AoE_SimpleHeals_NeutralSectThreshold", 80),
+            //HEALS
+            AST_ST_SimpleHeals_Spire = new("AST_ST_SimpleHeals_Spire", 80),
+            AST_ST_SimpleHeals_Ewer = new("AST_ST_SimpleHeals_Ewer", 80),
+            AST_ST_SimpleHeals_Arrow = new("AST_ST_SimpleHeals_Arrow", 80),
+            AST_ST_SimpleHeals_Bole = new("AST_ST_SimpleHeals_Bole", 80),
+            AST_ST_SimpleHeals_CelestialIntersection = new("AST_ST_SimpleHeals_CelestialIntersection", 80),
+            AST_ST_SimpleHeals_EssentialDignity = new("AST_ST_SimpleHeals_EssentialDignity", 50),
+            AST_ST_SimpleHeals_Exaltation = new("AST_ST_SimpleHeals_Exaltation", 50),
             AST_ST_SimpleHeals_Esuna = new("AST_ST_SimpleHeals_Esuna", 100),
-            AST_DPS_AltMode = new("AST_DPS_AltMode"),
-            AST_AoEHeals_AltMode = new("AST_AoEHeals_AltMode"),
-            AST_DPS_DivinationOption = new("AST_DPS_DivinationOption"),
-            AST_AOE_DivinationOption = new("AST_AOE_DivinationOption"),
-            AST_DPS_LightSpeedOption = new("AST_DPS_LightSpeedOption"),
-            AST_AOE_LightSpeedOption = new("AST_AOE_LightSpeedOption"),
-            AST_DPS_CombustOption = new("AST_DPS_CombustOption"),
-            AST_QuickTarget_Override = new("AST_QuickTarget_Override"),
-            AST_ST_DPS_Balance_Content = new("AST_ST_DPS_Balance_Content", 1),
-            AST_ST_DPS_CombustSubOption = new("AST_ST_DPS_CombustSubOption", 0),
             AST_ST_SimpleHeals_AspectedBeneficHigh = new("AST_ST_SimpleHeals_AspectedBeneficHigh", 90),
             AST_ST_SimpleHeals_AspectedBeneficLow = new("AST_ST_SimpleHeals_AspectedBeneficLow", 40),
             AST_ST_SimpleHeals_AspectedBeneficRefresh = new("AST_ST_SimpleHeals_AspectedBeneficRefresh", 3),
-            AST_AOE_DPS_MacroCosmos_SubOption = new("AST_AOE_DPS_MacroCosmos_SubOption", 0);            
+            AST_ST_SimpleHeals_CollectiveUnconscious = new("AST_ST_SimpleHeals_CollectiveUnconscious", 80),
+            AST_ST_SimpleHeals_CelestialOpposition = new("AST_ST_SimpleHeals_CelestialOpposition", 80),
+            AST_ST_SimpleHeals_SoloLady = new("AST_ST_SimpleHeals_SoloLady", 80),
+            AST_AoE_SimpleHeals_AltMode = new("AST_AoE_SimpleHeals_AltMode"),
+            AST_AoE_SimpleHeals_LazyLady = new("AST_AoE_SimpleHeals_LazyLady", 80),
+            AST_AoE_SimpleHeals_Horoscope = new("AST_AoE_SimpleHeals_Horoscope", 80),
+            AST_AoE_SimpleHeals_CelestialOpposition = new("AST_AoE_SimpleHeals_CelestialOpposition", 80),
+            AST_AoE_SimpleHeals_NeutralSect = new("AST_AoE_SimpleHeals_NeutralSect", 80),
+            AST_AoE_SimpleHeals_HoroscopeHeal = new("AST_AoE_SimpleHeals_HoroscopeHeal", 80),
+            AST_AoE_SimpleHeals_StellarDetonation = new("AST_AoE_SimpleHeals_StellarDetonation", 80),
+            AST_AoE_SimpleHeals_Aspected = new("AST_AoE_SimpleHeals_Aspected", 80),
+            AST_AoE_SimpleHeals_Helios = new("AST_AoE_SimpleHeals_Helios", 80),
+            //DPS
+            AST_ST_DPS_DivinationOption = new("AST_ST_DPS_DivinationOption"),
+            AST_ST_DPS_AltMode = new("AST_ST_DPS_AltMode"),
+            AST_ST_DPS_LucidDreaming = new("AST_ST_DPS_LucidDreaming", 8000),
+            AST_ST_DPS_LightSpeedOption = new("AST_ST_DPS_LightSpeedOption"),
+            AST_ST_DPS_CombustOption = new("AST_ST_DPS_CombustOption"),
+            AST_ST_DPS_Balance_Content = new("AST_ST_DPS_Balance_Content", 1),
+            AST_ST_DPS_CombustSubOption = new("AST_ST_DPS_CombustSubOption", 0),
+            AST_AOE_LucidDreaming = new("AST_AOE_LucidDreaming", 8000),
+            AST_AOE_DivinationOption = new("AST_AOE_DivinationOption"),
+            AST_AOE_LightSpeedOption = new("AST_AOE_LightSpeedOption"),
+            AST_AOE_DPS_MacroCosmos_SubOption = new("AST_AOE_DPS_MacroCosmos_SubOption", 0),
+            AST_QuickTarget_Override = new("AST_QuickTarget_Override", 0);
 
         public static UserBool
-            AST_QuickTarget_Manuals = new("AST_QuickTarget_Manuals", true),
+            //HEALS
             AST_ST_SimpleHeals_Adv = new("AST_ST_SimpleHeals_Adv"),
             AST_ST_SimpleHeals_IncludeShields = new("AST_ST_SimpleHeals_IncludeShields"),
             AST_ST_SimpleHeals_WeaveDignity = new("AST_ST_SimpleHeals_WeaveDignity"),
@@ -52,63 +65,65 @@ internal partial class AST
             AST_ST_SimpleHeals_WeaveBole = new("AST_ST_SimpleHeals_WeaveBole"),
             AST_ST_SimpleHeals_WeaveExalt = new("AST_ST_SimpleHeals_WeaveExalt"),
             AST_AoE_SimpleHeals_WeaveLady = new("AST_AoE_SimpleHeals_WeaveLady"),
-            AST_AoE_SimpleHeals_Opposition = new("AST_AoE_SimpleHeals_Opposition"),
-            AST_AoE_SimpleHeals_Horoscope = new("AST_AoE_SimpleHeals_Horoscope"),
-            AST_AoE_SimpleHeals_NeutralSectWeave = new("AST_AoE_SimpleHeals_NeutralSectWeave"),
+            AST_AoE_SimpleHeals_WeaveOpposition = new("AST_AoE_SimpleHeals_WeaveOpposition"),
+            AST_AoE_SimpleHeals_WeaveHoroscope = new("AST_AoE_SimpleHeals_WeaveHoroscope"),
+            AST_AoE_SimpleHeals_WeaveNeutralSect = new("AST_AoE_SimpleHeals_WeaveNeutralSect"),
+            AST_AoE_SimpleHeals_WeaveHoroscopeHeal = new("AST_AoE_SimpleHeals_WeaveHoroscopeHeal"),
+            AST_AoE_SimpleHeals_WeaveStellarDetonation = new("AST_AoE_SimpleHeals_WeaveStellarDetonation"),
+            //DPS
             AST_ST_DPS_OverwriteHealCards = new("AST_ST_DPS_OverwriteHealCards"),
-            AST_AOE_DPS_OverwriteHealCards = new("AST_AOE_DPS_OverwriteHealCards");
+            AST_AOE_DPS_OverwriteHealCards = new("AST_AOE_DPS_OverwriteHealCards"),
+            AST_QuickTarget_Manuals = new("AST_QuickTarget_Manuals", true);
         public static UserFloat
             AST_ST_DPS_CombustUptime_Threshold = new("AST_ST_DPS_CombustUptime_Threshold");
+
+        public static UserBoolArray
+            AST_ST_SimpleHeals_CelestialOppositionOptions = new("AST_ST_SimpleHeals_CelestialOppositionOptions"),
+            AST_ST_SimpleHeals_CollectiveUnconsciousOptions = new("AST_ST_SimpleHeals_CollectiveUnconsciousOptions"),
+            AST_ST_SimpleHeals_SoloLadyOptions = new("AST_ST_SimpleHeals_SoloLadyOptions");
 
         internal static void Draw(CustomComboPreset preset)
         {
             switch (preset)
             {
+                #region DPS
                 case CustomComboPreset.AST_ST_DPS_Opener:
                     DrawBossOnlyChoice(AST_ST_DPS_Balance_Content);
                     break;
 
                 case CustomComboPreset.AST_ST_DPS:
-                    DrawRadioButton(AST_DPS_AltMode, $"On {Malefic.ActionName()}", "", 0);
-                    DrawRadioButton(AST_DPS_AltMode, $"On {Combust.ActionName()}", $"Alternative DPS Mode. Leaves {Malefic.ActionName()} alone for pure DPS, becomes {Malefic.ActionName()} when features are on cooldown", 1);
+                    DrawRadioButton(AST_ST_DPS_AltMode, $"On {Malefic.ActionName()}", "", 0);
+                    DrawRadioButton(AST_ST_DPS_AltMode, $"On {Combust.ActionName()}", $"Alternative DPS Mode. Leaves {Malefic.ActionName()} alone for pure DPS, becomes {Malefic.ActionName()} when features are on cooldown", 1);
                     break;
 
                 case CustomComboPreset.AST_DPS_Lucid:
-                    DrawSliderInt(4000, 9500, AST_LucidDreaming, "Set value for your MP to be at or under for this feature to work", 150, Hundreds);
+                    DrawSliderInt(4000, 9500, AST_ST_DPS_LucidDreaming, "Set value for your MP to be at or under for this feature to work", 150, Hundreds);
                     break;
 
                 case CustomComboPreset.AST_ST_DPS_CombustUptime:
-                    
-                    DrawSliderInt(0, 50, AST_DPS_CombustOption, "Stop using at Enemy HP %. Set to Zero to disable this check.");
-
+                    DrawSliderInt(0, 50, AST_ST_DPS_CombustOption, "Stop using at Enemy HP %. Set to Zero to disable this check.");
                     ImGui.Indent();
-
                     ImGui.TextColored(ImGuiColors.DalamudYellow, "Select what kind of enemies the HP check should be applied to:");
-
                     DrawHorizontalRadioButton(AST_ST_DPS_CombustSubOption,
                         "Non-Bosses", "Only applies the HP check above to non-bosses.\nAllows you to only stop DoTing early when it's not a boss.", 0);
-                    
                     DrawHorizontalRadioButton(AST_ST_DPS_CombustSubOption,
                         "All Enemies", "Applies the HP check above to all enemies.", 1);
-
-                    
-                    
-
                     DrawRoundedSliderFloat(0, 4, AST_ST_DPS_CombustUptime_Threshold, "Seconds remaining before reapplying the DoT. Set to Zero to disable this check.", digits: 1);
-
                     ImGui.Unindent();
-
                     break;
 
                 case CustomComboPreset.AST_DPS_Divination:
-                    DrawSliderInt(0, 100, AST_DPS_DivinationOption, "Stop using at Enemy HP %. Set to Zero to disable this check.");
+                    DrawSliderInt(0, 100, AST_ST_DPS_DivinationOption, "Stop using at Enemy HP %. Set to Zero to disable this check.");
                     break;
 
                 case CustomComboPreset.AST_DPS_LightSpeed:
-                    DrawSliderInt(0, 100, AST_DPS_LightSpeedOption, "Stop using at Enemy HP %. Set to Zero to disable this check.");
+                    DrawSliderInt(0, 100, AST_ST_DPS_LightSpeedOption, "Stop using at Enemy HP %. Set to Zero to disable this check.");
                     break;
-
-                //AOE added
+                
+                case CustomComboPreset.AST_DPS_AutoDraw:
+                    DrawAdditionalBoolChoice(AST_ST_DPS_OverwriteHealCards, "Overwrite Non-DPS Cards", "Will draw even if you have healing cards remaining.");
+                    break;
+                
                 case CustomComboPreset.AST_AOE_Lucid:
                     DrawSliderInt(4000, 9500, AST_AOE_LucidDreaming, "Set value for your MP to be at or under for this feature to work", 150, Hundreds);
                     break;
@@ -126,18 +141,13 @@ internal partial class AST
                     break;
 
                 case CustomComboPreset.AST_AOE_DPS_MacroCosmos:
-
-                    DrawHorizontalRadioButton(AST_AOE_DPS_MacroCosmos_SubOption,
-                        "Non-boss Encounters Only", $"Will not use on bosses", 0);
-                    DrawHorizontalRadioButton(AST_AOE_DPS_MacroCosmos_SubOption,
-                        "All Content", $"Will use in all content", 1);
-
-                    ImGui.Unindent();
-
+                    DrawHorizontalRadioButton(AST_AOE_DPS_MacroCosmos_SubOption, "Non-boss Encounters Only", $"Will not use on bosses", 0);
+                    DrawHorizontalRadioButton(AST_AOE_DPS_MacroCosmos_SubOption, "All Content", $"Will use in all content", 1);
                     break;
 
-                //end aoe added
-
+                #endregion
+                
+                #region ST Heals
                 case CustomComboPreset.AST_ST_SimpleHeals:
                     DrawAdditionalBoolChoice(AST_ST_SimpleHeals_Adv, "Advanced Options", "", isConditionalChoice: true);
                     if (AST_ST_SimpleHeals_Adv)
@@ -148,77 +158,141 @@ internal partial class AST
                         ImGui.Unindent();
                     }
                     break;
-
-                case CustomComboPreset.AST_ST_SimpleHeals_AspectedBenefic:
-                    DrawSliderInt(0, 100, AST_ST_SimpleHeals_AspectedBeneficHigh, "Start using when below set percentage");
-                    DrawSliderInt(0, 100, AST_ST_SimpleHeals_AspectedBeneficLow, "Stop using when below set percentage");
-                    DrawSliderInt(0, 15, AST_ST_SimpleHeals_AspectedBeneficRefresh, "Seconds remaining before reapplying (0 = Do not reapply early)");
-                    
-                    break;
-
-                case CustomComboPreset.AST_ST_SimpleHeals_EssentialDignity:
-                    DrawSliderInt(0, 100, AST_EssentialDignity, "Set percentage value");
-                    DrawAdditionalBoolChoice(AST_ST_SimpleHeals_WeaveDignity, "Only Weave", "Will only weave this action.");
-                    break;
-
-                case CustomComboPreset.AST_ST_SimpleHeals_CelestialIntersection:
-                    DrawAdditionalBoolChoice(AST_ST_SimpleHeals_WeaveIntersection, "Only Weave", "Will only weave this action.");
-                    break;
-
-                case CustomComboPreset.AST_ST_SimpleHeals_Exaltation:
-                    DrawAdditionalBoolChoice(AST_ST_SimpleHeals_WeaveExalt, "Only Weave", "Will only weave this action.");
-                    break;
-
-                case CustomComboPreset.AST_ST_SimpleHeals_Spire:
-                    DrawSliderInt(0, 100, AST_Spire, "Set percentage value");
-                    DrawAdditionalBoolChoice(AST_ST_SimpleHeals_WeaveSpire, "Only Weave", "Will only weave this action.");
-                    break;
-
-                case CustomComboPreset.AST_ST_SimpleHeals_Ewer:
-                    DrawSliderInt(0, 100, AST_Ewer, "Set percentage value");
-                    DrawAdditionalBoolChoice(AST_ST_SimpleHeals_WeaveEwer, "Only Weave", "Will only weave this action.");
-                    break;
-
-                case CustomComboPreset.AST_ST_SimpleHeals_Bole:
-                    DrawSliderInt(0, 100, AST_Bole, "Set percentage value");
-                    DrawAdditionalBoolChoice(AST_ST_SimpleHeals_WeaveBole, "Only Weave", "Will only weave this action.");
-                    break;
-
-                case CustomComboPreset.AST_ST_SimpleHeals_Arrow:
-                    DrawSliderInt(0, 100, AST_Arrow, "Set percentage value");
-                    DrawAdditionalBoolChoice(AST_ST_SimpleHeals_WeaveArrow, "Only Weave", "Will only weave this action.");
-                    break;
-
+                
                 case CustomComboPreset.AST_ST_SimpleHeals_Esuna:
                     DrawSliderInt(0, 100, AST_ST_SimpleHeals_Esuna, "Stop using when below HP %. Set to Zero to disable this check");
                     break;
+                
+                case CustomComboPreset.AST_ST_SimpleHeals_CelestialIntersection:
+                    DrawSliderInt(0, 100, AST_ST_SimpleHeals_CelestialIntersection, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(AST_ST_SimpleHeals_WeaveIntersection, "Only Weave", "Will only weave this action.");
+                    DrawPriorityInput(AST_ST_SimpleHeals_Priority, 11, 0, $"{CelestialIntersection.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.AST_ST_SimpleHeals_EssentialDignity:
+                    DrawSliderInt(0, 100, AST_ST_SimpleHeals_EssentialDignity, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(AST_ST_SimpleHeals_WeaveDignity, "Only Weave", "Will only weave this action.");
+                    DrawPriorityInput(AST_ST_SimpleHeals_Priority, 11, 1, $"{EssentialDignity.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.AST_ST_SimpleHeals_Exaltation:
+                    DrawSliderInt(0, 100, AST_ST_SimpleHeals_Exaltation, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(AST_ST_SimpleHeals_WeaveExalt, "Only Weave", "Will only weave this action.");
+                    DrawPriorityInput(AST_ST_SimpleHeals_Priority, 11, 2, $"{Exaltation.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.AST_ST_SimpleHeals_Bole:
+                    DrawSliderInt(0, 100, AST_ST_SimpleHeals_Bole, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(AST_ST_SimpleHeals_WeaveBole, "Only Weave", "Will only weave this action.");
+                    DrawPriorityInput(AST_ST_SimpleHeals_Priority, 11, 3, $"{Bole.ActionName()} Priority: ");
+                    break;
 
-                case CustomComboPreset.AST_AoE_SimpleHeals_AspectedHelios:
-                    DrawRadioButton(AST_AoEHeals_AltMode, $"On {AspectedHelios.ActionName()}", "", 0);
-                    DrawRadioButton(AST_AoEHeals_AltMode, $"On {Helios.ActionName()}", "Alternative AOE Mode. Leaves Aspected Helios alone for manual HoTs", 1);
+                case CustomComboPreset.AST_ST_SimpleHeals_Arrow:
+                    DrawSliderInt(0, 100, AST_ST_SimpleHeals_Arrow, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(AST_ST_SimpleHeals_WeaveArrow, "Only Weave", "Will only weave this action.");
+                    DrawPriorityInput(AST_ST_SimpleHeals_Priority, 11, 4, $"{Arrow.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.AST_ST_SimpleHeals_Ewer:
+                    DrawSliderInt(0, 100, AST_ST_SimpleHeals_Ewer, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(AST_ST_SimpleHeals_WeaveEwer, "Only Weave", "Will only weave this action.");
+                    DrawPriorityInput(AST_ST_SimpleHeals_Priority, 11, 5, $"{Ewer.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.AST_ST_SimpleHeals_Spire:
+                    DrawSliderInt(0, 100, AST_ST_SimpleHeals_Spire, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(AST_ST_SimpleHeals_WeaveSpire, "Only Weave", "Will only weave this action.");
+                    DrawPriorityInput(AST_ST_SimpleHeals_Priority, 11, 6, $"{Spire.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.AST_ST_SimpleHeals_AspectedBenefic:
+                    DrawSliderInt(0, 100, AST_ST_SimpleHeals_AspectedBeneficHigh, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, AST_ST_SimpleHeals_AspectedBeneficLow, "Stop using when below set percentage");
+                    DrawSliderInt(0, 15, AST_ST_SimpleHeals_AspectedBeneficRefresh, "Seconds remaining before reapplying (0 = Do not reapply early)");
+                    DrawPriorityInput(AST_ST_SimpleHeals_Priority, 11, 7, $"{AspectedBenefic.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.AST_ST_SimpleHeals_CelestialOpposition:
+                    DrawSliderInt(0, 100, AST_ST_SimpleHeals_CelestialOpposition, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawHorizontalMultiChoice(AST_ST_SimpleHeals_CelestialOppositionOptions,"Only Weave", "Will only weave this action.", 2, 0);
+                    DrawHorizontalMultiChoice(AST_ST_SimpleHeals_CelestialOppositionOptions," Not On Bosses", "Will not use on ST in Boss encounters.", 2, 1);
+                    DrawPriorityInput(AST_ST_SimpleHeals_Priority, 11, 8, $"{CelestialOpposition.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.AST_ST_SimpleHeals_CollectiveUnconscious:
+                    DrawSliderInt(0, 100, AST_ST_SimpleHeals_CollectiveUnconscious, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawHorizontalMultiChoice(AST_ST_SimpleHeals_CollectiveUnconsciousOptions,"Only Weave", "Will only weave this action.", 2, 0);
+                    DrawHorizontalMultiChoice(AST_ST_SimpleHeals_CollectiveUnconsciousOptions," Not On Bosses", "Will not use on ST in Boss encounters.", 2, 1);
+                    DrawPriorityInput(AST_ST_SimpleHeals_Priority, 11, 9, $"{CollectiveUnconscious.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.AST_ST_SimpleHeals_SoloLady:
+                    DrawSliderInt(0, 100, AST_ST_SimpleHeals_SoloLady, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawHorizontalMultiChoice(AST_ST_SimpleHeals_SoloLadyOptions,"Only Weave", "Will only weave this action.", 2, 0);
+                    DrawHorizontalMultiChoice(AST_ST_SimpleHeals_SoloLadyOptions," Not On Bosses", "Will not use on ST in Boss encounters.", 2, 1);
+                    DrawPriorityInput(AST_ST_SimpleHeals_Priority, 11, 10, $"{LadyOfCrown.ActionName()} Priority: ");
+                    break;
+                
+                
+                #endregion
+                
+                #region AOE Heals
+
+                case CustomComboPreset.AST_AoE_SimpleHeals:
+                    DrawRadioButton(AST_AoE_SimpleHeals_AltMode, $"On {AspectedHelios.ActionName()}", "", 0);
+                    DrawRadioButton(AST_AoE_SimpleHeals_AltMode, $"On {Helios.ActionName()}", "Alternative AOE Mode. Leaves Aspected Helios alone for manual HoTs", 1);
                     break;
 
                 case CustomComboPreset.AST_AoE_SimpleHeals_LazyLady:
-                    DrawSliderInt(0, 100, AST_AoE_SimpleHeals_LazyLadyThreshold, "Start using when below party average HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, AST_AoE_SimpleHeals_LazyLady, "Start using when below party average HP %. Set to 100 to disable this check");
                     DrawAdditionalBoolChoice(AST_AoE_SimpleHeals_WeaveLady, "Only Weave", "Will only weave this action.");
+                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 8, 0, $"{LadyOfCrown.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.AST_AoE_SimpleHeals_Horoscope:
-                    DrawSliderInt(0, 100, AST_AoE_SimpleHeals_HoroscopeThreshold, "Start using when below party average HP %. Set to 100 to disable this check");
-                    DrawAdditionalBoolChoice(AST_AoE_SimpleHeals_Horoscope, "Only Weave", "Will only weave this action.");
+                    DrawSliderInt(0, 100, AST_AoE_SimpleHeals_Horoscope, "Start using when below party average HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(AST_AoE_SimpleHeals_WeaveHoroscope, "Only Weave", "Will only weave this action.");
+                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 8, 1, $"{Horoscope.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.AST_AoE_SimpleHeals_HoroscopeHeal:
+                    DrawSliderInt(0, 100, AST_AoE_SimpleHeals_HoroscopeHeal, "Start using when below party average HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(AST_AoE_SimpleHeals_WeaveHoroscopeHeal, "Only Weave", "Will only weave this action.");
+                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 8, 2, $"{HoroscopeHeal.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.AST_AoE_SimpleHeals_CelestialOpposition:
-                    DrawSliderInt(0, 100, AST_AoE_SimpleHeals_CelestialOppositionThreshold, "Start using when below party average HP %. Set to 100 to disable this check");
-                    DrawAdditionalBoolChoice(AST_AoE_SimpleHeals_Opposition, "Only Weave", "Will only weave this action.");
+                    DrawSliderInt(0, 100, AST_AoE_SimpleHeals_CelestialOpposition, "Start using when below party average HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(AST_AoE_SimpleHeals_WeaveOpposition, "Only Weave", "Will only weave this action.");
+                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 8, 3, $"{CelestialOpposition.ActionName()} Priority: ");
                     break;
 
 
                 case CustomComboPreset.AST_AoE_SimpleHeals_NeutralSect:
-                    DrawSliderInt(0, 100, AST_AoE_SimpleHeals_NeutralSectThreshold, "Start using when below party average HP %. Set to 100 to disable this check");
-                    DrawAdditionalBoolChoice(AST_AoE_SimpleHeals_NeutralSectWeave, "Only Weave", "Will only weave this action.");
+                    DrawSliderInt(0, 100, AST_AoE_SimpleHeals_NeutralSect, "Start using when below party average HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(AST_AoE_SimpleHeals_WeaveNeutralSect, "Only Weave", "Will only weave this action.");
+                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 8, 4, $"{NeutralSect.ActionName()} Priority: ");
                     break;
-
+                
+                case CustomComboPreset.AST_AoE_SimpleHeals_StellarDetonation:
+                    DrawSliderInt(0, 100, AST_AoE_SimpleHeals_StellarDetonation, "Start using when below party average HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(AST_AoE_SimpleHeals_WeaveStellarDetonation, "Only Weave", "Will only weave this action.");
+                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 8, 5, $"{StellarDetonation.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.AST_AoE_SimpleHeals_Aspected:
+                    DrawSliderInt(0, 100, AST_AoE_SimpleHeals_Aspected, "Start using when below party average HP %. Set to 100 to disable this check");
+                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 8, 6, $"{AspectedHelios.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.AST_AoE_SimpleHeals_Helios:
+                    DrawSliderInt(0, 100, AST_AoE_SimpleHeals_Helios, "Start using when below party average HP %. Set to 100 to disable this check");
+                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 8, 7, $"{Helios.ActionName()} Priority: ");
+                    break;
+                
+                #endregion
+                
+                #region Standalone
                 case CustomComboPreset.AST_Cards_QuickTargetCards:
                     DrawAdditionalBoolChoice(AST_QuickTarget_Manuals,
                         "Also Retarget manually-used Cards",
@@ -234,13 +308,7 @@ internal partial class AST
                     DrawRadioButton(AST_QuickTarget_Override, "UI MouseOver Override", "Overrides selection with UI MouseOver target, if you have one that is in range and does not have damage down or rez sickness.", 2, descriptionAsTooltip: true);
                     DrawRadioButton(AST_QuickTarget_Override, "Any MouseOver Override", "Overrides selection with UI or Nameplate or Model MouseOver target (in that order), if you have one that is in range and does not have damage down or rez sickness.", 3, descriptionAsTooltip: true);
                     break;
-
-                case CustomComboPreset.AST_DPS_AutoDraw:
-                    DrawAdditionalBoolChoice(AST_ST_DPS_OverwriteHealCards, "Overwrite Non-DPS Cards", "Will draw even if you have healing cards remaining.");
-                    break;
-
-               
-                
+                #endregion
             }
         }
     }

--- a/WrathCombo/Combos/PvE/AST/AST_Config.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Config.cs
@@ -34,6 +34,7 @@ internal partial class AST
             AST_AoE_SimpleHeals_LazyLady = new("AST_AoE_SimpleHeals_LazyLady", 80),
             AST_AoE_SimpleHeals_Horoscope = new("AST_AoE_SimpleHeals_Horoscope", 80),
             AST_AoE_SimpleHeals_CelestialOpposition = new("AST_AoE_SimpleHeals_CelestialOpposition", 80),
+            AST_AoE_SimpleHeals_CollectiveUnconscious = new("AST_AoE_SimpleHeals_CollectiveUnconscious", 80),
             AST_AoE_SimpleHeals_NeutralSect = new("AST_AoE_SimpleHeals_NeutralSect", 80),
             AST_AoE_SimpleHeals_HoroscopeHeal = new("AST_AoE_SimpleHeals_HoroscopeHeal", 80),
             AST_AoE_SimpleHeals_StellarDetonation = new("AST_AoE_SimpleHeals_StellarDetonation", 80),
@@ -66,6 +67,7 @@ internal partial class AST
             AST_ST_SimpleHeals_WeaveExalt = new("AST_ST_SimpleHeals_WeaveExalt"),
             AST_AoE_SimpleHeals_WeaveLady = new("AST_AoE_SimpleHeals_WeaveLady"),
             AST_AoE_SimpleHeals_WeaveOpposition = new("AST_AoE_SimpleHeals_WeaveOpposition"),
+            AST_AoE_SimpleHeals_WeaveCollectiveUnconscious = new("AST_AoE_SimpleHeals_WeaveCollectiveUnconscious"),
             AST_AoE_SimpleHeals_WeaveHoroscope = new("AST_AoE_SimpleHeals_WeaveHoroscope"),
             AST_AoE_SimpleHeals_WeaveNeutralSect = new("AST_AoE_SimpleHeals_WeaveNeutralSect"),
             AST_AoE_SimpleHeals_WeaveHoroscopeHeal = new("AST_AoE_SimpleHeals_WeaveHoroscopeHeal"),
@@ -246,48 +248,54 @@ internal partial class AST
                 case CustomComboPreset.AST_AoE_SimpleHeals_LazyLady:
                     DrawSliderInt(0, 100, AST_AoE_SimpleHeals_LazyLady, "Start using when below party average HP %. Set to 100 to disable this check");
                     DrawAdditionalBoolChoice(AST_AoE_SimpleHeals_WeaveLady, "Only Weave", "Will only weave this action.");
-                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 8, 0, $"{LadyOfCrown.ActionName()} Priority: ");
+                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 9, 0, $"{LadyOfCrown.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.AST_AoE_SimpleHeals_Horoscope:
                     DrawSliderInt(0, 100, AST_AoE_SimpleHeals_Horoscope, "Start using when below party average HP %. Set to 100 to disable this check");
                     DrawAdditionalBoolChoice(AST_AoE_SimpleHeals_WeaveHoroscope, "Only Weave", "Will only weave this action.");
-                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 8, 1, $"{Horoscope.ActionName()} Priority: ");
+                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 9, 1, $"{Horoscope.ActionName()} Priority: ");
                     break;
                 
                 case CustomComboPreset.AST_AoE_SimpleHeals_HoroscopeHeal:
                     DrawSliderInt(0, 100, AST_AoE_SimpleHeals_HoroscopeHeal, "Start using when below party average HP %. Set to 100 to disable this check");
                     DrawAdditionalBoolChoice(AST_AoE_SimpleHeals_WeaveHoroscopeHeal, "Only Weave", "Will only weave this action.");
-                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 8, 2, $"{HoroscopeHeal.ActionName()} Priority: ");
+                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 9, 2, $"{HoroscopeHeal.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.AST_AoE_SimpleHeals_CelestialOpposition:
                     DrawSliderInt(0, 100, AST_AoE_SimpleHeals_CelestialOpposition, "Start using when below party average HP %. Set to 100 to disable this check");
                     DrawAdditionalBoolChoice(AST_AoE_SimpleHeals_WeaveOpposition, "Only Weave", "Will only weave this action.");
-                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 8, 3, $"{CelestialOpposition.ActionName()} Priority: ");
+                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 9, 3, $"{CelestialOpposition.ActionName()} Priority: ");
                     break;
 
 
                 case CustomComboPreset.AST_AoE_SimpleHeals_NeutralSect:
                     DrawSliderInt(0, 100, AST_AoE_SimpleHeals_NeutralSect, "Start using when below party average HP %. Set to 100 to disable this check");
                     DrawAdditionalBoolChoice(AST_AoE_SimpleHeals_WeaveNeutralSect, "Only Weave", "Will only weave this action.");
-                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 8, 4, $"{NeutralSect.ActionName()} Priority: ");
+                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 9, 4, $"{NeutralSect.ActionName()} Priority: ");
                     break;
                 
                 case CustomComboPreset.AST_AoE_SimpleHeals_StellarDetonation:
                     DrawSliderInt(0, 100, AST_AoE_SimpleHeals_StellarDetonation, "Start using when below party average HP %. Set to 100 to disable this check");
                     DrawAdditionalBoolChoice(AST_AoE_SimpleHeals_WeaveStellarDetonation, "Only Weave", "Will only weave this action.");
-                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 8, 5, $"{StellarDetonation.ActionName()} Priority: ");
+                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 9, 5, $"{StellarDetonation.ActionName()} Priority: ");
                     break;
                 
                 case CustomComboPreset.AST_AoE_SimpleHeals_Aspected:
                     DrawSliderInt(0, 100, AST_AoE_SimpleHeals_Aspected, "Start using when below party average HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 8, 6, $"{AspectedHelios.ActionName()} Priority: ");
+                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 9, 6, $"{AspectedHelios.ActionName()} Priority: ");
                     break;
                 
                 case CustomComboPreset.AST_AoE_SimpleHeals_Helios:
                     DrawSliderInt(0, 100, AST_AoE_SimpleHeals_Helios, "Start using when below party average HP %. Set to 100 to disable this check");
-                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 8, 7, $"{Helios.ActionName()} Priority: ");
+                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 9, 7, $"{Helios.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.AST_AoE_SimpleHeals_CollectiveUnconscious:
+                    DrawSliderInt(0, 100, AST_AoE_SimpleHeals_CollectiveUnconscious, "Start using when below party average HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(AST_AoE_SimpleHeals_WeaveCollectiveUnconscious, "Only Weave", "Will only weave this action.");
+                    DrawPriorityInput(AST_AoE_SimpleHeals_Priority, 9, 8, $"{CollectiveUnconscious.ActionName()} Priority: ");
                     break;
                 
                 #endregion

--- a/WrathCombo/Combos/PvE/AST/AST_Helper.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Helper.cs
@@ -31,37 +31,27 @@ internal partial class AST
             { Combust2, Debuffs.Combust2 },
             { Combust3, Debuffs.Combust3 }
         };
-    public static ASTOpenerMaxLevel1 Opener1 = new();
+    
 
     public static ASTGauge Gauge => GetJobGauge<ASTGauge>();
     public static CardType DrawnDPSCard => Gauge.DrawnCards[0];
 
-    public static int SpellsSinceDraw()
-    {
-        if (ActionWatching.CombatActions.Count == 0)
-            return 0;
+    internal static bool HasNoCards => Gauge.DrawnCards.All(x => x is CardType.None);
+    internal static bool HasNoDPSCard => DrawnDPSCard == CardType.None;
+    internal static bool HasDPSCard => Gauge.DrawnCards[0] is not CardType.None;
 
-        uint spellToCheck = Gauge.ActiveDraw == DrawType.Astral ? UmbralDraw : AstralDraw;
-        int idx = ActionWatching.CombatActions.LastIndexOf(spellToCheck);
-        if (idx == -1)
-            idx = 0;
+    internal static bool HasLord => Gauge.DrawnCrownCard is CardType.Lord;
+    internal static bool HasLady => Gauge.DrawnCrownCard is CardType.Lady;
 
-        int ret = 0;
-        for (int i = idx; i < ActionWatching.CombatActions.Count; i++)
-        {
-            if (ActionWatching.GetAttackType(ActionWatching.CombatActions[i]) == ActionWatching.ActionAttackType.Spell)
-                ret++;
-        }
-        return ret;
-    }
 
-    public static WrathOpener Opener()
-    {
-        if (Opener1.LevelChecked)
-            return Opener1;
+    
+    internal static bool HasDivination=> HasStatusEffect(Buffs.Divination, anyOwner: true);
+    
+    
+    internal static float DivinationCD => GetCooldownRemainingTime(Divination);
+    internal static float LightspeedChargeCD => GetCooldownChargeRemainingTime(Lightspeed);
 
-        return WrathOpener.Dummy;
-    }
+    
 
     #region Card Targeting
 
@@ -239,7 +229,18 @@ internal partial class AST
     #endregion
 
     #endregion
+    
+    #region Opener
+    public static WrathOpener Opener()
+    {
+        if (Opener1.LevelChecked)
+            return Opener1;
 
+        return WrathOpener.Dummy;
+    }
+    
+    public static ASTOpenerMaxLevel1 Opener1 = new();
+    
     internal class ASTOpenerMaxLevel1 : WrathOpener
     {
         public override List<uint> OpenerActions { get; set; } =
@@ -294,6 +295,7 @@ internal partial class AST
             return true;
         }
     }
+    #endregion
 
     #region ID's
 

--- a/WrathCombo/Combos/PvE/AST/AST_Helper.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Helper.cs
@@ -186,6 +186,13 @@ internal partial class AST
                 action = Helios;
                 enabled = IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_Helios);
                 return Config.AST_AoE_SimpleHeals_Helios;
+            
+            case 8:
+                action = CollectiveUnconscious;
+                enabled = IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_CollectiveUnconscious) &&
+                          ActionReady(CollectiveUnconscious) &&
+                          (CanSpellWeave() || !Config.AST_AoE_SimpleHeals_WeaveCollectiveUnconscious);
+                return Config.AST_AoE_SimpleHeals_CollectiveUnconscious;
         }
 
         enabled = false;


### PR DESCRIPTION
- General
 - A bit of general cleanup utilizing helper file for the more complicated looking card stuff. 
 - Organize it to be ST, AoE, ST Heal, AoE Heal, Standalones
 
- ST Heal Priority System
 - 11 Total Options
 - The 8 normal single target heals
  - Aspected Heal, Essential Dignity, Celestial Intersection, Exaltation, 4 healing cards
 - Added 3 AoE OGCDs, with Not on Bosses option to allow for better usage during dungeon trash. 
  - Celestial Opposition, Lady card, Collective Unconscious 
  
- AoE Heal Priority System
 - 9 Total Options
  - Aspected Helios and Helios, so the users choice of Alt Mode wont hinder Automatic. 
  - Horoscope and Horoscope Heal Separately
   - Horoscope Is set up to be followed directly by a form of Helios to enabled Horoscope Heal
  - Celestial Opposition, Collective Unconscious, Lazy Lady, Neutral Sect
  - Stellar Detonation only when you have reached giant dominance

