### PR TITLE
[Core] Squash Obsolete Warnings

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -2077,10 +2077,6 @@ public enum CustomComboPreset
     DRK_ST_Adv = 5010,
 
     [ParentCombo(DRK_ST_Adv)]
-    [CustomComboInfo("Prevent Triple Weaves Option", "Tries to prevent any triple-weaving (even when it may not clip).", DRK.JobID)]
-    DRK_PreventTripleWeaves = 5038,
-
-    [ParentCombo(DRK_ST_Adv)]
     [CustomComboInfo("Balance Opener (Level 100)",
         "Adds the Balance opener at level 100." +
         "\nRequirements:" +

--- a/WrathCombo/Combos/PvE/AST/AST.cs
+++ b/WrathCombo/Combos/PvE/AST/AST.cs
@@ -52,33 +52,33 @@ internal partial class AST : Healer
                     return Role.LucidDreaming;
 
                 //Play Card
-                if (HasDPSCard && CanSpellWeave())
+                if (HasDPSCard && CanWeave())
                     return OriginalHook(Play1).Retarget(replacedActions, CardResolver);
                        
 
                 //Minor Arcana / Lord of Crowns
                 if (ActionReady(OriginalHook(MinorArcana)) &&
-                    HasLord && HasBattleTarget() && CanSpellWeave())
+                    HasLord && HasBattleTarget() && CanWeave())
                     return OriginalHook(MinorArcana);
 
                 //Card Draw
-                if (ActionReady(OriginalHook(AstralDraw)) && HasNoDPSCard && CanSpellWeave())
+                if (ActionReady(OriginalHook(AstralDraw)) && HasNoDPSCard && CanWeave())
                     return OriginalHook(AstralDraw);
 
                 //Divination
                 if (IsEnabled(CustomComboPreset.AST_DPS_Divination) && HasBattleTarget() &&
                     ActionReady(Divination) && !HasDivination &&
                     !HasStatusEffect(Buffs.Divining) &&
-                    CanSpellWeave() && ActionWatching.NumberOfGcdsUsed >= 3)
+                    CanWeave() && ActionWatching.NumberOfGcdsUsed >= 3)
                     return Divination;
 
                 //Earthly Star
                 if (!HasStatusEffect(Buffs.EarthlyDominance) && ActionReady(EarthlyStar) &&
-                    IsOffCooldown(EarthlyStar) && CanSpellWeave())
+                    IsOffCooldown(EarthlyStar) && CanWeave())
                     return EarthlyStar.Retarget(replacedActions, SimpleTarget.AnyEnemy ?? SimpleTarget.Stack.Allies);
 
                 //Oracle
-                if (HasStatusEffect(Buffs.Divining) && CanSpellWeave())
+                if (HasStatusEffect(Buffs.Divining) && CanWeave())
                     return Oracle;
 
                 if (NeedsDoT())
@@ -170,7 +170,7 @@ internal partial class AST : Healer
 
                 //Play Card
                 if (IsEnabled(CustomComboPreset.AST_DPS_AutoPlay) &&
-                    HasDPSCard && CanSpellWeave() &&
+                    HasDPSCard && CanWeave() &&
                     (HasDivination || !cardPooling || !LevelChecked(Divination)))
                     return IsEnabled(CustomComboPreset.AST_Cards_QuickTargetCards)
                         ? OriginalHook(Play1).Retarget(replacedActions, CardResolver)
@@ -179,7 +179,7 @@ internal partial class AST : Healer
                 //Minor Arcana / Lord of Crowns
                 if (ActionReady(OriginalHook(MinorArcana)) &&
                     IsEnabled(CustomComboPreset.AST_DPS_LazyLord) &&
-                    HasLord && HasBattleTarget() && CanSpellWeave() &&
+                    HasLord && HasBattleTarget() && CanWeave() &&
                     (HasDivination || !lordPooling || !LevelChecked(Divination)))
                     return OriginalHook(MinorArcana);
 
@@ -187,13 +187,13 @@ internal partial class AST : Healer
                 if (IsEnabled(CustomComboPreset.AST_DPS_AutoDraw) &&
                     ActionReady(OriginalHook(AstralDraw)) &&
                     (HasNoCards || HasNoDPSCard && Config.AST_ST_DPS_OverwriteHealCards) &&
-                    CanSpellWeave())
+                    CanWeave())
                     return OriginalHook(AstralDraw);
 
                 //Lightspeed Burst
                 if (IsEnabled(CustomComboPreset.AST_DPS_LightspeedBurst) &&
                     ActionReady(Lightspeed) && !HasStatusEffect(Buffs.Lightspeed) &&
-                    DivinationCD < 5 && CanSpellWeave())
+                    DivinationCD < 5 && CanWeave())
                     return Lightspeed;
 
                 //Divination
