### PR TITLE
[Various] some weekly stuffs

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1091,8 +1091,8 @@ public enum CustomComboPreset
     [CustomComboInfo("Fire I/III Feature", "Replaces Fire I with Fire III outside of Astral Fire or when Firestarter is up.", BLM.JobID)]
     BLM_Fire1to3 = 2054,
 
-    [ReplaceSkill(BLM.Blizzard, BLM.Freeze)]
-    [CustomComboInfo("Blizzard I/III Feature", "Replaces Blizzard I with Blizzard III when out of Umbral Ice.\nReplaces Freeze with Blizzard II when synced below Lv.40.", BLM.JobID)]
+    [ReplaceSkill(BLM.Blizzard, BLM.Blizzard3, BLM.Freeze)]
+    [CustomComboInfo("Blizzard I/III Feature", "Replaces Blizzard I or Blizzard III.\nReplaces Freeze with Blizzard II when synced below Lv.40.", BLM.JobID)]
     BLM_Blizzard1to3 = 2052,
 
     [ReplaceSkill(BLM.Fire4, BLM.Flare)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -4159,16 +4159,11 @@ public enum CustomComboPreset
     NIN_ST_AeolianEdgeCombo = 10074,
 
     [ReplaceSkill(NIN.ArmorCrush)]
-    [CustomComboInfo("Armor Crush Combo", "Replace Armor Crush with its combo chain.", NIN.JobID)]
-    [BasicCombo]
-    NIN_ST_ArmorCrushCombo = 10075,
-
-    #endregion
-
-    [ReplaceSkill(NIN.ArmorCrush)]
     [CustomComboInfo("Armor Crush Combo Feature", "Replace Armor Crush with its combo chain.", NIN.JobID)]
     NIN_ArmorCrushCombo = 10053,
 
+    #endregion
+    
     [ReplaceSkill(NIN.Kassatsu)]
     [CustomComboInfo("Kassatsu to Trick Feature",
         "Replaces Kassatsu with Trick Attack/Kunai's Bane while Suiton or Hidden is up.\nCooldown tracking plugin recommended.",

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1112,10 +1112,18 @@ public enum CustomComboPreset
     [CustomComboInfo(" Fire and Flare to Star", "Replaces Fire4 and Flare to Flarestar when on max stacks.", BLM.JobID)]
     BLM_FireFlarestar = 2058,
 
+    [ReplaceSkill(BLM.Freeze)]
+    [CustomComboInfo("Freeze to Paradox", "Replaces Freeze with Ice Paradox when you have 3 Umbral Heart stacks.", BLM.JobID)]
+    BLM_FreezeParadox = 2062,
+
+    [ReplaceSkill(BLM.FlareStar)]
+    [CustomComboInfo("Flarestar to Paradox", "Replaces Flarestar with Fire Paradox when not at max Flarestar stacks.", BLM.JobID)]
+    BLM_FlareParadox = 2063,
+
     [ReplaceSkill(BLM.Amplifier)]
     [CustomComboInfo("Amplifier to Xenoglossy", "Replaces Amplifier with Xenoglossy when at max Polyglot stacks.", BLM.JobID)]
     BLM_AmplifierXeno = 2061,
-
+    
     [ReplaceSkill(BLM.Transpose)]
     [CustomComboInfo("Umbral Soul/Transpose Feature", "Replaces Transpose with Umbral Soul when Umbral Soul is available.", BLM.JobID)]
     BLM_UmbralSoul = 2050,
@@ -1136,7 +1144,7 @@ public enum CustomComboPreset
 
     // Last value ST = 2117
     //Last Value AoE = 2212
-    //Last Value misc = 2061
+    //Last Value misc = 2063
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1087,14 +1087,23 @@ public enum CustomComboPreset
     [CustomComboInfo("Triplecast Protection", "Replaces Triplecast with Savage Blade when you already have triplecast active.", BLM.JobID)]
     BLM_TriplecastProtection = 2056,
 
-    [ReplaceSkill(BLM.Fire)]
-    [CustomComboInfo("Fire I/III Feature", "Replaces Fire I with Fire III outside of Astral Fire or when Firestarter is up.", BLM.JobID)]
+    [ReplaceSkill(BLM.Fire, BLM.Fire3)]
+    [CustomComboInfo("Fire I/III Feature", "Replaces Fire I or Fire III.", BLM.JobID)]
     BLM_Fire1to3 = 2054,
 
     [ReplaceSkill(BLM.Blizzard, BLM.Blizzard3, BLM.Freeze)]
     [CustomComboInfo("Blizzard I/III Feature", "Replaces Blizzard I or Blizzard III.\nReplaces Freeze with Blizzard II when synced below Lv.40.", BLM.JobID)]
     BLM_Blizzard1to3 = 2052,
 
+    [ReplaceSkill(BLM.Fire4)]
+    [ConflictingCombos(BLM_FireandIce)]
+    [CustomComboInfo("Fire 4 to 3", "Replaces Fire 4 with Fire 3 when not in Astral Fire III.", BLM.JobID)]
+    BLM_Fire4to3 = 2059,
+
+    [ReplaceSkill(BLM.Blizzard4)]
+    [CustomComboInfo("Blizzard 4 to Despair", "Replaces Blizzard 4 with Despair when in Astral Fire.", BLM.JobID)]
+    BLM_Blizzard4toDespair = 2060,
+    
     [ReplaceSkill(BLM.Fire4, BLM.Flare)]
     [CustomComboInfo("Fire & Ice", "Replaces Fire4 with Blizzard4 when in Umbral Ice.\nReplaces Flare with Freeze when in Umbral Ice.", BLM.JobID)]
     BLM_FireandIce = 2057,
@@ -1102,6 +1111,10 @@ public enum CustomComboPreset
     [ReplaceSkill(BLM.Fire4, BLM.Flare)]
     [CustomComboInfo(" Fire and Flare to Star", "Replaces Fire4 and Flare to Flarestar when on max stacks.", BLM.JobID)]
     BLM_FireFlarestar = 2058,
+
+    [ReplaceSkill(BLM.Amplifier)]
+    [CustomComboInfo("Amplifier to Xenoglossy", "Replaces Amplifier with Xenoglossy when at max Polyglot stacks.", BLM.JobID)]
+    BLM_AmplifierXeno = 2061,
 
     [ReplaceSkill(BLM.Transpose)]
     [CustomComboInfo("Umbral Soul/Transpose Feature", "Replaces Transpose with Umbral Soul when Umbral Soul is available.", BLM.JobID)]
@@ -1118,20 +1131,7 @@ public enum CustomComboPreset
     [ReplaceSkill(BLM.AetherialManipulation)]
     [CustomComboInfo("Aetherial Manipulation Feature", "Replaces Aetherial Manipulation with Between the Lines when you are out of active Ley Lines and standing still.", BLM.JobID)]
     BLM_Aetherial_Manipulation = 2055,
-
-    [ReplaceSkill(BLM.Fire4)]
-    [ConflictingCombos(BLM_FireandIce)]
-    [CustomComboInfo("Fire 4 to 3", "Replaces Fire 4 with Fire 3 when not in Astral Fire.", BLM.JobID)]
-    BLM_Fire4to3 = 2059,
-
-    [ReplaceSkill(BLM.Blizzard4)]
-    [CustomComboInfo("Blizzard 4 to Despair", "Replaces Blizzard 4 with Despair when in Astral Fire.", BLM.JobID)]
-    BLM_Blizzard4toDespair = 2060,
-
-    [ReplaceSkill(BLM.Amplifier)]
-    [CustomComboInfo("Amplifier to Xenoglossy", "Replaces Amplifier with Xenoglossy when at max Polyglot stacks.", BLM.JobID)]
-    BLM_AmplifierXeno = 2061,
-
+    
     #endregion
 
     // Last value ST = 2117

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1097,7 +1097,7 @@ public enum CustomComboPreset
 
     [ReplaceSkill(BLM.Fire4)]
     [ConflictingCombos(BLM_FireandIce)]
-    [CustomComboInfo("Fire 4 to 3", "Replaces Fire 4 with Fire 3 when not in Astral Fire III.", BLM.JobID)]
+    [CustomComboInfo("Fire 4 to 3", "Replaces Fire 4 with Fire 3 when not in Astral Fire III or not in combat.", BLM.JobID)]
     BLM_Fire4to3 = 2059,
 
     [ReplaceSkill(BLM.Blizzard4)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1092,6 +1092,7 @@ public enum CustomComboPreset
     BLM_Fire1to3 = 2054,
 
     [ReplaceSkill(BLM.Blizzard, BLM.Blizzard3, BLM.Freeze)]
+    [ConflictingCombos(BLM_FreezeParadox)]
     [CustomComboInfo("Blizzard I/III Feature", "Replaces Blizzard I or Blizzard III.\nReplaces Freeze with Blizzard II when synced below Lv.40.", BLM.JobID)]
     BLM_Blizzard1to3 = 2052,
 
@@ -1105,6 +1106,7 @@ public enum CustomComboPreset
     BLM_Blizzard4toDespair = 2060,
     
     [ReplaceSkill(BLM.Fire4, BLM.Flare)]
+    [ConflictingCombos(BLM_Fire4to3)]
     [CustomComboInfo("Fire & Ice", "Replaces Fire4 with Blizzard4 when in Umbral Ice.\nReplaces Flare with Freeze when in Umbral Ice.", BLM.JobID)]
     BLM_FireandIce = 2057,
 
@@ -1113,6 +1115,7 @@ public enum CustomComboPreset
     BLM_FireFlarestar = 2058,
 
     [ReplaceSkill(BLM.Freeze)]
+    [ConflictingCombos(BLM_Blizzard1to3)]
     [CustomComboInfo("Freeze to Paradox", "Replaces Freeze with Ice Paradox when you have 3 Umbral Heart stacks.", BLM.JobID)]
     BLM_FreezeParadox = 2062,
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1091,8 +1091,7 @@ public enum CustomComboPreset
     [CustomComboInfo("Fire I/III Feature", "Replaces Fire I or Fire III.", BLM.JobID)]
     BLM_Fire1to3 = 2054,
 
-    [ReplaceSkill(BLM.Blizzard, BLM.Blizzard3, BLM.Freeze)]
-    [ConflictingCombos(BLM_FreezeParadox)]
+    [ReplaceSkill(BLM.Blizzard, BLM.Blizzard3)]
     [CustomComboInfo("Blizzard I/III Feature", "Replaces Blizzard I or Blizzard III.\nReplaces Freeze with Blizzard II when synced below Lv.40.", BLM.JobID)]
     BLM_Blizzard1to3 = 2052,
 
@@ -1110,12 +1109,17 @@ public enum CustomComboPreset
     [CustomComboInfo("Fire & Ice", "Replaces Fire4 with Blizzard4 when in Umbral Ice.\nReplaces Flare with Freeze when in Umbral Ice.", BLM.JobID)]
     BLM_FireandIce = 2057,
 
+    [ReplaceSkill(BLM.Blizzard, BLM.Blizzard3)]
+    [ConflictingCombos(BLM_FreezeParadox)]
+    [CustomComboInfo("Freeze to Blizzard II", "nReplaces Freeze with Blizzard II when synced below Lv.40.", BLM.JobID)]
+    BLM_FreezeBlizzard2 = 2064,
+
     [ReplaceSkill(BLM.Fire4, BLM.Flare)]
     [CustomComboInfo(" Fire and Flare to Star", "Replaces Fire4 and Flare to Flarestar when on max stacks.", BLM.JobID)]
     BLM_FireFlarestar = 2058,
 
     [ReplaceSkill(BLM.Freeze)]
-    [ConflictingCombos(BLM_Blizzard1to3)]
+    [ConflictingCombos(BLM_FreezeBlizzard2)]
     [CustomComboInfo("Freeze to Paradox", "Replaces Freeze with Ice Paradox when you have 3 Umbral Heart stacks.", BLM.JobID)]
     BLM_FreezeParadox = 2062,
 
@@ -1147,7 +1151,7 @@ public enum CustomComboPreset
 
     // Last value ST = 2117
     //Last Value AoE = 2212
-    //Last Value misc = 2063
+    //Last Value misc = 2064
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -629,7 +629,8 @@ internal partial class BLM : Caster
         protected override uint Invoke(uint actionID) =>
             actionID switch
             {
-                Blizzard when LevelChecked(Blizzard3) && (FirePhase || UmbralIceStacks is 1 or 2) => Blizzard3,
+                Blizzard when BLM_B1to3 == 0 && LevelChecked(Blizzard3) && FirePhase  => Blizzard3,
+                Blizzard3 when BLM_B1to3 == 1 && LevelChecked(Blizzard3) && IcePhase => OriginalHook(Blizzard),
                 Freeze when !LevelChecked(Freeze) => Blizzard2,
                 var _ => actionID
             };

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -57,7 +57,7 @@ internal partial class BLM : Caster
                         return Role.Swiftcast;
                 }
 
-                if (ActionReady(Manaward) && PlayerHealthPercentageHp() < 25)
+                if (ActionReady(Manaward) && PlayerHealthPercentageHp() < 40)
                     return Manaward;
             }
 
@@ -123,9 +123,9 @@ internal partial class BLM : Caster
 
                 if (ActiveParadox &&
                     CurMp > 1600 &&
-                    AstralFireStacks is 3 &&
-                    (JustUsed(FlareStar, 5) ||
-                     !LevelChecked(FlareStar) && LevelChecked(Despair)))
+                    (AstralFireStacks < 3 ||
+                     JustUsed(FlareStar, 5) ||
+                     !LevelChecked(FlareStar) && ActionReady(Despair)))
                     return OriginalHook(Paradox);
 
                 if (FlarestarReady)
@@ -329,9 +329,9 @@ internal partial class BLM : Caster
 
                 if (ActiveParadox &&
                     CurMp > 1600 &&
-                    AstralFireStacks is 3 &&
-                    (JustUsed(FlareStar, 5) ||
-                     !LevelChecked(FlareStar) && LevelChecked(Despair)))
+                    (AstralFireStacks < 3 ||
+                     JustUsed(FlareStar, 5) ||
+                     !LevelChecked(FlareStar) && ActionReady(Despair)))
                     return OriginalHook(Paradox);
 
                 if (IsEnabled(CustomComboPreset.BLM_ST_FlareStar) &&

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -611,15 +611,13 @@ internal partial class BLM : Caster
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_Blizzard1to3;
 
-        protected override uint Invoke(uint actionID)
-        {
-            return actionID switch
+        protected override uint Invoke(uint actionID) =>
+            actionID switch
             {
                 Blizzard when LevelChecked(Blizzard3) && (FirePhase || UmbralIce1 || UmbralIce2) => Blizzard3,
                 Freeze when !LevelChecked(Freeze) => Blizzard2,
                 var _ => actionID
             };
-        }
     }
 
     internal class BLM_Fire1to3 : CustomCombo
