### PR TITLE
[Healers] Cleanup, Simple Modes. Merge #682 first

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6265,7 +6265,7 @@ public enum CustomComboPreset
     [ReplaceSkill(SCH.Ruin, SCH.Broil, SCH.Broil2, SCH.Broil3, SCH.Broil4)]
     [SimpleCombo]
     [ConflictingCombos(SCH_ST_ADV_DPS)]
-    [CustomComboInfo("Simple Single Target DPS Feature", "Replaces Ruin I / Broils with a full one-button single target rotation.\nThis is the ideal option for newcomers to the job.", SCH.JobID)]
+    [CustomComboInfo("Simple DPS Mode - Single Target", "Replaces Ruin I / Broils with a full one-button single target rotation.\nThis is the ideal option for newcomers to the job.", SCH.JobID)]
     SCH_ST_Simple_DPS = 16070,
     
     
@@ -6273,7 +6273,7 @@ public enum CustomComboPreset
     [ReplaceSkill(SCH.ArtOfWar, SCH.ArtOfWarII)]
     [SimpleCombo]
     [ConflictingCombos(SCH_AoE_ADV_DPS)]
-    [CustomComboInfo("Simple AoE DPS Feature", "Replaces Art of War with a full one-button AoE rotation.\nThis is the ideal option for newcomers to the job.", SCH.JobID)]
+    [CustomComboInfo("Simple DPS Mode - AoE", "Replaces Art of War with a full one-button AoE rotation.\nThis is the ideal option for newcomers to the job.", SCH.JobID)]
     SCH_AoE_Simple_DPS = 16071,
     
     #endregion

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6187,11 +6187,6 @@ public enum CustomComboPreset
         "Use Energy Drain to consume remaining Aetherflow stacks when Aetherflow is about to come off cooldown.",
         SCH.JobID)]
     SCH_DPS_EnergyDrain = 16005,
-
-    [ParentCombo(SCH_DPS_EnergyDrain)]
-    [CustomComboInfo("Energy Drain Burst Option",
-        "Holds Energy Drain when Chain Stratagem is ready or has less than 10 seconds cooldown remaining.", SCH.JobID)]
-    SCH_DPS_EnergyDrain_BurstSaver = 16006,
     
     [ParentCombo(SCH_DPS)]
     [CustomComboInfo("Chain Stratagem",
@@ -6229,21 +6224,11 @@ public enum CustomComboPreset
         "Use Energy Drain to consume remaining Aetherflow stacks when Aetherflow is about to come off cooldown.",
         SCH.JobID)]
     SCH_AoE_EnergyDrain = 16056,
-
-    [ParentCombo(SCH_AoE_EnergyDrain)]
-    [CustomComboInfo("Energy Drain Burst Option",
-        "Holds Energy Drain when Chain Stratagem is ready or has less than 10 seconds cooldown remaining.", SCH.JobID)]
-    SCH_AoE_EnergyDrain_BurstSaver = 16055,
     
     [ParentCombo(SCH_AoE)]
     [CustomComboInfo("Chain Stratagem",
         "Adds Chain Stratagem on cooldown with overlap protection", SCH.JobID)]
     SCH_AoE_ChainStrat = 16054,