@@ -201,19 +201,19 @@ internal partial class AST : Healer
                     ActionReady(Divination) && !HasDivination && //Overwrite protection
                     !HasStatusEffect(Buffs.Divining) &&
                     GetTargetHPPercent() > divHPThreshold &&
-                    CanSpellWeave() && ActionWatching.NumberOfGcdsUsed >= 3)
+                    CanWeave() && ActionWatching.NumberOfGcdsUsed >= 3)
                     return Divination;
 
                 //Earthly Star
                 if (IsEnabled(CustomComboPreset.AST_ST_DPS_EarthlyStar) &&
                     !HasStatusEffect(Buffs.EarthlyDominance) && ActionReady(EarthlyStar) &&
-                    IsOffCooldown(EarthlyStar) && CanSpellWeave())
+                    IsOffCooldown(EarthlyStar) && CanWeave())
                     return EarthlyStar.Retarget(replacedActions,
                         SimpleTarget.AnyEnemy ?? SimpleTarget.Stack.Allies);
 
                 //Oracle
                 if (IsEnabled(CustomComboPreset.AST_DPS_Oracle) &&
-                    HasStatusEffect(Buffs.Divining) && CanSpellWeave())
+                    HasStatusEffect(Buffs.Divining) && CanWeave())
                     return Oracle;
                 
                 //Combust
@@ -257,31 +257,31 @@ internal partial class AST : Healer
                 return Role.LucidDreaming;
 
             //Play Card
-            if (HasDPSCard && CanSpellWeave())
+            if (HasDPSCard && CanWeave())
                 return OriginalHook(Play1).Retarget(GravityList.ToArray(), CardResolver);
 
             //Minor Arcana / Lord of Crowns
             if (ActionReady(OriginalHook(MinorArcana)) && HasLord &&
-                HasBattleTarget() && CanSpellWeave())
+                HasBattleTarget() && CanWeave())
                 return OriginalHook(MinorArcana);
 
             //Card Draw
-            if (ActionReady(OriginalHook(AstralDraw)) && HasNoDPSCard && CanSpellWeave())
+            if (ActionReady(OriginalHook(AstralDraw)) && HasNoDPSCard && CanWeave())
                 return OriginalHook(AstralDraw);
 
             //Divination
-            if (HasBattleTarget() && ActionReady(Divination) && !HasDivination && CanSpellWeave() &&
+            if (HasBattleTarget() && ActionReady(Divination) && !HasDivination && CanWeave() &&
                 ActionWatching.NumberOfGcdsUsed >= 3)
                 return Divination;
 
             //Earthly Star
             if (!IsMoving() && !HasStatusEffect(Buffs.EarthlyDominance) && ActionReady(EarthlyStar) &&
-                IsOffCooldown(EarthlyStar) && CanSpellWeave() &&
+                IsOffCooldown(EarthlyStar) && CanWeave() &&
                 ActionWatching.NumberOfGcdsUsed >= 3)
                 return EarthlyStar.Retarget(GravityList.ToArray(), SimpleTarget.AnyEnemy ?? SimpleTarget.Stack.Allies);            
             
             //Oracle
-            if (HasStatusEffect(Buffs.Divining) && CanSpellWeave())
+            if (HasStatusEffect(Buffs.Divining) && CanWeave())
                 return Oracle;
 
             //MacroCosmos
@@ -345,7 +345,7 @@ internal partial class AST : Healer
 
             //Play Card
             if (IsEnabled(CustomComboPreset.AST_AOE_AutoPlay) &&
-                HasDPSCard && CanSpellWeave() && 
+                HasDPSCard && CanWeave() && 
                 (HasDivination || !cardPooling || !LevelChecked(Divination)))
                 return IsEnabled(CustomComboPreset.AST_Cards_QuickTargetCards)
                     ? OriginalHook(Play1).Retarget(GravityList.ToArray(),
@@ -355,7 +355,7 @@ internal partial class AST : Healer
             //Minor Arcana / Lord of Crowns
             if (ActionReady(OriginalHook(MinorArcana)) &&
                 IsEnabled(CustomComboPreset.AST_AOE_LazyLord) && HasLord &&
-                HasBattleTarget() && CanSpellWeave() &&
+                HasBattleTarget() && CanWeave() &&
                 (HasDivination || !lordPooling || !LevelChecked(Divination)))
                 return OriginalHook(MinorArcana);
 
@@ -363,34 +363,34 @@ internal partial class AST : Healer
             if (IsEnabled(CustomComboPreset.AST_AOE_AutoDraw) &&
                 ActionReady(OriginalHook(AstralDraw)) &&
                 (HasNoCards || HasNoDPSCard && Config.AST_AOE_DPS_OverwriteHealCards) &&
-                CanSpellWeave())
+                CanWeave())
                 return OriginalHook(AstralDraw);
             
             //Lightspeed Burst
             if (IsEnabled(CustomComboPreset.AST_AOE_LightspeedBurst) &&
                 ActionReady(Lightspeed) && !HasStatusEffect(Buffs.Lightspeed) &&
                 DivinationCD < 5 && ActionWatching.NumberOfGcdsUsed >= 3 &&
-                CanSpellWeave())
+                CanWeave())
                 return Lightspeed;
 
             //Divination
             if (IsEnabled(CustomComboPreset.AST_AOE_Divination) && HasBattleTarget() &&
                 ActionReady(Divination) && !HasDivination && //Overwrite protection
-                GetTargetHPPercent() > divHPThreshold && CanSpellWeave() &&
+                GetTargetHPPercent() > divHPThreshold && CanWeave() &&
                 ActionWatching.NumberOfGcdsUsed >= 3)
                 return Divination;
 
             //Earthly Star
             if (IsEnabled(CustomComboPreset.AST_AOE_DPS_EarthlyStar) && !IsMoving() &&
                 !HasStatusEffect(Buffs.EarthlyDominance) && ActionReady(EarthlyStar) &&
-                IsOffCooldown(EarthlyStar) && CanSpellWeave() &&
+                IsOffCooldown(EarthlyStar) && CanWeave() &&
                 ActionWatching.NumberOfGcdsUsed >= 3)
                 return EarthlyStar.Retarget(GravityList.ToArray(),
                     SimpleTarget.AnyEnemy ?? SimpleTarget.Stack.Allies);            
             
             //Oracle
             if (IsEnabled(CustomComboPreset.AST_AOE_Oracle) &&
-                HasStatusEffect(Buffs.Divining) && CanSpellWeave())
+                HasStatusEffect(Buffs.Divining) && CanWeave())
                 return Oracle;
 
             //MacroCosmos