@@ -679,9 +677,8 @@ internal partial class BLM : Caster
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_FireandIce;
 
-        protected override uint Invoke(uint actionID)
-        {
-            return actionID switch
+        protected override uint Invoke(uint actionID) =>
+            actionID switch
             {
                 Fire4 when FirePhase && LevelChecked(Fire4) => Fire4,
                 Fire4 when IcePhase && LevelChecked(Blizzard4) => Blizzard4,
@@ -689,7 +686,6 @@ internal partial class BLM : Caster
                 Flare when IcePhase && LevelChecked(Freeze) => Freeze,
                 var _ => actionID
             };
-        }
     }
 
     internal class BLM_FireFlarestar : CustomCombo

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -629,7 +629,7 @@ internal partial class BLM : Caster
         protected override uint Invoke(uint actionID) =>
             actionID switch
             {
-                Blizzard when BLM_B1to3 == 0 && LevelChecked(Blizzard3) && FirePhase => Blizzard3,
+                Blizzard when BLM_B1to3 == 0 && LevelChecked(Blizzard3) && (FirePhase || UmbralIceStacks is 1 || UmbralIceStacks is 2) => Blizzard3,
                 Blizzard3 when BLM_B1to3 == 1 && LevelChecked(Blizzard3) && IcePhase => OriginalHook(Blizzard),
                 Freeze when !LevelChecked(Freeze) => Blizzard2,
                 var _ => actionID

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -49,7 +49,9 @@ internal partial class BLM : Caster
 
                 if (IcePhase)
                 {
-                    if (CurMp is MP.MaxMP && JustUsed(Paradox))
+                    if (CurMp is MP.MaxMP && 
+                        JustUsed(Paradox) &&
+                        ActionReady(Transpose))
                         return Transpose;
 
                     if (LevelChecked(Blizzard3) && UmbralIceStacks < 3 &&
@@ -243,7 +245,8 @@ internal partial class BLM : Caster
                 if (IcePhase)
                 {
                     if (IsEnabled(CustomComboPreset.BLM_ST_Transpose) &&
-                        CurMp is MP.MaxMP && JustUsed(Paradox))
+                        CurMp is MP.MaxMP && JustUsed(Paradox) &&
+                        ActionReady(Transpose))
                         return Transpose;
 
                     if (LevelChecked(Blizzard3) && UmbralIceStacks < 3)
@@ -369,7 +372,8 @@ internal partial class BLM : Caster
                         return Fire3;
 
                     if (IsEnabled(CustomComboPreset.BLM_ST_Transpose) &&
-                        ActionReady(Transpose) && !LevelChecked(Blizzard3))
+                        ActionReady(Transpose) &&
+                        !LevelChecked(Blizzard3))
                         return Transpose;
                 }
 

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -166,7 +166,9 @@ internal partial class BLM : Caster
                 }
 
                 if (LevelChecked(Blizzard3) && UmbralIceStacks < 3 &&
-                    (JustUsed(Transpose, 5f) || JustUsed(Freeze, 10f)))
+                    (HasStatusEffect(Role.Buffs.Swiftcast) ||
+                     HasStatusEffect(Buffs.Triplecast) ||
+                     JustUsed(Freeze, 10f)))
                     return Blizzard3;
 
                 if (ActionReady(BlizzardSpam))
@@ -378,7 +380,9 @@ internal partial class BLM : Caster
                 }
 
                 if (LevelChecked(Blizzard3) && UmbralIceStacks < 3 &&
-                    (JustUsed(Transpose, 5f) || JustUsed(Freeze, 10f)))
+                    (HasStatusEffect(Role.Buffs.Swiftcast) ||
+                     HasStatusEffect(Buffs.Triplecast) ||
+                     JustUsed(Freeze, 10f)))
                     return Blizzard3;
 
                 if (ActionReady(BlizzardSpam))

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -630,7 +630,7 @@ internal partial class BLM : Caster
             actionID switch
             {
                 Blizzard when BLM_B1to3 == 0 && LevelChecked(Blizzard3) && (FirePhase || UmbralIceStacks is 1 || UmbralIceStacks is 2) => Blizzard3,
-                Blizzard3 when BLM_B1to3 == 1 && LevelChecked(Blizzard3) && IcePhase => OriginalHook(Blizzard),
+                Blizzard3 when BLM_B1to3 == 1 && LevelChecked(Blizzard3) && IcePhase && UmbralIceStacks is 3 => OriginalHook(Blizzard),
                 Freeze when !LevelChecked(Freeze) => Blizzard2,
                 var _ => actionID
             };

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -629,7 +629,7 @@ internal partial class BLM : Caster
         protected override uint Invoke(uint actionID) =>
             actionID switch
             {
-                Blizzard when BLM_B1to3 == 0 && LevelChecked(Blizzard3) && FirePhase  => Blizzard3,
+                Blizzard when BLM_B1to3 == 0 && LevelChecked(Blizzard3) && FirePhase => Blizzard3,
                 Blizzard3 when BLM_B1to3 == 1 && LevelChecked(Blizzard3) && IcePhase => OriginalHook(Blizzard),
                 Freeze when !LevelChecked(Freeze) => Blizzard2,
                 var _ => actionID

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -138,7 +138,8 @@ internal partial class BLM : Caster
                     !HasStatusEffect(Role.Buffs.Swiftcast) && !HasStatusEffect(Buffs.Triplecast))
                     return Blizzard3;
 
-                if (ActionReady(Transpose))
+                if (ActionReady(Transpose) &&
+                    !LevelChecked(Fire3))
                     return Transpose; //Level 4-34
             }
 
@@ -343,7 +344,8 @@ internal partial class BLM : Caster
                     return Blizzard3;
 
                 if (IsEnabled(CustomComboPreset.BLM_ST_Transpose) &&
-                    ActionReady(Transpose))
+                    ActionReady(Transpose) &&
+                    !LevelChecked(Fire3))
                     return Transpose; //Level 4-34
             }
 

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -631,7 +631,6 @@ internal partial class BLM : Caster
             {
                 Blizzard when BLM_B1to3 == 0 && LevelChecked(Blizzard3) && (FirePhase || UmbralIceStacks is 1 || UmbralIceStacks is 2) => Blizzard3,
                 Blizzard3 when BLM_B1to3 == 1 && LevelChecked(Blizzard3) && IcePhase && UmbralIceStacks is 3 => OriginalHook(Blizzard),
-                Freeze when !LevelChecked(Freeze) => Blizzard2,
                 var _ => actionID
             };
     }