-    
-    [ParentCombo(SCH_AoE_ChainStrat)]
-    [CustomComboInfo("Chain Stratagem",
-        "Will only use Chain Strategem when high enough level for Baneful Impaction and it is enabled.", SCH.JobID)]
-    SCH_AoE_ChainStrat_BanefulOnly = 16057,
     
     [ParentCombo(SCH_AoE)]
     [CustomComboInfo("Baneful Impact",

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6249,12 +6249,10 @@ public enum CustomComboPreset
 
     #endregion
 
-    #region Healing
-
+    #region  ST Healing
     [AutoAction(false, true)]
     [ReplaceSkill(SCH.Physick)]
-    [CustomComboInfo("Simple Heals - Single Target",
-        "Change Physick into Adloquium, Lustrate, then Physick with below options:", SCH.JobID)]
+    [CustomComboInfo("Advanced Heals - Single Target", "Change Physick based on the below options:", SCH.JobID)]
     [PossiblyRetargeted]
     SCH_ST_Heal = 16023,
 
@@ -6314,9 +6312,12 @@ public enum CustomComboPreset
 
     [AutoAction(true, true)]
     [ReplaceSkill(SCH.Succor)]
-    [CustomComboInfo("Simple Heals - AoE", "Replaces Succor with options below:", SCH.JobID)]
+    [CustomComboInfo("Advance Heals - AoE", "Replaces Succor with options below:", SCH.JobID)]
     SCH_AoE_Heal = 16018,
     
+    #endregion
+    
+    #region AoE Healing
     [ParentCombo(SCH_AoE_Heal)]
     [CustomComboInfo("Indomitability Option", "Use Indomitabilty", SCH.JobID)]
     SCH_AoE_Heal_Indomitability = 16022,

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6244,9 +6244,18 @@ public enum CustomComboPreset
     
     [AutoAction(false, false)]
     [ReplaceSkill(SCH.Ruin, SCH.Broil, SCH.Broil2, SCH.Broil3, SCH.Broil4)]
+    [SimpleCombo]
     [ConflictingCombos(SCH_ST_ADV_DPS)]
-    [CustomComboInfo("Simple Single Target DPS Feature", "Replaces Ruin I / Broils with a full one-button single target rotation.\nThis is the ideal option for newcomers to the job..", SCH.JobID)]
+    [CustomComboInfo("Simple Single Target DPS Feature", "Replaces Ruin I / Broils with a full one-button single target rotation.\nThis is the ideal option for newcomers to the job.", SCH.JobID)]
     SCH_ST_Simple_DPS = 16070,
+    
+    
+    [AutoAction(true, false)]
+    [ReplaceSkill(SCH.ArtOfWar, SCH.ArtOfWarII)]
+    [SimpleCombo]
+    [ConflictingCombos(SCH_AoE_ADV_DPS)]
+    [CustomComboInfo("Simple AoE DPS Feature", "Replaces Art of War with a full one-button AoE rotation.\nThis is the ideal option for newcomers to the job.", SCH.JobID)]
+    SCH_AoE_Simple_DPS = 16071,
     
     #endregion
     
@@ -6302,41 +6311,40 @@ public enum CustomComboPreset
     #endregion
     
     #region AoE DPS
-
     [AutoAction(true, false)]
     [ReplaceSkill(SCH.ArtOfWar, SCH.ArtOfWarII)]
+    [ConflictingCombos(SCH_AoE_Simple_DPS)]
     [CustomComboInfo("Advanced DPS Mode - AoE", "Replaces Art of War with options below.", SCH.JobID)]
     [AdvancedCombo]
-    SCH_AoE_DPS = 16010,
-
+    SCH_AoE_ADV_DPS = 16010,
     
-    [ParentCombo(SCH_AoE_DPS)]
+    [ParentCombo(SCH_AoE_ADV_DPS)]
     [CustomComboInfo("Energy Drain Weave Option",
         "Use Energy Drain to consume remaining Aetherflow stacks when Aetherflow is about to come off cooldown.",
         SCH.JobID)]
-    SCH_AoE_DPS_EnergyDrain = 16056,
+    SCH_AoE_ADV_DPS_EnergyDrain = 16056,
     
-    [ParentCombo(SCH_AoE_DPS)]
+    [ParentCombo(SCH_AoE_ADV_DPS)]
     [CustomComboInfo("Chain Stratagem",
         "Adds Chain Stratagem on cooldown with overlap protection", SCH.JobID)]
-    SCH_AoE_DPS_ChainStrat = 16054,
+    SCH_AoE_ADV_DPS_ChainStrat = 16054,
     
-    [ParentCombo(SCH_AoE_DPS)]
+    [ParentCombo(SCH_AoE_ADV_DPS)]
     [CustomComboInfo("Baneful Impact",
         "Adds Baneful Impact when available.", SCH.JobID)]
-    SCH_AoE_DPS_BanefulImpact = 16053,
+    SCH_AoE_ADV_DPS_BanefulImpact = 16053,
 
-    [ParentCombo(SCH_AoE_DPS)]
+    [ParentCombo(SCH_AoE_ADV_DPS)]
     [CustomComboInfo("Fairy Reminder", "Adds Summon Eos whenever you've not summoned your fairy.", SCH.JobID)]
-    SCH_AoE_DPS_FairyReminder = 16049,
+    SCH_AoE_ADV_DPS_FairyReminder = 16049,
 
-    [ParentCombo(SCH_AoE_DPS)]
+    [ParentCombo(SCH_AoE_ADV_DPS)]
     [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value:", SCH.JobID)]
-    SCH_AoE_DPS_Lucid = 16011,
+    SCH_AoE_ADV_DPS_Lucid = 16011,
 
-    [ParentCombo(SCH_AoE_DPS)]
+    [ParentCombo(SCH_AoE_ADV_DPS)]
     [CustomComboInfo("Aetherflow Weave Option", "Use Aetherflow when out of Aetherflow stacks.", SCH.JobID)]
-    SCH_AoE_DPS_Aetherflow = 16012,
+    SCH_AoE_ADV_DPS_Aetherflow = 16012,
 
     #endregion
 
@@ -6537,13 +6545,13 @@ public enum CustomComboPreset
     SCH_Raise_Retarget = 16050,
     
     [Variant]
-    [VariantParent(SCH_ST_ADV_DPS, SCH_AoE_DPS)]
+    [VariantParent(SCH_ST_ADV_DPS, SCH_AoE_ADV_DPS)]
     [CustomComboInfo("Spirit Dart Option",
         "Use Variant Spirit Dart whenever the debuff is not present or less than 3s.", SCH.JobID)]
     SCH_DPS_Variant_SpiritDart = 16036,
 
     [Variant]
-    [VariantParent(SCH_ST_ADV_DPS, SCH_AoE_DPS)]
+    [VariantParent(SCH_ST_ADV_DPS, SCH_AoE_ADV_DPS)]
     [CustomComboInfo("Rampart Option", "Use Variant Rampart on cooldown.", SCH.JobID)]
     SCH_DPS_Variant_Rampart = 16037,
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6217,35 +6217,35 @@ public enum CustomComboPreset
     [AutoAction(true, false)]
     [ReplaceSkill(SCH.ArtOfWar, SCH.ArtOfWarII)]
     [CustomComboInfo("AoE DPS Feature", "Replaces Art of War with options below.", SCH.JobID)]
-    SCH_AoE = 16010,
+    SCH_AoE_DPS = 16010,
     
-    [ParentCombo(SCH_AoE)]
+    [ParentCombo(SCH_AoE_DPS)]
     [CustomComboInfo("Energy Drain Weave Option",
         "Use Energy Drain to consume remaining Aetherflow stacks when Aetherflow is about to come off cooldown.",
         SCH.JobID)]
-    SCH_AoE_EnergyDrain = 16056,
+    SCH_AoE_DPS_EnergyDrain = 16056,
     
-    [ParentCombo(SCH_AoE)]
+    [ParentCombo(SCH_AoE_DPS)]
     [CustomComboInfo("Chain Stratagem",
         "Adds Chain Stratagem on cooldown with overlap protection", SCH.JobID)]
-    SCH_AoE_ChainStrat = 16054,
+    SCH_AoE_DPS_ChainStrat = 16054,
     
-    [ParentCombo(SCH_AoE)]
+    [ParentCombo(SCH_AoE_DPS)]
     [CustomComboInfo("Baneful Impact",
         "Adds Baneful Impact when available.", SCH.JobID)]
-    SCH_AoE_BanefulImpact = 16053,
+    SCH_AoE_DPS_BanefulImpact = 16053,
 
-    [ParentCombo(SCH_AoE)]
+    [ParentCombo(SCH_AoE_DPS)]
     [CustomComboInfo("Fairy Reminder", "Adds Summon Eos whenever you've not summoned your fairy.", SCH.JobID)]
-    SCH_AoE_FairyReminder = 16049,
+    SCH_AoE_DPS_FairyReminder = 16049,
 
-    [ParentCombo(SCH_AoE)]
+    [ParentCombo(SCH_AoE_DPS)]
     [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value:", SCH.JobID)]
-    SCH_AoE_Lucid = 16011,
+    SCH_AoE_DPS_Lucid = 16011,
 
-    [ParentCombo(SCH_AoE)]
+    [ParentCombo(SCH_AoE_DPS)]
     [CustomComboInfo("Aetherflow Weave Option", "Use Aetherflow when out of Aetherflow stacks.", SCH.JobID)]
-    SCH_AoE_Aetherflow = 16012,
+    SCH_AoE_DPS_Aetherflow = 16012,
 
     #endregion
 
@@ -6349,19 +6349,9 @@ public enum CustomComboPreset
     [CustomComboInfo("Aetherflow Option", "Use Aetherflow when out of Aetherflow stacks.", SCH.JobID)]
     SCH_AoE_Heal_Aetherflow = 16020,
 
-    [ParentCombo(SCH_AoE_Heal_Aetherflow)]
-    [CustomComboInfo("Indomitability Ready Only Option", "Only uses Aetherflow if Indomitability is ready to use.",
-        SCH.JobID)]
-    SCH_AoE_Heal_Aetherflow_Indomitability = 16021,
-
     [ParentCombo(SCH_AoE_Heal)]
     [CustomComboInfo("Disspation Option", "Use Dissipation when out of Aetherflow stacks.", SCH.JobID)]
     SCH_AoE_Heal_Dissipation = 16041,
-    
-    [ParentCombo(SCH_AoE_Heal_Dissipation)]
-    [CustomComboInfo("Indomitability Ready Only Option", "Only uses Dissipation if Indomitability is ready to use.",
-        SCH.JobID)]
-    SCH_AoE_Heal_Dissipation_Indomitability = 16058,
     
     [ParentCombo(SCH_AoE_Heal)]
     [CustomComboInfo("Lucid Dreaming Option", "Adds Lucid Dreaming when MP isn't high enough to cast Succor.",
@@ -6452,13 +6442,13 @@ public enum CustomComboPreset
     SCH_Raise_Retarget = 16050,
     
     [Variant]
-    [VariantParent(SCH_DPS_Bio, SCH_AoE)]
+    [VariantParent(SCH_DPS_Bio, SCH_AoE_DPS)]
     [CustomComboInfo("Spirit Dart Option",
         "Use Variant Spirit Dart whenever the debuff is not present or less than 3s.", SCH.JobID)]
     SCH_DPS_Variant_SpiritDart = 16036,
 
     [Variant]
-    [VariantParent(SCH_DPS, SCH_AoE)]
+    [VariantParent(SCH_DPS, SCH_AoE_DPS)]
     [CustomComboInfo("Rampart Option", "Use Variant Rampart on cooldown.", SCH.JobID)]
     SCH_DPS_Variant_Rampart = 16037,
 
@@ -6473,11 +6463,6 @@ public enum CustomComboPreset
     [CustomComboInfo("RaidWide Succor Option", "Will try to cast Succor when a raidwide casting is detected if shieldcheck from succor setting passes. \nWill be used in all 4 main combos.", SCH.JobID)]
     [Hidden]
     SCH_Hidden_Succor_Raidwide = 16062,
-    
-    [ParentCombo(SCH_Hidden_Succor_Raidwide)]
-    [CustomComboInfo("Recitation Option", "Use Recitation to buff before the Raidwide Succor.", SCH.JobID)]
-    [Hidden]
-    SCH_Hidden_Succor_Raidwide_Recitation = 16051,
     
     [ParentCombo(SCH_Hidden)]
     [CustomComboInfo("Sacred Soil Option", "Will try to use Sacred Soil on self when a raidwide casting is detected..\nWill be used in all 4 main combos", SCH.JobID)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -581,11 +581,22 @@ public enum CustomComboPreset
 
     #region ASTROLOGIAN
 
+    #region Simple Modes
+    [AutoAction(false, false)]
+    [ReplaceSkill(AST.Malefic, AST.Malefic2, AST.Malefic3, AST.Malefic4, AST.FallMalefic)]
+    [ConflictingCombos(AST_ST_DPS)]
+    [CustomComboInfo("Simple DPS Mode - Single Target", "Replaces Malefic with a full one-button single target rotation, including automatic dps card assignment.\nThis is the ideal option for newcomers to the job.", AST.JobID)]
+    [SimpleCombo]
+    AST_ST_Simple_DPS = 1179,
+        
+    #endregion
+    
     #region ST DPS
 
     [AutoAction(false, false)]
     [ReplaceSkill(AST.Malefic, AST.Malefic2, AST.Malefic3, AST.Malefic4, AST.FallMalefic, AST.Combust, AST.Combust2,
         AST.Combust3)]
+    [ConflictingCombos(AST_ST_Simple_DPS)]
     [CustomComboInfo("Advanced DPS Mode - Single Target", "Replaces Malefic or Combust with options below", AST.JobID)]
     [AdvancedCombo]
     AST_ST_DPS = 1004,

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6163,52 +6163,62 @@ public enum CustomComboPreset
 
     #region SCHOLAR
 
+    #region Simples
+    
+    [AutoAction(false, false)]
+    [ReplaceSkill(SCH.Ruin, SCH.Broil, SCH.Broil2, SCH.Broil3, SCH.Broil4)]
+    [ConflictingCombos(SCH_ST_ADV_DPS)]
+    [CustomComboInfo("Simple Single Target DPS Feature", "Replaces Ruin I / Broils with a full one-button single target rotation.\nThis is the ideal option for newcomers to the job..", SCH.JobID)]
+    SCH_ST_Simple_DPS = 16070,
+    
+    #endregion
+    
     #region ST DPS
-
     [AutoAction(false, false)]
     [ReplaceSkill(SCH.Ruin, SCH.Broil, SCH.Broil2, SCH.Broil3, SCH.Broil4, SCH.Bio, SCH.Bio2, SCH.Biolysis)]
-    [CustomComboInfo("Single Target DPS Feature", "Replaces Ruin I / Broils with options below.", SCH.JobID)]
-    SCH_DPS = 16001,
+    [ConflictingCombos(SCH_ST_Simple_DPS)]
+    [CustomComboInfo("Advanced ST DPS Feature", "Replaces Ruin I / Broils with options below.", SCH.JobID)]
+    SCH_ST_ADV_DPS = 16001,
 
-    [ParentCombo(SCH_DPS)]
+    [ParentCombo(SCH_ST_ADV_DPS)]
     [CustomComboInfo("Balance Opener (Level 100)", "Adds the Balance opener at level 100.", SCH.JobID)]
-    SCH_DPS_Balance_Opener = 16009,
+    SCH_ST_ADV_DPS_Balance_Opener = 16009,
     
-    [ParentCombo(SCH_DPS)]
+    [ParentCombo(SCH_ST_ADV_DPS)]
     [CustomComboInfo("Bio / Biolysis Option", "Automatic DoT uptime.", SCH.JobID)]
-    SCH_DPS_Bio = 16008,
+    SCH_ST_ADV_DPS_Bio = 16008,
 
-    [ParentCombo(SCH_DPS)]
+    [ParentCombo(SCH_ST_ADV_DPS)]
     [CustomComboInfo("Aetherflow Weave Option", "Use Aetherflow when out of Aetherflow stacks.", SCH.JobID)]
-    SCH_DPS_Aetherflow = 16004,
+    SCH_ST_ADV_DPS_Aetherflow = 16004,
 
-    [ParentCombo(SCH_DPS)]
+    [ParentCombo(SCH_ST_ADV_DPS)]
     [CustomComboInfo("Energy Drain Weave Option",
         "Use Energy Drain to consume remaining Aetherflow stacks when Aetherflow is about to come off cooldown.",
         SCH.JobID)]
-    SCH_DPS_EnergyDrain = 16005,
+    SCH_ST_ADV_DPS_EnergyDrain = 16005,
     
-    [ParentCombo(SCH_DPS)]
+    [ParentCombo(SCH_ST_ADV_DPS)]
     [CustomComboInfo("Chain Stratagem",
         "Adds Chain Stratagem on cooldown with overlap protection", SCH.JobID)]
-    SCH_DPS_ChainStrat = 16003,
+    SCH_ST_ADV_DPS_ChainStrat = 16003,
     
-    [ParentCombo(SCH_DPS)]
+    [ParentCombo(SCH_ST_ADV_DPS)]
     [CustomComboInfo("Baneful Impact",
         "Adds Baneful Impact when available.", SCH.JobID)]
-    SCH_DPS_BanefulImpact = 16052,
+    SCH_ST_ADV_DPS_BanefulImpact = 16052,
 
-    [ParentCombo(SCH_DPS)]
+    [ParentCombo(SCH_ST_ADV_DPS)]
     [CustomComboInfo("Ruin II Moving Option", "Use Ruin II when you have to move.", SCH.JobID)]
-    SCH_DPS_Ruin2Movement = 16007,
+    SCH_ST_ADV_DPS_Ruin2Movement = 16007,
     
-    [ParentCombo(SCH_DPS)]
+    [ParentCombo(SCH_ST_ADV_DPS)]
     [CustomComboInfo("Fairy Reminder", "Adds Summon Eos whenever you've not summoned your fairy.", SCH.JobID)]
-    SCH_DPS_FairyReminder = 16048,
+    SCH_ST_ADV_DPS_FairyReminder = 16048,
 
-    [ParentCombo(SCH_DPS)]
+    [ParentCombo(SCH_ST_ADV_DPS)]
     [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value:", SCH.JobID)]
-    SCH_DPS_Lucid = 16002,
+    SCH_ST_ADV_DPS_Lucid = 16002,
     
     #endregion
     
@@ -6443,13 +6453,13 @@ public enum CustomComboPreset
     SCH_Raise_Retarget = 16050,
     
     [Variant]
-    [VariantParent(SCH_DPS_Bio, SCH_AoE_DPS)]
+    [VariantParent(SCH_ST_ADV_DPS, SCH_AoE_DPS)]
     [CustomComboInfo("Spirit Dart Option",
         "Use Variant Spirit Dart whenever the debuff is not present or less than 3s.", SCH.JobID)]
     SCH_DPS_Variant_SpiritDart = 16036,
 
     [Variant]
-    [VariantParent(SCH_DPS, SCH_AoE_DPS)]
+    [VariantParent(SCH_ST_ADV_DPS, SCH_AoE_DPS)]
     [CustomComboInfo("Rampart Option", "Use Variant Rampart on cooldown.", SCH.JobID)]
     SCH_DPS_Variant_Rampart = 16037,
 
@@ -6461,18 +6471,18 @@ public enum CustomComboPreset
     SCH_Hidden = 16065,
     
     [ParentCombo(SCH_Hidden)]
-    [CustomComboInfo("RaidWide Succor Option", "Will try to cast Succor when a raidwide casting is detected if shieldcheck from succor setting passes. \nWill be used in all 4 main combos.", SCH.JobID)]
+    [CustomComboInfo("RaidWide Succor Option", "Will try to cast Succor when a raidwide casting is detected if shieldcheck from succor setting passes. \nWill be used in all 4 Advanced combos.", SCH.JobID)]
     [Hidden]
     SCH_Hidden_Succor_Raidwide = 16062,
     
     [ParentCombo(SCH_Hidden)]
-    [CustomComboInfo("Sacred Soil Option", "Will try to use Sacred Soil on self when a raidwide casting is detected..\nWill be used in all 4 main combos", SCH.JobID)]
+    [CustomComboInfo("Sacred Soil Option", "Will try to use Sacred Soil on self when a raidwide casting is detected..\nWill be used in all 4 Advanced combos", SCH.JobID)]
     [Hidden]
     [Retargeted]
     SCH_Hidden_SacredSoil = 16059,
     
     [ParentCombo(SCH_Hidden)]
-    [CustomComboInfo("Expedient Raidwide Option", "Will try to use Expedient when a raidwide casting is detected. \nWill be used in all 4 main combos.", SCH.JobID)]
+    [CustomComboInfo("Expedient Raidwide Option", "Will try to use Expedient when a raidwide casting is detected. \nWill be used in all 4 Advanced combos.", SCH.JobID)]
     [Hidden]
     SCH_Hidden_Expedient = 16064,
     #endregion

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -588,6 +588,13 @@ public enum CustomComboPreset
     [CustomComboInfo("Simple DPS Mode - Single Target", "Replaces Malefic with a full one-button single target rotation, including automatic dps card assignment.\nThis is the ideal option for newcomers to the job.", AST.JobID)]
     [SimpleCombo]
     AST_ST_Simple_DPS = 1179,
+    
+    [AutoAction(true, false)]
+    [ReplaceSkill(AST.Gravity, AST.Gravity2)]
+    [ConflictingCombos(AST_AOE_DPS)]
+    [CustomComboInfo("Simple DPS Mode - AoE", "Replaces Gravity with a full one-button AoE rotation, including automatic dps card assignment.\nThis is the ideal option for newcomers to the job.", AST.JobID)]
+    [SimpleCombo]
+    AST_AOE_Simple_DPS = 1180,
         
     #endregion
     
@@ -668,6 +675,7 @@ public enum CustomComboPreset
 
     [AutoAction(true, false)]
     [ReplaceSkill(AST.Gravity, AST.Gravity2)]
+    [ConflictingCombos(AST_AOE_Simple_DPS)]
     [CustomComboInfo("Advanced DPS Mode - AoE", "Replaces Gravity with options below", AST.JobID)]
     [AdvancedCombo]
     AST_AOE_DPS = 1041,
@@ -917,7 +925,7 @@ public enum CustomComboPreset
     
     #endregion
 
-    // Last value = 1078
+    // Last value = 1080
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/AST/AST.cs
+++ b/WrathCombo/Combos/PvE/AST/AST.cs
@@ -48,7 +48,7 @@ internal partial class AST : Healer
                     return Lightspeed;  
 
                 //Lucid Dreaming
-                if (Role.CanLucidDream(Config.AST_ST_DPS_LucidDreaming))
+                if (Role.CanLucidDream(6500))
                     return Role.LucidDreaming;
 
                 //Play Card
@@ -87,6 +87,7 @@ internal partial class AST : Healer
             return actionID;
         }
     }
+    
     internal class AST_ST_DPS : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AST_ST_DPS;
@@ -225,6 +226,69 @@ internal partial class AST : Healer
                 
             
             }
+            return actionID;
+        }
+    }
+    
+    internal class AST_AOE_Simple_DPS : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AST_AOE_Simple_DPS;
+        protected override uint Invoke(uint actionID)
+        {
+            if (!GravityList.Contains(actionID))
+                return actionID;
+
+            //Variant stuff
+            if (Variant.CanRampart(CustomComboPreset.AST_Variant_Rampart))
+                return Variant.Rampart;
+
+            if (Variant.CanSpiritDart(CustomComboPreset.AST_Variant_SpiritDart))
+                return Variant.SpiritDart;
+
+            if (OccultCrescent.ShouldUsePhantomActions())
+                return OccultCrescent.BestPhantomAction();
+
+            //Lightspeed Movement
+            if (ActionReady(Lightspeed) && IsMoving() && !HasStatusEffect(Buffs.Lightspeed))
+                return Lightspeed;  
+
+            //Lucid Dreaming
+            if (Role.CanLucidDream(6500))
+                return Role.LucidDreaming;
+
+            //Play Card
+            if (HasDPSCard && CanSpellWeave())
+                return OriginalHook(Play1).Retarget(GravityList.ToArray(), CardResolver);
+
+            //Minor Arcana / Lord of Crowns
+            if (ActionReady(OriginalHook(MinorArcana)) && HasLord &&
+                HasBattleTarget() && CanSpellWeave())
+                return OriginalHook(MinorArcana);
+
+            //Card Draw
+            if (ActionReady(OriginalHook(AstralDraw)) && HasNoDPSCard && CanSpellWeave())
+                return OriginalHook(AstralDraw);
+
+            //Divination
+            if (HasBattleTarget() && ActionReady(Divination) && !HasDivination && CanSpellWeave() &&
+                ActionWatching.NumberOfGcdsUsed >= 3)
+                return Divination;
+
+            //Earthly Star
+            if (!IsMoving() && !HasStatusEffect(Buffs.EarthlyDominance) && ActionReady(EarthlyStar) &&
+                IsOffCooldown(EarthlyStar) && CanSpellWeave() &&
+                ActionWatching.NumberOfGcdsUsed >= 3)
+                return EarthlyStar.Retarget(GravityList.ToArray(), SimpleTarget.AnyEnemy ?? SimpleTarget.Stack.Allies);            
+            
+            //Oracle
+            if (HasStatusEffect(Buffs.Divining) && CanSpellWeave())
+                return Oracle;
+
+            //MacroCosmos
+            if (ActionReady(Macrocosmos) && !HasStatusEffect(Buffs.Macrocosmos) &&
+                ActionWatching.NumberOfGcdsUsed >= 3 && !InBossEncounter())
+                return Macrocosmos;
+
             return actionID;
         }
     }

--- a/WrathCombo/Combos/PvE/AST/AST_Helper.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Helper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Frozen;
 using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
@@ -21,13 +22,13 @@ internal partial class AST
     internal static readonly List<uint>
         MaleficList = [Malefic, Malefic2, Malefic3, Malefic4, FallMalefic],
         GravityList = [Gravity, Gravity2];
-    internal static Dictionary<uint, ushort>
-        CombustList = new()
-        {
-            { Combust, Debuffs.Combust },
-            { Combust2, Debuffs.Combust2 },
-            { Combust3, Debuffs.Combust3 }
-        };
+    
+    internal static readonly FrozenDictionary<uint, ushort> CombustList = new Dictionary<uint, ushort>
+    {
+        { Combust, Debuffs.Combust },
+        { Combust2, Debuffs.Combust2 },
+        { Combust3, Debuffs.Combust3 }
+    }.ToFrozenDictionary();
 
     public static ASTGauge Gauge => GetJobGauge<ASTGauge>();
     public static CardType DrawnDPSCard => Gauge.DrawnCards[0];

--- a/WrathCombo/Combos/PvE/AST/AST_Helper.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Helper.cs
@@ -44,6 +44,24 @@ internal partial class AST
     internal static float DivinationCD => GetCooldownRemainingTime(Divination);
     internal static float LightspeedChargeCD => GetCooldownChargeRemainingTime(Lightspeed);
     
+    #region Dot Checker
+    internal static bool NeedsDoT()
+    {
+        var dotAction = OriginalHook(Combust);
+        var hpThreshold = IsNotEnabled(CustomComboPreset.AST_ST_Simple_DPS) && (Config.AST_ST_DPS_CombustSubOption == 1 || !InBossEncounter()) ? Config.AST_ST_DPS_CombustOption : 0;
+        CombustList.TryGetValue(dotAction, out var dotDebuffID);
+        var dotRefresh = IsNotEnabled(CustomComboPreset.AST_ST_Simple_DPS) ? Config.AST_ST_DPS_CombustUptime_Threshold : 2.5;
+        var dotRemaining = GetStatusEffectRemainingTime(dotDebuffID, CurrentTarget);
+
+        return ActionReady(dotAction) &&
+               CanApplyStatus(CurrentTarget, dotDebuffID) &&
+               !JustUsedOn(dotAction, CurrentTarget, 5f) &&
+               HasBattleTarget() &&
+               GetTargetHPPercent() > hpThreshold &&
+               dotRemaining <= dotRefresh;
+    }
+    #endregion
+    
     #region Hidden Raidwides
     
     internal static bool HiddenCollectiveUnconscious()

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using ECommons.DalamudServices;
+using Lumina.Excel.Sheets;
+using System;
 using System.Linq;
 using WrathCombo.Data;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
@@ -11,6 +13,7 @@ namespace WrathCombo.Combos.PvE;
 internal partial class OccultCrescent
 {
     public const byte JobID = 100;
+    public static string ContentName => Svc.Data.GetExcelSheet<BannerBg>().GetRow(312).Name.ToString();
     internal static uint BestPhantomAction()
     {
         if (!IsInOccult)

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Helper.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Helper.cs
@@ -49,7 +49,7 @@ internal partial class OccultCrescent
             #endregion
     }
 
-    public static ushort
+    public static uint
     //Freelancer
     OccultResuscitation = 41650,
     OccultTreasuresight = 41651,

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -5,10 +5,69 @@ namespace WrathCombo.Combos.PvE;
 
 internal partial class SCH : Healer
 {
-    #region ST DPS
-    internal class SCH_DPS : CustomCombo
+    #region Simple ST DPS
+    internal class SCH_ST_Simple_DPS : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_DPS;
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_ST_Simple_DPS;
+        protected override uint Invoke(uint actionID)
+        {
+            if (!BroilList.Contains(actionID))
+                return actionID;
+
+            if (NeedToSummon)
+                return SummonEos;
+            
+            #region Special Content
+            if (Variant.CanRampart(CustomComboPreset.SCH_DPS_Variant_Rampart))
+                return Variant.Rampart;
+            
+            if (Variant.CanSpiritDart(CustomComboPreset.SCH_DPS_Variant_SpiritDart))
+                return Variant.SpiritDart;
+
+            if (OccultCrescent.ShouldUsePhantomActions())
+                return OccultCrescent.BestPhantomAction();
+            #endregion
+            
+            #region Dissolve Union
+            if (EndAetherpact)
+                return DissolveUnion;
+            #endregion
+
+            if (InCombat() && CanSpellWeave())
+            {
+                if (!WasLastAction(Dissipation) && ActionReady(Aetherflow) && !HasAetherflow)
+                    return Aetherflow;
+                
+                if (HasStatusEffect(Buffs.ImpactImminent) && !JustUsed(ChainStratagem))
+                    return BanefulImpaction;
+                
+                if (ActionWatching.NumberOfGcdsUsed > 3 && CanChainStrategem)
+                    return ChainStratagem;
+                    
+                if (ActionReady(EnergyDrain) && AetherflowCD <= 10 &&
+                    (ChainStrategemCD > 10 || !LevelChecked(ChainStratagem)))
+                    return EnergyDrain;
+                
+                if (Role.CanLucidDream(6500))
+                    return Role.LucidDreaming;
+            }
+            //Bio/Biolysis
+            if (NeedsDoT() && InCombat())
+                return OriginalHook(Bio);
+
+            //Ruin 2 Movement
+            if (ActionReady(Ruin2) && IsMoving() && InCombat())
+                return OriginalHook(Ruin2);
+            
+            return actionID;
+        }
+    }
+    #endregion
+    
+    #region Advanced ST DPS
+    internal class SCH_ST_ADV_DPS : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_ST_ADV_DPS;
         protected override uint Invoke(uint actionID)
         {
             #region Variables
@@ -22,10 +81,10 @@ internal partial class SCH : Healer
             if (!actionFound)
                 return actionID;
 
-            if (IsEnabled(CustomComboPreset.SCH_DPS_FairyReminder) && NeedToSummon)
+            if (IsEnabled(CustomComboPreset.SCH_ST_ADV_DPS_FairyReminder) && NeedToSummon)
                 return SummonEos;
             //Opener
-            if (IsEnabled(CustomComboPreset.SCH_DPS_Balance_Opener) && Opener().FullOpener(ref actionID))
+            if (IsEnabled(CustomComboPreset.SCH_ST_ADV_DPS_Balance_Opener) && Opener().FullOpener(ref actionID))
                 return actionID;
             
             #region Special Content
@@ -55,33 +114,33 @@ internal partial class SCH : Healer
 
             if (InCombat() && CanSpellWeave())
             {
-                if (IsEnabled(CustomComboPreset.SCH_DPS_Aetherflow) && !WasLastAction(Dissipation) && ActionReady(Aetherflow) && !HasAetherflow)
+                if (IsEnabled(CustomComboPreset.SCH_ST_ADV_DPS_Aetherflow) && !WasLastAction(Dissipation) && ActionReady(Aetherflow) && !HasAetherflow)
                     return Aetherflow;
                 
-                if (IsEnabled(CustomComboPreset.SCH_DPS_BanefulImpact) && HasStatusEffect(Buffs.ImpactImminent) && !JustUsed(ChainStratagem))
+                if (IsEnabled(CustomComboPreset.SCH_ST_ADV_DPS_BanefulImpact) && HasStatusEffect(Buffs.ImpactImminent) && !JustUsed(ChainStratagem))
                     return BanefulImpaction;
                 
-                if (IsEnabled(CustomComboPreset.SCH_DPS_ChainStrat) && ActionWatching.NumberOfGcdsUsed > 3 && CanChainStrategem &&
+                if (IsEnabled(CustomComboPreset.SCH_ST_ADV_DPS_ChainStrat) && ActionWatching.NumberOfGcdsUsed > 3 && CanChainStrategem &&
                     GetTargetHPPercent() > chainThreshold)
                     return ChainStratagem;
                     
-                if (IsEnabled(CustomComboPreset.SCH_DPS_EnergyDrain) && ActionReady(EnergyDrain) && 
+                if (IsEnabled(CustomComboPreset.SCH_ST_ADV_DPS_EnergyDrain) && ActionReady(EnergyDrain) && 
                     AetherflowCD <= Config.SCH_ST_DPS_EnergyDrain &&
                     (!Config.SCH_ST_DPS_EnergyDrain_Burst ||
                      ChainStrategemCD > 10 ||
                      !LevelChecked(ChainStratagem)))
                     return EnergyDrain;
                 
-                if (IsEnabled(CustomComboPreset.SCH_DPS_Lucid) && Role.CanLucidDream(Config.SCH_ST_DPS_LucidOption))
+                if (IsEnabled(CustomComboPreset.SCH_ST_ADV_DPS_Lucid) && Role.CanLucidDream(Config.SCH_ST_DPS_LucidOption))
                     return Role.LucidDreaming;
             }
             
             //Bio/Biolysis
-            if (IsEnabled(CustomComboPreset.SCH_DPS_Bio) && NeedsDoT() && InCombat())
+            if (IsEnabled(CustomComboPreset.SCH_ST_ADV_DPS_Bio) && NeedsDoT() && InCombat())
                 return OriginalHook(Bio);
 
             //Ruin 2 Movement
-            if (IsEnabled(CustomComboPreset.SCH_DPS_Ruin2Movement) && ActionReady(Ruin2) && IsMoving() && InCombat())
+            if (IsEnabled(CustomComboPreset.SCH_ST_ADV_DPS_Ruin2Movement) && ActionReady(Ruin2) && IsMoving() && InCombat())
                 return OriginalHook(Ruin2);
             
             return actionID;
@@ -89,7 +148,7 @@ internal partial class SCH : Healer
     }
     #endregion
     
-    #region AoE DPS
+    #region Advanced AoE DPS
     internal class SCH_AoE : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AoE_DPS;

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -92,7 +92,7 @@ internal partial class SCH : Healer
     #region AoE DPS
     internal class SCH_AoE : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AoE;
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AoE_DPS;
         protected override uint Invoke(uint actionID)
         {
             #region Variables
@@ -102,7 +102,7 @@ internal partial class SCH : Healer
             if (actionID is not (ArtOfWar or ArtOfWarII))
                 return actionID;
 
-            if (IsEnabled(CustomComboPreset.SCH_AoE_FairyReminder) &&
+            if (IsEnabled(CustomComboPreset.SCH_AoE_DPS_FairyReminder) &&
                 NeedToSummon)
                 return SummonEos;
             
@@ -133,25 +133,25 @@ internal partial class SCH : Healer
             
             if (!InCombat() || !CanSpellWeave()) return actionID;
             
-            if (IsEnabled(CustomComboPreset.SCH_AoE_Aetherflow) && !WasLastAction(Dissipation) && ActionReady(Aetherflow) && !HasAetherflow)
+            if (IsEnabled(CustomComboPreset.SCH_AoE_DPS_Aetherflow) && !WasLastAction(Dissipation) && ActionReady(Aetherflow) && !HasAetherflow)
                 return Aetherflow;
                 
-            if (IsEnabled(CustomComboPreset.SCH_AoE_BanefulImpact) && HasStatusEffect(Buffs.ImpactImminent) && !JustUsed(ChainStratagem))
+            if (IsEnabled(CustomComboPreset.SCH_AoE_DPS_BanefulImpact) && HasStatusEffect(Buffs.ImpactImminent) && !JustUsed(ChainStratagem))
                 return BanefulImpaction;
                 
-            if (IsEnabled(CustomComboPreset.SCH_AoE_ChainStrat) && ActionWatching.NumberOfGcdsUsed > 3 && CanChainStrategem && 
+            if (IsEnabled(CustomComboPreset.SCH_AoE_DPS_ChainStrat) && ActionWatching.NumberOfGcdsUsed > 3 && CanChainStrategem && 
                 GetTargetHPPercent() > chainThreshold &&
                 (LevelChecked(BanefulImpaction)|| !Config.SCH_AoE_DPS_ChainStratagemBanefulOption))
                 return ChainStratagem;
                     
-            if (IsEnabled(CustomComboPreset.SCH_AoE_EnergyDrain) && ActionReady(EnergyDrain) && 
+            if (IsEnabled(CustomComboPreset.SCH_AoE_DPS_EnergyDrain) && ActionReady(EnergyDrain) && 
                 AetherflowCD <= Config.SCH_AoE_DPS_EnergyDrain &&
                 (!Config.SCH_AoE_DPS_EnergyDrain_Burst ||
                  ChainStrategemCD > 10 ||
                  !LevelChecked(ChainStratagem)))
                 return EnergyDrain;
                 
-            if (IsEnabled(CustomComboPreset.SCH_AoE_Lucid) && Role.CanLucidDream(Config.SCH_AoE_DPS_LucidOption))
+            if (IsEnabled(CustomComboPreset.SCH_AoE_DPS_Lucid) && Role.CanLucidDream(Config.SCH_AoE_DPS_LucidOption))
                 return Role.LucidDreaming;
 
             return actionID;
@@ -271,11 +271,11 @@ internal partial class SCH : Healer
             if (!HasAetherflow && InCombat())
             {
                 if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Aetherflow) && ActionReady(Aetherflow) && 
-                    (!IsEnabled(CustomComboPreset.SCH_AoE_Heal_Aetherflow_Indomitability) || GetCooldownRemainingTime(Indomitability) <= 1))
+                    (!Config.SCH_AoE_Heal_Aetherflow_Indomitability || GetCooldownRemainingTime(Indomitability) <= 1))
                     return Aetherflow;
 
                 if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Dissipation) && ActionReady(Dissipation) && !FairyBusy &&
-                    (!IsEnabled(CustomComboPreset.SCH_AoE_Heal_Dissipation_Indomitability) || GetCooldownRemainingTime(Indomitability) <= 1))
+                    (!Config.SCH_AoE_Heal_Dissipation_Indomitability || GetCooldownRemainingTime(Indomitability) <= 1))
                     return Dissipation;
             }
             if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Lucid) && Role.CanLucidDream(Config.SCH_AoE_Heal_LucidOption))

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -1,8 +1,6 @@
-using System.Linq;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Data;
-using WrathCombo.Extensions;
 namespace WrathCombo.Combos.PvE;
 
 internal partial class SCH : Healer
@@ -11,20 +9,12 @@ internal partial class SCH : Healer
     internal class SCH_DPS : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_DPS;
-        internal static int BroilCount => ActionWatching.CombatActions.Count(x => x == OriginalHook(Broil));
         protected override uint Invoke(uint actionID)
         {
             #region Determine Replaced Action
-            bool actionFound;
-            if (Config.SCH_ST_DPS_Adv && Config.SCH_ST_DPS_Adv_Actions.Count > 0)
-            {
-                bool onBroils = Config.SCH_ST_DPS_Adv_Actions[0] && BroilList.Contains(actionID);
-                bool onBios = Config.SCH_ST_DPS_Adv_Actions[1] && BioList.ContainsKey(actionID);
-                bool onRuinII = Config.SCH_ST_DPS_Adv_Actions[2] && actionID is Ruin2;
-                actionFound = onBroils || onBios || onRuinII;
-            }
-            else
-                actionFound = BroilList.Contains(actionID); //default handling
+            bool actionFound = Config.SCH_ST_DPS_Adv_Actions == 0 && BroilList.Contains(actionID) ||
+                               Config.SCH_ST_DPS_Adv_Actions == 1 && BioList.ContainsKey(actionID) ||
+                               Config.SCH_ST_DPS_Adv_Actions == 2 && actionID is Ruin2;
             #endregion
             
             if (!actionFound)

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -148,10 +148,62 @@ internal partial class SCH : Healer
     }
     #endregion
     
-    #region Advanced AoE DPS
-    internal class SCH_AoE : CustomCombo
+    #region Simple AoE DPS
+    internal class SCH_AoE_Simple_DPS : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AoE_DPS;
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AoE_Simple_DPS;
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not (ArtOfWar or ArtOfWarII))
+                return actionID;
+
+            if (NeedToSummon)
+                return SummonEos;
+            
+            #region Special Content
+            if (Variant.CanRampart(CustomComboPreset.SCH_DPS_Variant_Rampart))
+                return Variant.Rampart;
+
+            if (Variant.CanSpiritDart(CustomComboPreset.SCH_DPS_Variant_SpiritDart))
+                return Variant.SpiritDart;
+
+            if (OccultCrescent.ShouldUsePhantomActions())
+                return OccultCrescent.BestPhantomAction();
+            #endregion
+            
+            #region Dissolve Union
+            if (EndAetherpact)
+                return DissolveUnion;
+            #endregion
+            
+            if (!InCombat() || !CanSpellWeave()) return actionID;
+            
+            if (!WasLastAction(Dissipation) && ActionReady(Aetherflow) && !HasAetherflow)
+                return Aetherflow;
+                
+            if (HasStatusEffect(Buffs.ImpactImminent) && !JustUsed(ChainStratagem))
+                return BanefulImpaction;
+                
+            if (ActionWatching.NumberOfGcdsUsed > 3 && CanChainStrategem)
+                return ChainStratagem;
+                    
+            if (IsEnabled(CustomComboPreset.SCH_AoE_ADV_DPS_EnergyDrain) && ActionReady(EnergyDrain) && 
+                AetherflowCD <= 10)
+                return EnergyDrain;
+                
+            if (Role.CanLucidDream(Config.SCH_AoE_DPS_LucidOption))
+                return Role.LucidDreaming;
+
+            return actionID;
+        }
+    }
+
+    #endregion
+    
+    #region Advanced AoE DPS
+    internal class SCH_AoE_ADV_DPS : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AoE_ADV_DPS;
         protected override uint Invoke(uint actionID)
         {
             #region Variables
@@ -161,7 +213,7 @@ internal partial class SCH : Healer
             if (actionID is not (ArtOfWar or ArtOfWarII))
                 return actionID;
 
-            if (IsEnabled(CustomComboPreset.SCH_AoE_DPS_FairyReminder) &&
+            if (IsEnabled(CustomComboPreset.SCH_AoE_ADV_DPS_FairyReminder) &&
                 NeedToSummon)
                 return SummonEos;
             
@@ -192,25 +244,25 @@ internal partial class SCH : Healer
             
             if (!InCombat() || !CanSpellWeave()) return actionID;
             
-            if (IsEnabled(CustomComboPreset.SCH_AoE_DPS_Aetherflow) && !WasLastAction(Dissipation) && ActionReady(Aetherflow) && !HasAetherflow)
+            if (IsEnabled(CustomComboPreset.SCH_AoE_ADV_DPS_Aetherflow) && !WasLastAction(Dissipation) && ActionReady(Aetherflow) && !HasAetherflow)
                 return Aetherflow;
                 
-            if (IsEnabled(CustomComboPreset.SCH_AoE_DPS_BanefulImpact) && HasStatusEffect(Buffs.ImpactImminent) && !JustUsed(ChainStratagem))
+            if (IsEnabled(CustomComboPreset.SCH_AoE_ADV_DPS_BanefulImpact) && HasStatusEffect(Buffs.ImpactImminent) && !JustUsed(ChainStratagem))
                 return BanefulImpaction;
                 
-            if (IsEnabled(CustomComboPreset.SCH_AoE_DPS_ChainStrat) && ActionWatching.NumberOfGcdsUsed > 3 && CanChainStrategem && 
+            if (IsEnabled(CustomComboPreset.SCH_AoE_ADV_DPS_ChainStrat) && ActionWatching.NumberOfGcdsUsed > 3 && CanChainStrategem && 
                 GetTargetHPPercent() > chainThreshold &&
                 (LevelChecked(BanefulImpaction)|| !Config.SCH_AoE_DPS_ChainStratagemBanefulOption))
                 return ChainStratagem;
                     
-            if (IsEnabled(CustomComboPreset.SCH_AoE_DPS_EnergyDrain) && ActionReady(EnergyDrain) && 
+            if (IsEnabled(CustomComboPreset.SCH_AoE_ADV_DPS_EnergyDrain) && ActionReady(EnergyDrain) && 
                 AetherflowCD <= Config.SCH_AoE_DPS_EnergyDrain &&
                 (!Config.SCH_AoE_DPS_EnergyDrain_Burst ||
                  ChainStrategemCD > 10 ||
                  !LevelChecked(ChainStratagem)))
                 return EnergyDrain;
                 
-            if (IsEnabled(CustomComboPreset.SCH_AoE_DPS_Lucid) && Role.CanLucidDream(Config.SCH_AoE_DPS_LucidOption))
+            if (IsEnabled(CustomComboPreset.SCH_AoE_ADV_DPS_Lucid) && Role.CanLucidDream(Config.SCH_AoE_DPS_LucidOption))
                 return Role.LucidDreaming;
 
             return actionID;

--- a/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
@@ -1,4 +1,6 @@
-﻿using Dalamud.Interface.Colors;
+﻿using System;
+using Dalamud.Interface.Colors;
+using Dalamud.Interface.Style;
 using ImGuiNET;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
@@ -23,16 +25,12 @@ internal partial class SCH
                     break;
 
                 case CustomComboPreset.SCH_DPS:
-                    DrawAdditionalBoolChoice(SCH_ST_DPS_Adv, "Advanced Action Options", "Change how actions are handled", isConditionalChoice: true);
-                    if (SCH_ST_DPS_Adv)
-                    {
-                        ImGui.Indent();
-                        ImGui.Spacing();
-                        DrawHorizontalMultiChoice(SCH_ST_DPS_Adv_Actions, "On Ruin/Broils", "Apply options to Ruin and all Broils.", 3, 0);
-                        DrawHorizontalMultiChoice(SCH_ST_DPS_Adv_Actions, "On Bio/Bio II/Biolysis", "Apply options to Bio and Biolysis.", 3, 1);
-                        DrawHorizontalMultiChoice(SCH_ST_DPS_Adv_Actions, "On Ruin II", "Apply options to Ruin II.", 3, 2);
-                        ImGui.Unindent();
-                    }
+                    DrawHorizontalRadioButton(SCH_ST_DPS_Adv_Actions, "On Ruin/Broils", "Apply options to Ruin and all Broils.", 0,
+                        descriptionColor:ImGuiColors.DalamudWhite);
+                    DrawHorizontalRadioButton(SCH_ST_DPS_Adv_Actions, "On Bio/Bio II/Biolysis", "Apply options to Bio and Biolysis.", 1,
+                        descriptionColor:ImGuiColors.DalamudWhite);
+                    DrawHorizontalRadioButton(SCH_ST_DPS_Adv_Actions, "On Ruin II", "Apply options to Ruin II.", 2,
+                        descriptionColor:ImGuiColors.DalamudWhite);
                     break;
                 
                 case CustomComboPreset.SCH_DPS_Lucid:
@@ -276,15 +274,14 @@ internal partial class SCH
             SCH_ST_DPS_EnergyDrain = new("SCH_ST_DPS_EnergyDrain", 3),
             SCH_ST_DPS_ChainStratagemSubOption = new("SCH_ST_DPS_ChainStratagemSubOption", 1),
             SCH_AoE_DPS_EnergyDrain = new("SCH_AoE_DPS_EnergyDrain", 3),
-            SCH_AoE_DPS_ChainStratagemSubOption = new("SCH_AoE_DPS_ChainStratagemSubOption", 1);
-        public static UserBool
-            SCH_ST_DPS_Adv = new("SCH_ST_DPS_Adv");
+            SCH_AoE_DPS_ChainStratagemSubOption = new("SCH_AoE_DPS_ChainStratagemSubOption", 1),
+            SCH_ST_DPS_Adv_Actions = new("SCH_ST_DPS_Adv_Actions");
+        
 
         public static UserFloat
             SCH_DPS_BioUptime_Threshold = new("SCH_DPS_BioUptime_Threshold", 3.0f);
             
-        public static UserBoolArray
-            SCH_ST_DPS_Adv_Actions = new("SCH_ST_DPS_Adv_Actions");
+        
 
         #endregion
 

--- a/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
@@ -58,19 +58,28 @@ internal partial class SCH
                     break;
 
                 case CustomComboPreset.SCH_DPS_ChainStrat:
-                    DrawHorizontalRadioButton(SCH_ST_DPS_ChainStratagemSubOption,
-                        "All content",
-                        $"Uses {ActionWatching.GetActionName(ChainStratagem)} regardless of content.", 0);
-
-                    DrawHorizontalRadioButton(SCH_ST_DPS_ChainStratagemSubOption,
-                        "Boss encounters Only",
-                        $"Only uses {ActionWatching.GetActionName(ChainStratagem)} when in Boss encounters.", 1);
-
+                    
                     DrawSliderInt(0, 100, SCH_ST_DPS_ChainStratagemOption, "Stop using at Enemy HP%. Set to Zero to disable this check.");
+                    
+                    ImGui.Indent();
+                    
+                    ImGui.TextColored(ImGuiColors.DalamudYellow, "Select what kind of enemies the HP check should be applied to:");
+                    
+                    DrawHorizontalRadioButton(SCH_ST_DPS_ChainStratagemSubOption,
+                        "Non-Bosses", "Only applies the HP check above to non-bosses.\nAllows you to only stop DoTing early when it's not a boss.", 0);
+
+                    DrawHorizontalRadioButton(SCH_ST_DPS_ChainStratagemSubOption,
+                        "All Enemies", "Applies the HP check above to all enemies.", 1);
+                    
+                    ImGui.Unindent();
+                    
                     break;
 
                 case CustomComboPreset.SCH_DPS_EnergyDrain:
                     DrawSliderInt(0, 60, SCH_ST_DPS_EnergyDrain, "Aetherflow remaining cooldown");
+                    
+                    DrawAdditionalBoolChoice(SCH_ST_DPS_EnergyDrain_Burst, 
+                        "Energy Drain Burst", "Holds Energy Drain when Chain Stratagem is ready or has less than 10 seconds cooldown remaining.");
                     break;
                 
                 case CustomComboPreset.SCH_AoE_Lucid:
@@ -78,19 +87,30 @@ internal partial class SCH
                     break;
                 
                 case CustomComboPreset.SCH_AoE_ChainStrat:
-                    DrawHorizontalRadioButton(SCH_AoE_DPS_ChainStratagemSubOption,
-                        "All content",
-                        $"Uses {ActionWatching.GetActionName(ChainStratagem)} regardless of content.", 0);
-
-                    DrawHorizontalRadioButton(SCH_AoE_DPS_ChainStratagemSubOption,
-                        "Boss encounters Only",
-                        $"Only uses {ActionWatching.GetActionName(ChainStratagem)} when in Boss encounters.", 1);
-
+                    DrawAdditionalBoolChoice(SCH_AoE_DPS_ChainStratagemBanefulOption, 
+                        "Baneful Only", "Will only use Chain Strategem when high enough level to use Baneful Impaction");
+                    
                     DrawSliderInt(0, 100, SCH_AoE_DPS_ChainStratagemOption, "Stop using at Enemy HP%. Set to Zero to disable this check.");
+                    
+                    ImGui.Indent();
+                    
+                    ImGui.TextColored(ImGuiColors.DalamudYellow, "Select what kind of enemies the HP check should be applied to:");
+                    
+                    DrawHorizontalRadioButton(SCH_AoE_DPS_ChainStratagemSubOption,
+                        "Non-Bosses", "Only applies the HP check above to non-bosses.\nAllows you to only stop DoTing early when it's not a boss.", 0);
+
+                    DrawHorizontalRadioButton(SCH_AoE_DPS_ChainStratagemSubOption,
+                        "All Enemies", "Applies the HP check above to all enemies.", 1);
+                    
+                    ImGui.Unindent();
+                    
                     break;
 
                 case CustomComboPreset.SCH_AoE_EnergyDrain:
                     DrawSliderInt(0, 60, SCH_AoE_DPS_EnergyDrain, "Aetherflow remaining cooldown");
+                    
+                    DrawAdditionalBoolChoice(SCH_AoE_DPS_EnergyDrain_Burst, 
+                        "Energy Drain Burst", "Holds Energy Drain when Chain Stratagem is ready or has less than 10 seconds cooldown remaining.");
                     break;
                 #endregion
                 
@@ -276,6 +296,11 @@ internal partial class SCH
             SCH_AoE_DPS_EnergyDrain = new("SCH_AoE_DPS_EnergyDrain", 3),
             SCH_AoE_DPS_ChainStratagemSubOption = new("SCH_AoE_DPS_ChainStratagemSubOption", 1),
             SCH_ST_DPS_Adv_Actions = new("SCH_ST_DPS_Adv_Actions");
+
+        internal static UserBool
+            SCH_ST_DPS_EnergyDrain_Burst = new("SCH_ST_DPS_EnergyDrain_Burst"),
+            SCH_AoE_DPS_EnergyDrain_Burst = new("SCH_AoE_DPS_EnergyDrain_Burst"),
+            SCH_AoE_DPS_ChainStratagemBanefulOption = new("SCH_AoE_DPS_ChainStratagemBanefulOption");
         
 
         public static UserFloat

--- a/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
@@ -82,11 +82,11 @@ internal partial class SCH
                         "Energy Drain Burst", "Holds Energy Drain when Chain Stratagem is ready or has less than 10 seconds cooldown remaining.");
                     break;
                 
-                case CustomComboPreset.SCH_AoE_Lucid:
+                case CustomComboPreset.SCH_AoE_DPS_Lucid:
                     DrawSliderInt(4000, 9500, SCH_AoE_DPS_LucidOption, "MP Threshold", 150, Hundreds);
                     break;
                 
-                case CustomComboPreset.SCH_AoE_ChainStrat:
+                case CustomComboPreset.SCH_AoE_DPS_ChainStrat:
                     DrawAdditionalBoolChoice(SCH_AoE_DPS_ChainStratagemBanefulOption, 
                         "Baneful Only", "Will only use Chain Strategem when high enough level to use Baneful Impaction");
                     
@@ -106,7 +106,7 @@ internal partial class SCH
                     
                     break;
 
-                case CustomComboPreset.SCH_AoE_EnergyDrain:
+                case CustomComboPreset.SCH_AoE_DPS_EnergyDrain:
                     DrawSliderInt(0, 60, SCH_AoE_DPS_EnergyDrain, "Aetherflow remaining cooldown");
                     
                     DrawAdditionalBoolChoice(SCH_AoE_DPS_EnergyDrain_Burst, 
@@ -116,13 +116,11 @@ internal partial class SCH
                 
                 #region Healing
                 case CustomComboPreset.SCH_ST_Heal:
-                    DrawAdditionalBoolChoice(SCH_ST_Heal_Adv, "Advanced Options", "", isConditionalChoice: true);
-                    if (SCH_ST_Heal_Adv)
-                    {
+                    
                         ImGui.Indent();
-                        DrawAdditionalBoolChoice(SCH_ST_Heal_IncludeShields, "Include Shields in HP Percent Sliders", "");
+                        DrawAdditionalBoolChoice(SCH_ST_Heal_IncludeShields, "Advanced Option: Include Shields in HP Percent Sliders", "");
                         ImGui.Unindent();
-                    }
+                    
                     break;
 
                 case CustomComboPreset.SCH_ST_Heal_Lucid:
@@ -238,6 +236,16 @@ internal partial class SCH
                     DrawPriorityInput(SCH_AoE_Heals_Priority, 8, 5, $"{Indomitability.ActionName()} Priority: ");
                     break;
                 
+                case CustomComboPreset.SCH_AoE_Heal_Aetherflow:
+                    DrawAdditionalBoolChoice(SCH_AoE_Heal_Aetherflow_Indomitability,
+                        "Indomitability Ready Only Option", "Only uses Aetherflow if Indomitability is ready to use.");
+                    break;
+                
+                case CustomComboPreset.SCH_AoE_Heal_Dissipation:
+                    DrawAdditionalBoolChoice(SCH_AoE_Heal_Dissipation_Indomitability,
+                        "Indomitability Ready Only Option", "Only uses Dissipation if Indomitability is ready to use.");
+                    break;
+                
                 #endregion
                 
                 #region Standalones
@@ -274,6 +282,11 @@ internal partial class SCH
                     DrawRadioButton(SCH_Recitation_Mode, "Indomitability", "", 2);
                     DrawRadioButton(SCH_Recitation_Mode, "Excogitation", "", 3);
                     break; 
+                
+                case CustomComboPreset.SCH_Hidden_Succor_Raidwide:
+                    DrawAdditionalBoolChoice(SCH_Hidden_Succor_Raidwide_Recitation, "Recitation Option", "Use Recitation to buff before the Raidwide Succor.");
+                    break;
+                
                 #endregion
             }
         }
@@ -300,7 +313,10 @@ internal partial class SCH
         internal static UserBool
             SCH_ST_DPS_EnergyDrain_Burst = new("SCH_ST_DPS_EnergyDrain_Burst"),
             SCH_AoE_DPS_EnergyDrain_Burst = new("SCH_AoE_DPS_EnergyDrain_Burst"),
-            SCH_AoE_DPS_ChainStratagemBanefulOption = new("SCH_AoE_DPS_ChainStratagemBanefulOption");
+            SCH_AoE_DPS_ChainStratagemBanefulOption = new("SCH_AoE_DPS_ChainStratagemBanefulOption"),
+            SCH_AoE_Heal_Aetherflow_Indomitability = new("SCH_AoE_Heal_Aetherflow_Indomitability"),
+            SCH_AoE_Heal_Dissipation_Indomitability = new("SCH_AoE_Heal_Dissipation_Indomitability"),
+            SCH_Hidden_Succor_Raidwide_Recitation = new ("SCH_Hidden_Succor_Raidwide_Recitation");
         
 
         public static UserFloat

--- a/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
@@ -18,13 +18,13 @@ internal partial class SCH
             switch (preset)
             {
                 #region DPS
-                case CustomComboPreset.SCH_DPS_Balance_Opener:
+                case CustomComboPreset.SCH_ST_ADV_DPS_Balance_Opener:
                     DrawHorizontalRadioButton(SCH_ST_DPS_OpenerOption, "Dissipation First", "Uses Dissipation first, then Aetherflow", 0);
                     DrawHorizontalRadioButton(SCH_ST_DPS_OpenerOption, "Aetherflow First", "Uses Aetherflow first, then Dissipation", 1);
                     DrawBossOnlyChoice(SCH_ST_DPS_OpenerContent);
                     break;
 
-                case CustomComboPreset.SCH_DPS:
+                case CustomComboPreset.SCH_ST_ADV_DPS:
                     DrawHorizontalRadioButton(SCH_ST_DPS_Adv_Actions, "On Ruin/Broils", "Apply options to Ruin and all Broils.", 0,
                         descriptionColor:ImGuiColors.DalamudWhite);
                     DrawHorizontalRadioButton(SCH_ST_DPS_Adv_Actions, "On Bio/Bio II/Biolysis", "Apply options to Bio and Biolysis.", 1,
@@ -33,11 +33,11 @@ internal partial class SCH
                         descriptionColor:ImGuiColors.DalamudWhite);
                     break;
                 
-                case CustomComboPreset.SCH_DPS_Lucid:
+                case CustomComboPreset.SCH_ST_ADV_DPS_Lucid:
                     DrawSliderInt(4000, 9500, SCH_ST_DPS_LucidOption, "MP Threshold", 150, Hundreds);
                     break;
 
-                case CustomComboPreset.SCH_DPS_Bio:
+                case CustomComboPreset.SCH_ST_ADV_DPS_Bio:
 
                     DrawSliderInt(0, 50, SCH_DPS_BioOption, "Stop using at Enemy HP %. Set to Zero to disable this check.");
 
@@ -57,7 +57,7 @@ internal partial class SCH
 
                     break;
 
-                case CustomComboPreset.SCH_DPS_ChainStrat:
+                case CustomComboPreset.SCH_ST_ADV_DPS_ChainStrat:
                     
                     DrawSliderInt(0, 100, SCH_ST_DPS_ChainStratagemOption, "Stop using at Enemy HP%. Set to Zero to disable this check.");
                     
@@ -75,7 +75,7 @@ internal partial class SCH
                     
                     break;
 
-                case CustomComboPreset.SCH_DPS_EnergyDrain:
+                case CustomComboPreset.SCH_ST_ADV_DPS_EnergyDrain:
                     DrawSliderInt(0, 60, SCH_ST_DPS_EnergyDrain, "Aetherflow remaining cooldown");
                     
                     DrawAdditionalBoolChoice(SCH_ST_DPS_EnergyDrain_Burst, 

--- a/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
@@ -82,11 +82,11 @@ internal partial class SCH
                         "Energy Drain Burst", "Holds Energy Drain when Chain Stratagem is ready or has less than 10 seconds cooldown remaining.");
                     break;
                 
-                case CustomComboPreset.SCH_AoE_DPS_Lucid:
+                case CustomComboPreset.SCH_AoE_ADV_DPS_Lucid:
                     DrawSliderInt(4000, 9500, SCH_AoE_DPS_LucidOption, "MP Threshold", 150, Hundreds);
                     break;
                 
-                case CustomComboPreset.SCH_AoE_DPS_ChainStrat:
+                case CustomComboPreset.SCH_AoE_ADV_DPS_ChainStrat:
                     DrawAdditionalBoolChoice(SCH_AoE_DPS_ChainStratagemBanefulOption, 
                         "Baneful Only", "Will only use Chain Strategem when high enough level to use Baneful Impaction");
                     
@@ -106,7 +106,7 @@ internal partial class SCH
                     
                     break;
 
-                case CustomComboPreset.SCH_AoE_DPS_EnergyDrain:
+                case CustomComboPreset.SCH_AoE_ADV_DPS_EnergyDrain:
                     DrawSliderInt(0, 60, SCH_AoE_DPS_EnergyDrain, "Aetherflow remaining cooldown");
                     
                     DrawAdditionalBoolChoice(SCH_AoE_DPS_EnergyDrain_Burst, 

--- a/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
@@ -27,7 +27,7 @@ internal partial class SCH
     internal static readonly List<uint>
         BroilList = [Ruin, Broil, Broil2, Broil3, Broil4],
         AetherflowList = [EnergyDrain, Lustrate, SacredSoil, Indomitability, Excogitation],
-        ReplacedActionsList = [Ruin, Broil, Broil2, Broil3, Broil4, Bio, Biolysis, Bio2, Ruin2, Succor, Concitation, Accession, Physick],
+        ReplacedActionsList = [Ruin, Broil, Broil2, Broil3, Broil4, Bio, Biolysis, Bio2, Ruin2, Succor, Concitation, Accession, Physick], //Used for Hidden Features Retarget Sacred Soil
         FairyList = [WhisperingDawn, FeyBlessing, FeyIllumination, Dissipation, Aetherpact, SummonSeraph];
     #endregion
     internal static SCHGauge Gauge => GetJobGauge<SCHGauge>();
@@ -40,9 +40,15 @@ internal partial class SCH
                                             && OriginalHook(Aetherpact) is DissolveUnion //Quick check to see if Fairy Aetherpact is Active
                                             && AetherPactTarget is not null //Null checking so GetTargetHPPercent doesn't fall back to CurrentTarget
                                             && GetTargetHPPercent(AetherPactTarget) >= Config.SCH_ST_Heal_AetherpactDissolveOption;
-    
     internal static bool ShieldCheck => GetPartyBuffPercent(Buffs.Galvanize) <= Config.SCH_AoE_Heal_SuccorShieldOption &&
-                                       GetPartyBuffPercent(SGE.Buffs.EukrasianPrognosis) <= Config.SCH_AoE_Heal_SuccorShieldOption;
+                                        GetPartyBuffPercent(SGE.Buffs.EukrasianPrognosis) <= Config.SCH_AoE_Heal_SuccorShieldOption;
+    internal static bool CanChainStrategem => ActionReady(ChainStratagem) &&
+                                              CanApplyStatus(CurrentTarget, Debuffs.ChainStratagem) &&
+                                              !HasStatusEffect(Debuffs.ChainStratagem, CurrentTarget, true);
+
+    internal static float AetherflowCD => GetCooldownRemainingTime(Aetherflow);
+    
+    internal static float ChainStrategemCD => GetCooldownRemainingTime(ChainStratagem);
     
     #region Hidden Raidwides
     

--- a/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
@@ -66,7 +66,7 @@ internal partial class SCH
     }
     internal static bool HiddenRecitation()
     {
-        return IsEnabled(CustomComboPreset.SCH_Hidden_Succor_Raidwide_Recitation) && ActionReady(Recitation);
+        return Config.SCH_Hidden_Succor_Raidwide_Recitation&& ActionReady(Recitation);
     }
     #endregion
     

--- a/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
@@ -89,11 +89,10 @@ internal partial class SCH
     internal static bool NeedsDoT()
     {
         var dotAction = OriginalHook(Bio);
-        var hpThreshold = Config.SCH_DPS_BioSubOption == 1 ||
-                          !InBossEncounter()
-            ? Config.SCH_DPS_BioSubOption
-            : 0;
+        var hpThreshold = IsNotEnabled(CustomComboPreset.SCH_ST_Simple_DPS) &&
+            (Config.SCH_DPS_BioSubOption == 1 || !InBossEncounter())? Config.SCH_DPS_BioSubOption : 0;
         BioList.TryGetValue(dotAction, out var dotDebuffID);
+        var dotRefresh = IsNotEnabled(CustomComboPreset.SCH_ST_Simple_DPS) ? Config.SCH_DPS_BioUptime_Threshold : 2.5;
         var dotRemaining = GetStatusEffectRemainingTime(dotDebuffID, CurrentTarget);
 
         return ActionReady(dotAction) &&
@@ -101,7 +100,7 @@ internal partial class SCH
                !JustUsedOn(dotAction, CurrentTarget, 5f) &&
                HasBattleTarget() &&
                GetTargetHPPercent() > hpThreshold &&
-               dotRemaining <= Config.SCH_DPS_BioUptime_Threshold;
+               dotRemaining <= dotRefresh;
     }
     #endregion
     

--- a/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
@@ -3,6 +3,7 @@ using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.Types;
 using ECommons.DalamudServices;
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using WrathCombo.Core;
@@ -16,22 +17,20 @@ namespace WrathCombo.Combos.PvE;
 internal partial class SCH
 {
     #region Lists
+    internal static readonly FrozenDictionary<uint, ushort> BioList = new Dictionary<uint, ushort>
+    {
+        { Bio, Debuffs.Bio1 },
+        { Bio2, Debuffs.Bio2},
+        { Biolysis, Debuffs.Biolysis},
+    }.ToFrozenDictionary();
+
     internal static readonly List<uint>
         BroilList = [Ruin, Broil, Broil2, Broil3, Broil4],
         AetherflowList = [EnergyDrain, Lustrate, SacredSoil, Indomitability, Excogitation],
         ReplacedActionsList = [Ruin, Broil, Broil2, Broil3, Broil4, Bio, Biolysis, Bio2, Ruin2, Succor, Concitation, Accession, Physick],
         FairyList = [WhisperingDawn, FeyBlessing, FeyIllumination, Dissipation, Aetherpact, SummonSeraph];
-    
-    internal static readonly Dictionary<uint, ushort>
-        BioList = new()
-        {
-            { Bio, Debuffs.Bio1 },
-            { Bio2, Debuffs.Bio2 },
-            { Biolysis, Debuffs.Biolysis }
-        };
     #endregion
     internal static SCHGauge Gauge => GetJobGauge<SCHGauge>();
-    
     internal static IBattleChara? AetherPactTarget => Svc.Objects.Where(x => x is IBattleChara chara && chara.StatusList.Any(y => y.StatusId == 1223 && y.SourceObject.GameObjectId == Svc.Buddies.PetBuddy.ObjectId)).Cast<IBattleChara>().FirstOrDefault();
     internal static bool HasAetherflow => Gauge.Aetherflow > 0;
     internal static bool FairyDismissed => Gauge.DismissedFairy > 0;

--- a/WrathCombo/Combos/PvE/SGE/SGE.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE.cs
@@ -91,7 +91,7 @@ internal partial class SGE : Healer
                     LevelChecked(Eukrasia) && InCombat() &&
                     !JustUsedOn(DosisList[OriginalHook(Dosis)].Eukrasian, CurrentTarget))
                 {
-                    float refreshTimer = SGE_ST_DPS_EDosisThreshold;
+                    float refreshTimer = SGE_ST_DPS_EDosisRefresh;
                     int hpThreshold = SGE_ST_DPS_EDosisSubOption == 1 || !InBossEncounter() ? SGE_ST_DPS_EDosisOption : 0;
 
                     if (CanApplyStatus(CurrentTarget, DosisList[OriginalHook(Dosis)].Debuff) &&

--- a/WrathCombo/CustomCombo/Functions/Misc.cs
+++ b/WrathCombo/CustomCombo/Functions/Misc.cs
@@ -73,7 +73,7 @@ namespace WrathCombo.CustomComboNS.Functions
                     return "General/Multiple Jobs";
 
                 if (key == 100)
-                    return "Occult Crescent";
+                    return OccultCrescent.ContentName;
 
                 //Override DOH/DOL
                 if (key is DOH.JobID) key = 08; //Set to Carpenter

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -463,7 +463,7 @@ namespace WrathCombo.Data
                 : ActionAttackType.Unknown;
         }
 
-        public enum ActionAttackType
+        public enum ActionAttackType : uint
         {
             Unknown = 0,
             Spell = 2,

--- a/WrathCombo/Window/Tabs/AutoRotationTab.cs
+++ b/WrathCombo/Window/Tabs/AutoRotationTab.cs
@@ -216,7 +216,7 @@ namespace WrathCombo.Window.Tabs
                 P.UIHelper.ShowIPCControlledIndicatorIfNeeded("AutoRez");
                 changed |= P.UIHelper.ShowIPCControlledCheckboxIfNeeded(
                     "Auto-Resurrect", ref cfg.HealerSettings.AutoRez, "AutoRez");
-                ImGuiComponents.HelpMarker($"Will attempt to resurrect dead party members. Applies to {WHM.ClassID.JobAbbreviation()}, {WHM.JobID.JobAbbreviation()}, {SCH.JobID.JobAbbreviation()}, {AST.JobID.JobAbbreviation()}, {SGE.JobID.JobAbbreviation()} and Occult Crescent {Svc.Data.GetExcelSheet<MKDSupportJob>().GetRow(10).Unknown0} {OccultCrescent.Revive.ActionName()}");
+                ImGuiComponents.HelpMarker($"Will attempt to resurrect dead party members. Applies to {WHM.ClassID.JobAbbreviation()}, {WHM.JobID.JobAbbreviation()}, {SCH.JobID.JobAbbreviation()}, {AST.JobID.JobAbbreviation()}, {SGE.JobID.JobAbbreviation()} and {OccultCrescent.ContentName} {Svc.Data.GetExcelSheet<MKDSupportJob>().GetRow(10).Unknown0} {OccultCrescent.Revive.ActionName()}");
                 var autoRez = (bool)P.IPC.GetAutoRotationConfigState(AutoRotationConfigOption.AutoRez)!;
                 if (autoRez)
                 {

--- a/WrathCombo/Window/Tabs/AutoRotationTab.cs
+++ b/WrathCombo/Window/Tabs/AutoRotationTab.cs
@@ -216,7 +216,7 @@ namespace WrathCombo.Window.Tabs
                 P.UIHelper.ShowIPCControlledIndicatorIfNeeded("AutoRez");
                 changed |= P.UIHelper.ShowIPCControlledCheckboxIfNeeded(
                     "Auto-Resurrect", ref cfg.HealerSettings.AutoRez, "AutoRez");
-                ImGuiComponents.HelpMarker($"Will attempt to resurrect dead party members. Applies to {WHM.ClassID.JobAbbreviation()}, {WHM.JobID.JobAbbreviation()}, {SCH.JobID.JobAbbreviation()}, {AST.JobID.JobAbbreviation()}, {SGE.JobID.JobAbbreviation()} and Occult Crescent {Svc.Data.GetExcelSheet<MKDSupportJob>().GetRow(10).Unknown0} {OccultCrescent.Revive.StatusName()}");
+                ImGuiComponents.HelpMarker($"Will attempt to resurrect dead party members. Applies to {WHM.ClassID.JobAbbreviation()}, {WHM.JobID.JobAbbreviation()}, {SCH.JobID.JobAbbreviation()}, {AST.JobID.JobAbbreviation()}, {SGE.JobID.JobAbbreviation()} and Occult Crescent {Svc.Data.GetExcelSheet<MKDSupportJob>().GetRow(10).Unknown0} {OccultCrescent.Revive.ActionName()}");
                 var autoRez = (bool)P.IPC.GetAutoRotationConfigState(AutoRotationConfigOption.AutoRez)!;
                 if (autoRez)
                 {

--- a/WrathCombo/WrathCombo.csproj
+++ b/WrathCombo/WrathCombo.csproj
@@ -5,7 +5,7 @@
     <PropertyGroup>
         <Authors>Team Wrath</Authors>
         <Company>-</Company>
-        <Version>1.0.1.12</Version>
+        <Version>1.0.1.13</Version>
         <!-- This is the version that will be used when pushing to the repo.-->
         <Description>XIVCombo for very lazy players</Description>
         <Copyright>Copyleft attick 2021 thanks attick UwU</Copyright>


### PR DESCRIPTION
- Merged Zbees IPC changes into this so I could do this stuff without conflicts of ccp. 

- SCH
  - Added Simple Dps Mode for ST and AoE
  - Cleaned up UI. Utilized configs to remove some ugly parent boxes. 
  - Changed Button selection to radio buttons for a cleaner look and smoother function
  - Adjusted how boss and slider options work for chain strategem to be in line with more recent works.
  - I froze my dic
  
- AST
  - Added Simple DPS mode for ST and AoE
  - Adopted Dot Checker Function from SCH that Stole it from WHM for cleaner dot section
  - I froze Taurens dic