--- a/WrathCombo/Combos/PvE/AST/AST_Helper.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Helper.cs
@@ -67,11 +67,11 @@ internal partial class AST
     
     internal static bool HiddenCollectiveUnconscious()
     {
-        return IsEnabled(CustomComboPreset.AST_Hidden_CollectiveUnconscious) && ActionReady(CollectiveUnconscious) && CanSpellWeave() && RaidWideCasting();
+        return IsEnabled(CustomComboPreset.AST_Hidden_CollectiveUnconscious) && ActionReady(CollectiveUnconscious) && CanWeave() && RaidWideCasting();
     }
     internal static bool HiddenNeutralSect()
     {
-        return IsEnabled(CustomComboPreset.AST_Hidden_NeutralSect) && ActionReady(OriginalHook(NeutralSect)) && CanSpellWeave() && RaidWideCasting();
+        return IsEnabled(CustomComboPreset.AST_Hidden_NeutralSect) && ActionReady(OriginalHook(NeutralSect)) && CanWeave() && RaidWideCasting();
     }
     internal static bool HiddenAspectedHelios()
     {
@@ -96,43 +96,43 @@ internal partial class AST
                 action = CelestialIntersection;
                 enabled = IsEnabled(CustomComboPreset.AST_ST_Heals_CelestialIntersection) &&
                           ActionReady(CelestialIntersection) && !(healTarget as IBattleChara)!.HasShield() &&
-                          (CanSpellWeave() || !Config.AST_ST_SimpleHeals_WeaveIntersection);
+                          (CanWeave() || !Config.AST_ST_SimpleHeals_WeaveIntersection);
                 return Config.AST_ST_SimpleHeals_CelestialIntersection;
             case 1:
                 action = EssentialDignity;
                 enabled = IsEnabled(CustomComboPreset.AST_ST_Heals_EssentialDignity) &&
                           ActionReady(EssentialDignity) &&
-                          (CanSpellWeave() || !Config.AST_ST_SimpleHeals_WeaveDignity);
+                          (CanWeave() || !Config.AST_ST_SimpleHeals_WeaveDignity);
                 return Config.AST_ST_SimpleHeals_EssentialDignity;
             case 2:
                 action = Exaltation;
                 enabled = IsEnabled(CustomComboPreset.AST_ST_Heals_Exaltation) &&
                           ActionReady(Exaltation) &&
-                          (CanSpellWeave() || !Config.AST_ST_SimpleHeals_WeaveExalt);
+                          (CanWeave() || !Config.AST_ST_SimpleHeals_WeaveExalt);
                 return Config.AST_ST_SimpleHeals_Exaltation;
             case 3:
                 action = Bole;
                 enabled = IsEnabled(CustomComboPreset.AST_ST_Heals_Bole) &&
                           HasBole &&
-                          (CanSpellWeave() || !Config.AST_ST_SimpleHeals_WeaveBole);
+                          (CanWeave() || !Config.AST_ST_SimpleHeals_WeaveBole);
                 return Config.AST_ST_SimpleHeals_Bole;
             case 4:
                 action = Arrow;
                 enabled = IsEnabled(CustomComboPreset.AST_ST_Heals_Arrow) &&
                           HasArrow &&
-                          (CanSpellWeave() || !Config.AST_ST_SimpleHeals_WeaveArrow);
+                          (CanWeave() || !Config.AST_ST_SimpleHeals_WeaveArrow);
                 return Config.AST_ST_SimpleHeals_Arrow;
             case 5:
                 action = Ewer;
                 enabled = IsEnabled(CustomComboPreset.AST_ST_Heals_Ewer) &&
                           HasEwer &&
-                          (CanSpellWeave() || !Config.AST_ST_SimpleHeals_WeaveEwer);
+                          (CanWeave() || !Config.AST_ST_SimpleHeals_WeaveEwer);
                 return Config.AST_ST_SimpleHeals_Ewer;
             case 6:
                 action = Spire;
                 enabled = IsEnabled(CustomComboPreset.AST_ST_Heals_Spire) &&
                           HasSpire &&
-                          (CanSpellWeave() || !Config.AST_ST_SimpleHeals_WeaveSpire);
+                          (CanWeave() || !Config.AST_ST_SimpleHeals_WeaveSpire);
                 return Config.AST_ST_SimpleHeals_Spire;
             case 7:
                 action = AspectedBenefic;
@@ -146,19 +146,19 @@ internal partial class AST
                 action = CelestialOpposition;
                 enabled = IsEnabled(CustomComboPreset.AST_ST_Heals_CelestialOpposition) && ActionReady(CelestialOpposition) &&
                             (!Config.AST_ST_SimpleHeals_CelestialOppositionOptions[1] || !InBossEncounter()) &&
-                            (!Config.AST_ST_SimpleHeals_CelestialOppositionOptions[0] || CanSpellWeave());
+                            (!Config.AST_ST_SimpleHeals_CelestialOppositionOptions[0] || CanWeave());
                 return Config.AST_ST_SimpleHeals_CelestialOpposition;
             case 9:
                 action = CollectiveUnconscious;
                 enabled = IsEnabled(CustomComboPreset.AST_ST_Heals_CollectiveUnconscious) && ActionReady(CollectiveUnconscious) &&
                           (!Config.AST_ST_SimpleHeals_CollectiveUnconsciousOptions[1] || !InBossEncounter()) &&
-                          (!Config.AST_ST_SimpleHeals_CollectiveUnconsciousOptions[0] || CanSpellWeave());
+                          (!Config.AST_ST_SimpleHeals_CollectiveUnconsciousOptions[0] || CanWeave());
                 return Config.AST_ST_SimpleHeals_CollectiveUnconscious;
             case 10:
                 action = LadyOfCrown;
                 enabled = IsEnabled(CustomComboPreset.AST_ST_Heals_SoloLady) && HasLady &&
                           (!Config.AST_ST_SimpleHeals_SoloLadyOptions[1] || !InBossEncounter()) &&
-                          (!Config.AST_ST_SimpleHeals_SoloLadyOptions[0] || CanSpellWeave());
+                          (!Config.AST_ST_SimpleHeals_SoloLadyOptions[0] || CanWeave());
                 return Config.AST_ST_SimpleHeals_SoloLady;
         }
 