@@ -708,6 +707,15 @@ internal partial class BLM : Caster
         protected override uint Invoke(uint actionID) =>
             actionID is FlareStar && FirePhase && LevelChecked(FlareStar) && ActiveParadox && AstralSoulStacks < 6
                 ? OriginalHook(Fire)
+                : actionID;
+    }
+
+    internal class BLM_FreezeBlizzard2 : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_FreezeBlizzard2;
+        protected override uint Invoke(uint actionID) =>
+            actionID is Freeze && !LevelChecked(Freeze)
+                ? Blizzard2
                 : actionID;
     }
 

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -641,10 +641,64 @@ internal partial class BLM : Caster
         protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_Fire1to3;
 
         protected override uint Invoke(uint actionID) =>
-            actionID is Fire &&
-            (LevelChecked(Fire3) && !FirePhase ||
-             HasStatusEffect(Buffs.Firestarter))
+            actionID switch
+            {
+                Fire when BLM_F1to3 == 0 && LevelChecked(Fire3) && (IcePhase || AstralFireStacks is 1 || AstralFireStacks is 2 || HasStatusEffect(Buffs.Firestarter) || !InCombat()) => Fire3,
+                Fire3 when BLM_F1to3 == 1 && LevelChecked(Fire3) && FirePhase && AstralFireStacks is 3 => OriginalHook(Fire),
+                var _ => actionID
+            };
+    }
+
+    internal class BLM_Fire4to3 : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_Fire4to3;
+        protected override uint Invoke(uint actionID) =>
+            actionID is Fire4 && LevelChecked(Fire4) && (IcePhase || AstralFireStacks is 1 || AstralFireStacks is 2 || !InCombat())
                 ? Fire3
+                : actionID;
+    }
+
+    internal class BLM_FireandIce : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_FireandIce;
+
+        protected override uint Invoke(uint actionID) =>
+            actionID switch
+            {
+                Fire4 when FirePhase && LevelChecked(Fire4) => Fire4,
+                Fire4 when IcePhase && LevelChecked(Blizzard4) => Blizzard4,
+                Flare when FirePhase && LevelChecked(Flare) => Flare,
+                Flare when IcePhase && LevelChecked(Freeze) => Freeze,
+                var _ => actionID
+            };
+    }
+
+    internal class BLM_FireFlarestar : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_FireFlarestar;
+
+        protected override uint Invoke(uint actionID) =>
+            actionID is Fire4 && FirePhase && FlarestarReady && LevelChecked(FlareStar) ||
+            actionID is Flare && FirePhase && FlarestarReady && LevelChecked(FlareStar)
+                ? FlareStar
+                : actionID;
+    }
+
+    internal class BLM_Blizzard4toDespair : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_Blizzard4toDespair;
+        protected override uint Invoke(uint actionID) =>
+            actionID is Blizzard4 && FirePhase && LevelChecked(Despair)
+                ? Despair
+                : actionID;
+    }
+
+    internal class BLM_AmplifierXeno : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_AmplifierXeno;
+        protected override uint Invoke(uint actionID) =>
+            actionID is Amplifier && HasMaxPolyglotStacks
+                ? Xenoglossy
                 : actionID;
     }
 
@@ -686,59 +740,6 @@ internal partial class BLM : Caster
         protected override uint Invoke(uint actionID) =>
             actionID is Triplecast && HasStatusEffect(Buffs.Triplecast) && LevelChecked(Triplecast)
                 ? All.SavageBlade
-                : actionID;
-    }
-
-    internal class BLM_FireandIce : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_FireandIce;
-
-        protected override uint Invoke(uint actionID) =>
-            actionID switch
-            {
-                Fire4 when FirePhase && LevelChecked(Fire4) => Fire4,
-                Fire4 when IcePhase && LevelChecked(Blizzard4) => Blizzard4,
-                Flare when FirePhase && LevelChecked(Flare) => Flare,
-                Flare when IcePhase && LevelChecked(Freeze) => Freeze,
-                var _ => actionID
-            };
-    }
-
-    internal class BLM_FireFlarestar : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_FireFlarestar;
-
-        protected override uint Invoke(uint actionID) =>
-            actionID is Fire4 && FirePhase && FlarestarReady && LevelChecked(FlareStar) ||
-            actionID is Flare && FirePhase && FlarestarReady && LevelChecked(FlareStar)
-                ? FlareStar
-                : actionID;
-    }
-
-    internal class BLM_Fire4to3 : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_Fire4to3;
-        protected override uint Invoke(uint actionID) =>
-            actionID is Fire4 && !(FirePhase && LevelChecked(Fire4))
-                ? Fire3
-                : actionID;
-    }
-
-    internal class BLM_Blizzard4toDespair : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_Blizzard4toDespair;
-        protected override uint Invoke(uint actionID) =>
-            actionID is Blizzard4 && FirePhase && LevelChecked(Despair)
-                ? Despair
-                : actionID;
-    }
-
-    internal class BLM_AmplifierXeno : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_AmplifierXeno;
-        protected override uint Invoke(uint actionID) =>
-            actionID is Amplifier && HasMaxPolyglotStacks
-                ? Xenoglossy
                 : actionID;
     }
 }

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -133,7 +133,7 @@ internal partial class BLM : Caster
                 if (FlarestarReady)
                     return FlareStar;
 
-                if (LevelChecked(FireSpam) && (LevelChecked(Despair) && CurMp - MP.FireI >= 800 || !LevelChecked(Despair)))
+                if (ActionReady(FireSpam) && (LevelChecked(Despair) && CurMp - MP.FireI >= 800 || !LevelChecked(Despair)))
                     return FireSpam;
 
                 if (ActionReady(Despair))
@@ -169,7 +169,7 @@ internal partial class BLM : Caster
                     (JustUsed(Transpose, 5f) || JustUsed(Freeze, 10f)))
                     return Blizzard3;
 
-                if (LevelChecked(BlizzardSpam))
+                if (ActionReady(BlizzardSpam))
                     return BlizzardSpam;
             }
 

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -616,6 +616,8 @@ internal partial class BLM : Caster
             switch (actionID)
             {
                 case Blizzard when LevelChecked(Blizzard3) && !IcePhase:
+                
+                case Blizzard3 when LevelChecked(Blizzard3) && (FirePhase || UmbralIce1 || UmbralIce2):
                     return Blizzard3;
 
                 case Freeze when !LevelChecked(Freeze):

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -49,7 +49,7 @@ internal partial class BLM : Caster
 
                 if (IcePhase)
                 {
-                    if (CurMp is MP.MaxMP && 
+                    if (CurMp is MP.MaxMP &&
                         JustUsed(Paradox) &&
                         ActionReady(Transpose))
                         return Transpose;

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -613,19 +613,12 @@ internal partial class BLM : Caster
 
         protected override uint Invoke(uint actionID)
         {
-            switch (actionID)
+            return actionID switch
             {
-                case Blizzard when LevelChecked(Blizzard3) && !IcePhase:
-                
-                case Blizzard3 when LevelChecked(Blizzard3) && (FirePhase || UmbralIce1 || UmbralIce2):
-                    return Blizzard3;
-
-                case Freeze when !LevelChecked(Freeze):
-                    return Blizzard2;
-
-                default:
-                    return actionID;
-            }
+                Blizzard when LevelChecked(Blizzard3) && (FirePhase || UmbralIce1 || UmbralIce2) => Blizzard3,
+                Freeze when !LevelChecked(Freeze) => Blizzard2,
+                var _ => actionID
+            };
         }
     }
 
@@ -688,23 +681,14 @@ internal partial class BLM : Caster
 
         protected override uint Invoke(uint actionID)
         {
-            switch (actionID)
+            return actionID switch
             {
-                case Fire4 when FirePhase && LevelChecked(Fire4):
-                    return Fire4;
-
-                case Fire4 when IcePhase && LevelChecked(Blizzard4):
-                    return Blizzard4;
-
-                case Flare when FirePhase && LevelChecked(Flare):
-                    return Flare;
-
-                case Flare when IcePhase && LevelChecked(Freeze):
-                    return Freeze;
-
-                default:
-                    return actionID;
-            }
+                Fire4 when FirePhase && LevelChecked(Fire4) => Fire4,
+                Fire4 when IcePhase && LevelChecked(Blizzard4) => Blizzard4,
+                Flare when FirePhase && LevelChecked(Flare) => Flare,
+                Flare when IcePhase && LevelChecked(Freeze) => Freeze,
+                var _ => actionID
+            };
         }
     }
 

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -41,20 +41,18 @@ internal partial class BLM : Caster
                         return Role.Swiftcast;
 
                     if (ActionReady(Transpose) &&
+                        LevelChecked(Fire3) &&
                         (HasStatusEffect(Role.Buffs.Swiftcast) ||
-                         HasStatusEffect(Buffs.Triplecast) ||
-                         !LevelChecked(Fire3)))
+                         HasStatusEffect(Buffs.Triplecast)))
                         return Transpose;
                 }
 
                 if (IcePhase)
                 {
-                    if (CurMp is MP.MaxMP &&
-                        (JustUsed(Paradox) ||
-                         !LevelChecked(Blizzard3)))
+                    if (CurMp is MP.MaxMP && JustUsed(Paradox))
                         return Transpose;
 
-                    if (ActionReady(Blizzard3) && UmbralIceStacks < 3 &&
+                    if (LevelChecked(Blizzard3) && UmbralIceStacks < 3 &&
                         ActionReady(Role.Swiftcast) && !HasStatusEffect(Buffs.Triplecast))
                         return Role.Swiftcast;
                 }
@@ -92,7 +90,7 @@ internal partial class BLM : Caster
                     !HasStatusEffect(Buffs.LeyLines))
                     return Triplecast;
 
-                if (ActionReady(Paradox) &&
+                if (LevelChecked(Paradox) &&
                     FirePhase && ActiveParadox &&
                     !HasStatusEffect(Buffs.Firestarter) &&
                     !HasStatusEffect(Buffs.Triplecast) &&
@@ -120,28 +118,33 @@ internal partial class BLM : Caster
 
                 if ((LevelChecked(Paradox) && HasStatusEffect(Buffs.Firestarter) ||
                      TimeSinceFirestarterBuff >= 2) && AstralFireStacks < 3 ||
-                    !LevelChecked(Fire4) && TimeSinceFirestarterBuff >= 2 && ActionReady(Fire3))
+                    !LevelChecked(Fire4) && TimeSinceFirestarterBuff >= 2 && LevelChecked(Fire3))
                     return Fire3;
 
                 if (ActiveParadox &&
                     CurMp > 1600 &&
-                    (AstralFireStacks < 3 ||
-                     JustUsed(FlareStar, 5) ||
-                     !LevelChecked(FlareStar) && ActionReady(Despair)))
+                    AstralFireStacks is 3 &&
+                    (JustUsed(FlareStar, 5) ||
+                     !LevelChecked(FlareStar) && LevelChecked(Despair)))
                     return OriginalHook(Paradox);
 
                 if (FlarestarReady)
                     return FlareStar;
 
