### PR TITLE
[UI] Update Sidebar's default size, +min size, +collapse button

### DIFF
--- a/WrathCombo/Core/PluginConfiguration.cs
+++ b/WrathCombo/Core/PluginConfiguration.cs
@@ -128,6 +128,8 @@ namespace WrathCombo.Core
         public bool ShowHiddenFeatures = false;
 
         public bool SuppressQueuedActions = true;
+        
+        public bool UILeftColumnCollapsed = false;
 
         #endregion
 

--- a/WrathCombo/Window/ConfigWindow.cs
+++ b/WrathCombo/Window/ConfigWindow.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using Dalamud.Interface;
 using Dalamud.Interface.Colors;
 using ECommons.Logging;
 using ECommons.Throttlers;
@@ -19,6 +20,7 @@ using WrathCombo.Combos;
 using WrathCombo.Combos.PvE;
 using WrathCombo.Core;
 using WrathCombo.Data;
+using WrathCombo.Services;
 using WrathCombo.Window.Tabs;
 
 namespace WrathCombo.Window
@@ -99,15 +101,23 @@ namespace WrathCombo.Window
             var topLeftSideHeight = region.Y;
             var columns = 2;
             var tableName = "###MainTable";
+            if (Service.Configuration.UILeftColumnCollapsed)
+            {
+                columns = 1;
+                tableName = "###NoSidebarMainTable";
+            }
             
             using var style = ImRaii.PushStyle(ImGuiStyleVar.CellPadding, new Vector2(4, 0).Scale());
             using (var table = ImRaii.Table(tableName, columns, ImGuiTableFlags.Resizable)) {
                 if (!table) return;
                 
-                DrawSidebar(topLeftSideHeight);
+                if (!Service.Configuration.UILeftColumnCollapsed)
+                    DrawSidebar(topLeftSideHeight);
                 
                 DrawBody();
             }
+            
+            DrawCollapseButton();
         }
 
         private void DrawSidebar(float topLeftSideHeight)
@@ -259,6 +269,25 @@ namespace WrathCombo.Window
                     AutoRotationTab.Draw();
                     break;
             };
+        }
+
+        private void DrawCollapseButton()
+        {
+            // Go to the bottom of the window
+            ImGui.SetCursorPos(ImGui.GetCursorPos() with
+            {
+                X = ImGui.GetStyle().WindowPadding.X,
+                Y = ImGui.GetWindowSize().Y - ImGui.GetStyle().WindowPadding.Y*2 -
+                    ImGui.GetTextLineHeight(),
+            });
+            using var overlay = ImRaii.Child("ButtonOverlay", Vector2.Zero, false, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoBackground);
+            if (!overlay) return;
+            
+            if (ImGuiEx.IconButton(FontAwesomeIcon.CaretLeft))
+                Service.Configuration.UILeftColumnCollapsed =
+                    !Service.Configuration.UILeftColumnCollapsed;
+            if (ImGui.IsItemHovered())
+                ImGui.SetTooltip("Collapse this Sidebar");
         }
 
 


### PR DESCRIPTION
- [X] Changes the default size of the plugin's Left Column (the column with the tabs and icon)
      It is now the width of the plugin icon, plus some, instead of 1/3 the window size.
- [X] Adds a minimum size to the Left Column
      (which is the plugin icon's width)
      If the user reduces the size below the minimum, the column sets itself to be non-resizable (to stop the drag event), and sets itself to the default column width.
- [X] Adds a collapse button, at the bottom left
      To prevent the loss of being able to crunch the sidebar down to its minimum size (which was never zero) I have also added a collapse button.
      When pressed, it redraws the window to a table with a singular column for only the body of the content, removing the sidebar.
      (note: this also changes the ID of the table, to prevent the sidebar being set to the full width of the window when un-collapsed after being collapsed)

> The code diff is not particularly readable on GitHub nor SemanticDiff, because the code needed broken into different methods to support conditional rendering.
> I would recommend just pulling this PR and trying it instead of trying to look at these diffs.