@@ -177,37 +177,37 @@ internal partial class AST
                 action = LadyOfCrown;
                 enabled = IsEnabled(CustomComboPreset.AST_AoE_Heals_LazyLady) &&
                           ActionReady(MinorArcana) && HasLady &&
-                          (CanSpellWeave() || !Config.AST_AoE_SimpleHeals_WeaveLady);
+                          (CanWeave() || !Config.AST_AoE_SimpleHeals_WeaveLady);
                 return Config.AST_AoE_SimpleHeals_LazyLady;
             case 1:
                 action = CelestialOpposition;
                 enabled = IsEnabled(CustomComboPreset.AST_AoE_Heals_CelestialOpposition) &&
                           ActionReady(CelestialOpposition) &&
-                          (CanSpellWeave() || !Config.AST_AoE_SimpleHeals_WeaveOpposition);
+                          (CanWeave() || !Config.AST_AoE_SimpleHeals_WeaveOpposition);
                 return Config.AST_AoE_SimpleHeals_CelestialOpposition;
             case 2:
                 action = Horoscope;
                 enabled = IsEnabled(CustomComboPreset.AST_AoE_Heals_Horoscope) && ActionReady(Horoscope) &&
                           !HasStatusEffect(Buffs.Horoscope) && !HasStatusEffect(Buffs.HoroscopeHelios) &&