-                if (ActionReady(FireSpam) && (LevelChecked(Despair) && CurMp - MP.FireI >= 800 || !LevelChecked(Despair)))
+                if (LevelChecked(FireSpam) && (LevelChecked(Despair) && CurMp - MP.FireI >= 800 || !LevelChecked(Despair)))
                     return FireSpam;
 
                 if (ActionReady(Despair))
                     return Despair;
 
-                if (ActionReady(Blizzard3) &&
+                if (LevelChecked(Blizzard3) &&
                     !HasStatusEffect(Role.Buffs.Swiftcast) && !HasStatusEffect(Buffs.Triplecast))
                     return Blizzard3;
+
+                if (ActionReady(Transpose) &&
+                    !LevelChecked(Fire3) &&
+                    CurMp < MP.FireI)
+                    return Transpose;
             }
 
             if (IcePhase)
@@ -151,14 +154,20 @@ internal partial class BLM : Caster
                     ActiveParadox)
                     return OriginalHook(Paradox);
 
-                if (CurMp is MP.MaxMP && ActionReady(Fire3))
-                    return Fire3; //35-100, pre-Paradox/scuffed starting combat
+                if (CurMp is MP.MaxMP)
+                {
+                    if (LevelChecked(Fire3))
+                        return Fire3;
 
-                if (ActionReady(Blizzard3) && UmbralIceStacks < 3 &&
+                    if (ActionReady(Transpose) && !LevelChecked(Blizzard3))
+                        return Transpose;
+                }
+
+                if (LevelChecked(Blizzard3) && UmbralIceStacks < 3 &&
                     (JustUsed(Transpose, 5f) || JustUsed(Freeze, 10f)))
                     return Blizzard3;
 
-                if (ActionReady(BlizzardSpam))
+                if (LevelChecked(BlizzardSpam))
                     return BlizzardSpam;
             }
 
@@ -227,20 +236,17 @@ internal partial class BLM : Caster
                     if (IsEnabled(CustomComboPreset.BLM_ST_Transpose) &&
                         ActionReady(Transpose) &&
                         (HasStatusEffect(Role.Buffs.Swiftcast) ||
-                         HasStatusEffect(Buffs.Triplecast) ||
-                         !LevelChecked(Fire3)))
+                         HasStatusEffect(Buffs.Triplecast)))
                         return Transpose;
                 }
 
                 if (IcePhase)
                 {
                     if (IsEnabled(CustomComboPreset.BLM_ST_Transpose) &&
-                        CurMp is MP.MaxMP &&
-                        (JustUsed(Paradox) ||
-                         !LevelChecked(Blizzard3)))
+                        CurMp is MP.MaxMP && JustUsed(Paradox))
                         return Transpose;
 
-                    if (ActionReady(Blizzard3) && UmbralIceStacks < 3)
+                    if (LevelChecked(Blizzard3) && UmbralIceStacks < 3)
                     {
                         if (IsEnabled(CustomComboPreset.BLM_ST_Swiftcast) &&
                             ActionReady(Role.Swiftcast) && !HasStatusEffect(Buffs.Triplecast))
@@ -318,14 +324,14 @@ internal partial class BLM : Caster
 
                 if ((LevelChecked(Paradox) && HasStatusEffect(Buffs.Firestarter) ||
                      TimeSinceFirestarterBuff >= 2) && AstralFireStacks < 3 ||
-                    !LevelChecked(Fire4) && TimeSinceFirestarterBuff >= 2 && ActionReady(Fire3))
+                    !LevelChecked(Fire4) && TimeSinceFirestarterBuff >= 2 && LevelChecked(Fire3))
                     return Fire3;
 
                 if (ActiveParadox &&
                     CurMp > 1600 &&
-                    (AstralFireStacks < 3 ||
-                     JustUsed(FlareStar, 5) ||
-                     !LevelChecked(FlareStar) && ActionReady(Despair)))
+                    AstralFireStacks is 3 &&
+                    (JustUsed(FlareStar, 5) ||
+                     !LevelChecked(FlareStar) && LevelChecked(Despair)))
                     return OriginalHook(Paradox);
 
                 if (IsEnabled(CustomComboPreset.BLM_ST_FlareStar) &&
@@ -339,9 +345,15 @@ internal partial class BLM : Caster
                     ActionReady(Despair))
                     return Despair;
 
-                if (ActionReady(Blizzard3) &&
+                if (LevelChecked(Blizzard3) &&
                     !HasStatusEffect(Role.Buffs.Swiftcast) && !HasStatusEffect(Buffs.Triplecast))
                     return Blizzard3;
+
+                if (IsEnabled(CustomComboPreset.BLM_ST_Transpose) &&
+                    ActionReady(Transpose) &&
+                    !LevelChecked(Fire3) &&
+                    CurMp < MP.FireI)
+                    return Transpose;
             }
 
             if (IcePhase)
@@ -351,10 +363,17 @@ internal partial class BLM : Caster
                     ActiveParadox)
                     return OriginalHook(Paradox);
 
-                if (CurMp is MP.MaxMP && ActionReady(Fire3))
-                    return Fire3;
+                if (CurMp is MP.MaxMP)
+                {
+                    if (LevelChecked(Fire3))
+                        return Fire3;
 
-                if (ActionReady(Blizzard3) && UmbralIceStacks < 3 &&
+                    if (IsEnabled(CustomComboPreset.BLM_ST_Transpose) &&
+                        ActionReady(Transpose) && !LevelChecked(Blizzard3))
+                        return Transpose;
+                }
+
+                if (LevelChecked(Blizzard3) && UmbralIceStacks < 3 &&
                     (JustUsed(Transpose, 5f) || JustUsed(Freeze, 10f)))
                     return Blizzard3;
 
@@ -397,9 +416,7 @@ internal partial class BLM : Caster
 
                 if (ActionReady(Transpose) &&
                     (EndOfFirePhase ||
-                     EndOfIcePhaseAoEMaxLevel ||
-                     CurMp is MP.MaxMP ||
-                     HasMaxUmbralHeartStacks))
+                     EndOfIcePhaseAoEMaxLevel))
                     return Transpose;
 
                 if (ActionReady(Amplifier) && PolyglotTimer >= 20000)
@@ -431,7 +448,7 @@ internal partial class BLM : Caster
                 if (FlarestarReady)
                     return FlareStar;
 
-                if (ActionReady(Fire2) && !TraitLevelChecked(Traits.UmbralHeart))
+                if (LevelChecked(Fire2) && !TraitLevelChecked(Traits.UmbralHeart))
                     return OriginalHook(Fire2);
 
                 if (!HasStatusEffect(Buffs.Triplecast) && ActionReady(Triplecast) &&
@@ -441,17 +458,26 @@ internal partial class BLM : Caster
 
                 if (ActionReady(Flare))
                     return Flare;
+
+                if (ActionReady(Transpose) &&
+                    !LevelChecked(Fire3) &&
+                    CurMp < MP.FireAoE)
+                    return Transpose;
             }
 
             if (IcePhase)
             {
-                if (ActionReady(Freeze))
+                if ((CurMp is MP.MaxMP || HasMaxUmbralHeartStacks) &&
+                    ActionReady(Transpose))
+                    return Transpose;
+
+                if (LevelChecked(Freeze))
                     return LevelChecked(Blizzard4) && HasBattleTarget() &&
                            NumberOfEnemiesInRange(Freeze, CurrentTarget) == 2
                         ? Blizzard4
                         : Freeze;
 
-                if (!LevelChecked(Freeze) && ActionReady(Blizzard2))
+                if (!LevelChecked(Freeze) && LevelChecked(Blizzard2))
                     return OriginalHook(Blizzard2);
             }
 
@@ -487,10 +513,7 @@ internal partial class BLM : Caster
 
                 if (IsEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
                     ActionReady(Transpose) &&
-                    (EndOfFirePhase ||
-                     EndOfIcePhaseAoEMaxLevel ||
-                     CurMp is MP.MaxMP ||
-                     HasMaxUmbralHeartStacks))
+                    (EndOfFirePhase || EndOfIcePhaseAoEMaxLevel))
                     return Transpose;
 
                 if (IsEnabled(CustomComboPreset.BLM_AoE_Amplifier) &&
@@ -540,25 +563,34 @@ internal partial class BLM : Caster
                     return Flare;
 
                 if (IsNotEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
-                    ActionReady(Blizzard2) && TraitLevelChecked(Traits.AspectMasteryIII) && !TraitLevelChecked(Traits.UmbralHeart))
+                    LevelChecked(Blizzard2) && TraitLevelChecked(Traits.AspectMasteryIII) && !TraitLevelChecked(Traits.UmbralHeart))
                     return OriginalHook(Blizzard2);
+
+                if (IsEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
+                    ActionReady(Transpose) && CurMp < MP.FireAoE)
+                    return Transpose;
             }
 
             if (IcePhase)
             {
-                if (IsNotEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
-                    HasMaxUmbralHeartStacks && CurMp is MP.MaxMP &&
-                    ActionReady(Fire2) && TraitLevelChecked(Traits.AspectMasteryIII))
-                    return OriginalHook(Fire2);
+                if (HasMaxUmbralHeartStacks || CurMp is MP.MaxMP)
+                {
+                    if (IsNotEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
+                        LevelChecked(Fire2) && TraitLevelChecked(Traits.AspectMasteryIII))
+                        return OriginalHook(Fire2);
 
-                if (ActionReady(Freeze))
+                    if (IsEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
+                        ActionReady(Transpose))
+                        return Transpose;
+                }
+                if (LevelChecked(Freeze))
                     return IsEnabled(CustomComboPreset.BLM_AoE_Blizzard4Sub) &&
                            LevelChecked(Blizzard4) && HasBattleTarget() &&
                            NumberOfEnemiesInRange(Freeze, CurrentTarget) == 2
                         ? Blizzard4
                         : Freeze;
 
-                if (!LevelChecked(Freeze) && ActionReady(Blizzard2))
+                if (!LevelChecked(Freeze) && LevelChecked(Blizzard2))
                     return OriginalHook(Blizzard2);
             }
 
