### PR TITLE
[AST] Early Stellar Detonation Option + dancer tiny fix for level check

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -664,6 +664,10 @@ public enum CustomComboPreset
     [CustomComboInfo("Earthly Star Option", "Adds Earthly Star placement, but not detonation, to the rotation.\nWill be targeted to any enemy, then your focus target, then soft and hard targets, before falling back to placing it at your feet.", AST.JobID)]
     [Retargeted]
     AST_ST_DPS_EarthlyStar = 1051,
+    
+    [ParentCombo(AST_ST_DPS)]
+    [CustomComboInfo("Stellar Detonation Option", "Adds early Stellar Detonation with Giant Dominance based on targets HP percentage and type of encounter", AST.JobID)]
+    AST_ST_DPS_StellarDetonation = 1081,
 
     [ParentCombo(AST_ST_DPS)]
     [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value", AST.JobID)]
@@ -727,6 +731,10 @@ public enum CustomComboPreset
     [CustomComboInfo("Earthly Star Option", "Adds Earthly Star placement, but not detonation, to the rotation.\nWill be targeted to your focus target, then soft and hard targets, before falling back to placing it at your feet.", AST.JobID)]
     [Retargeted]
     AST_AOE_DPS_EarthlyStar = 1052,
+    
+    [ParentCombo(AST_AOE_DPS)]
+    [CustomComboInfo("Stellar Detonation Option", "Adds early Stellar Detonation with Giant Dominance based on targets HP percentage and type of encounter", AST.JobID)]
+    AST_AOE_DPS_StellarDetonation = 1082,
 
     [ParentCombo(AST_AOE_DPS)]
     [CustomComboInfo("MacroCosmos Option", "Adds Macrocosmos to the Aoe rotation after 3 GCDs", AST.JobID)]    

--- a/WrathCombo/Combos/PvE/AST/AST.cs
+++ b/WrathCombo/Combos/PvE/AST/AST.cs
@@ -210,6 +210,13 @@ internal partial class AST : Healer
                     IsOffCooldown(EarthlyStar) && CanWeave())
                     return EarthlyStar.Retarget(replacedActions,
                         SimpleTarget.AnyEnemy ?? SimpleTarget.Stack.Allies);