-                          (CanSpellWeave() || !Config.AST_AoE_SimpleHeals_WeaveHoroscope);
+                          (CanWeave() || !Config.AST_AoE_SimpleHeals_WeaveHoroscope);
                 return Config.AST_AoE_SimpleHeals_Horoscope;
             case 3:
                 action = HoroscopeHeal;
                 enabled = IsEnabled(CustomComboPreset.AST_AoE_Heals_HoroscopeHeal) &&
                           HasStatusEffect(Buffs.HoroscopeHelios) &&
-                          (CanSpellWeave() || !Config.AST_AoE_SimpleHeals_WeaveHoroscopeHeal);
+                          (CanWeave() || !Config.AST_AoE_SimpleHeals_WeaveHoroscopeHeal);
                 return Config.AST_AoE_SimpleHeals_HoroscopeHeal;
             case 4:
                 action = NeutralSect;
                 enabled = IsEnabled(CustomComboPreset.AST_AoE_Heals_NeutralSect) &&
                           ActionReady(OriginalHook(NeutralSect)) &&
-                          (CanSpellWeave() || !Config.AST_AoE_SimpleHeals_WeaveNeutralSect);
+                          (CanWeave() || !Config.AST_AoE_SimpleHeals_WeaveNeutralSect);
                 return Config.AST_AoE_SimpleHeals_NeutralSect;
             case 5:
                 action = StellarDetonation;
                 enabled = IsEnabled(CustomComboPreset.AST_AoE_Heals_StellarDetonation) && 
                           HasStatusEffect(Buffs.GiantDominance) && 
-                          (CanSpellWeave() || !Config.AST_AoE_SimpleHeals_WeaveStellarDetonation);
+                          (CanWeave() || !Config.AST_AoE_SimpleHeals_WeaveStellarDetonation);
                 return Config.AST_AoE_SimpleHeals_StellarDetonation;
             case 6:
                 action = OriginalHook(AspectedHelios);
@@ -226,7 +226,7 @@ internal partial class AST
                 action = CollectiveUnconscious;
                 enabled = IsEnabled(CustomComboPreset.AST_AoE_Heals_CollectiveUnconscious) &&
                           ActionReady(CollectiveUnconscious) &&
-                          (CanSpellWeave() || !Config.AST_AoE_SimpleHeals_WeaveCollectiveUnconscious);
+                          (CanWeave() || !Config.AST_AoE_SimpleHeals_WeaveCollectiveUnconscious);
                 return Config.AST_AoE_SimpleHeals_CollectiveUnconscious;
         }
 

--- a/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
@@ -42,8 +42,8 @@ internal partial class BRD
 
     //Useful Bools
     internal static bool BardHasTarget => HasBattleTarget();
-    internal static bool CanBardWeave => CanWeave() && !ActionWatching.HasDoubleWeaved();
-    internal static bool CanWeaveDelayed => CanDelayedWeave() && !ActionWatching.HasDoubleWeaved();
+    internal static bool CanBardWeave => CanWeave();
+    internal static bool CanWeaveDelayed => CanDelayedWeave();
     internal static bool CanIronJaws => LevelChecked(IronJaws);
     internal static bool BuffTime => GetCooldownRemainingTime(RagingStrikes) < 2.7;
     internal static bool BuffWindow => HasStatusEffect(Buffs.RagingStrikes) && 

--- a/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
@@ -34,14 +34,7 @@ internal partial class DRK
     /// </summary>
     /// <seealso cref="CustomComboFunctions.CanWeave(double)" />
     /// <seealso cref="CanDelayedWeave(double,double)" />
-    private static bool CanWeave =>
-        (IsEnabled(Preset.DRK_ST_Adv) &&
-         IsEnabled(Preset.DRK_PreventTripleWeaves) &&
-         CanWeave() &&
-         !ActionWatching.HasDoubleWeaved()) ||
-        ((IsNotEnabled(Preset.DRK_ST_Adv) ||
-          IsNotEnabled(Preset.DRK_PreventTripleWeaves)) &&
-         (CanWeave() || CanDelayedWeave()));
+    private static bool CanWeave => CanWeave() || CanDelayedWeave();
 
     /// <summary>
     ///     DRK's job gauge.
@@ -210,7 +203,7 @@ internal partial class DRK
     {
         if (castLocations.Contains(currentAction) &&
             (Gauge.HasDarkArts || LocalPlayer.CurrentMp > 3000) &&
-            CanWeave() && !ActionWatching.HasDoubleWeaved())
+            CanWeave())
             action = OriginalHook(EdgeOfDarkness);
     }
 