@@ -593,7 +625,7 @@ internal partial class BLM : Caster
         protected override uint Invoke(uint actionID) =>
             actionID switch
             {
-                Blizzard when LevelChecked(Blizzard3) && (FirePhase || UmbralIce1 || UmbralIce2) => Blizzard3,
+                Blizzard when LevelChecked(Blizzard3) && (FirePhase || UmbralIceStacks is 1 or 2) => Blizzard3,
                 Freeze when !LevelChecked(Freeze) => Blizzard2,
                 var _ => actionID
             };

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -40,13 +40,18 @@ internal partial class BLM : Caster
                         !ActionReady(Manafont) && !HasStatusEffect(Buffs.Triplecast))
                         return Role.Swiftcast;
 
-                    if (ActionReady(Transpose) && (HasStatusEffect(Role.Buffs.Swiftcast) || HasStatusEffect(Buffs.Triplecast)))
+                    if (ActionReady(Transpose) &&
+                        (HasStatusEffect(Role.Buffs.Swiftcast) ||
+                         HasStatusEffect(Buffs.Triplecast) ||
+                         !LevelChecked(Fire3)))
                         return Transpose;
                 }
 
                 if (IcePhase)
                 {
-                    if (JustUsed(Paradox) && CurMp is MP.MaxMP)
+                    if (CurMp is MP.MaxMP &&
+                        (JustUsed(Paradox) ||
+                         !LevelChecked(Blizzard3)))
                         return Transpose;
 
                     if (ActionReady(Blizzard3) && UmbralIceStacks < 3 &&
@@ -137,10 +142,6 @@ internal partial class BLM : Caster
                 if (ActionReady(Blizzard3) &&
                     !HasStatusEffect(Role.Buffs.Swiftcast) && !HasStatusEffect(Buffs.Triplecast))
                     return Blizzard3;
-
-                if (ActionReady(Transpose) &&
-                    !LevelChecked(Fire3))
-                    return Transpose; //Level 4-34
             }
 
             if (IcePhase)
@@ -150,14 +151,8 @@ internal partial class BLM : Caster
                     ActiveParadox)
                     return OriginalHook(Paradox);
 
-                if (CurMp == MP.MaxMP)
-                {
-                    if (ActionReady(Fire3))
-                        return Fire3; //35-100, pre-Paradox/scuffed starting combat
-
-                    if (ActionReady(Transpose))
-                        return Transpose; //Levels 4-34
-                }
+                if (CurMp is MP.MaxMP && ActionReady(Fire3))
+                    return Fire3; //35-100, pre-Paradox/scuffed starting combat
 
                 if (ActionReady(Blizzard3) && UmbralIceStacks < 3 &&
                     (JustUsed(Transpose, 5f) || JustUsed(Freeze, 10f)))
@@ -230,14 +225,19 @@ internal partial class BLM : Caster
                         return Triplecast;
 
                     if (IsEnabled(CustomComboPreset.BLM_ST_Transpose) &&
-                        ActionReady(Transpose) && (HasStatusEffect(Role.Buffs.Swiftcast) || HasStatusEffect(Buffs.Triplecast)))
+                        ActionReady(Transpose) &&
+                        (HasStatusEffect(Role.Buffs.Swiftcast) ||
+                         HasStatusEffect(Buffs.Triplecast) ||
+                         !LevelChecked(Fire3)))
                         return Transpose;
                 }
 
                 if (IcePhase)
                 {
                     if (IsEnabled(CustomComboPreset.BLM_ST_Transpose) &&
-                        JustUsed(Paradox) && CurMp is MP.MaxMP)
+                        CurMp is MP.MaxMP &&
+                        (JustUsed(Paradox) ||
+                         !LevelChecked(Blizzard3)))
                         return Transpose;
 
                     if (ActionReady(Blizzard3) && UmbralIceStacks < 3)
@@ -342,11 +342,6 @@ internal partial class BLM : Caster
                 if (ActionReady(Blizzard3) &&
                     !HasStatusEffect(Role.Buffs.Swiftcast) && !HasStatusEffect(Buffs.Triplecast))
                     return Blizzard3;
-
-                if (IsEnabled(CustomComboPreset.BLM_ST_Transpose) &&
-                    ActionReady(Transpose) &&
-                    !LevelChecked(Fire3))
-                    return Transpose; //Level 4-34
             }
 
             if (IcePhase)
@@ -356,17 +351,8 @@ internal partial class BLM : Caster
                     ActiveParadox)
                     return OriginalHook(Paradox);
 
-                if (CurMp == MP.MaxMP)
-                {
-                    //35-100, pre-Paradox/scuffed starting combat
-                    if (ActionReady(Fire3))
-                        return Fire3;
-
-                    //Levels 4-34
-                    if (IsEnabled(CustomComboPreset.BLM_ST_Transpose) &&
-                        ActionReady(Transpose))
-                        return Transpose;
-                }
+                if (CurMp is MP.MaxMP && ActionReady(Fire3))
+                    return Fire3;
 
                 if (ActionReady(Blizzard3) && UmbralIceStacks < 3 &&
                     (JustUsed(Transpose, 5f) || JustUsed(Freeze, 10f)))
@@ -409,7 +395,11 @@ internal partial class BLM : Caster
                     EndOfFirePhase)
                     return Manafont;
 
-                if (ActionReady(Transpose) && (EndOfFirePhase || EndOfIcePhaseAoEMaxLevel))
+                if (ActionReady(Transpose) &&
+                    (EndOfFirePhase ||
+                     EndOfIcePhaseAoEMaxLevel ||
+                     CurMp is MP.MaxMP ||
+                     HasMaxUmbralHeartStacks))
                     return Transpose;
 
                 if (ActionReady(Amplifier) && PolyglotTimer >= 20000)
@@ -451,17 +441,10 @@ internal partial class BLM : Caster
 
                 if (ActionReady(Flare))
                     return Flare;
-
-                if (ActionReady(Transpose))
-                    return Transpose;
             }
 
             if (IcePhase)
             {
-                if ((CurMp == MP.MaxMP || HasMaxUmbralHeartStacks) &&
-                    ActionReady(Transpose))
-                    return Transpose;
-
                 if (ActionReady(Freeze))
                     return LevelChecked(Blizzard4) && HasBattleTarget() &&
                            NumberOfEnemiesInRange(Freeze, CurrentTarget) == 2
@@ -503,7 +486,11 @@ internal partial class BLM : Caster
                     return Manafont;
 
                 if (IsEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
-                    ActionReady(Transpose) && (EndOfFirePhase || EndOfIcePhaseAoEMaxLevel))
+                    ActionReady(Transpose) &&
+                    (EndOfFirePhase ||
+                     EndOfIcePhaseAoEMaxLevel ||
+                     CurMp is MP.MaxMP ||
+                     HasMaxUmbralHeartStacks))
                     return Transpose;
 
                 if (IsEnabled(CustomComboPreset.BLM_AoE_Amplifier) &&
@@ -555,24 +542,14 @@ internal partial class BLM : Caster
                 if (IsNotEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
                     ActionReady(Blizzard2) && TraitLevelChecked(Traits.AspectMasteryIII) && !TraitLevelChecked(Traits.UmbralHeart))
                     return OriginalHook(Blizzard2);
-
-                if (IsEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
-                    ActionReady(Transpose))
-                    return Transpose;
             }
 
             if (IcePhase)
             {
-                if (HasMaxUmbralHeartStacks)
-                {
-                    if (IsNotEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
-                        CurMp == MP.MaxMP && ActionReady(Fire2) && TraitLevelChecked(Traits.AspectMasteryIII))
-                        return OriginalHook(Fire2);
-
-                    if (IsEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
-                        ActionReady(Transpose))
-                        return Transpose;
-                }
+                if (IsNotEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
+                    HasMaxUmbralHeartStacks && CurMp is MP.MaxMP &&
+                    ActionReady(Fire2) && TraitLevelChecked(Traits.AspectMasteryIII))
+                    return OriginalHook(Fire2);
 
                 if (ActionReady(Freeze))
                     return IsEnabled(CustomComboPreset.BLM_AoE_Blizzard4Sub) &&

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -693,6 +693,24 @@ internal partial class BLM : Caster
                 : actionID;
     }
 
+    internal class BLM_FreezeParadox : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_FreezeParadox;
+        protected override uint Invoke(uint actionID) =>
+            actionID is Freeze && HasMaxUmbralHeartStacks && LevelChecked(Paradox) && ActiveParadox && IcePhase
+                ? OriginalHook(Blizzard)
+                : actionID;
+    }
+
+    internal class BLM_FlareParadox : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_FlareParadox;
+        protected override uint Invoke(uint actionID) =>
+            actionID is FlareStar && FirePhase && LevelChecked(FlareStar) && ActiveParadox && AstralSoulStacks < 6
+                ? OriginalHook(Fire)
+                : actionID;
+    }
+
     internal class BLM_AmplifierXeno : CustomCombo
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_AmplifierXeno;

--- a/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
@@ -127,6 +127,14 @@ internal partial class BLM
                     DrawSliderInt(1, 100, BLM_VariantCure,
                         "HP% to be at or under", 200);
                     break;
+
+                case CustomComboPreset.BLM_Blizzard1to3:
+                    DrawRadioButton(BLM_B1to3,
+                        $"Replaces {Blizzard.ActionName()}", $"Replaces {Blizzard.ActionName()} with {Blizzard3.ActionName()} when out of Umbral Ice.", 0);
+
+                    DrawRadioButton(BLM_B1to3,
+                        $"Replaces {Blizzard3.ActionName()}", $"Replaces {Blizzard3.ActionName()} with {Blizzard.ActionName()} when in Umbral Ice.", 1);
+                    break;
             }
         }
 
@@ -147,7 +155,8 @@ internal partial class BLM
             BLM_AoE_Triplecast_HoldCharges = new("BLM_AoE_Triplecast_HoldCharges", 0),
             BLM_AoE_LeyLinesCharges = new("BLM_AoE_LeyLinesCharges", 1),
             BLM_AoE_ThunderHP = new("BLM_AoE_ThunderHP", 20),
-            BLM_VariantCure = new("BLM_VariantCure", 50);
+            BLM_VariantCure = new("BLM_VariantCure", 50),
+            BLM_B1to3 = new("BLM_B1to3", 0);
 
         public static UserBoolArray
             BLM_ST_MovementOption = new("BLM_ST_MovementOption");

