### PR TITLE
[BLU] MoonFlute Fix

### DIFF
--- a/WrathCombo/Combos/PvE/BLU/BLU.cs
+++ b/WrathCombo/Combos/PvE/BLU/BLU.cs
@@ -114,7 +114,7 @@ internal partial class BLU : Caster
                         return Whistle;
                     if (!HasStatusEffect(Buffs.Tingle) && IsSpellActive(Tingle) && !WasLastSpell(Tingle) && IsOffCooldown(JKick))
                         return Tingle;
-                    if (!HasStatusEffect(Buffs.MoonFlute) && !HasStatusEffect(Buffs.WaningNocturne) && IsSpellActive(MoonFlute) && !WasLastSpell(MoonFlute))
+                    if (!HasStatusEffect(Buffs.MoonFlute) && !HasStatusEffect(Buffs.WaningNocturne) && IsSpellActive(MoonFlute) && !WasLastSpell(MoonFlute) && !JustUsed(MoonFlute))
                         return MoonFlute;
                     if (IsOffCooldown(JKick) && IsSpellActive(JKick))
                         return JKick;
@@ -129,7 +129,7 @@ internal partial class BLU : Caster
                         return Whistle;
                     if (!HasStatusEffect(Buffs.Tingle) && IsSpellActive(Tingle) && !WasLastSpell(Tingle) && IsOffCooldown(JKick))
                         return Tingle;
-                    if (!HasStatusEffect(Buffs.MoonFlute) && !HasStatusEffect(Buffs.WaningNocturne) && IsSpellActive(MoonFlute))
+                    if (!HasStatusEffect(Buffs.MoonFlute) && !HasStatusEffect(Buffs.WaningNocturne) && IsSpellActive(MoonFlute) && !JustUsed(MoonFlute))
                         return MoonFlute;
                     if (IsOffCooldown(JKick) && IsSpellActive(JKick))
                         return JKick;
@@ -408,7 +408,7 @@ internal partial class BLU : Caster
                     if (IsSpellActive(RoseOfDestruction) && GetCooldown(RoseOfDestruction).CooldownRemaining < 1f)
                         return RoseOfDestruction;
 
-                    if (IsSpellActive(MoonFlute))
+                    if (IsSpellActive(MoonFlute) && !JustUsed(MoonFlute))
                         return MoonFlute;
                 }
 


### PR DESCRIPTION
Added a `!JustUsed(MoonFlute)` to all instances of MoonFlute on lvl 70 and 80 combos to avoid double casting it due to latency. @zbee 