### PR TITLE
[Core] Move Performance Mode under Action Replacing

### DIFF
--- a/WrathCombo/Window/Tabs/Settings.cs
+++ b/WrathCombo/Window/Tabs/Settings.cs
@@ -159,7 +159,7 @@ namespace WrathCombo.Window.Tabs
                 if (ImGui.Checkbox("Block spells if moving", ref Service.Configuration.BlockSpellOnMove))
                     Service.Configuration.Save();
 
-                ImGuiComponents.HelpMarker("Completely blocks spells from being used if you are moving, by replacing your actions with Savage Blade.\nThis would supersede combo-specific movement options, available for most jobs.");
+                ImGuiComponents.HelpMarker("Completely blocks spells from being used if you are moving, by replacing your actions with Savage Blade.\nThis would supersede combo-specific movement options, available for most jobs.\n\nIt is recommended to keep this off, as most combos already handle this more gracefully.\nDefault: Off");
 
                 #endregion
 
@@ -168,7 +168,7 @@ namespace WrathCombo.Window.Tabs
                 if (ImGui.Checkbox("Action Replacing", ref Service.Configuration.ActionChanging))
                     Service.Configuration.Save();
 
-                ImGuiComponents.HelpMarker("Controls whether Actions will be Intercepted Replaced with combos from the plugin.\nIf disabled, your manual presses of abilities will no longer be affected by your Wrath settings.\n\nAuto-Rotation will work regardless of the setting.\n\nControlled by the `/wrath combo` command.");
+                ImGuiComponents.HelpMarker("Controls whether Actions will be Intercepted Replaced with combos from the plugin.\nIf disabled, your manual presses of abilities will no longer be affected by your Wrath settings.\n\nAuto-Rotation will work regardless of the setting.\n\nControlled by the `/wrath combo` command.\n\nIt is REQUIRED to keep this on if you use want to use Wrath without Auto Rotation.\nDefault: On");
 
                 #endregion
 
@@ -179,7 +179,7 @@ namespace WrathCombo.Window.Tabs
                     if (ImGui.Checkbox("Performance Mode", ref Service.Configuration.PerformanceMode))
                         Service.Configuration.Save();
 
-                    ImGuiComponents.HelpMarker("This mode will disable actions being changed on your hotbar, but will still continue to work in the background as you press your buttons.");
+                    ImGuiComponents.HelpMarker("This mode will disable actions being changed on your hotbar, but will still continue to work in the background as you press your buttons.\n\nIt is recommended to try turing this on if you have performance issues.\nDefault: Off");
                     ImGui.Unindent();
                 }
 


### PR DESCRIPTION
- [X] Makes the UI match the logic as of 6bf60ab by moving Performance Mode under Action Replacing (which it now explicitly requires)
- [X] Adds more default info to the helpmarks for rotation behavior settings