--- a/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
@@ -130,10 +130,18 @@ internal partial class BLM
 
                 case CustomComboPreset.BLM_Blizzard1to3:
                     DrawRadioButton(BLM_B1to3,
-                        $"Replaces {Blizzard.ActionName()}", $"Replaces {Blizzard.ActionName()} with {Blizzard3.ActionName()} when out of Umbral Ice.", 0);
+                        $"Replaces {Blizzard.ActionName()}", $"Replaces {Blizzard.ActionName()} with {Blizzard3.ActionName()} when out of Umbral Ice III.", 0);
 
                     DrawRadioButton(BLM_B1to3,
-                        $"Replaces {Blizzard3.ActionName()}", $"Replaces {Blizzard3.ActionName()} with {Blizzard.ActionName()} when in Umbral Ice.", 1);
+                        $"Replaces {Blizzard3.ActionName()}", $"Replaces {Blizzard3.ActionName()} with {Blizzard.ActionName()} when in Umbral Ice III.", 1);
+                    break;
+
+                case CustomComboPreset.BLM_Fire1to3:
+                    DrawRadioButton(BLM_F1to3,
+                        $"Replaces {Fire.ActionName()}", $"Replaces {Fire.ActionName()} with {Fire3.ActionName()} when out of Astral Fire III.", 0);
+
+                    DrawRadioButton(BLM_F1to3,
+                        $"Replaces {Fire3.ActionName()}", $"Replaces {Fire3.ActionName()} with {Fire.ActionName()} when in Astral Fire III.", 1);
                     break;
             }
         }
@@ -156,7 +164,8 @@ internal partial class BLM
             BLM_AoE_LeyLinesCharges = new("BLM_AoE_LeyLinesCharges", 1),
             BLM_AoE_ThunderHP = new("BLM_AoE_ThunderHP", 20),
             BLM_VariantCure = new("BLM_VariantCure", 50),
-            BLM_B1to3 = new("BLM_B1to3", 0);
+            BLM_B1to3 = new("BLM_B1to3", 0),
+            BLM_F1to3 = new("BLM_F1to3", 0);
 
         public static UserBoolArray
             BLM_ST_MovementOption = new("BLM_ST_MovementOption");

--- a/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
@@ -138,7 +138,7 @@ internal partial class BLM
 
                 case CustomComboPreset.BLM_Fire1to3:
                     DrawRadioButton(BLM_F1to3,
-                        $"Replaces {Fire.ActionName()}", $"Replaces {Fire.ActionName()} with {Fire3.ActionName()} when out of Astral Fire III.", 0);
+                        $"Replaces {Fire.ActionName()}", $"Replaces {Fire.ActionName()} with {Fire3.ActionName()} when out of Astral Fire III or not in combat.", 0);
 
                     DrawRadioButton(BLM_F1to3,
                         $"Replaces {Fire3.ActionName()}", $"Replaces {Fire3.ActionName()} with {Fire.ActionName()} when in Astral Fire III.", 1);

--- a/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
@@ -21,7 +21,7 @@ internal partial class BLM
         FirePhase && !ActionReady(Despair) && !ActionReady(FireSpam) && !ActionReady(FlareStar);
 
     internal static bool EndOfIcePhase =>
-        IcePhase && CurMp == MP.MaxMP && HasMaxUmbralHeartStacks;
+        IcePhase && CurMp is MP.MaxMP && HasMaxUmbralHeartStacks;
 
     internal static bool EndOfIcePhaseAoEMaxLevel =>
         IcePhase && HasMaxUmbralHeartStacks && TraitLevelChecked(Traits.EnhancedAstralFire);
@@ -246,10 +246,6 @@ internal partial class BLM
     internal static byte AstralFireStacks => Gauge.AstralFireStacks;
 
     internal static bool IcePhase => Gauge.InUmbralIce;
-
-    internal static bool UmbralIce1 => Gauge.UmbralIceStacks == 1;
-
-    internal static bool UmbralIce2 => Gauge.UmbralIceStacks == 2;
 
     internal static byte UmbralIceStacks => Gauge.UmbralIceStacks;
 

--- a/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
@@ -247,6 +247,10 @@ internal partial class BLM
 
     internal static bool IcePhase => Gauge.InUmbralIce;
 
+    internal static bool UmbralIce1 => Gauge.UmbralIceStacks == 1;
+    
+    internal static bool UmbralIce2 => Gauge.UmbralIceStacks == 2;
+
     internal static byte UmbralIceStacks => Gauge.UmbralIceStacks;
 
     internal static byte UmbralHearts => Gauge.UmbralHearts;

--- a/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
@@ -248,7 +248,7 @@ internal partial class BLM
     internal static bool IcePhase => Gauge.InUmbralIce;
 
     internal static bool UmbralIce1 => Gauge.UmbralIceStacks == 1;
-    
+
     internal static bool UmbralIce2 => Gauge.UmbralIceStacks == 2;
 
     internal static byte UmbralIceStacks => Gauge.UmbralIceStacks;

--- a/WrathCombo/Combos/PvE/DRG/DRG_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRG/DRG_Helper.cs
@@ -40,11 +40,8 @@ internal partial class DRG
 
     #region Animation Locks
 
-    internal static bool CanDRGWeave(float weaveTime = BaseAnimationLock, bool forceFirst = false)
-
-    {
-        return !HasWeavedAction(Stardiver) && (!forceFirst || !HasWeaved()) && CanWeave(weaveTime);
-    }
+    internal static bool CanDRGWeave(float weaveTime = BaseAnimationLock, bool forceFirst = false) =>
+        !HasWeavedAction(Stardiver) && (!forceFirst || !HasWeaved()) && CanWeave(weaveTime);
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/MCH/MCH_Config.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Config.cs
@@ -47,15 +47,15 @@ internal partial class MCH
 
                 case CustomComboPreset.MCH_ST_Adv_TurretQueen:
                     DrawHorizontalRadioButton(MCH_ST_Adv_Turret_SubOption,
-                        "All content", $"Uses {AutomatonQueen.ActionName()} logic regardless of content.", 0);
+                        "Use The Balance Logic in all content", $"Uses {AutomatonQueen.ActionName()} logic regardless of content.", 0);
 
                     DrawHorizontalRadioButton(MCH_ST_Adv_Turret_SubOption,
-                        "Boss encounters Only", $"Only uses {AutomatonQueen.ActionName()} logic when in Boss encounters.", 1);
+                        "Use The Balance logic only in Boss encounters", $"Only uses {AutomatonQueen.ActionName()} logic when in Boss encounters.", 1);
 
                     if (MCH_ST_Adv_Turret_SubOption == 1)
                     {
                         DrawSliderInt(50, 100, MCH_ST_TurretUsage,
-                            $"Uses {AutomatonQueen.ActionName()} at this battery threshold outside of Boss encounter.\n Only counts for 'Boss encounters Only setting'.");
+                            $"Uses {AutomatonQueen.ActionName()} at this battery threshold outside of Boss encounter.");
                     }
                     break;
 

--- a/WrathCombo/Combos/PvE/SMN/SMN.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN.cs
@@ -734,8 +734,8 @@ internal partial class SMN : Caster
                     return OriginalHook(Gemshine);
 
                 if (IfritAstralFlowCyclone && HasStatusEffect(Buffs.IfritsFavor) &&
-                   ((!Config.SMN_ST_CrimsonCycloneMelee) || (Config.SMN_ST_CrimsonCycloneMelee && GetTargetDistance() <= Config.SMN_ST_CrimsonCycloneMeleeDistance))  //Melee Check
-                   || (IfritAstralFlowStrike && HasStatusEffect(Buffs.CrimsonStrike) && InMeleeRange())) //After Strike
+                  ((GetTargetDistance() <= Config.SMN_ST_CrimsonCycloneMeleeDistance)  //Melee Check
+                   || (IfritAstralFlowStrike && HasStatusEffect(Buffs.CrimsonStrike) && InMeleeRange()))) //After Strike
                     return OriginalHook(AstralFlow);
 
                 if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_Ruin4) && HasStatusEffect(Buffs.FurtherRuin) && !HasStatusEffect(Role.Buffs.Swiftcast))
@@ -950,7 +950,7 @@ internal partial class SMN : Caster
                     return OriginalHook(PreciousBrilliance);
 
                 if (IfritAstralFlowCyclone && HasStatusEffect(Buffs.IfritsFavor) &&
-                   ((!Config.SMN_AoE_CrimsonCycloneMelee) || (Config.SMN_AoE_CrimsonCycloneMelee && GetTargetDistance() <= Config.SMN_AoE_CrimsonCycloneMeleeDistance)) //Melee Check
+                   ((GetTargetDistance() <= Config.SMN_AoE_CrimsonCycloneMeleeDistance)) //Melee Check
                    || (IfritAstralFlowStrike && HasStatusEffect(Buffs.CrimsonStrike) && InMeleeRange())) //After Strike
                     return OriginalHook(AstralFlow);
 

--- a/WrathCombo/Combos/PvE/SMN/SMN.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN.cs
@@ -734,7 +734,7 @@ internal partial class SMN : Caster
                     return OriginalHook(Gemshine);
 
                 if (IfritAstralFlowCyclone && HasStatusEffect(Buffs.IfritsFavor) &&
-                   ((!Config.SMN_ST_CrimsonCycloneMelee) || (Config.SMN_ST_CrimsonCycloneMelee && InMeleeRange()))  //Melee Check
+                   ((!Config.SMN_ST_CrimsonCycloneMelee) || (Config.SMN_ST_CrimsonCycloneMelee && GetTargetDistance() <= Config.SMN_ST_CrimsonCycloneMeleeDistance))  //Melee Check
                    || (IfritAstralFlowStrike && HasStatusEffect(Buffs.CrimsonStrike) && InMeleeRange())) //After Strike
                     return OriginalHook(AstralFlow);
 
@@ -950,7 +950,7 @@ internal partial class SMN : Caster
                     return OriginalHook(PreciousBrilliance);
 
                 if (IfritAstralFlowCyclone && HasStatusEffect(Buffs.IfritsFavor) &&
-                   ((!Config.SMN_AoE_CrimsonCycloneMelee) || (Config.SMN_AoE_CrimsonCycloneMelee && InMeleeRange()))  //Melee Check
+                   ((!Config.SMN_AoE_CrimsonCycloneMelee) || (Config.SMN_AoE_CrimsonCycloneMelee && GetTargetDistance() <= Config.SMN_AoE_CrimsonCycloneMeleeDistance)) //Melee Check
                    || (IfritAstralFlowStrike && HasStatusEffect(Buffs.CrimsonStrike) && InMeleeRange())) //After Strike
                     return OriginalHook(AstralFlow);
 

--- a/WrathCombo/Combos/PvE/SMN/SMN_Config.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN_Config.cs
@@ -2,7 +2,6 @@ using ImGuiNET;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Extensions;
 using WrathCombo.Window.Functions;