--- a/WrathCombo/Combos/PvE/GNB/GNB_Config.cs
+++ b/WrathCombo/Combos/PvE/GNB/GNB_Config.cs
@@ -111,9 +111,9 @@ internal partial class GNB
 
                 case CustomComboPreset.GNB_ST_NoMercy:
                     UserConfig.DrawHorizontalRadioButton(GNB_ST_NoMercy_SubOption,
-                        "All content", $"Uses {ActionWatching.GetActionName(NoMercy)} regardless of content", 0);
+                        "All content", $"Uses {CustomComboFunctions.GetActionName(NoMercy)} regardless of content", 0);
                     UserConfig.DrawHorizontalRadioButton(GNB_ST_NoMercy_SubOption,
-                        "Boss encounters Only", $"Only uses {ActionWatching.GetActionName(NoMercy)} when in Boss encounters", 1);
+                        "Boss encounters Only", $"Only uses {CustomComboFunctions.GetActionName(NoMercy)} when in Boss encounters", 1);
                     
                     UserConfig.DrawSliderInt(0, 75, GNB_ST_NoMercyStop,
                         " Stop usage if Target HP% is below set value.\n  To disable this, set value to 0");

--- a/WrathCombo/Combos/PvE/PCT/PCT.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT.cs
@@ -51,7 +51,7 @@ internal partial class PCT : Caster
 
             #region OGCD
             // General Weaves