+                
+                //Stellar Detonation
+                if (IsEnabled(CustomComboPreset.AST_ST_DPS_StellarDetonation) && CanWeave() &&
+                    HasStatusEffect(Buffs.GiantDominance, anyOwner:false) && HasBattleTarget() &&
+                    GetTargetHPPercent() <= Config.AST_ST_DPS_StellarDetonation_Threshold && 
+                    (Config.AST_ST_DPS_StellarDetonation_SubOption == 1 || !InBossEncounter()))
+                    return StellarDetonation;
 
                 //Oracle
                 if (IsEnabled(CustomComboPreset.AST_DPS_Oracle) &&
@@ -386,7 +393,14 @@ internal partial class AST : Healer
                 IsOffCooldown(EarthlyStar) && CanWeave() &&
                 ActionWatching.NumberOfGcdsUsed >= 3)
                 return EarthlyStar.Retarget(GravityList.ToArray(),
-                    SimpleTarget.AnyEnemy ?? SimpleTarget.Stack.Allies);            
+                    SimpleTarget.AnyEnemy ?? SimpleTarget.Stack.Allies); 
+            
+            //Stellar Detonation
+            if (IsEnabled(CustomComboPreset.AST_AOE_DPS_StellarDetonation) && CanWeave() &&
+                HasStatusEffect(Buffs.GiantDominance, anyOwner:false) && HasBattleTarget() &&
+                GetTargetHPPercent() <= Config.AST_AOE_DPS_StellarDetonation_Threshold && 
+                (Config.AST_AOE_DPS_StellarDetonation_SubOption == 1 || !InBossEncounter()))
+                return StellarDetonation;
             
             //Oracle
             if (IsEnabled(CustomComboPreset.AST_AOE_Oracle) &&

--- a/WrathCombo/Combos/PvE/AST/AST_Config.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Config.cs
@@ -49,10 +49,14 @@ internal partial class AST
             AST_ST_DPS_DivinationSubOption = new("AST_ST_DPS_DivinationSubOption", 0),
             AST_ST_DPS_Balance_Content = new("AST_ST_DPS_Balance_Content", 1),
             AST_ST_DPS_CombustSubOption = new("AST_ST_DPS_CombustSubOption", 0),
+            AST_ST_DPS_StellarDetonation_Threshold = new("AST_ST_DPS_StellarDetonation_Threshold", 0),
+            AST_ST_DPS_StellarDetonation_SubOption = new("AST_ST_DPS_StellarDetonation_SubOption", 0),
             AST_AOE_LucidDreaming = new("AST_AOE_LucidDreaming", 8000),
             AST_AOE_DivinationSubOption = new("AST_AOE_DivinationSubOption", 0),
             AST_AOE_DivinationOption = new("AST_AOE_DivinationOption"),
             AST_AOE_LightSpeedOption = new("AST_AOE_LightSpeedOption"),
+            AST_AOE_DPS_StellarDetonation_Threshold = new("AST_AOE_DPS_StellarDetonation_Threshold", 0),
+            AST_AOE_DPS_StellarDetonation_SubOption = new("AST_AOE_DPS_StellarDetonation_SubOption", 0),
             AST_AOE_DPS_MacroCosmos_SubOption = new("AST_AOE_DPS_MacroCosmos_SubOption", 0),
             AST_QuickTarget_Override = new("AST_QuickTarget_Override", 0);
 
@@ -135,6 +139,17 @@ internal partial class AST
                     DrawAdditionalBoolChoice(AST_ST_DPS_OverwriteHealCards, "Overwrite Non-DPS Cards", "Will draw even if you have healing cards remaining.");
                     break;
                 
+                case CustomComboPreset.AST_ST_DPS_StellarDetonation:
+                    DrawHorizontalRadioButton(AST_ST_DPS_StellarDetonation_SubOption,
+                        "Non-boss Encounters Only", $"Non-Boss Encounters only", 0);
+
+                    DrawHorizontalRadioButton(AST_ST_DPS_StellarDetonation_SubOption,
+                        "All Content", $"All Content", 1);
+                    
+                    DrawSliderInt(0, 100, AST_ST_DPS_StellarDetonation_Threshold,
+                        $"Use when Target is at or below HP% (0% = Never Detonate Early, 100% = Detonate ASAP).");
+                    break;
+                
                 case CustomComboPreset.AST_AOE_Lucid:
                     DrawSliderInt(4000, 9500, AST_AOE_LucidDreaming, "Set value for your MP to be at or under for this feature to work", 150, Hundreds);
                     break;
@@ -156,6 +171,17 @@ internal partial class AST
 
                 case CustomComboPreset.AST_AOE_AutoDraw:
                     DrawAdditionalBoolChoice(AST_AOE_DPS_OverwriteHealCards, "Overwrite Non-DPS Cards", "Will draw even if you have healing cards remaining.");
+                    break;
+                
+                case CustomComboPreset.AST_AOE_DPS_StellarDetonation:
+                    DrawHorizontalRadioButton(AST_AOE_DPS_StellarDetonation_SubOption,
+                        "Non-boss Encounters Only", $"Non-Boss Encounters only", 0);
+
+                    DrawHorizontalRadioButton(AST_AOE_DPS_StellarDetonation_SubOption,
+                        "All Content", $"All Content", 1);
+                    
+                    DrawSliderInt(0, 100, AST_AOE_DPS_StellarDetonation_Threshold,
+                        $"Use when Target is at or below HP% (0% = Never Detonate Early, 100% = Detonate ASAP).");
                     break;
 
                 case CustomComboPreset.AST_AOE_DPS_MacroCosmos:

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -221,7 +221,9 @@ internal partial class DNC : PhysicalRanged
             }
 
             // Dance Partner