-using static WrathCombo.Extensions.UIntExtensions;
 using static WrathCombo.Window.Functions.UserConfig;
 
 namespace WrathCombo.Combos.PvE;
@@ -17,13 +16,15 @@ internal partial class SMN
             SMN_ST_BurstPhase = new("SMN_ST_BurstPhase", 1),
             SMN_ST_SwiftcastPhase = new("SMN_SwiftcastPhase", 1),
             SMN_ST_Burst_Delay = new("SMN_Burst_Delay", 0),
+            SMN_ST_CrimsonCycloneMeleeDistance = new("SMN_ST_CrimsonCycloneMeleeDistance", 3),
             SMN_Opener_SkipSwiftcast = new("SMN_Opener_SkipSwiftcast", 1),
-
+            
             SMN_AoE_Lucid = new("SMN_AoE_Lucid", 8000),
             SMN_AoE_BurstPhase = new("SMN_AoE_BurstPhase", 1),
+            SMN_AoE_CrimsonCycloneMeleeDistance = new("SMN_AoE_CrimsonCycloneMeleeDistance", 3),
             SMN_AoE_SwiftcastPhase = new("SMN_AoE_SwiftcastPhase", 1),
             SMN_AoE_Burst_Delay = new("SMN_AoE_Burst_Delay", 0),
-
+            
             SMN_VariantCure = new("SMN_VariantCure"),
             SMN_Balance_Content = new("SMN_Balance_Content", 1);
 
@@ -37,130 +38,138 @@ internal partial class SMN
             SMN_ST_Searing_Any = new("SMN_ST_Searing_Any"),
             SMN_AoE_Searing_Any = new("SMN_AoE_Searing_Any");
 
-        internal static UserIntArray 
+        internal static UserIntArray
             SMN_ST_Egi_Priority = new("SMN_ST_Egi_Priority"),