-            if (InCombat() && CanSpellWeave())
+            if (InCombat() && CanWeave())
             {
                 // ScenicMuse pre-100
                 if (ScenicMuseReady && !LevelChecked(StarPrism))
@@ -268,7 +268,7 @@ internal partial class PCT : Caster
 
             #region OGCD
             // General Weaves
-            if (InCombat() && CanSpellWeave())
+            if (InCombat() && CanWeave())
             {
                 // ScenicMuse
                 if (scenicMuseEnabled && ScenicMuseReady && (!burstPhaseEnabled || !LevelChecked(StarPrism)))
@@ -449,7 +449,7 @@ internal partial class PCT : Caster
 
             #region OGCD
             // General Weaves
-            if (InCombat() && CanSpellWeave())
+            if (InCombat() && CanWeave())
             {
                 // ScenicMuse
                 if (ScenicMuseReady)
@@ -655,7 +655,7 @@ internal partial class PCT : Caster
 
             #region OGCD
             // General Weaves
-            if (InCombat() && CanSpellWeave())
+            if (InCombat() && CanWeave())
             {
                 // ScenicMuse
                 if (scenicMuseEnabled && ScenicMuseReady)

--- a/WrathCombo/Combos/PvE/PCT/PCT_Helper.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT_Helper.cs
@@ -90,7 +90,7 @@ internal partial class PCT
 
         if (HasStatusEffect(Buffs.StarryMuse) && GetStatusEffectRemainingTime(Buffs.StarryMuse) < 15)
         {
-            if (CanSpellWeave() && !HasStatusEffect(Buffs.MonochromeTones))
+            if (CanWeave() && !HasStatusEffect(Buffs.MonochromeTones))
             {                
                 if (ActionReady(SubtractivePalette) && !HasStatusEffect(Buffs.Starstruck) &&
                     !HasStatusEffect(Buffs.SubtractivePalette) && (HasStatusEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50))

--- a/WrathCombo/Combos/PvE/RDM/RDM.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM.cs
@@ -29,7 +29,7 @@ internal partial class RDM : Caster
             #endregion
             
             #region OGCDs
-            if (CanSpellWeave() && !ActionWatching.HasDoubleWeaved())
+            if (CanWeave())
             {
                 //Gap Closer
                 if (ActionReady(Corpsacorps) && (HasEnoughManaToStart || CanMagickedSwordplay) && !InMeleeRange()) 
@@ -129,7 +129,7 @@ internal partial class RDM : Caster
             #endregion
             
             #region OGCDs
-            if (CanSpellWeave() && !ActionWatching.HasDoubleWeaved())  
+            if (CanWeave())
             {
                 //Gap Closer Option
                 if (ActionReady(Corpsacorps) && (HasEnoughManaToStart || CanMagickedSwordplay) && !InMeleeRange()) 
@@ -235,7 +235,7 @@ internal partial class RDM : Caster
             #endregion
 
             #region OGCDs
-            if (CanSpellWeave() && !ActionWatching.HasDoubleWeaved())
+            if (CanWeave())
             {
                 if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_GapCloser) && 
                     ActionReady(Corpsacorps) && (HasEnoughManaToStart || CanMagickedSwordplay) && !InMeleeRange()) 
@@ -345,7 +345,7 @@ internal partial class RDM : Caster
             #endregion
 
             #region OGCDs
-            if (CanSpellWeave() && !ActionWatching.HasDoubleWeaved())
+            if (CanWeave())
             {
                 if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo_GapCloser) && 
                     ActionReady(Corpsacorps) && (HasEnoughManaToStart || CanMagickedSwordplay) && !InMeleeRange()) 

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -33,7 +33,7 @@ internal partial class SCH : Healer
                 return DissolveUnion;
             #endregion
 
-            if (InCombat() && CanSpellWeave())
+            if (InCombat() && CanWeave())
             {
                 if (!WasLastAction(Dissipation) && ActionReady(Aetherflow) && !HasAetherflow)
                     return Aetherflow;
@@ -112,7 +112,7 @@ internal partial class SCH : Healer
                 return HiddenRecitation() ? Recitation : OriginalHook(Succor);
             #endregion
 
-            if (InCombat() && CanSpellWeave())
+            if (InCombat() && CanWeave())
             {
                 if (IsEnabled(CustomComboPreset.SCH_ST_ADV_DPS_Aetherflow) && !WasLastAction(Dissipation) && ActionReady(Aetherflow) && !HasAetherflow)
                     return Aetherflow;
@@ -176,7 +176,7 @@ internal partial class SCH : Healer
                 return DissolveUnion;
             #endregion
             
-            if (!InCombat() || !CanSpellWeave()) return actionID;
+            if (!InCombat() || !CanWeave()) return actionID;
             
             if (!WasLastAction(Dissipation) && ActionReady(Aetherflow) && !HasAetherflow)
                 return Aetherflow;
@@ -242,7 +242,7 @@ internal partial class SCH : Healer
                 return HiddenRecitation() ? Recitation : OriginalHook(Succor);
             #endregion
             
-            if (!InCombat() || !CanSpellWeave()) return actionID;
+            if (!InCombat() || !CanWeave()) return actionID;
             
             if (IsEnabled(CustomComboPreset.SCH_AoE_ADV_DPS_Aetherflow) && !WasLastAction(Dissipation) && ActionReady(Aetherflow) && !HasAetherflow)
                 return Aetherflow;
@@ -313,7 +313,7 @@ internal partial class SCH : Healer
             // Aetherflow
             if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Aetherflow) &&
                 ActionReady(Aetherflow) && !HasAetherflow &&
-                InCombat() && CanSpellWeave())
+                InCombat() && CanWeave())
                 return Aetherflow;
 
             // Dissipation

--- a/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
@@ -54,11 +54,11 @@ internal partial class SCH
     
     internal static bool HiddenSacredSoil()
     {
-        return IsEnabled(CustomComboPreset.SCH_Hidden_SacredSoil) && ActionReady(SacredSoil) && CanSpellWeave() && RaidWideCasting();
+        return IsEnabled(CustomComboPreset.SCH_Hidden_SacredSoil) && ActionReady(SacredSoil) && CanWeave() && RaidWideCasting();
     }
     internal static bool HiddenExpedient()
     {
-        return IsEnabled(CustomComboPreset.SCH_Hidden_Expedient) && ActionReady(Expedient) && CanSpellWeave() && RaidWideCasting();
+        return IsEnabled(CustomComboPreset.SCH_Hidden_Expedient) && ActionReady(Expedient) && CanWeave() && RaidWideCasting();
     }
     internal static bool HiddenSuccor()
     {

--- a/WrathCombo/Combos/PvE/SMN/SMN_Helper.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN_Helper.cs
@@ -174,7 +174,7 @@ internal partial class SMN
     internal static bool DemiNotPheonix => CurrentDemiSummon is not DemiSummon.Phoenix;
     internal static bool DemiPheonix => CurrentDemiSummon is DemiSummon.Phoenix;
     internal static bool SearingBurstDriftCheck => SearingCD >=3 && SearingCD <=8;
-    internal static bool SummonerWeave => CanSpellWeave() && !ActionWatching.HasDoubleWeaved();
+    internal static bool SummonerWeave => CanWeave();
     internal static float SearingCD => GetCooldownRemainingTime(SearingLight);
    
     #endregion

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -67,7 +67,7 @@ internal partial class WHM : Healer
 
             #region Weaves
 
-            if (CanSpellWeave())
+            if (CanWeave())
             {
                 if (Variant.CanRampart(CustomComboPreset.WHM_DPS_Variant_Rampart))
                     return Variant.Rampart;
@@ -152,7 +152,7 @@ internal partial class WHM : Healer
 
             #region Weaves
 
-            if (CanSpellWeave() || IsMoving())
+            if (CanWeave() || IsMoving())
             {
                 if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_Assize) &&
                     ActionReady(Assize))
@@ -248,7 +248,7 @@ internal partial class WHM : Healer
 
             #region OGCD Tools
 
-            if (IsEnabled(CustomComboPreset.WHM_STHeals_Lucid) && CanSpellWeave() &&
+            if (IsEnabled(CustomComboPreset.WHM_STHeals_Lucid) && CanWeave() &&
                 Role.CanLucidDream(Config.WHM_STHeals_Lucid))
                 return Role.LucidDreaming;
 
@@ -316,12 +316,12 @@ internal partial class WHM : Healer
             var canPlenary = ActionReady(PlenaryIndulgence) &&
                              (!Config.WHM_AoEHeals_PlenaryWeave ||
                               Config.WHM_AoEHeals_PlenaryWeave &&
-                              CanSpellWeave());
+                              CanWeave());
 
             var canAssize = ActionReady(Assize) &&
                             (!Config.WHM_AoEHeals_AssizeWeave ||
                              Config.WHM_AoEHeals_AssizeWeave &&
-                             CanSpellWeave());
+                             CanWeave());
 
             var healTarget = OptionalTarget ?? SimpleTarget.Stack.AllyToHeal;
 
@@ -371,7 +371,7 @@ internal partial class WHM : Healer
 
             if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Temperance) &&
                 ActionReady(Temperance) &&
-                (!Config.WHM_AoEHeals_TemperanceWeave || CanSpellWeave()) &&
+                (!Config.WHM_AoEHeals_TemperanceWeave || CanWeave()) &&
                 temperanceHPCheckPassed &&
                 ContentCheck.IsInConfiguredContent(
                     Config.WHM_AoEHeals_TemperanceDifficulty,
@@ -401,7 +401,7 @@ internal partial class WHM : Healer
                 return Asylum.Retarget(Medica1, asylumTarget);
 
             if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Lucid) &&
-                CanSpellWeave() &&
+                CanWeave() &&
                 Role.CanLucidDream(Config.WHM_AoEHeals_Lucid))
                 return Role.LucidDreaming;
 

--- a/WrathCombo/CustomCombo/Functions/Action.cs
+++ b/WrathCombo/CustomCombo/Functions/Action.cs
@@ -254,11 +254,6 @@ internal abstract partial class CustomComboFunctions
                RemainingGCD > (remainingCast + estimatedWeaveTime + animationLock);  // Window End Threshold
     }
 
-    /// <summary> Checks if an action can be weaved within the GCD window when casting spells or weaponskills. </summary>
-    /// <param name="weaveEnd"> Remaining GCD time when the window ends. </param>
-    [Obsolete("Use CanWeave instead. This method will be removed in a future update.")]
-    public static bool CanSpellWeave(float weaveEnd = BaseAnimationLock) => CanWeave(weaveEnd);
-
     /// <summary> Checks if an action can be weaved within the GCD window, limited by specific GCD thresholds. </summary>
     /// <param name="weaveStart">
     ///     Remaining GCD time when the window starts. <br/>

--- a/WrathCombo/Window/Functions/Presets.cs
+++ b/WrathCombo/Window/Functions/Presets.cs
@@ -217,7 +217,7 @@ namespace WrathCombo.Window.Functions
                 if (blueAttr.Actions.Count > 0)
                 {
                     ImGui.PushStyleColor(ImGuiCol.Text, blueAttr.NoneSet ? ImGuiColors.DPSRed : ImGuiColors.DalamudOrange);
-                    ImGui.Text($"{(blueAttr.NoneSet ? "No Required Spells Active:" : "Missing active spells:")} {string.Join(", ", blueAttr.Actions.Select(x => ActionWatching.GetBLUIndex(x) + ActionWatching.GetActionName(x)))}");
+                    ImGui.Text($"{(blueAttr.NoneSet ? "No Required Spells Active:" : "Missing active spells:")} {string.Join(", ", blueAttr.Actions.Select(x => ActionWatching.GetBLUIndex(x) + GetActionName(x)))}");
                     ImGui.PopStyleColor();
                 }
 


### PR DESCRIPTION
- [X] Replaces `CanSpellWeave()` with `CanWeave()`
      `CanSpellWeave()` was obsoleted in #689, with a direct replacement for the logic in `CanWeave()`
- [X] Removes all `!HasDoubleWeaved()` calls
      Weave count is now managed by a global setting (defaulted to `2`) handled within `CanWeave`.
- [X] Removes DRK's Triple Weave-prevention Preset

@edewen AST used `CanSpellWeave()` about a billion times, may want to group together the oGCDs under a big `if (CanWeave())` like many other jobs do, if possible.