-            if (IsEnabled(CustomComboPreset.DNC_ST_Adv_AutoPartner) && LevelChecked(ClosedPosition) && IsOffCooldown(ClosedPosition) &&
+            if (IsEnabled(CustomComboPreset.DNC_ST_Adv_AutoPartner) &&
+                LevelChecked(ClosedPosition) &&
+                IsOffCooldown(ClosedPosition) &&
                 CanWeave() &&
                 CurrentPartnerNonOptimal)
                 return HasStatusEffect(Buffs.ClosedPosition)
@@ -550,7 +552,8 @@ internal partial class DNC : PhysicalRanged
             }
 
             // Dance Partner
-            if (CanWeave() && LevelChecked(ClosedPosition) && IsOffCooldown(ClosedPosition) &&
+            if (CanWeave() && LevelChecked(ClosedPosition) &&
+                IsOffCooldown(ClosedPosition) &&
                 CurrentPartnerNonOptimal)
                 return HasStatusEffect(Buffs.ClosedPosition)
                     ? Ending

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -221,7 +221,7 @@ internal partial class DNC : PhysicalRanged
             }
 
             // Dance Partner
-            if (IsEnabled(CustomComboPreset.DNC_ST_Adv_AutoPartner) && LevelChecked(ClosedPosition) &&
+            if (IsEnabled(CustomComboPreset.DNC_ST_Adv_AutoPartner) && ActionReady(ClosedPosition) &&
                 CanWeave() &&
                 CurrentPartnerNonOptimal)
                 return HasStatusEffect(Buffs.ClosedPosition)
@@ -550,7 +550,7 @@ internal partial class DNC : PhysicalRanged
             }
 
             // Dance Partner
-            if (CanWeave() && LevelChecked(ClosedPosition) &&
+            if (CanWeave() && ActionReady(ClosedPosition) &&
                 CurrentPartnerNonOptimal)
                 return HasStatusEffect(Buffs.ClosedPosition)
                     ? Ending

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -221,7 +221,7 @@ internal partial class DNC : PhysicalRanged
             }
 
             // Dance Partner
-            if (IsEnabled(CustomComboPreset.DNC_ST_Adv_AutoPartner) && ActionReady(ClosedPosition) &&
+            if (IsEnabled(CustomComboPreset.DNC_ST_Adv_AutoPartner) && LevelChecked(ClosedPosition) && IsOffCooldown(ClosedPosition) &&
                 CanWeave() &&
                 CurrentPartnerNonOptimal)
                 return HasStatusEffect(Buffs.ClosedPosition)
@@ -550,7 +550,7 @@ internal partial class DNC : PhysicalRanged
             }
 
             // Dance Partner
-            if (CanWeave() && ActionReady(ClosedPosition) &&
+            if (CanWeave() && LevelChecked(ClosedPosition) && IsOffCooldown(ClosedPosition) &&
                 CurrentPartnerNonOptimal)
                 return HasStatusEffect(Buffs.ClosedPosition)
                     ? Ending

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -221,7 +221,7 @@ internal partial class DNC : PhysicalRanged
             }
 
             // Dance Partner
-            if (IsEnabled(CustomComboPreset.DNC_ST_Adv_AutoPartner) &&
+            if (IsEnabled(CustomComboPreset.DNC_ST_Adv_AutoPartner) && LevelChecked(ClosedPosition) &&
                 CanWeave() &&
                 CurrentPartnerNonOptimal)
                 return HasStatusEffect(Buffs.ClosedPosition)
@@ -550,7 +550,7 @@ internal partial class DNC : PhysicalRanged
             }
 
             // Dance Partner
-            if (CanWeave() &&
+            if (CanWeave() && LevelChecked(ClosedPosition) &&
                 CurrentPartnerNonOptimal)
                 return HasStatusEffect(Buffs.ClosedPosition)
                     ? Ending


### PR DESCRIPTION
<img width="757" height="129" alt="image" src="https://github.com/user-attachments/assets/6523b835-e462-4ac8-b205-1d56325a61da" />

Added option for early stellar detonation, with boss toggle and hp slider to help prevent waste on dungeon trash. Properly set for non bosses would not interfere with the party hp check for aoe healing that also exists. At least how I would use it. 

did a quick fix for dancer issue not using fans at lower levels. it was being blocked in st from it trying to pick a dance partner before it was high enough to use closed position