### PR TITLE
[WHM] Add Only Bosses option to DOT

### DIFF
--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -63,36 +63,38 @@ internal partial class WHM
                     break;
 
                 case CustomComboPreset.WHM_ST_MainCombo_DoT:
-                    DrawSliderInt(0, 50, WHM_ST_DPS_AeroOption,
-                        targetStopUsingAtDescription,
+                    DrawSliderInt(0, 100, WHM_ST_DPS_AeroOptionBoss,
+                        targetStopUsingOnBossAtDescription,
                         itemWidth: medium);
 
+                    ImGui.Spacing();
+                    DrawSliderInt(0, 100, WHM_ST_DPS_AeroOptionNonBoss,
+                        targetStopUsingAtDescription,
+                        itemWidth: medium);
+      
                     ImGui.Indent();
+                    ImGui.TextUnformatted("For non-bosses, select what kind of content this applies to:");
+                    DrawHorizontalRadioButton(
+                        WHM_Dia_Uptime_Content, "All Content",
+                        "Applies to all content in the game.",
+                        outputValue: 0,
+                        descriptionColor: ImGuiColors.DalamudYellow
+                    );
+                    DrawHorizontalRadioButton(
+                        WHM_Dia_Uptime_Content, "Boss Only Content",
+                        "Only applies in instances where you directly fight a boss. Excludes many A Realm Reborn & Heavensward raids that include trash.",
+                        outputValue: 1,
+                        descriptionColor: ImGuiColors.DalamudYellow
+                    );
+                    DrawHorizontalRadioButton(
+                        WHM_Dia_Uptime_Content, "Non-Boss Only Content",
+                        "Only applies when not facing a boss. Includes many A Realm Reborn & Heavensward raids that include trash.",
+                        outputValue: 2,
+                        descriptionColor: ImGuiColors.DalamudYellow
+                    );
 
-                    ImGui.TextWrapped(
-                        "Select what kind of enemies the HP check should be applied to:");
-                    ImGui.NewLine();
-
-                    DrawHorizontalRadioButton(WHM_ST_DPS_AeroOptionSubOption,
-                        "Non-Bosses",
-                        "Only applies the HP check above to non-bosses.\n" +
-                        "Allows you to only stop DoTing early when it's not a boss.",
-                        (int)EnemyRestriction.NonBosses,
-                        descriptionColor: ImGuiColors.DalamudWhite);
-
-                    DrawHorizontalRadioButton(WHM_ST_DPS_AeroOptionSubOption,
-                        "All Enemies",
-                        "Applies the HP check above to all enemies.",
-                        (int)EnemyRestriction.AllEnemies,
-                        descriptionColor: ImGuiColors.DalamudWhite);
-                    
-                    DrawHorizontalRadioButton(WHM_ST_DPS_AeroOptionSubOption,
-                        "Only Bosses",
-                        "Applies the HP check above only when it's a boss. \n"+
-                        "This will not apply DoTs to non-bosses enemies",
-                        (int)EnemyRestriction.OnlyBosses,
-                        descriptionColor: ImGuiColors.DalamudWhite);
-
+                    ImGui.Spacing();
+                    ImGui.Unindent();
                     DrawRoundedSliderFloat(0, 4, WHM_ST_MainCombo_DoT_Threshold,
                         reapplyTimeRemainingDescription,
                         itemWidth: little, digits: 1);
@@ -230,14 +232,15 @@ internal partial class WHM
                 case CustomComboPreset.WHM_AoEHeals_Temperance:
                     DrawSliderInt(1, 100, WHM_AoEHeals_TemperanceHP,
                         "Average party HP% to use at or below");
-                    DrawDifficultyMultiChoice(WHM_AoEHeals_TemperanceDifficulty, WHM_AoEHeals_TemperanceDifficultyListSet,
+                    DrawDifficultyMultiChoice(WHM_AoEHeals_TemperanceDifficulty,
+                        WHM_AoEHeals_TemperanceDifficultyListSet,
                         "Select what content difficulties Temperance should be used in:");
                     ImGui.Spacing();
-                    
+
                     DrawAdditionalBoolChoice(WHM_AoEHeals_TemperanceWeave,
                         weaveDescription,
                         "");
-                    
+
                     DrawAdditionalBoolChoice(WHM_AoEHeals_TemperanceRaidwide,
                         "Also use for Raidwides",
                         "Will also use for mitigation before raidwides (and a healing boost after them), if the party is low enough.",
@@ -245,9 +248,10 @@ internal partial class WHM
                     if (WHM_AoEHeals_TemperanceRaidwide)
                     {
                         ImGui.Indent();
-                        DrawDifficultyMultiChoice(WHM_AoEHeals_TemperanceRaidwideDifficulty, WHM_AoEHeals_TemperanceRaidwideDifficultyListSet,
+                        DrawDifficultyMultiChoice(WHM_AoEHeals_TemperanceRaidwideDifficulty,
+                            WHM_AoEHeals_TemperanceRaidwideDifficultyListSet,
                             "Select what content difficulties the Raidwide option should apply to:");
-                    
+
                         DrawAdditionalBoolChoice(WHM_AoEHeals_TemperanceRaidwidePrioritization,
                             "Prioritize use for Raidwides",
                             "Will ignore the Party HP% check for Raidwides, essentially using Temperance for mitigation.\n" +
@@ -255,6 +259,7 @@ internal partial class WHM
                             indentDescription: true);
                         ImGui.Unindent();
                     }
+
                     break;
 
                 case CustomComboPreset.WHM_AoEHeals_Lucid:
@@ -289,16 +294,17 @@ internal partial class WHM
                         DrawRadioButton(
                             WHM_AoEHeals_LiturgyRaidwideOnlyBoss, "All Enemies",
                             "Will check for a Raidwide before using Bell at all times, on all enemies.",
-                            outputValue: (int) BossRequirement.Off, itemWidth: 125f,
+                            outputValue: (int)BossRequirement.Off, itemWidth: 125f,
                             descriptionAsTooltip: true);
                         DrawRadioButton(
                             WHM_AoEHeals_LiturgyRaidwideOnlyBoss, "Only Bosses",
                             "Will try to only check for Raidwide when fighting bosses.\n" +
                             "(will use on cooldown versus regular enemies)\n" +
                             "(Note: don't rely on this 100%, square sometimes marks enemies inconsistently)",
-                            outputValue: (int) BossRequirement.On, itemWidth: 125f,
+                            outputValue: (int)BossRequirement.On, itemWidth: 125f,
                             descriptionAsTooltip: true);
                     }
+
                     break;
 
                 case CustomComboPreset.WHM_AoEHeals_Asylum:
@@ -325,7 +331,11 @@ internal partial class WHM
 
         /// Bar Description for target HP% to start using plus disable text
         private const string targetStopUsingAtDescription =
-            "Target HP% to stop using (0 = Use Always)";
+            " Non-bosses HP% to stop using (0 = Use Always, 100 = Never)";
+
+        /// Bar Description for target HP% to start using plus disable text
+        private const string targetStopUsingOnBossAtDescription =
+            " Bosses HP% to stop using (0 = Use Always, 100 = Never)";
 
         /// Description for MP threshold
         private const string mpThresholdDescription =
@@ -405,16 +415,40 @@ internal partial class WHM
             new("WHM_Balance_Content", 0);
 
         /// <summary>
+        ///     Content type of Balance Opener.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: All Content<br />
+        ///     <b>Options</b>: All Content or
+        ///     <see cref="ContentCheck.IsInBossOnlyContent" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_ST_MainCombo_Opener" />
+        internal static UserInt WHM_Dia_Uptime_Content =
+            new("WHM_Dia_Uptime_Content", 0);
+
+        /// <summary>
         ///     HP threshold to stop applying DoTs.
         /// </summary>
         /// <value>
         ///     <b>Default</b>: 0 <br />
-        ///     <b>Range</b>: 0 - 50 <br />
+        ///     <b>Range</b>: 0 - 100 <br />
         ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
         /// </value>
         /// <seealso cref="CustomComboPreset.WHM_ST_MainCombo_DoT" />
-        internal static UserInt WHM_ST_DPS_AeroOption =
-            new("WHM_ST_DPS_AeroOption");
+        internal static UserInt WHM_ST_DPS_AeroOptionBoss =
+            new("WHM_ST_DPS_AeroOptionBoss");
+
+        /// <summary>
+        ///     HP threshold to stop applying DoTs.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 0 <br />
+        ///     <b>Range</b>: 0 - 100 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_ST_MainCombo_DoT" />
+        internal static UserInt WHM_ST_DPS_AeroOptionNonBoss =
+            new("WHM_ST_DPS_AeroOptionNonBoss");
 
         /// <summary>
         ///     Time threshold in seconds before reapplying DoT.
@@ -510,7 +544,7 @@ internal partial class WHM
         /// <seealso cref="CustomComboPreset.WHM_STHeals_Regen" />
         internal static UserInt WHM_STHeals_RegenHPLower =
             new("WHM_STHeals_RegenHPLower", 30);
-        
+
         /// <summary>
         ///     Upper HP threshold to start using Regen.
         /// </summary>
@@ -805,7 +839,7 @@ internal partial class WHM
         /// <seealso cref="CustomComboPreset.WHM_AoEHeals_LiturgyOfTheBell" />
         public static readonly UserInt
             WHM_AoEHeals_LiturgyRaidwideOnlyBoss =
-                new("WHM_AoEHeals_LiturgyRaidwideOnlyBoss", (int) BossRequirement.On);
+                new("WHM_AoEHeals_LiturgyRaidwideOnlyBoss", (int)BossRequirement.On);
 
         /// <summary>
         ///     Content difficulty selector for Liturgy of the Bell.

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -438,7 +438,7 @@ internal partial class WHM
         /// </value>
         /// <seealso cref="CustomComboPreset.WHM_ST_MainCombo_DoT" />
         internal static UserInt WHM_ST_DPS_AeroOptionNonBoss =
-            new("WHM_ST_DPS_AeroOptionNonBoss");
+            new("WHM_ST_DPS_AeroOptionNonBoss", 50);
 
         /// <summary>
         ///     Time threshold in seconds before reapplying DoT.
@@ -461,7 +461,7 @@ internal partial class WHM
         /// </value>
         /// <seealso cref="CustomComboPreset.WHM_ST_MainCombo_DoT" />
         internal static UserInt WHM_ST_DPS_AeroOptionSubOption =
-            new("WHM_ST_DPS_AeroOptionSubOption", (int)EnemyRestriction.NonBosses);
+            new("WHM_ST_DPS_AeroOptionSubOption", (int)EnemyRestriction.AllEnemies);
 
         /// <summary>
         ///     MP threshold to use Lucid Dreaming in single target rotations.

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -77,20 +77,20 @@ internal partial class WHM
                         "Non-Bosses",
                         "Only applies the HP check above to non-bosses.\n" +
                         "Allows you to only stop DoTing early when it's not a boss.",
-                        (int)DotEnemyRestriction.NonBosses,
+                        (int)EnemyRestriction.NonBosses,
                         descriptionColor: ImGuiColors.DalamudWhite);
 
                     DrawHorizontalRadioButton(WHM_ST_DPS_AeroOptionSubOption,
                         "All Enemies",
                         "Applies the HP check above to all enemies.",
-                        (int)DotEnemyRestriction.AllEnemies,
+                        (int)EnemyRestriction.AllEnemies,
                         descriptionColor: ImGuiColors.DalamudWhite);
                     
                     DrawHorizontalRadioButton(WHM_ST_DPS_AeroOptionSubOption,
                         "Only Bosses",
                         "Applies the HP check above only when it's a boss. \n"+
                         "This will not apply DoTs to non-bosses enemies",
-                        (int)DotEnemyRestriction.OnlyBosses,
+                        (int)EnemyRestriction.OnlyBosses,
                         descriptionColor: ImGuiColors.DalamudWhite);
 
                     DrawRoundedSliderFloat(0, 4, WHM_ST_MainCombo_DoT_Threshold,
@@ -358,7 +358,7 @@ internal partial class WHM
         /// <summary>
         ///     Enemy type restriction for HP threshold checks.
         /// </summary>
-        internal enum DotEnemyRestriction
+        internal enum EnemyRestriction
         {
             NonBosses = 0,
             AllEnemies = 1,
@@ -432,12 +432,12 @@ internal partial class WHM
         ///     Enemy type to apply the HP threshold check to.
         /// </summary>
         /// <value>
-        ///     <b>Default</b>: <see cref="DotEnemyRestriction.NonBosses" /> <br />
-        ///     <b>Options</b>: <see cref="DotEnemyRestriction">DotEnemyRestriction Enum</see>
+        ///     <b>Default</b>: <see cref="EnemyRestriction.NonBosses" /> <br />
+        ///     <b>Options</b>: <see cref="EnemyRestriction">EnemyRestriction Enum</see>
         /// </value>
         /// <seealso cref="CustomComboPreset.WHM_ST_MainCombo_DoT" />
         internal static UserInt WHM_ST_DPS_AeroOptionSubOption =
-            new("WHM_ST_DPS_AeroOptionSubOption", (int)DotEnemyRestriction.NonBosses);
+            new("WHM_ST_DPS_AeroOptionSubOption", (int)EnemyRestriction.NonBosses);
 
         /// <summary>
         ///     MP threshold to use Lucid Dreaming in single target rotations.

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -456,7 +456,7 @@ internal partial class WHM
         ///     Enemy type to apply the HP threshold check to.
         /// </summary>
         /// <value>
-        ///     <b>Default</b>: <see cref="EnemyRestriction.NonBosses" /> <br />
+        ///     <b>Default</b>: <see cref="EnemyRestriction.AllEnemies" /> <br />
         ///     <b>Options</b>: <see cref="EnemyRestriction">EnemyRestriction Enum</see>
         /// </value>
         /// <seealso cref="CustomComboPreset.WHM_ST_MainCombo_DoT" />

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -73,8 +73,9 @@ internal partial class WHM
                         itemWidth: medium);
       
                     ImGui.Indent();
-                    ImGui.Indent();
                     ImGui.TextUnformatted("For Non-Bosses, select what kind of content this applies to:");
+                    ImGui.NewLine();
+                    ImGui.Indent();
                     DrawHorizontalRadioButton(
                         WHM_ST_DPS_AeroOptionSubOption, "All Content",
                         "Apply the HP% for Non-Bosses to all content.",

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -1,6 +1,7 @@
 ﻿#region
 
 using System.Numerics;
+using Dalamud.Interface.Colors;
 using ECommons.ImGuiMethods;
 using ImGuiNET;
 using WrathCombo.CustomComboNS.Functions;
@@ -73,21 +74,24 @@ internal partial class WHM
       
                     ImGui.Indent();
                     ImGui.Indent();
-                    ImGui.TextUnformatted("For non-bosses, select what kind of content this applies to:");
+                    ImGui.TextUnformatted("For Non-Bosses, select what kind of content this applies to:");
                     DrawHorizontalRadioButton(
                         WHM_ST_DPS_AeroOptionSubOption, "All Content",
-                        "Applies to all content in the game.",
-                        outputValue: (int)EnemyRestriction.AllEnemies
+                        "Apply the HP% for Non-Bosses to all content.",
+                        outputValue: (int)EnemyRestriction.AllEnemies,
+                        descriptionColor: ImGuiColors.DalamudWhite
                     );
                     DrawHorizontalRadioButton(
                         WHM_ST_DPS_AeroOptionSubOption, "Boss Only Content",
-                        "Only applies in instances where you directly fight a boss. Excludes many A Realm Reborn & Heavensward raids that include trash.",
-                        outputValue: (int)EnemyRestriction.OnlyBosses
+                        "Apply the HP% for Non-Bosses, only in Boss content, to adds. Always applies DoTs at any HP outside of Boss content.",
+                        outputValue: (int)EnemyRestriction.OnlyBosses,
+                        descriptionColor: ImGuiColors.DalamudWhite
                     );
                     DrawHorizontalRadioButton(
                         WHM_ST_DPS_AeroOptionSubOption, "Non-Boss Only Content",
-                        "Only applies when not facing a boss. Includes many A Realm Reborn & Heavensward raids that include trash.",
-                        outputValue: (int)EnemyRestriction.NonBosses
+                        "Apply the HP% for Non-Bosses, only outside Boss content. Always applies DoTs at any HP to adds in boss content.",
+                        outputValue: (int)EnemyRestriction.NonBosses,
+                        descriptionColor: ImGuiColors.DalamudWhite
                     );
 
                     ImGui.Spacing();
@@ -328,7 +332,7 @@ internal partial class WHM
 
         /// Bar Description for target HP% to start using plus disable text
         private const string targetStopUsingAtDescription =
-            " Non-bosses HP% to stop using (0 = Use Always, 100 = Never)";
+            " Non-Bosses HP% to stop using (0 = Use Always, 100 = Never)";
 
         /// Bar Description for target HP% to start using plus disable text
         private const string targetStopUsingOnBossAtDescription =

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -77,13 +77,20 @@ internal partial class WHM
                         "Non-Bosses",
                         "Only applies the HP check above to non-bosses.\n" +
                         "Allows you to only stop DoTing early when it's not a boss.",
-                        (int)BossAvoidance.On,
+                        (int)DotEnemyRestriction.NonBosses,
                         descriptionColor: ImGuiColors.DalamudWhite);
 
                     DrawHorizontalRadioButton(WHM_ST_DPS_AeroOptionSubOption,
                         "All Enemies",
                         "Applies the HP check above to all enemies.",
-                        (int)BossAvoidance.Off,
+                        (int)DotEnemyRestriction.AllEnemies,
+                        descriptionColor: ImGuiColors.DalamudWhite);
+                    
+                    DrawHorizontalRadioButton(WHM_ST_DPS_AeroOptionSubOption,
+                        "Only Bosses",
+                        "Applies the HP check above only when it's a boss. \n"+
+                        "This will not apply DoTs to non-bosses enemies",
+                        (int)DotEnemyRestriction.OnlyBosses,
                         descriptionColor: ImGuiColors.DalamudWhite);
 
                     DrawRoundedSliderFloat(0, 4, WHM_ST_MainCombo_DoT_Threshold,
@@ -351,10 +358,11 @@ internal partial class WHM
         /// <summary>
         ///     Enemy type restriction for HP threshold checks.
         /// </summary>
-        internal enum BossAvoidance
+        internal enum DotEnemyRestriction
         {
-            On = 0,
-            Off = 1,
+            NonBosses = 0,
+            AllEnemies = 1,
+            OnlyBosses = 2,
         }
 
         #endregion
@@ -424,12 +432,12 @@ internal partial class WHM
         ///     Enemy type to apply the HP threshold check to.
         /// </summary>
         /// <value>
-        ///     <b>Default</b>: <see cref="BossAvoidance.On" /> <br />
-        ///     <b>Options</b>: <see cref="BossAvoidance">BossAvoidance Enum</see>
+        ///     <b>Default</b>: <see cref="DotEnemyRestriction.NonBosses" /> <br />
+        ///     <b>Options</b>: <see cref="DotEnemyRestriction">DotEnemyRestriction Enum</see>
         /// </value>
         /// <seealso cref="CustomComboPreset.WHM_ST_MainCombo_DoT" />
         internal static UserInt WHM_ST_DPS_AeroOptionSubOption =
-            new("WHM_ST_DPS_AeroOptionSubOption", (int)BossAvoidance.On);
+            new("WHM_ST_DPS_AeroOptionSubOption", (int)DotEnemyRestriction.NonBosses);
 
         /// <summary>
         ///     MP threshold to use Lucid Dreaming in single target rotations.

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -84,13 +84,13 @@ internal partial class WHM
                     );
                     DrawHorizontalRadioButton(
                         WHM_ST_DPS_AeroOptionSubOption, "Boss Only Content",
-                        "Apply the HP% for Non-Bosses, only in Boss content (to adds). Always applies DoTs at any HP outside of Boss content.",
+                        "Apply the HP% for Non-Bosses, only in Boss content (to adds).\nAlways applies DoTs at any HP outside of Boss content.",
                         outputValue: (int)EnemyRestriction.OnlyBosses,
                         descriptionColor: ImGuiColors.DalamudWhite
                     );
                     DrawHorizontalRadioButton(
                         WHM_ST_DPS_AeroOptionSubOption, "Non-Boss Only Content",
-                        "Apply the HP% for Non-Bosses, only outside Boss content. Always applies DoTs at any HP to adds in boss content.",
+                        "Apply the HP% for Non-Bosses, only outside Boss content.\nAlways applies DoTs at any HP to adds in boss content.",
                         outputValue: (int)EnemyRestriction.NonBosses,
                         descriptionColor: ImGuiColors.DalamudWhite
                     );

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -83,7 +83,7 @@ internal partial class WHM
                     );
                     DrawHorizontalRadioButton(
                         WHM_ST_DPS_AeroOptionSubOption, "Boss Only Content",
-                        "Apply the HP% for Non-Bosses, only in Boss content, to adds. Always applies DoTs at any HP outside of Boss content.",
+                        "Apply the HP% for Non-Bosses, only in Boss content (to adds). Always applies DoTs at any HP outside of Boss content.",
                         outputValue: (int)EnemyRestriction.OnlyBosses,
                         descriptionColor: ImGuiColors.DalamudWhite
                     );

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -1,7 +1,6 @@
 ﻿#region
 
 using System.Numerics;
-using Dalamud.Interface.Colors;
 using ECommons.ImGuiMethods;
 using ImGuiNET;
 using WrathCombo.CustomComboNS.Functions;
@@ -73,24 +72,22 @@ internal partial class WHM
                         itemWidth: medium);
       
                     ImGui.Indent();
+                    ImGui.Indent();
                     ImGui.TextUnformatted("For non-bosses, select what kind of content this applies to:");
                     DrawHorizontalRadioButton(
-                        WHM_Dia_Uptime_Content, "All Content",
+                        WHM_ST_DPS_AeroOptionSubOption, "All Content",
                         "Applies to all content in the game.",
-                        outputValue: 0,
-                        descriptionColor: ImGuiColors.DalamudYellow
+                        outputValue: (int)EnemyRestriction.AllEnemies
                     );
                     DrawHorizontalRadioButton(
-                        WHM_Dia_Uptime_Content, "Boss Only Content",
+                        WHM_ST_DPS_AeroOptionSubOption, "Boss Only Content",
                         "Only applies in instances where you directly fight a boss. Excludes many A Realm Reborn & Heavensward raids that include trash.",
-                        outputValue: 1,
-                        descriptionColor: ImGuiColors.DalamudYellow
+                        outputValue: (int)EnemyRestriction.OnlyBosses
                     );
                     DrawHorizontalRadioButton(
-                        WHM_Dia_Uptime_Content, "Non-Boss Only Content",
+                        WHM_ST_DPS_AeroOptionSubOption, "Non-Boss Only Content",
                         "Only applies when not facing a boss. Includes many A Realm Reborn & Heavensward raids that include trash.",
-                        outputValue: 2,
-                        descriptionColor: ImGuiColors.DalamudYellow
+                        outputValue: (int)EnemyRestriction.NonBosses
                     );
 
                     ImGui.Spacing();
@@ -413,18 +410,6 @@ internal partial class WHM
         /// <seealso cref="CustomComboPreset.WHM_ST_MainCombo_Opener" />
         internal static UserInt WHM_Balance_Content =
             new("WHM_Balance_Content", 0);
-
-        /// <summary>
-        ///     Content type of Balance Opener.
-        /// </summary>
-        /// <value>
-        ///     <b>Default</b>: All Content<br />
-        ///     <b>Options</b>: All Content or
-        ///     <see cref="ContentCheck.IsInBossOnlyContent" />
-        /// </value>
-        /// <seealso cref="CustomComboPreset.WHM_ST_MainCombo_Opener" />
-        internal static UserInt WHM_Dia_Uptime_Content =
-            new("WHM_Dia_Uptime_Content", 0);
 
         /// <summary>
         ///     HP threshold to stop applying DoTs on Bosses.

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -427,7 +427,7 @@ internal partial class WHM
             new("WHM_Dia_Uptime_Content", 0);
 
         /// <summary>
-        ///     HP threshold to stop applying DoTs.
+        ///     HP threshold to stop applying DoTs on Bosses.
         /// </summary>
         /// <value>
         ///     <b>Default</b>: 0 <br />
@@ -439,7 +439,7 @@ internal partial class WHM
             new("WHM_ST_DPS_AeroOptionBoss");
 
         /// <summary>
-        ///     HP threshold to stop applying DoTs.
+        ///     HP threshold to stop applying DoTs on Non-Bosses.
         /// </summary>
         /// <value>
         ///     <b>Default</b>: 0 <br />

--- a/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
@@ -42,15 +42,20 @@ internal partial class WHM
 
     internal static int computeHpThreshold()
     {
+        if (TargetIsBoss() && InBossEncounter())
+        {
+            return Config.WHM_ST_DPS_AeroOptionBoss;
+        }
+
         switch ((int)Config.WHM_ST_DPS_AeroOptionSubOption)
         {
+            case (int)Config.EnemyRestriction.AllEnemies:
+                return Config.WHM_ST_DPS_AeroOptionNonBoss;
+            case (int)Config.EnemyRestriction.OnlyBosses:
+                return InBossEncounter() ? Config.WHM_ST_DPS_AeroOptionNonBoss : 0;
             default:
             case (int)Config.EnemyRestriction.NonBosses:
-                return InBossEncounter() ? 0 : Config.WHM_ST_DPS_AeroOption;
-            case (int)Config.EnemyRestriction.AllEnemies:
-                return Config.WHM_ST_DPS_AeroOption;
-            case (int)Config.EnemyRestriction.OnlyBosses:
-                return InBossEncounter() && TargetIsBoss() ? Config.WHM_ST_DPS_AeroOption : 101;
+                return !InBossEncounter() ? Config.WHM_ST_DPS_AeroOptionNonBoss : 0;
         }
     }
 

--- a/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
@@ -45,11 +45,11 @@ internal partial class WHM
         switch ((int)Config.WHM_ST_DPS_AeroOptionSubOption)
         {
             default:
-            case (int)Config.DotEnemyRestriction.NonBosses:
+            case (int)Config.EnemyRestriction.NonBosses:
                 return InBossEncounter() ? 0 : Config.WHM_ST_DPS_AeroOption;
-            case (int)Config.DotEnemyRestriction.AllEnemies:
+            case (int)Config.EnemyRestriction.AllEnemies:
                 return Config.WHM_ST_DPS_AeroOption;
-            case (int)Config.DotEnemyRestriction.OnlyBosses:
+            case (int)Config.EnemyRestriction.OnlyBosses:
                 return InBossEncounter() && TargetIsBoss() ? Config.WHM_ST_DPS_AeroOption : 101;
         }
     }