-            SMN_AoE_Egi_Priority = new ("SMN_AoE_Egi_Priority");
+            SMN_AoE_Egi_Priority = new("SMN_AoE_Egi_Priority");
 
         internal static void Draw(CustomComboPreset preset)
         {
             switch (preset)
             {
                 case CustomComboPreset.SMN_ST_Advanced_Combo:
-                    DrawRadioButton(SMN_ST_Advanced_Combo_AltMode, $"On Ruin 1, 2, and 3", "", 0);
-                    DrawRadioButton(SMN_ST_Advanced_Combo_AltMode, $"On Ruin 1 and 2 Only", $"Alternative DPS Mode. Leaves Ruin 3 alone for pure DPS.", 1);
+                    DrawRadioButton(SMN_ST_Advanced_Combo_AltMode, "On Ruin 1, 2, and 3", "", 0);
+                    DrawRadioButton(SMN_ST_Advanced_Combo_AltMode, "On Ruin 1 and 2 Only", "Alternative DPS Mode. Leaves Ruin 3 alone for pure DPS.", 1);
                     break;
 
                 case CustomComboPreset.SMN_ST_Advanced_Combo_Balance_Opener:
-                    
-                    UserConfig.DrawBossOnlyChoice(SMN_Balance_Content);
+
+                    DrawBossOnlyChoice(SMN_Balance_Content);
 
                     ImGui.NewLine();
 
-                    UserConfig.DrawHorizontalRadioButton(SMN_Opener_SkipSwiftcast, "Use Swiftcast",
+                    DrawHorizontalRadioButton(SMN_Opener_SkipSwiftcast, "Use Swiftcast",
                         "Will use Swiftcast in opener to try and snapshot in pots for lower gcds", 1);
 
-                    UserConfig.DrawHorizontalRadioButton(SMN_Opener_SkipSwiftcast, "Skip Swiftcast",
+                    DrawHorizontalRadioButton(SMN_Opener_SkipSwiftcast, "Skip Swiftcast",
                         "Will not use swiftcast in opener for higher gcds", 2);
                     break;
 
-                case CustomComboPreset.SMN_ST_Advanced_Combo_Titan:                    
-                    UserConfig.DrawPriorityInput(SMN_ST_Egi_Priority, 3, 0,
+                case CustomComboPreset.SMN_ST_Advanced_Combo_Titan:
+                    DrawPriorityInput(SMN_ST_Egi_Priority, 3, 0,
                         $"{SummonTopaz.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SMN_ST_Advanced_Combo_Garuda:
-                    UserConfig.DrawPriorityInput(SMN_ST_Egi_Priority, 3, 1,
+                    DrawPriorityInput(SMN_ST_Egi_Priority, 3, 1,
                         $"{SummonEmerald.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SMN_ST_Advanced_Combo_Ifrit:
-                    UserConfig.DrawPriorityInput(SMN_ST_Egi_Priority, 3, 2,
+                    DrawPriorityInput(SMN_ST_Egi_Priority, 3, 2,
                         $"{SummonRuby.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SMN_AoE_Advanced_Combo_Titan:
-                    UserConfig.DrawPriorityInput(SMN_AoE_Egi_Priority, 3, 0,
+                    DrawPriorityInput(SMN_AoE_Egi_Priority, 3, 0,
                         $"{SummonTopaz.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SMN_AoE_Advanced_Combo_Garuda:
-                    UserConfig.DrawPriorityInput(SMN_AoE_Egi_Priority, 3, 1,
+                    DrawPriorityInput(SMN_AoE_Egi_Priority, 3, 1,
                         $"{SummonEmerald.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SMN_AoE_Advanced_Combo_Ifrit:
-                    UserConfig.DrawPriorityInput(SMN_AoE_Egi_Priority, 3, 2,
+                    DrawPriorityInput(SMN_AoE_Egi_Priority, 3, 2,
                         $"{SummonRuby.ActionName()} Priority: ");
-                    break;              
+                    break;
 
                 case CustomComboPreset.SMN_ST_Advanced_Combo_DemiEgiMenu_SwiftcastEgi:
-                    UserConfig.DrawHorizontalRadioButton(SMN_ST_SwiftcastPhase, "Garuda", "Swiftcasts Slipstream", 1);
+                    DrawHorizontalRadioButton(SMN_ST_SwiftcastPhase, "Garuda", "Swiftcasts Slipstream", 1);
 
-                    UserConfig.DrawHorizontalRadioButton(SMN_ST_SwiftcastPhase, "Ifrit", "Swiftcasts Ruby Ruin/Ruby Rite",
+                    DrawHorizontalRadioButton(SMN_ST_SwiftcastPhase, "Ifrit", "Swiftcasts Ruby Ruin/Ruby Rite",
                         2);
 
-                    UserConfig.DrawHorizontalRadioButton(SMN_ST_SwiftcastPhase, "Flexible (SpS) Option",
+                    DrawHorizontalRadioButton(SMN_ST_SwiftcastPhase, "Flexible (SpS) Option",
                         "Swiftcasts the first available Egi when Swiftcast is ready.", 3);
 
                     break;
 
                 case CustomComboPreset.SMN_AoE_Advanced_Combo_DemiEgiMenu_SwiftcastEgi:
-                    UserConfig.DrawHorizontalRadioButton(SMN_AoE_SwiftcastPhase, "Garuda", "Swiftcasts Slipstream", 1);
+                    DrawHorizontalRadioButton(SMN_AoE_SwiftcastPhase, "Garuda", "Swiftcasts Slipstream", 1);
 
-                    UserConfig.DrawHorizontalRadioButton(SMN_AoE_SwiftcastPhase, "Ifrit", "Swiftcasts Ruby Ruin/Ruby Rite",
+                    DrawHorizontalRadioButton(SMN_AoE_SwiftcastPhase, "Ifrit", "Swiftcasts Ruby Ruin/Ruby Rite",
                         2);
 
-                    UserConfig.DrawHorizontalRadioButton(SMN_AoE_SwiftcastPhase, "Flexible (SpS) Option",
+                    DrawHorizontalRadioButton(SMN_AoE_SwiftcastPhase, "Flexible (SpS) Option",
                         "Swiftcasts the first available Egi when Swiftcast is ready.", 3);
 
                     break;
 
                 case CustomComboPreset.SMN_ST_Advanced_Combo_Lucid:
-                    UserConfig.DrawSliderInt(4000, 9500, SMN_ST_Lucid,
+                    DrawSliderInt(4000, 9500, SMN_ST_Lucid,
                         "Set value for your MP to be at or under for this feature to take effect.", 150,
                         SliderIncrements.Hundreds);
 
                     break;
 
                 case CustomComboPreset.SMN_AoE_Advanced_Combo_Lucid:
-                    UserConfig.DrawSliderInt(4000, 9500, SMN_AoE_Lucid,
+                    DrawSliderInt(4000, 9500, SMN_AoE_Lucid,
                         "Set value for your MP to be at or under for this feature to take effect.", 150,
                         SliderIncrements.Hundreds);
 
                     break;
 
                 case CustomComboPreset.SMN_Variant_Cure:
-                    UserConfig.DrawSliderInt(1, 100, SMN_VariantCure, "HP% to be at or under", 200);
+                    DrawSliderInt(1, 100, SMN_VariantCure, "HP% to be at or under", 200);
 
                     break;
 
                 case CustomComboPreset.SMN_ST_Advanced_Combo_Egi_AstralFlow:
-                    {
-                        UserConfig.DrawHorizontalMultiChoice(SMN_ST_Egi_AstralFlow, "Add Mountain Buster", "", 4, 0);
-                        UserConfig.DrawHorizontalMultiChoice(SMN_ST_Egi_AstralFlow, "Add Crimson Cyclone", "", 4, 1);
-                        UserConfig.DrawHorizontalMultiChoice(SMN_ST_Egi_AstralFlow, "Add Crimson Strike", "", 4, 3);
-                        UserConfig.DrawHorizontalMultiChoice(SMN_ST_Egi_AstralFlow, "Add Slipstream", "", 4, 2);
+                {
+                    DrawHorizontalMultiChoice(SMN_ST_Egi_AstralFlow, "Add Mountain Buster", "", 4, 0);
+                    DrawHorizontalMultiChoice(SMN_ST_Egi_AstralFlow, "Add Crimson Cyclone", "", 4, 1);
+                    DrawHorizontalMultiChoice(SMN_ST_Egi_AstralFlow, "Add Crimson Strike", "", 4, 3);
+                    DrawHorizontalMultiChoice(SMN_ST_Egi_AstralFlow, "Add Slipstream", "", 4, 2);
 
-                        if (SMN_ST_Egi_AstralFlow[1])
-                            UserConfig.DrawAdditionalBoolChoice(SMN_ST_CrimsonCycloneMelee,
-                                "Enforced Crimson Cyclone Melee Check", "Only uses Crimson Cyclone within melee range.");
+                    if (SMN_ST_Egi_AstralFlow[1])
+                        DrawAdditionalBoolChoice(SMN_ST_CrimsonCycloneMelee,
+                            "Enforced Crimson Cyclone Melee Check", "Only uses Crimson Cyclone when range is equal or lower than.");
 
-                        break;
-                    }
+                    if (SMN_ST_CrimsonCycloneMelee)
+                        DrawSliderInt(1, 3, SMN_ST_CrimsonCycloneMeleeDistance,
+                            " Range of when to use Crimson Cyclone.");
+
+                    break;
+                }
 
                 case CustomComboPreset.SMN_AoE_Advanced_Combo_Egi_AstralFlow:
-                    {
-                        UserConfig.DrawHorizontalMultiChoice(SMN_AoE_Egi_AstralFlow, "Add Mountain Buster", "", 4, 0);
-                        UserConfig.DrawHorizontalMultiChoice(SMN_AoE_Egi_AstralFlow, "Add Crimson Cyclone", "", 4, 1);
-                        UserConfig.DrawHorizontalMultiChoice(SMN_AoE_Egi_AstralFlow, "Add Crimson Strike", "", 4, 3);
-                        UserConfig.DrawHorizontalMultiChoice(SMN_AoE_Egi_AstralFlow, "Add Slipstream", "", 4, 2);
+                {
+                    DrawHorizontalMultiChoice(SMN_AoE_Egi_AstralFlow, "Add Mountain Buster", "", 4, 0);
+                    DrawHorizontalMultiChoice(SMN_AoE_Egi_AstralFlow, "Add Crimson Cyclone", "", 4, 1);
+                    DrawHorizontalMultiChoice(SMN_AoE_Egi_AstralFlow, "Add Crimson Strike", "", 4, 3);
+                    DrawHorizontalMultiChoice(SMN_AoE_Egi_AstralFlow, "Add Slipstream", "", 4, 2);
 
-                        if (SMN_AoE_Egi_AstralFlow[1])
-                            UserConfig.DrawAdditionalBoolChoice(SMN_AoE_CrimsonCycloneMelee,
-                                "Enforced Crimson Cyclone Melee Check", "Only uses Crimson Cyclone within melee range.");
+                    if (SMN_AoE_Egi_AstralFlow[1])
+                        DrawAdditionalBoolChoice(SMN_AoE_CrimsonCycloneMelee,
+                            "Enforced Crimson Cyclone Melee Check", "Only uses Crimson Cyclone when range is equal or lower than.");
 
-                        break;
-                    }  
+                    if(SMN_AoE_CrimsonCycloneMelee)
+                        DrawSliderInt(1, 3, SMN_AoE_CrimsonCycloneMeleeDistance,
+                            " Range of when to use Crimson Cyclone.");
+
+                    break;
+                }
             }
         }
     }

--- a/WrathCombo/Combos/PvE/SMN/SMN_Config.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN_Config.cs
@@ -141,7 +141,7 @@ internal partial class SMN
                     DrawHorizontalMultiChoice(SMN_ST_Egi_AstralFlow, "Add Slipstream", "", 4, 2);
 
                     if (SMN_ST_Egi_AstralFlow[1])
-                        DrawSliderInt(0, 25, SMN_ST_CrimsonCycloneMeleeDistance, " Range of when to use Crimson Cyclone.");
+                        DrawSliderInt(0, 25, SMN_ST_CrimsonCycloneMeleeDistance, " Maximum range to use Crimson Cyclone.");
 
                     break;
                 }
@@ -154,7 +154,7 @@ internal partial class SMN
                     DrawHorizontalMultiChoice(SMN_AoE_Egi_AstralFlow, "Add Slipstream", "", 4, 2);
 
                     if (SMN_AoE_Egi_AstralFlow[1])
-                        DrawSliderInt(0, 25, SMN_AoE_CrimsonCycloneMeleeDistance, " Range of when to use Crimson Cyclone.");
+                        DrawSliderInt(0, 25, SMN_AoE_CrimsonCycloneMeleeDistance, " Maximum range to use Crimson Cyclone.");
 
                     break;
                 }

--- a/WrathCombo/Combos/PvE/SMN/SMN_Config.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN_Config.cs
@@ -33,8 +33,6 @@ internal partial class SMN
             SMN_AoE_Egi_AstralFlow = new("SMN_AoE_Egi_AstralFlow");
 
         public static UserBool
-            SMN_ST_CrimsonCycloneMelee = new("SMN_ST_CrimsonCycloneMelee"),
-            SMN_AoE_CrimsonCycloneMelee = new("SMN_AoE_CrimsonCycloneMelee"),
             SMN_ST_Searing_Any = new("SMN_ST_Searing_Any"),
             SMN_AoE_Searing_Any = new("SMN_AoE_Searing_Any");
 
@@ -143,12 +141,7 @@ internal partial class SMN
                     DrawHorizontalMultiChoice(SMN_ST_Egi_AstralFlow, "Add Slipstream", "", 4, 2);
 
                     if (SMN_ST_Egi_AstralFlow[1])
-                        DrawAdditionalBoolChoice(SMN_ST_CrimsonCycloneMelee,
-                            "Enforced Crimson Cyclone Melee Check", "Only uses Crimson Cyclone when range is equal or lower than.");
-
-                    if (SMN_ST_CrimsonCycloneMelee)
-                        DrawSliderInt(1, 3, SMN_ST_CrimsonCycloneMeleeDistance,
-                            " Range of when to use Crimson Cyclone.");
+                        DrawSliderInt(0, 25, SMN_ST_CrimsonCycloneMeleeDistance, " Range of when to use Crimson Cyclone.");
 
                     break;
                 }
@@ -161,12 +154,7 @@ internal partial class SMN
                     DrawHorizontalMultiChoice(SMN_AoE_Egi_AstralFlow, "Add Slipstream", "", 4, 2);
 
                     if (SMN_AoE_Egi_AstralFlow[1])
-                        DrawAdditionalBoolChoice(SMN_AoE_CrimsonCycloneMelee,
-                            "Enforced Crimson Cyclone Melee Check", "Only uses Crimson Cyclone when range is equal or lower than.");
-
-                    if(SMN_AoE_CrimsonCycloneMelee)
-                        DrawSliderInt(1, 3, SMN_AoE_CrimsonCycloneMeleeDistance,
-                            " Range of when to use Crimson Cyclone.");
+                        DrawSliderInt(0, 25, SMN_AoE_CrimsonCycloneMeleeDistance, " Range of when to use Crimson Cyclone.");
 
                     break;
                 }

--- a/WrathCombo/Combos/PvE/SMN/SMN_Config.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN_Config.cs
@@ -16,12 +16,12 @@ internal partial class SMN
             SMN_ST_BurstPhase = new("SMN_ST_BurstPhase", 1),
             SMN_ST_SwiftcastPhase = new("SMN_SwiftcastPhase", 1),
             SMN_ST_Burst_Delay = new("SMN_Burst_Delay", 0),
-            SMN_ST_CrimsonCycloneMeleeDistance = new("SMN_ST_CrimsonCycloneMeleeDistance", 3),
+            SMN_ST_CrimsonCycloneMeleeDistance = new("SMN_ST_CrimsonCycloneMeleeDistance", 25),
             SMN_Opener_SkipSwiftcast = new("SMN_Opener_SkipSwiftcast", 1),
             
             SMN_AoE_Lucid = new("SMN_AoE_Lucid", 8000),
             SMN_AoE_BurstPhase = new("SMN_AoE_BurstPhase", 1),
-            SMN_AoE_CrimsonCycloneMeleeDistance = new("SMN_AoE_CrimsonCycloneMeleeDistance", 3),
+            SMN_AoE_CrimsonCycloneMeleeDistance = new("SMN_AoE_CrimsonCycloneMeleeDistance", 25),
             SMN_AoE_SwiftcastPhase = new("SMN_AoE_SwiftcastPhase", 1),
             SMN_AoE_Burst_Delay = new("SMN_AoE_Burst_Delay", 0),
             

--- a/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
@@ -54,7 +54,9 @@ internal partial class VPR
             !IsEmpowermentExpiring(6))
         {
             //Use whenever
-            if (SerpentOffering >= 50 && TargetIsBoss() && GetTargetHPPercent() < VPR_ST_ReAwaken_Threshold)
+            if (SerpentOffering >= 50 && TargetIsBoss() &&
+                ((IsEnabled(CustomComboPreset.VPR_ST_SimpleMode) && GetTargetHPPercent() < 5) ||
+                 (IsEnabled(CustomComboPreset.VPR_ST_AdvancedMode) && GetTargetHPPercent() < VPR_ST_ReAwaken_Threshold)))
                 return true;
 
             //2min burst


### PR DESCRIPTION
DRG
- Make `CanDRGWeave` an expression

MCH
- better phrasing of queen usage in MCH ST (no functional changes)

BLM
- Optimize `B1/B3` standalone option
  <img width="678" height="193" alt="image" src="https://github.com/user-attachments/assets/50bfa4df-fd96-4eef-9f14-102809300429" />
- Optimize `F1/F3` standalone option
  <img width="676" height="178" alt="image" src="https://github.com/user-attachments/assets/a6d98291-6889-44a0-9bb9-5f3bf6b8df05" />
- Add combat check to `Fire 4 to 3`
  <img width="667" height="130" alt="image" src="https://github.com/user-attachments/assets/abec9fb0-51a9-45be-9cca-3fc6fc66cac2" />
- Add new standalone option `Freeze to Paradox`
  <img width="741" height="130" alt="image" src="https://github.com/user-attachments/assets/d6d659ff-e3dc-4892-9e32-80fbca3f64b2" />
- Add new standalone option `Flarestar to Paradox`
  <img width="741" height="94" alt="image" src="https://github.com/user-attachments/assets/fb345575-b79d-4f38-9fc8-13c712fa68b5" />
- Add new standalone option `Freeze to Blizzard II`
  <img width="749" height="128" alt="image" src="https://github.com/user-attachments/assets/3ca219ce-eb17-4ea5-8ab3-1942f3d49843" />
- Fix `ActionReady` and `Levelchecked` usage
- Added Levelchecks for pre 35 Transpose usage
- Fixes #698 

VPR
- Add better Reawaken usage for Simple mode ( dont use below 5%)

SMN
- Add Crimson Cyclone range slider
   <img width="704" height="127" alt="image" src="https://github.com/user-attachments/assets/b0315022-8b12-46f7-9556-700b263bc516" />