### PR DESCRIPTION
### Changes
- Added the **Only Bosses** option to DoT uptime for WHM
- Refactored a bit how the HP Treshold is calculated
- Renamed BossAvoidance to DotEnemyRestriction in WHM module


<details>
  <summary>Proposed design</summary>

| Checkbox at start | Avoid adds option | Double slider |
| -- | -- | -- | 
| More flexibility on allowed targets, still the same HP% for all selected | Not much UI Changes, easy to understand, still the same HP% for all selected | Change the UI, more configurations | 
| <img width="742" height="263" alt="image" src="https://github.com/user-attachments/assets/c413c4c9-43f6-4fcd-ac2c-9674fc8a7f7b" /> | <img width="777" height="260" alt="image" src="https://github.com/user-attachments/assets/e15bfb87-559d-410a-8bc5-ed562fa18cf0" /> |  <img width="866" height="253" alt="image" src="https://github.com/user-attachments/assets/6403f06b-bc02-4647-81f8-41101639479a" /> | 
</details>

### Final design

<img width="532" height="206" alt="image" src="https://github.com/user-attachments/assets/35beeff2-c085-4b9d-bbd8-39eec8919838" />

Tooltips: 
- "Apply the HP% for Non-Bosses to all content."
- "Apply the HP% for Non-Bosses, only in Boss content (to adds). Always applies DoTs at any HP outside of Boss content."
- "Apply the HP% for Non-Bosses, only outside Boss content. Always applies DoTs at any HP to adds in boss content."