### PR TITLE
[WHM] Priority Treatment

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -7765,6 +7765,11 @@ public enum CustomComboPreset
     [CustomComboInfo("Afflatus Misery Option", "Adds Afflatus Misery to the AoE combo when it is ready to be used.",
         WHM.JobID)]
     WHM_AoE_DPS_Misery = 19194,
+    
+    [ParentCombo(WHM_AoE_DPS)]
+    [CustomComboInfo("Multitarget Dot Option", "Maintains dots on multiple targets.",
+        WHM.JobID)]
+    WHM_AoE_MainCombo_DoT = 19198,
 
     [ParentCombo(WHM_AoE_DPS)]
     [CustomComboInfo("Lily Overcap Protection Option", "Adds Afflatus Rapture to the AoE combo when at three Lilies.",
@@ -7941,9 +7946,6 @@ public enum CustomComboPreset
     #endregion
     
     #region DPS Small Features
-
-    
-    
     
     [ReplaceSkill(WHM.AfflatusSolace)]
     [CustomComboInfo("Solace into Misery Feature",

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -7789,54 +7789,64 @@ public enum CustomComboPreset
     [PossiblyRetargeted]
     [HealingCombo]
     WHM_STHeals = 19300,
-
+    
     [ParentCombo(WHM_STHeals)]
-    [CustomComboInfo("Regen Option", "Applies Regen to the target if missing.", WHM.JobID)]
+    [CustomComboInfo("Esuna Option", "Applies Esuna to your target if there is a cleansable debuff.", WHM.JobID)]
     [PossiblyRetargeted]
-    WHM_STHeals_Regen = 19301,
-
+    WHM_STHeals_Esuna = 19309,
+    
     [ParentCombo(WHM_STHeals)]
-    [CustomComboInfo("Benediction Option", "Uses Benediction when target is below HP threshold.", WHM.JobID)]
-    [PossiblyRetargeted]
-    WHM_STHeals_Benediction = 19302,
-
-    [ParentCombo(WHM_STHeals)]
-    [CustomComboInfo("Afflatus Solace Option", "Uses Afflatus Solace when available.", WHM.JobID)]
-    [PossiblyRetargeted]
-    WHM_STHeals_Solace = 19303,
-
+    [CustomComboInfo("Lucid Dreaming Option", "Uses Lucid Dreaming when available.", WHM.JobID)]
+    WHM_STHeals_Lucid = 19308,
+    
     [ParentCombo(WHM_STHeals)]
     [CustomComboInfo("Thin Air Option", "Uses Thin Air when available.", WHM.JobID)]
     WHM_STHeals_ThinAir = 19304,
 
     [ParentCombo(WHM_STHeals)]
-    [CustomComboInfo("Tetragrammaton Option", "Uses Tetragrammaton when available.", WHM.JobID)]
+    [CustomComboInfo("Regen Option", "Adds Regen.", WHM.JobID)]
+    [PossiblyRetargeted]
+    WHM_STHeals_Regen = 19301,
+
+    [ParentCombo(WHM_STHeals)]
+    [CustomComboInfo("Afflatus Solace Option", "Adds Afflatus Solace", WHM.JobID)]
+    [PossiblyRetargeted]
+    WHM_STHeals_Solace = 19303,
+
+    [ParentCombo(WHM_STHeals)]
+    [CustomComboInfo("Tetragrammaton Option", "Adds Tetragrammaton.", WHM.JobID)]
     [PossiblyRetargeted]
     WHM_STHeals_Tetragrammaton = 19305,
 
     [ParentCombo(WHM_STHeals)]
-    [CustomComboInfo("Divine Benison Option", "Uses Divine Benison when available.", WHM.JobID)]
+    [CustomComboInfo("Divine Benison Option", "Adds Divine Benison.", WHM.JobID)]
     [PossiblyRetargeted]
     WHM_STHeals_Benison = 19306,
 
     [ParentCombo(WHM_STHeals)]
-    [CustomComboInfo("Aquaveil Option", "Uses Aquaveil when available.", WHM.JobID)]
+    [CustomComboInfo("Aquaveil Option", "Adds Aquaveil.", WHM.JobID)]
     [PossiblyRetargeted]
     WHM_STHeals_Aquaveil = 19307,
+    
+    [ParentCombo(WHM_STHeals)]
+    [CustomComboInfo("Benediction Option", "Adds Benediciton.", WHM.JobID)]
+    [PossiblyRetargeted]
+    WHM_STHeals_Benediction = 19302,
 
     [ParentCombo(WHM_STHeals)]
-    [CustomComboInfo("Lucid Dreaming Option", "Uses Lucid Dreaming when available.", WHM.JobID)]
-    WHM_STHeals_Lucid = 19308,
-
-    [ParentCombo(WHM_STHeals)]
-    [CustomComboInfo("Temperance Option", "Uses Temperance when available for mitigation and healing boost.", WHM.JobID)]
+    [CustomComboInfo("Temperance Option", "Adds Temperance and it's followup Divine Caress.", WHM.JobID)]
     [PossiblyRetargeted]
     WHM_STHeals_Temperance = 19310,
-
+    
     [ParentCombo(WHM_STHeals)]
-    [CustomComboInfo("Esuna Option", "Applies Esuna to your target if there is a cleansable debuff.", WHM.JobID)]
+    [CustomComboInfo("Asylum Option", "Adds Asylum.", WHM.JobID)]
     [PossiblyRetargeted]
-    WHM_STHeals_Esuna = 19309,
+    WHM_STHeals_Asylum = 19311,
+    
+    [ParentCombo(WHM_STHeals)]
+    [CustomComboInfo("LiturgyOfTheBell Option", "Adds LiturgyOfTheBell.", WHM.JobID)]
+    [PossiblyRetargeted]
+    WHM_STHeals_LiturgyOfTheBell = 19312,
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -7897,6 +7897,31 @@ public enum CustomComboPreset
     
     #endregion
     
+    #region Raidwide Heals
+    
+    #region Hidden Features
+    [CustomComboInfo("Boss Raidwide Options", "Collection of tools designed to try and cast during a raidwide attack when detected." +
+                                       "\nThis will work for most, but not all raidwide attacks and is no substitute for learning the fight", WHM.JobID)]
+    WHM_Raidwide = 19220,
+    
+    [ParentCombo(WHM_Raidwide)]
+    [CustomComboInfo("RaidWide Asylum Option", "Will try to Weave Asylum when a raidwide casting. \nWill be used in all 4 main combos.", WHM.JobID)]
+    WHM_Raidwide_Asylum = 19221,
+    
+    [ParentCombo(WHM_Raidwide)]
+    [CustomComboInfo("RaidWide Temperance Combo Option", "Will try to Weave Temperance and Divine Caress when a raidwide casting. " +
+                                                           "\nWill be used in all 4 main combos.", WHM.JobID)]
+    WHM_Raidwide_Temperance = 19222,
+    
+    [ParentCombo(WHM_Raidwide)]
+    [CustomComboInfo("RaidWide LiturgyOfTheBell Option", "Will try to weave LiturgyOfTheBell when a raidwide casting. " +
+                                                        "\nWill be used in all 4 main combos.", WHM.JobID)]
+    WHM_Raidwide_LiturgyOfTheBell = 19223,
+    
+    #endregion
+    
+    #endregion
+    
     #region DPS Small Features
 
     [ReplaceSkill(WHM.AfflatusSolace)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -7709,17 +7709,9 @@ public enum CustomComboPreset
     WHM_ST_MainCombo_Opener = 19023,
 
     [ParentCombo(WHM_ST_MainCombo)]
-    [CustomComboInfo("Movement Options", "Various options to keep you casting while moving.", WHM.JobID)]
-    WHM_ST_MainCombo_Movement = 19052,
-
-    [ParentCombo(WHM_ST_MainCombo_Movement)]
-    [CustomComboInfo("DoT Option", "Will reapply DoT early to all enemies within range while moving.", WHM.JobID)]
+    [CustomComboInfo("Movement DoT Option", "Will reapply DoT early to all enemies within range while moving.", WHM.JobID)]
     [Retargeted]
     WHM_ST_MainCombo_Move_DoT = 19053,
-
-    [ParentCombo(WHM_ST_MainCombo_Movement)]
-    [CustomComboInfo("Afflatus Misery Option", "Will prioritize Afflatus Misery higher while moving.", WHM.JobID)]
-    WHM_ST_MainCombo_Move_Lily = 19054,
 
     [ParentCombo(WHM_ST_MainCombo)]
     [CustomComboInfo("Aero/Dia Uptime Option",

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -7766,20 +7766,6 @@ public enum CustomComboPreset
 
     #endregion
 
-    #region DPS Small Features
-
-    [ReplaceSkill(WHM.AfflatusSolace)]
-    [CustomComboInfo("Solace into Misery Feature",
-        "Replaces Afflatus Solace with Afflatus Misery when it is ready to be used.", WHM.JobID)]
-    WHM_SolaceMisery = 19000,
-
-    [ReplaceSkill(WHM.AfflatusRapture)]
-    [CustomComboInfo("Rapture into Misery Feature",
-        "Replaces Afflatus Rapture with Afflatus Misery when it is ready to be used.", WHM.JobID)]
-    WHM_RaptureMisery = 19001,
-
-    #endregion
-
     #region Single Target Heals
 
     [AutoAction(false, true)]
@@ -7857,18 +7843,27 @@ public enum CustomComboPreset
     [CustomComboInfo("Advanced Healing Mode - AoE", "Replaces Medica with a one button AoE healing setup.", WHM.JobID)]
     [HealingCombo]
     WHM_AoEHeals = 19007,
+    
+    [ParentCombo(WHM_AoEHeals)]
+    [CustomComboInfo("Lucid Dreaming Option", "Uses Lucid Dreaming when available.", WHM.JobID)]
+    WHM_AoEHeals_Lucid = 19204,
+    
+    [ParentCombo(WHM_AoEHeals)]
+    [CustomComboInfo("Thin Air Option", "Uses Thin Air when available.", WHM.JobID)]
+    WHM_AoEHeals_ThinAir = 19200,
+    
+    [ParentCombo(WHM_AoEHeals)]
+    [CustomComboInfo("Afflatus Misery Option", "Uses Afflatus Misery when available.", WHM.JobID)]
+    WHM_AoEHeals_Misery = 19010,
+    
+    [ParentCombo(WHM_AoEHeals)]
+    [CustomComboInfo("Medica II Option", "Uses Medica II when current target doesn't have Medica II buff." +
+                                         "\nUpgrades to Medica III when level allows.", WHM.JobID)]
+    WHM_AoEHeals_Medica2 = 19205,
 
     [ParentCombo(WHM_AoEHeals)]
     [CustomComboInfo("Afflatus Rapture Option", "Uses Afflatus Rapture when available.", WHM.JobID)]
     WHM_AoEHeals_Rapture = 19011,
-
-    [ParentCombo(WHM_AoEHeals)]
-    [CustomComboInfo("Afflatus Misery Option", "Uses Afflatus Misery when available.", WHM.JobID)]
-    WHM_AoEHeals_Misery = 19010,
-
-    [ParentCombo(WHM_AoEHeals)]
-    [CustomComboInfo("Thin Air Option", "Uses Thin Air when available.", WHM.JobID)]
-    WHM_AoEHeals_ThinAir = 19200,
 
     [ParentCombo(WHM_AoEHeals)]
     [CustomComboInfo("Cure III Option", "Replaces Medica with Cure III when available.", WHM.JobID)]
@@ -7881,19 +7876,15 @@ public enum CustomComboPreset
     [ParentCombo(WHM_AoEHeals)]
     [CustomComboInfo("Plenary Indulgence Option", "Uses Plenary Indulgence when available.", WHM.JobID)]
     WHM_AoEHeals_Plenary = 19203,
+    
+    [ParentCombo(WHM_AoEHeals)]
+    [CustomComboInfo("Asylum Option", "Adds Asylum placement, when standing still, to the rotation.\nWill Retarget it onto yourself.", WHM.JobID)]
+    [Retargeted]
+    WHM_AoEHeals_Asylum = 19028,
 
     [ParentCombo(WHM_AoEHeals)]
     [CustomComboInfo("Temperance Option", "Uses Temperance when available for a healing boost whenever the party average falls below the set threshold.", WHM.JobID)]
     WHM_AoEHeals_Temperance = 19210,
-
-    [ParentCombo(WHM_AoEHeals)]
-    [CustomComboInfo("Lucid Dreaming Option", "Uses Lucid Dreaming when available.", WHM.JobID)]
-    WHM_AoEHeals_Lucid = 19204,
-
-    [ParentCombo(WHM_AoEHeals)]
-    [CustomComboInfo("Medica II Option", "Uses Medica II when current target doesn't have Medica II buff." +
-                                         "\nUpgrades to Medica III when level allows.", WHM.JobID)]
-    WHM_AoEHeals_Medica2 = 19205,
 
     [ParentCombo(WHM_AoEHeals)]
     [CustomComboInfo("Divine Caress", "Uses Divine Caress when Divine Grace from Temperance is active.", WHM.JobID)]
@@ -7903,31 +7894,20 @@ public enum CustomComboPreset
     [CustomComboInfo("Liturgy of the Bell Option", "Adds Liturgy of the Bell (Lilybell) placement to the rotation.", WHM.JobID)]
     [Retargeted]
     WHM_AoEHeals_LiturgyOfTheBell = 19206,
+    
+    #endregion
+    
+    #region DPS Small Features
 
-    [ParentCombo(WHM_AoEHeals_LiturgyOfTheBell)]
-    [CustomComboInfo("Enemy Placement Option", "Will add an enemy hard target as the top priority placement for Liturgy of the Bell.", WHM.JobID)]
-    [Retargeted]
-    WHM_AoEHeals_LiturgyOfTheBell_Enemy = 19208,
+    [ReplaceSkill(WHM.AfflatusSolace)]
+    [CustomComboInfo("Solace into Misery Feature",
+        "Replaces Afflatus Solace with Afflatus Misery when it is ready to be used.", WHM.JobID)]
+    WHM_SolaceMisery = 19000,
 
-    [ParentCombo(WHM_AoEHeals_LiturgyOfTheBell)]
-    [CustomComboInfo("Ally Placement Option", "Will add any ally UI MouseOver target, focus target, soft target, or hard target as the priority placement for Liturgy of the Bell.\nBeneath the Enemy placement option, but above yourself.", WHM.JobID)]
-    [Retargeted]
-    WHM_AoEHeals_LiturgyOfTheBell_Allies = 19209,
-
-    [ParentCombo(WHM_AoEHeals)]
-    [CustomComboInfo("Asylum Option", "Adds Asylum placement, when standing still, to the rotation.\nWill Retarget it onto yourself.", WHM.JobID)]
-    [Retargeted]
-    WHM_AoEHeals_Asylum = 19028,
-
-    [ParentCombo(WHM_AoEHeals_Asylum)]
-    [CustomComboInfo("Enemy Placement Option", "Will add an enemy hard target as the top priority Retarget for Asylum.", WHM.JobID)]
-    [Retargeted]
-    WHM_AoEHeals_Asylum_Enemy = 19030,
-
-    [ParentCombo(WHM_AoEHeals_Asylum)]
-    [CustomComboInfo("Ally Placement Option", "Will add any ally UI MouseOver target, focus target, soft target, or hard target as the priority Retarget for Asylum.\nBeneath the Enemy placement option, but above yourself.", WHM.JobID)]
-    [Retargeted]
-    WHM_AoEHeals_Asylum_Allies = 19031,
+    [ReplaceSkill(WHM.AfflatusRapture)]
+    [CustomComboInfo("Rapture into Misery Feature",
+        "Replaces Afflatus Rapture with Afflatus Misery when it is ready to be used.", WHM.JobID)]
+    WHM_RaptureMisery = 19001,
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -683,6 +683,10 @@ public enum CustomComboPreset
     [CustomComboInfo("Advanced DPS Mode - AoE", "Replaces Gravity with options below", AST.JobID)]
     [AdvancedCombo]
     AST_AOE_DPS = 1041,
+    
+    [ParentCombo(AST_AOE_DPS)]
+    [CustomComboInfo("Multitarget Dot Option", "Maintains dots on multiple targets.", AST.JobID)]
+    AST_AOE_DPS_DoT = 1083,
 
     [ParentCombo(AST_AOE_DPS)]
     [CustomComboInfo("Lightspeed Weave Option", "Adds Lightspeed when moving", AST.JobID)]
@@ -908,32 +912,29 @@ public enum CustomComboPreset
 
     #endregion
     
-    #region Hidden Features
-    [CustomComboInfo("Hidden Options", "Collection of cheeky or encounter-specific extra options only available to those in the know." +
-                                       "\nDo not expect these options to be maintained, or even kept, after they are no longer Current.", AST.JobID)]
-    [Hidden]
-    AST_Hidden = 1075,
+    #region Raidwide Features
+    [CustomComboInfo("Boss Raidwide Options",
+        "Collection of tools designed to try and cast during a raidwide attack when detected." +
+        "\nThis will work for most, but not all raidwide attacks and is no substitute for learning the fight", AST.JobID)]
+    AST_Raidwide = 1075,
     
-    [ParentCombo(AST_Hidden)]
+    [ParentCombo(AST_Raidwide)]
     [CustomComboInfo("RaidWide Collective Unconscious Option", "Additionally, Will try to Weave Collective Unconscious when a raidwide casting. \nWill be used in all 4 main combos.", AST.JobID)]
-    [Hidden]
-    AST_Hidden_CollectiveUnconscious = 1076,
+    AST_Raidwide_CollectiveUnconscious = 1076,
     
-    [ParentCombo(AST_Hidden)]
+    [ParentCombo(AST_Raidwide)]
     [CustomComboInfo("RaidWide Neutral Sect Combo Option", "Additionally, Will try to Weave Neutral Sect and Sun sign when a raidwide casting. " +
                                                                "\nWill be used in all 4 main combos.", AST.JobID)]
-    [Hidden]
-    AST_Hidden_NeutralSect = 1077,
+    AST_Raidwide_NeutralSect = 1077,
     
-    [ParentCombo(AST_Hidden)]
+    [ParentCombo(AST_Raidwide)]
     [CustomComboInfo("RaidWide Aspected Helios Option", "Additionally, Will try to cast Aspected Helios for with Neutral Sect Buff for shields when a raidwide casting. " +
                                                            "\nWill be used in all 4 main combos.", AST.JobID)]
-    [Hidden]
-    AST_Hidden_AspectedHelios = 1078,
+    AST_Raidwide_AspectedHelios = 1078,
     
     #endregion
 
-    // Last value = 1080
+    // Last value = 1083
 
     #endregion
 
@@ -6325,6 +6326,10 @@ public enum CustomComboPreset
     SCH_AoE_ADV_DPS = 16010,
     
     [ParentCombo(SCH_AoE_ADV_DPS)]
+    [CustomComboInfo("Multitarget Dot Option", "Maintains dots on multiple targets.", SCH.JobID)]
+    SCH_AoE_ADV_DPS_DoT = 16072,
+    
+    [ParentCombo(SCH_AoE_ADV_DPS)]
     [CustomComboInfo("Energy Drain Weave Option",
         "Use Energy Drain to consume remaining Aetherflow stacks when Aetherflow is about to come off cooldown.",
         SCH.JobID)]
@@ -6581,7 +6586,7 @@ public enum CustomComboPreset
     SCH_Raidwide_Expedient = 16064,
     #endregion
 
-    // Last value = 16069
+    // Last value = 16072
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -8021,7 +8021,7 @@ public enum CustomComboPreset
     
     [ParentCombo(WHM_Retargets)]
     [ReplaceSkill(WHM.Aquaveil)]
-    [CustomComboInfo("Afflatus Option", "Retargets Afflatus to the heal stack (even from the Solace into Misery Feature above).", WHM.JobID)]
+    [CustomComboInfo("Afflatus Solace Option", "Retargets Afflatus Solace to the heal stack (even from the Solace into Misery Feature above).", WHM.JobID)]
     [Retargeted]
     WHM_Re_Solace = 19039,
     

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -7880,8 +7880,9 @@ public enum CustomComboPreset
     WHM_AoEHeals_Misery = 19010,
     
     [ParentCombo(WHM_AoEHeals)]
-    [CustomComboInfo("Medica II Option", "Uses Medica II when current target doesn't have Medica II buff." +
-                                         "\nUpgrades to Medica III when level allows.", WHM.JobID)]
+    [CustomComboInfo("Medica II Option",
+        "Uses Medica II when heal target doesn't have Medica II buff." +
+        "\nUpgrades to Medica III when level allows.", WHM.JobID)]
     WHM_AoEHeals_Medica2 = 19205,
 
     [ParentCombo(WHM_AoEHeals)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6563,26 +6563,22 @@ public enum CustomComboPreset
 
     #endregion
     
-    #region Hidden Features
-    [CustomComboInfo("Hidden Options", "Collection of cheeky or encounter-specific extra options only available to those in the know.\nDo not expect these options to be maintained, or even kept, after they are no longer Current.", SCH.JobID)]
-    [Hidden]
+    #region Raidwide Features
+    [CustomComboInfo("Raidwide Options", "Collection of tools designed to try and cast during a raidwide attack when detected." +
+                                         "\nThis will work for most, but not all raidwide attacks and is no substitute for learning the fight", SCH.JobID)]
     SCH_Hidden = 16065,
     
     [ParentCombo(SCH_Hidden)]
     [CustomComboInfo("RaidWide Succor Option", "Will try to cast Succor when a raidwide casting is detected if shieldcheck from succor setting passes. \nWill be used in all 4 Advanced combos.", SCH.JobID)]
-    [Hidden]
-    SCH_Hidden_Succor_Raidwide = 16062,
+    SCH_Raidwide_Succor = 16062,
     
     [ParentCombo(SCH_Hidden)]
     [CustomComboInfo("Sacred Soil Option", "Will try to use Sacred Soil on self when a raidwide casting is detected..\nWill be used in all 4 Advanced combos", SCH.JobID)]
-    [Hidden]
-    [Retargeted]
-    SCH_Hidden_SacredSoil = 16059,
+    SCH_Raidwide_SacredSoil = 16059,
     
     [ParentCombo(SCH_Hidden)]
     [CustomComboInfo("Expedient Raidwide Option", "Will try to use Expedient when a raidwide casting is detected. \nWill be used in all 4 Advanced combos.", SCH.JobID)]
-    [Hidden]
-    SCH_Hidden_Expedient = 16064,
+    SCH_Raidwide_Expedient = 16064,
     #endregion
 
     // Last value = 16069

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -7672,7 +7672,9 @@ public enum CustomComboPreset
     #endregion
 
     #region WHITE MAGE
-    
+
+    #region Simple Mode
+
     [AutoAction(false, false)]
     [ReplaceSkill(WHM.Stone1, WHM.Stone2, WHM.Stone3, WHM.Stone4, WHM.Glare1, WHM.Glare3)]
     [ConflictingCombos(WHM_ST_MainCombo)]
@@ -7689,7 +7691,9 @@ public enum CustomComboPreset
     [SimpleCombo]
     WHM_AoE_Simple_DPS = 19051,
 
-    #region Single Target DPS Feature
+    #endregion
+
+    #region Advanced Single Target DPS Combo
 
     [AutoAction(false, false)]
     [ReplaceSkill(WHM.Stone1, WHM.Stone2, WHM.Stone3, WHM.Stone4, WHM.Glare1, WHM.Glare3)]
@@ -7738,7 +7742,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    #region AoE DPS Feature
+    #region Advanced AoE DPS Combo
 
     [AutoAction(true, false)]
     [ReplaceSkill(WHM.Holy, WHM.Holy3)]
@@ -7789,7 +7793,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    #region Single Target Heals
+    #region Advanced Single Target Heals Combo
 
     [AutoAction(false, true)]
     [ReplaceSkill(WHM.Cure)]
@@ -7859,7 +7863,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    #region AoE Heals Feature
+    #region Advanced AoE Heals Combo
 
     [AutoAction(true, true)]
     [ReplaceSkill(WHM.Medica1)]
@@ -7921,33 +7925,8 @@ public enum CustomComboPreset
     
     #endregion
     
-    #region Raidwide Heals
-    
-    #region Hidden Features
-    [CustomComboInfo("Boss Raidwide Options", "Collection of tools designed to try and cast during a raidwide attack when detected." +
-                                       "\nThis will work for most, but not all raidwide attacks and is no substitute for learning the fight", WHM.JobID)]
-    WHM_Raidwide = 19220,
-    
-    [ParentCombo(WHM_Raidwide)]
-    [CustomComboInfo("RaidWide Asylum Option", "Will try to Weave Asylum when a raidwide casting. \nWill be used in all 4 main combos.", WHM.JobID)]
-    WHM_Raidwide_Asylum = 19221,
-    
-    [ParentCombo(WHM_Raidwide)]
-    [CustomComboInfo("RaidWide Temperance Combo Option", "Will try to Weave Temperance and Divine Caress when a raidwide casting. " +
-                                                           "\nWill be used in all 4 main combos.", WHM.JobID)]
-    WHM_Raidwide_Temperance = 19222,
-    
-    [ParentCombo(WHM_Raidwide)]
-    [CustomComboInfo("RaidWide LiturgyOfTheBell Option", "Will try to weave LiturgyOfTheBell when a raidwide casting. " +
-                                                        "\nWill be used in all 4 main combos.", WHM.JobID)]
-    WHM_Raidwide_LiturgyOfTheBell = 19223,
-    
-    #endregion
-    
-    #endregion
-    
-    #region Small Features
-    
+    #region Mitigation Features
+
     [ReplaceSkill(WHM.Aquaveil)]
     [CustomComboInfo("Mitigation Feature - Single Target", "Changes Aquaveil into Tetragrammaton and/or Divine Benison after use.\nEach action can be Retargeted with the Retargeting Features below.", WHM.JobID)]
     WHM_Mit_ST = 19041,
@@ -7955,6 +7934,35 @@ public enum CustomComboPreset
     [ReplaceSkill(WHM.Asylum)]
     [CustomComboInfo("Mitigation Feature - AoE", "Changes Asylum into Temperance and then Divine Caress after use.\nCan be Retargeted with the Retargeting Features below.", WHM.JobID)]
     WHM_Mit_AoE = 19040,
+
+    #endregion
+    
+    #region Raidwide Heals
+    
+    [CustomComboInfo("Boss Raidwide Options",
+        "Collection of tools designed to try and cast during a raidwide attack when detected." +
+        "\nThis will work for most, but not all raidwide attacks and is no substitute for learning the fight", WHM.JobID)]
+    WHM_Raidwide = 19220,
+    
+    [ParentCombo(WHM_Raidwide)]
+    [CustomComboInfo("RaidWide Asylum Option", "Will try to Weave Asylum when a raidwide casting. \nWill be used in all 4 main combos.", WHM.JobID)]
+    WHM_Raidwide_Asylum = 19221,
+    
+    [ParentCombo(WHM_Raidwide)]
+    [CustomComboInfo("RaidWide Temperance Combo Option",
+        "Will try to Weave Temperance and Divine Caress when a raidwide casting. " +
+        "\nWill be used in all 4 main combos.", WHM.JobID)]
+    WHM_Raidwide_Temperance = 19222,
+    
+    [ParentCombo(WHM_Raidwide)]
+    [CustomComboInfo("RaidWide LiturgyOfTheBell Option",
+        "Will try to weave LiturgyOfTheBell when a raidwide casting. " +
+        "\nWill be used in all 4 main combos.", WHM.JobID)]
+    WHM_Raidwide_LiturgyOfTheBell = 19223,
+    
+    #endregion
+    
+    #region Small Features
     
     [ReplaceSkill(WHM.AfflatusSolace)]
     [CustomComboInfo("Solace into Misery Feature",
@@ -8069,7 +8077,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last value = 19041 (then skips to next last used: 19210)
+    // Last value = 19051 (then skips to next last used: 19210)
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -7672,11 +7672,28 @@ public enum CustomComboPreset
     #endregion
 
     #region WHITE MAGE
+    
+    [AutoAction(false, false)]
+    [ReplaceSkill(WHM.Stone1, WHM.Stone2, WHM.Stone3, WHM.Stone4, WHM.Glare1, WHM.Glare3)]
+    [ConflictingCombos(WHM_ST_MainCombo)]
+    [CustomComboInfo("Simple DPS Mode - Single Target", "Replaces Stone with a full one-button single target rotation. \nThis is the ideal option for newcomers to the job.",
+        WHM.JobID)]
+    [SimpleCombo]
+    WHM_ST_Simple_DPS = 19050,
+    
+    [AutoAction(true, false)]
+    [ReplaceSkill(WHM.Holy, WHM.Holy3)]
+    [ConflictingCombos(WHM_AoE_DPS)]
+    [CustomComboInfo("Simple DPS Mode - AoE", "Replaces Holy with a full one-button AoE rotation. \nThis is the ideal option for newcomers to the job.",
+        WHM.JobID)]
+    [SimpleCombo]
+    WHM_AoE_Simple_DPS = 19051,
 
     #region Single Target DPS Feature
 
     [AutoAction(false, false)]
     [ReplaceSkill(WHM.Stone1, WHM.Stone2, WHM.Stone3, WHM.Stone4, WHM.Glare1, WHM.Glare3)]
+    [ConflictingCombos(WHM_ST_Simple_DPS)]
     [CustomComboInfo("Advanced DPS Mode - Single Target", "Collection of cooldowns and spell features on Glare/Stone.",
         WHM.JobID)]
     [AdvancedCombo]
@@ -7725,6 +7742,7 @@ public enum CustomComboPreset
 
     [AutoAction(true, false)]
     [ReplaceSkill(WHM.Holy, WHM.Holy3)]
+    [ConflictingCombos(WHM_AoE_Simple_DPS)]
     [CustomComboInfo("Advanced DPS Mode - AoE", "Collection of cooldowns and spell features on Holy/Holy III.", WHM.JobID)]
     [AdvancedCombo]
     WHM_AoE_DPS = 19190,

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -7942,9 +7942,13 @@ public enum CustomComboPreset
     
     #region DPS Small Features
 
+    
+    
+    
     [ReplaceSkill(WHM.AfflatusSolace)]
     [CustomComboInfo("Solace into Misery Feature",
-        "Replaces Afflatus Solace with Afflatus Misery when it is ready to be used.", WHM.JobID)]
+        "Replaces Afflatus Solace with Afflatus Misery when it is ready to be used. \nWill retarget to heal stack if Retargetting is enabled", WHM.JobID)]
+    [PossiblyRetargeted]
     WHM_SolaceMisery = 19000,
 
     [ReplaceSkill(WHM.AfflatusRapture)]
@@ -7952,12 +7956,9 @@ public enum CustomComboPreset
         "Replaces Afflatus Rapture with Afflatus Misery when it is ready to be used.", WHM.JobID)]
     WHM_RaptureMisery = 19001,
 
-    #endregion
-
-    #region Heals Small Features
-
     [ReplaceSkill(WHM.Cure2)]
-    [CustomComboInfo("Cure II Sync Feature", "Changes Cure II to Cure when synced below Lv.30.", WHM.JobID)]
+    [CustomComboInfo("Cure II Sync Feature", "Changes Cure II to Cure when synced below Lv.30.\nWill retarget to heal stack if Retargetting is enabled", WHM.JobID)]
+    [PossiblyRetargeted]
     WHM_CureSync = 19002,
 
     [ReplaceSkill( RoleActions.Magic.Swiftcast)]
@@ -7975,6 +7976,11 @@ public enum CustomComboPreset
     [Retargeted]
     WHM_Raise_Retarget = 19029,
     
+    [ReplaceSkill(WHM.Aquaveil)]
+    [CustomComboInfo("Aquaveil Retarget Feature", "Retargets Aquaveil  to the heal stack.", WHM.JobID)]
+    [Retargeted]
+    WHM_Aquaveil  = 19036,
+    
     [ReplaceSkill(WHM.Asylum)]
     [CustomComboInfo("Asylum Retarget Feature", "Retargets Asylum on yourself.", WHM.JobID)]
     [Retargeted]
@@ -7989,6 +7995,26 @@ public enum CustomComboPreset
     [CustomComboInfo("Cure 3 Retarget Feature", "Retargets Cure 3 to the heal stack.", WHM.JobID)]
     [Retargeted]
     WHM_Cure3 = 19031,
+    
+    [ReplaceSkill(WHM.Benediction)]
+    [CustomComboInfo("Benediction Retarget Feature", "Retargets Benediction to the heal stack.", WHM.JobID)]
+    [Retargeted]
+    WHM_Benediction = 19032,
+    
+    [ReplaceSkill(WHM.Tetragrammaton)]
+    [CustomComboInfo("Tetragrammaton Retarget Feature", "Retargets Tetragrammaton to the heal stack.", WHM.JobID)]
+    [Retargeted]
+    WHM_Tetragrammaton = 19033,
+    
+    [ReplaceSkill(WHM.Regen)]
+    [CustomComboInfo("Regen Retarget Feature", "Retargets Regen to the heal stack.", WHM.JobID)]
+    [Retargeted]
+    WHM_Regen = 19034,
+    
+    [ReplaceSkill(WHM.DivineBenison)]
+    [CustomComboInfo("Divine Benison Retarget Feature", "Retargets Divine Benison to the heal stack.", WHM.JobID)]
+    [Retargeted]
+    WHM_DivineBenison = 19035,
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -7708,6 +7708,19 @@ public enum CustomComboPreset
     WHM_ST_MainCombo_Opener = 19023,
 
     [ParentCombo(WHM_ST_MainCombo)]
+    [CustomComboInfo("Movement Options", "Various options to keep you casting while moving.", WHM.JobID)]
+    WHM_ST_MainCombo_Movement = 19052,
+
+    [ParentCombo(WHM_ST_MainCombo_Movement)]
+    [CustomComboInfo("DoT Option", "Will reapply DoT early to all enemies within range while moving.", WHM.JobID)]
+    [Retargeted]
+    WHM_ST_MainCombo_Move_DoT = 19053,
+
+    [ParentCombo(WHM_ST_MainCombo_Movement)]
+    [CustomComboInfo("Afflatus Misery Option", "Will prioritize Afflatus Misery higher while moving.", WHM.JobID)]
+    WHM_ST_MainCombo_Move_Lily = 19054,
+
+    [ParentCombo(WHM_ST_MainCombo)]
     [CustomComboInfo("Aero/Dia Uptime Option",
         "Adds Aero/Dia to the single target combo if the debuff is not present on current target, or is about to expire.",
         WHM.JobID)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -7694,7 +7694,7 @@ public enum CustomComboPreset
     [AutoAction(false, false)]
     [ReplaceSkill(WHM.Stone1, WHM.Stone2, WHM.Stone3, WHM.Stone4, WHM.Glare1, WHM.Glare3)]
     [ConflictingCombos(WHM_ST_Simple_DPS)]
-    [CustomComboInfo("Advanced DPS Mode - Single Target", "Collection of cooldowns and spell features on Glare/Stone.",
+    [CustomComboInfo("Advanced DPS Mode - Single Target", "Collection of cooldowns and spell features on Glares/Stones/Aeros/Dia.",
         WHM.JobID)]
     [AdvancedCombo]
     WHM_ST_MainCombo = 19099,

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -7974,6 +7974,21 @@ public enum CustomComboPreset
     [CustomComboInfo("Retarget Raise", "Will Retarget the Raise affected here to your Heal Stack.", WHM.JobID)]
     [Retargeted]
     WHM_Raise_Retarget = 19029,
+    
+    [ReplaceSkill(WHM.Asylum)]
+    [CustomComboInfo("Asylum Retarget Feature", "Retargets Asylum on yourself.", WHM.JobID)]
+    [Retargeted]
+    WHM_Asylum = 19027,
+    
+    [ReplaceSkill(WHM.LiturgyOfTheBell)]
+    [CustomComboInfo("LiturgyOfTheBell Retarget Feature", "Retargets LiturgyOfTheBell on yourself.", WHM.JobID)]
+    [Retargeted]
+    WHM_LiturgyOfTheBell = 19030,
+    
+    [ReplaceSkill(WHM.Cure3)]
+    [CustomComboInfo("Cure 3 Retarget Feature", "Retargets Cure 3 to the heal stack.", WHM.JobID)]
+    [Retargeted]
+    WHM_Cure3 = 19031,
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -7945,12 +7945,19 @@ public enum CustomComboPreset
     
     #endregion
     
-    #region DPS Small Features
+    #region Small Features
+    
+    [ReplaceSkill(WHM.Aquaveil)]
+    [CustomComboInfo("Mitigation Feature - Single Target", "Changes Aquaveil into Tetragrammaton and/or Divine Benison after use.\nEach action can be Retargeted with the Retargeting Features below.", WHM.JobID)]
+    WHM_Mit_ST = 19041,
+    
+    [ReplaceSkill(WHM.Asylum)]
+    [CustomComboInfo("Mitigation Feature - AoE", "Changes Asylum into Temperance and then Divine Caress after use.\nCan be Retargeted with the Retargeting Features below.", WHM.JobID)]
+    WHM_Mit_AoE = 19040,
     
     [ReplaceSkill(WHM.AfflatusSolace)]
     [CustomComboInfo("Solace into Misery Feature",
-        "Replaces Afflatus Solace with Afflatus Misery when it is ready to be used. \nWill retarget to heal stack if Retargetting is enabled", WHM.JobID)]
-    [PossiblyRetargeted]
+        "Replaces Afflatus Solace with Afflatus Misery when it is ready to be used.\nSolace can be Retargeted with the Retargeting Features below.", WHM.JobID)]
     WHM_SolaceMisery = 19000,
 
     [ReplaceSkill(WHM.AfflatusRapture)]
@@ -7959,8 +7966,7 @@ public enum CustomComboPreset
     WHM_RaptureMisery = 19001,
 
     [ReplaceSkill(WHM.Cure2)]
-    [CustomComboInfo("Cure II Sync Feature", "Changes Cure II to Cure when synced below Lv.30.\nWill retarget to heal stack if Retargetting is enabled", WHM.JobID)]
-    [PossiblyRetargeted]
+    [CustomComboInfo("Cure II Sync Feature", "Changes Cure II to Cure when synced below Lv.30.\nCan be Retargeted with the Retargeting Features below.", WHM.JobID)]
     WHM_CureSync = 19002,
 
     [ReplaceSkill( RoleActions.Magic.Swiftcast)]
@@ -7968,55 +7974,82 @@ public enum CustomComboPreset
     [CustomComboInfo("Alternative Raise Feature", "Changes Swiftcast to Raise.", WHM.JobID)]
     WHM_Raise = 19004,
 
+    [ParentCombo(WHM_Raise)]
+    [CustomComboInfo("Retarget Raise", "Will Retarget the Raise affected here to your Raise Stack.", WHM.JobID)]
+    [Retargeted]
+    WHM_Raise_Retarget = 19029,
+
     [ReplaceSkill(WHM.Raise)]
     [CustomComboInfo("Thin Air Raise Feature", "Adds Thin Air to the Global Raise Feature/Alternative Raise Feature.",
         WHM.JobID)]
     WHM_ThinAirRaise = 19014,
 
-    [ParentCombo(WHM_Raise)]
-    [CustomComboInfo("Retarget Raise", "Will Retarget the Raise affected here to your Heal Stack.", WHM.JobID)]
-    [Retargeted]
-    WHM_Raise_Retarget = 19029,
+    #endregion
+
+    #region Retargeting
+
+    [CustomComboInfo("Retargeting Features", "Collection of Options to Retarget Manually-Used Single Target Heals.", WHM.JobID)]
+    WHM_Retargets = 19037,
     
+    [ParentCombo(WHM_Retargets)]
     [ReplaceSkill(WHM.Aquaveil)]
-    [CustomComboInfo("Aquaveil Retarget Feature", "Retargets Aquaveil  to the heal stack.", WHM.JobID)]
+    [CustomComboInfo("Cure Option", "Retargets Cure and Cure II to the heal stack (even from the Cure II Sync Feature above).", WHM.JobID)]
     [Retargeted]
-    WHM_Aquaveil  = 19036,
+    WHM_Re_Cure = 19038,
     
+    [ParentCombo(WHM_Retargets)]
+    [ReplaceSkill(WHM.Aquaveil)]
+    [CustomComboInfo("Afflatus Option", "Retargets Afflatus to the heal stack (even from the Solace into Misery Feature above).", WHM.JobID)]
+    [Retargeted]
+    WHM_Re_Solace = 19039,
+    
+    [ParentCombo(WHM_Retargets)]
+    [ReplaceSkill(WHM.Aquaveil)]
+    [CustomComboInfo("Aquaveil Option", "Retargets Aquaveil to the heal stack (even from the Mitigation Feature above).", WHM.JobID)]
+    [Retargeted]
+    WHM_Re_Aquaveil = 19036,
+    
+    [ParentCombo(WHM_Retargets)]
     [ReplaceSkill(WHM.Asylum)]
-    [CustomComboInfo("Asylum Retarget Feature", "Retargets Asylum on yourself.", WHM.JobID)]
+    [CustomComboInfo("Asylum Option", "Retargets Asylum to yourself (even from the Mitigation Feature above).", WHM.JobID)]
     [Retargeted]
-    WHM_Asylum = 19027,
+    WHM_Re_Asylum = 19027,
     
+    [ParentCombo(WHM_Retargets)]
     [ReplaceSkill(WHM.LiturgyOfTheBell)]
-    [CustomComboInfo("LiturgyOfTheBell Retarget Feature", "Retargets LiturgyOfTheBell on yourself.", WHM.JobID)]
+    [CustomComboInfo("Liturgy Of The Bell Option", "Retargets Liturgy Of The Bell to yourself.", WHM.JobID)]
     [Retargeted]
-    WHM_LiturgyOfTheBell = 19030,
+    WHM_Re_LiturgyOfTheBell = 19030,
     
+    [ParentCombo(WHM_Retargets)]
     [ReplaceSkill(WHM.Cure3)]
-    [CustomComboInfo("Cure 3 Retarget Feature", "Retargets Cure 3 to the heal stack.", WHM.JobID)]
+    [CustomComboInfo("Cure 3 Retarget Option", "Retargets Cure 3 to the heal stack.", WHM.JobID)]
     [Retargeted]
-    WHM_Cure3 = 19031,
+    WHM_Re_Cure3 = 19031,
     
+    [ParentCombo(WHM_Retargets)]
     [ReplaceSkill(WHM.Benediction)]
-    [CustomComboInfo("Benediction Retarget Feature", "Retargets Benediction to the heal stack.", WHM.JobID)]
+    [CustomComboInfo("Benediction Option", "Retargets Benediction to the heal stack.", WHM.JobID)]
     [Retargeted]
-    WHM_Benediction = 19032,
+    WHM_Re_Benediction = 19032,
     
+    [ParentCombo(WHM_Retargets)]
     [ReplaceSkill(WHM.Tetragrammaton)]
-    [CustomComboInfo("Tetragrammaton Retarget Feature", "Retargets Tetragrammaton to the heal stack.", WHM.JobID)]
+    [CustomComboInfo("Tetragrammaton Option", "Retargets Tetragrammaton to the heal stack (even from the Mitigation Feature above).", WHM.JobID)]
     [Retargeted]
-    WHM_Tetragrammaton = 19033,
+    WHM_Re_Tetragrammaton = 19033,
     
+    [ParentCombo(WHM_Retargets)]
     [ReplaceSkill(WHM.Regen)]
-    [CustomComboInfo("Regen Retarget Feature", "Retargets Regen to the heal stack.", WHM.JobID)]
+    [CustomComboInfo("Regen Option", "Retargets Regen to the heal stack.", WHM.JobID)]
     [Retargeted]
-    WHM_Regen = 19034,
+    WHM_Re_Regen = 19034,
     
+    [ParentCombo(WHM_Retargets)]
     [ReplaceSkill(WHM.DivineBenison)]
-    [CustomComboInfo("Divine Benison Retarget Feature", "Retargets Divine Benison to the heal stack.", WHM.JobID)]
+    [CustomComboInfo("Divine Benison Option", "Retargets Divine Benison to the heal stack (even from the Mitigation Feature above).", WHM.JobID)]
     [Retargeted]
-    WHM_DivineBenison = 19035,
+    WHM_Re_DivineBenison = 19035,
 
     #endregion
 
@@ -8035,7 +8068,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last value = 19209
+    // Last value = 19041 (then skips to next last used: 19210)
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/ALL/Roles/RoleActions.cs
+++ b/WrathCombo/Combos/PvE/ALL/Roles/RoleActions.cs
@@ -88,7 +88,7 @@ internal static partial class RoleActions
             ActionReady(SecondWind) && PlayerHealthPercentageHp() <= healthPercent;
 
         public static bool CanArmsLength(int enemyCount, All.Enums.BossAvoidance avoidanceSetting) =>
-            ActionReady(ArmsLength) && CanCircleAoe(7) >= enemyCount &&
+            ActionReady(ArmsLength) && NumberOfEnemiesInRange(ArmsLength) >= enemyCount &&
             ((int)avoidanceSetting == (int)All.Enums.BossAvoidance.Off || !InBossEncounter());
     }
 
@@ -192,7 +192,7 @@ internal static partial class RoleActions
 
         public static bool CanReprisal(int healthPercent = 100, int? enemyCount = null, bool checkTargetForDebuff = true) =>
             (checkTargetForDebuff && !HasStatusEffect(Debuffs.Reprisal, CurrentTarget, true) || !checkTargetForDebuff) &&
-            (enemyCount is null ? InActionRange(Reprisal) : CanCircleAoe(5) >= enemyCount) &&
+            (enemyCount is null ? InActionRange(Reprisal) : NumberOfEnemiesInRange(Reprisal) >= enemyCount) &&
             ActionReady(Reprisal) && PlayerHealthPercentageHp() <= healthPercent && CanApplyStatus(CurrentTarget, Debuffs.Reprisal);
 
         public static bool CanShirk() =>

--- a/WrathCombo/Combos/PvE/AST/AST.cs
+++ b/WrathCombo/Combos/PvE/AST/AST.cs
@@ -152,13 +152,13 @@ internal partial class AST : Healer
                     !LevelChecked(Divination)))
                     return Lightspeed;  
                 
-                #region Hidden Feature Raidwide
+                #region Healing Helper
 
-                if (HiddenCollectiveUnconscious())
+                if (RaidwideCollectiveUnconscious())
                     return CollectiveUnconscious;
-                if (HiddenNeutralSect())
+                if (RaidwideNeutralSect())
                     return OriginalHook(NeutralSect);
-                if (HiddenAspectedHelios())
+                if (RaidwideAspectedHelios())
                     return OriginalHook(AspectedHelios);
            
                 #endregion
@@ -295,6 +295,14 @@ internal partial class AST : Healer
             if (ActionReady(Macrocosmos) && !HasStatusEffect(Buffs.Macrocosmos) &&
                 ActionWatching.NumberOfGcdsUsed >= 3 && !InBossEncounter())
                 return Macrocosmos;
+            
+            var dotAction = OriginalHook(Combust);
+            CombustList.TryGetValue(dotAction, out var dotDebuffID);
+            var target =
+                SimpleTarget.DottableEnemy(dotAction, dotDebuffID, 30, 3, 4);
+
+            if (ActionReady(dotAction) && target != null)
+                return OriginalHook(Combust).Retarget([Gravity, Gravity2], target);
 
             return actionID;
         }
@@ -334,13 +342,13 @@ internal partial class AST : Healer
                 !LevelChecked(Divination)))
                 return Lightspeed;  
             
-            #region Hidden Feature Raidwide
+            #region Healing Helper
 
-            if (HiddenCollectiveUnconscious())
+            if (RaidwideCollectiveUnconscious())
                 return CollectiveUnconscious;
-            if (HiddenNeutralSect())
+            if (RaidwideNeutralSect())
                 return OriginalHook(NeutralSect);
-            if (HiddenAspectedHelios())
+            if (RaidwideAspectedHelios())
                 return OriginalHook(AspectedHelios);
            
             #endregion
@@ -415,6 +423,17 @@ internal partial class AST : Healer
                 (Config.AST_AOE_DPS_MacroCosmos_SubOption == 1 ||
                 !InBossEncounter()))
                 return Macrocosmos;
+            
+            var dotAction = OriginalHook(Combust);
+            CombustList.TryGetValue(dotAction, out var dotDebuffID);
+            var target = SimpleTarget.DottableEnemy(dotAction, dotDebuffID,
+                Config.AST_AOE_DPS_DoT_HPThreshold,
+                Config.AST_AOE_DPS_DoT_Reapply,
+                Config.AST_AOE_DPS_DoT_MaxTargets);
+
+            if (IsEnabled(CustomComboPreset.AST_AOE_DPS_DoT) &&
+                ActionReady(dotAction) && target != null)
+                return OriginalHook(Combust).Retarget([Gravity, Gravity2], target);
 
             return actionID;
         }
@@ -430,13 +449,13 @@ internal partial class AST : Healer
             
             var healTarget = OptionalTarget ?? SimpleTarget.Stack.AllyToHeal;
             
-            #region Hidden Feature Raidwide
+            #region Healing Helper
 
-            if (HiddenCollectiveUnconscious())
+            if (RaidwideCollectiveUnconscious())
                 return CollectiveUnconscious;
-            if (HiddenNeutralSect())
+            if (RaidwideNeutralSect())
                 return OriginalHook(NeutralSect);
-            if (HiddenAspectedHelios())
+            if (RaidwideAspectedHelios())
                 return OriginalHook(AspectedHelios);
            
             #endregion
@@ -482,13 +501,13 @@ internal partial class AST : Healer
             if (!LevelChecked(AspectedHelios)) 
                 return Helios;
             
-            #region Hidden Feature Raidwide
+            #region Healing Helper
 
-            if (HiddenCollectiveUnconscious())
+            if (RaidwideCollectiveUnconscious())
                 return CollectiveUnconscious;
-            if (HiddenNeutralSect())
+            if (RaidwideNeutralSect())
                 return OriginalHook(NeutralSect);
-            if (HiddenAspectedHelios())
+            if (RaidwideAspectedHelios())
                 return OriginalHook(AspectedHelios);
            
             #endregion

--- a/WrathCombo/Combos/PvE/AST/AST_Config.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Config.cs
@@ -58,6 +58,8 @@ internal partial class AST
             AST_AOE_DPS_StellarDetonation_Threshold = new("AST_AOE_DPS_StellarDetonation_Threshold", 0),
             AST_AOE_DPS_StellarDetonation_SubOption = new("AST_AOE_DPS_StellarDetonation_SubOption", 0),
             AST_AOE_DPS_MacroCosmos_SubOption = new("AST_AOE_DPS_MacroCosmos_SubOption", 0),
+            AST_AOE_DPS_DoT_HPThreshold = new("AST_AOE_DPS_DoT_HPThreshold", 30),
+            AST_AOE_DPS_DoT_MaxTargets = new("AST_AOE_DPS_DoT_MaxTargets", 4),
             AST_QuickTarget_Override = new("AST_QuickTarget_Override", 0);
 
         public static UserBool
@@ -83,6 +85,7 @@ internal partial class AST
             AST_AOE_DPS_OverwriteHealCards = new("AST_AOE_DPS_OverwriteHealCards"),
             AST_QuickTarget_Manuals = new("AST_QuickTarget_Manuals", true);
         public static UserFloat
+            AST_AOE_DPS_DoT_Reapply = new ("AST_AOE_DPS_DoT_Reapply", 2),
             AST_ST_DPS_CombustUptime_Threshold = new("AST_ST_DPS_CombustUptime_Threshold");
 
         public static UserBoolArray
@@ -187,6 +190,14 @@ internal partial class AST
                 case CustomComboPreset.AST_AOE_DPS_MacroCosmos:
                     DrawHorizontalRadioButton(AST_AOE_DPS_MacroCosmos_SubOption, "Non-boss Encounters Only", $"Will not use on bosses", 0);
                     DrawHorizontalRadioButton(AST_AOE_DPS_MacroCosmos_SubOption, "All Content", $"Will use in all content", 1);
+                    break;
+                
+                case CustomComboPreset.AST_AOE_DPS_DoT:
+                    DrawSliderInt(0, 100, AST_AOE_DPS_DoT_HPThreshold, "Target HP% to stop using (0 = Use Always, 100 = Never)");
+                    ImGui.Indent();
+                    DrawRoundedSliderFloat(0, 5, AST_AOE_DPS_DoT_Reapply,  "Seconds remaining before reapplying (0 = Do not reapply early)", digits: 1);
+                    ImGui.Unindent();
+                    DrawSliderInt(0, 10, AST_AOE_DPS_DoT_MaxTargets, "Maximum number of targets to employ multi-dotting ");
                     break;
 
                 #endregion

--- a/WrathCombo/Combos/PvE/AST/AST_Helper.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Helper.cs
@@ -65,17 +65,17 @@ internal partial class AST
     
     #region Hidden Raidwides
     
-    internal static bool HiddenCollectiveUnconscious()
+    internal static bool RaidwideCollectiveUnconscious()
     {
-        return IsEnabled(CustomComboPreset.AST_Hidden_CollectiveUnconscious) && ActionReady(CollectiveUnconscious) && CanWeave() && RaidWideCasting();
+        return IsEnabled(CustomComboPreset.AST_Raidwide_CollectiveUnconscious) && ActionReady(CollectiveUnconscious) && CanWeave() && RaidWideCasting();
     }
-    internal static bool HiddenNeutralSect()
+    internal static bool RaidwideNeutralSect()
     {
-        return IsEnabled(CustomComboPreset.AST_Hidden_NeutralSect) && ActionReady(OriginalHook(NeutralSect)) && CanWeave() && RaidWideCasting();
+        return IsEnabled(CustomComboPreset.AST_Raidwide_NeutralSect) && ActionReady(OriginalHook(NeutralSect)) && CanWeave() && RaidWideCasting();
     }
-    internal static bool HiddenAspectedHelios()
+    internal static bool RaidwideAspectedHelios()
     {
-        return IsEnabled(CustomComboPreset.AST_Hidden_AspectedHelios) && HasStatusEffect(Buffs.NeutralSect) && RaidWideCasting() && 
+        return IsEnabled(CustomComboPreset.AST_Raidwide_AspectedHelios) && HasStatusEffect(Buffs.NeutralSect) && RaidWideCasting() && 
                !HasStatusEffect(Buffs.NeutralSectShield);
     }
     

--- a/WrathCombo/Combos/PvE/Content/Variant/VariantActions.cs
+++ b/WrathCombo/Combos/PvE/Content/Variant/VariantActions.cs
@@ -70,6 +70,6 @@ internal static partial class Variant
 
     internal static bool CanUltimatum(CustomComboPreset preset, WeaveTypes weave = WeaveTypes.None) =>
         IsEnabled(preset) && ActionReady(VariantUltimatum)
-        && CanCircleAoe(5) > 0 && CheckWeave(weave);
+        && NumberOfEnemiesInRange(VariantUltimatum) > 0 && CheckWeave(weave);
 }
 #endregion

--- a/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
@@ -50,7 +50,7 @@ internal partial class DNC
     ///     <see cref="TechnicalFinish4" />, <see cref="FinishingMove" />,
     ///     and <see cref="Tillana" />.
     /// </remarks>
-    private static bool EnemyIn15Yalms => CanCircleAoe(15, true) > 0;
+    private static bool EnemyIn15Yalms => NumberOfEnemiesInRange(FinishingMove) > 0;
 
     /// <summary>
     ///     Checks if any enemy is within 8 yalms.
@@ -58,7 +58,7 @@ internal partial class DNC
     /// <remarks>
     ///     This is used for <see cref="Improvisation" />.
     /// </remarks>
-    private static bool EnemyIn8Yalms => CanCircleAoe(8, true) > 0;
+    private static bool EnemyIn8Yalms => NumberOfEnemiesInRange(Improvisation) > 0;
 
     /// <summary>
     ///     Logic to pick different openers.

--- a/WrathCombo/Combos/PvE/DRK/DRK.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK.cs
@@ -56,7 +56,7 @@ internal partial class DRK : Tank
             var skipBecauseOpener =
                 IsEnabled(Preset.DRK_ST_BalanceOpener) &&
                 Opener().HasCooldowns() &&
-                NumberOfEnemiesInRange(20) < 2; // don't skip if add-pulling
+                NumberOfObjectsInRange<SelfCircle>(20) < 2; // don't skip if add-pulling
             if (IsEnabled(Preset.DRK_ST_RangedUptime) &&
                 ActionReady(Unmend) &&
                 !InMeleeRange() &&

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -70,11 +70,14 @@ internal partial class SCH : Healer
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_ST_ADV_DPS;
         protected override uint Invoke(uint actionID)
         {
-            #region Variables
             bool actionFound = Config.SCH_ST_DPS_Adv_Actions == 0 && BroilList.Contains(actionID) ||
                                Config.SCH_ST_DPS_Adv_Actions == 1 && BioList.ContainsKey(actionID) ||
                                Config.SCH_ST_DPS_Adv_Actions == 2 && actionID is Ruin2;
             
+            if (!actionFound)
+                return actionID;
+            
+            #region Variables
             int chainThreshold = Config.SCH_ST_DPS_ChainStratagemSubOption == 1 || !InBossEncounter() ? Config.SCH_ST_DPS_ChainStratagemOption : 0;
             #endregion
             
@@ -98,18 +101,15 @@ internal partial class SCH : Healer
                 return OccultCrescent.BestPhantomAction();
             #endregion
             
-            #region Dissolve Union
+            #region Healing Helpers
             if (EndAetherpact)
                 return DissolveUnion;
-            #endregion
-            
-            #region Hidden Feature Raidwide
-            if (HiddenSacredSoil())
+            if (RaidwideSacredSoil())
                 return SacredSoil.Retarget(ReplacedActionsList.ToArray(), SimpleTarget.Self);
-            if (HiddenExpedient())
+            if (RaidwideExpedient())
                 return Expedient;
-            if (HiddenSuccor())
-                return HiddenRecitation() ? Recitation : OriginalHook(Succor);
+            if (RaidwideSuccor())
+                return RaidwideRecitation() ? Recitation : OriginalHook(Succor);
             #endregion
 
             if (InCombat() && CanWeave())
@@ -228,18 +228,15 @@ internal partial class SCH : Healer
                 return OccultCrescent.BestPhantomAction();
             #endregion
             
-            #region Dissolve Union
+            #region Healing Helpers
             if (EndAetherpact)
                 return DissolveUnion;
-            #endregion
-            
-            #region Hidden Feature Raidwide
-            if (HiddenSacredSoil())
+            if (RaidwideSacredSoil())
                 return SacredSoil.Retarget(ReplacedActionsList.ToArray(), SimpleTarget.Self);
-            if (HiddenExpedient())
+            if (RaidwideExpedient())
                 return Expedient;
-            if (HiddenSuccor())
-                return HiddenRecitation() ? Recitation : OriginalHook(Succor);
+            if (RaidwideSuccor())
+                return RaidwideRecitation() ? Recitation : OriginalHook(Succor);
             #endregion
             
             if (!InCombat() || !CanWeave()) return actionID;
@@ -294,20 +291,15 @@ internal partial class SCH : Healer
 
             #endregion
             
-            #region Dissolve Union
+            #region Healing Helpers
             if (EndAetherpact)
                 return DissolveUnion;
-            #endregion
-            
-            #region Hidden Feature Raidwide
-
-            if (HiddenSacredSoil())
+            if (RaidwideSacredSoil())
                 return SacredSoil.Retarget(ReplacedActionsList.ToArray(), SimpleTarget.Self);
-            if (HiddenExpedient())
+            if (RaidwideExpedient())
                 return Expedient;
-            if (HiddenSuccor())
-                return HiddenRecitation() ? Recitation : OriginalHook(Succor);
-           
+            if (RaidwideSuccor())
+                return RaidwideRecitation() ? Recitation : OriginalHook(Succor);
             #endregion
             
             // Aetherflow
@@ -363,20 +355,15 @@ internal partial class SCH : Healer
             if (actionID is not (Succor or Concitation or Accession))
                 return actionID;
             
-            #region Dissolve Union
+            #region Healing Helpers
             if (EndAetherpact)
                 return DissolveUnion;
-            #endregion
-            
-            #region Hidden Feature Raidwide
-
-            if (HiddenSacredSoil())
+            if (RaidwideSacredSoil())
                 return SacredSoil.Retarget(ReplacedActionsList.ToArray(), SimpleTarget.Self);
-            if (HiddenExpedient())
+            if (RaidwideExpedient())
                 return Expedient;
-            if (HiddenSuccor())
-                return HiddenRecitation() ? Recitation : OriginalHook(Succor);
-           
+            if (RaidwideSuccor())
+                return RaidwideRecitation() ? Recitation : OriginalHook(Succor);
             #endregion
 
             if (!HasAetherflow && InCombat())

--- a/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
@@ -112,6 +112,14 @@ internal partial class SCH
                     DrawAdditionalBoolChoice(SCH_AoE_DPS_EnergyDrain_Burst, 
                         "Energy Drain Burst", "Holds Energy Drain when Chain Stratagem is ready or has less than 10 seconds cooldown remaining.");
                     break;
+                
+                case CustomComboPreset.SCH_AoE_ADV_DPS_DoT:
+                    DrawSliderInt(0, 100, SCH_AoE_ADV_DPS_DoT_HPThreshold, "Target HP% to stop using (0 = Use Always, 100 = Never)");
+                    ImGui.Indent();
+                    DrawRoundedSliderFloat(0, 5, SCH_AoE_ADV_DPS_DoT_Reapply,  "Seconds remaining before reapplying (0 = Do not reapply early)", digits: 1);
+                    ImGui.Unindent();
+                    DrawSliderInt(0, 10, SCH_AoE_ADV_DPS_DoT_MaxTargets, "Maximum number of targets to employ multi-dotting ");
+                    break;
                 #endregion
                 
                 #region Healing
@@ -295,7 +303,7 @@ internal partial class SCH
     
         #region DPS
 
-        public static UserInt
+        internal static UserInt
             SCH_ST_DPS_LucidOption = new("SCH_ST_DPS_LucidOption", 6500),
             SCH_AoE_DPS_LucidOption = new("SCH_AoE_LucidOption", 6500),
             SCH_ST_DPS_OpenerOption = new("SCH_ST_DPS_OpenerOption"),
@@ -308,7 +316,11 @@ internal partial class SCH
             SCH_ST_DPS_ChainStratagemSubOption = new("SCH_ST_DPS_ChainStratagemSubOption", 1),
             SCH_AoE_DPS_EnergyDrain = new("SCH_AoE_DPS_EnergyDrain", 3),
             SCH_AoE_DPS_ChainStratagemSubOption = new("SCH_AoE_DPS_ChainStratagemSubOption", 1),
+            SCH_AoE_ADV_DPS_DoT_HPThreshold = new("SCH_AoE_ADV_DPS_DoT_HPThreshold", 30),
+            SCH_AoE_ADV_DPS_DoT_MaxTargets = new ("SCH_AoE_ADV_DPS_DoT_MaxTargets", 4),
             SCH_ST_DPS_Adv_Actions = new("SCH_ST_DPS_Adv_Actions");
+        
+        
 
         internal static UserBool
             SCH_ST_DPS_EnergyDrain_Burst = new("SCH_ST_DPS_EnergyDrain_Burst"),
@@ -317,10 +329,11 @@ internal partial class SCH
             SCH_AoE_Heal_Aetherflow_Indomitability = new("SCH_AoE_Heal_Aetherflow_Indomitability"),
             SCH_AoE_Heal_Dissipation_Indomitability = new("SCH_AoE_Heal_Dissipation_Indomitability"),
             SCH_Raidwide_Succor_Recitation = new ("SCH_Raidwide_Succor_Recitation");
-        
 
-        public static UserFloat
-            SCH_DPS_BioUptime_Threshold = new("SCH_DPS_BioUptime_Threshold", 3.0f);
+
+        internal static UserFloat
+            SCH_DPS_BioUptime_Threshold = new("SCH_DPS_BioUptime_Threshold", 3.0f),
+            SCH_AoE_ADV_DPS_DoT_Reapply = new("SCH_AoE_ADV_DPS_DoT_Reapply", 0);
             
         
 

--- a/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
@@ -283,8 +283,8 @@ internal partial class SCH
                     DrawRadioButton(SCH_Recitation_Mode, "Excogitation", "", 3);
                     break; 
                 
-                case CustomComboPreset.SCH_Hidden_Succor_Raidwide:
-                    DrawAdditionalBoolChoice(SCH_Hidden_Succor_Raidwide_Recitation, "Recitation Option", "Use Recitation to buff before the Raidwide Succor.");
+                case CustomComboPreset.SCH_Raidwide_Succor:
+                    DrawAdditionalBoolChoice(SCH_Raidwide_Succor_Recitation, "Recitation Option", "Use Recitation to buff before the Raidwide Succor.");
                     break;
                 
                 #endregion
@@ -316,7 +316,7 @@ internal partial class SCH
             SCH_AoE_DPS_ChainStratagemBanefulOption = new("SCH_AoE_DPS_ChainStratagemBanefulOption"),
             SCH_AoE_Heal_Aetherflow_Indomitability = new("SCH_AoE_Heal_Aetherflow_Indomitability"),
             SCH_AoE_Heal_Dissipation_Indomitability = new("SCH_AoE_Heal_Dissipation_Indomitability"),
-            SCH_Hidden_Succor_Raidwide_Recitation = new ("SCH_Hidden_Succor_Raidwide_Recitation");
+            SCH_Raidwide_Succor_Recitation = new ("SCH_Raidwide_Succor_Recitation");
         
 
         public static UserFloat

--- a/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Helper.cs
@@ -50,23 +50,23 @@ internal partial class SCH
     
     internal static float ChainStrategemCD => GetCooldownRemainingTime(ChainStratagem);
     
-    #region Hidden Raidwides
+    #region Raidwides
     
-    internal static bool HiddenSacredSoil()
+    internal static bool RaidwideSacredSoil()
     {
-        return IsEnabled(CustomComboPreset.SCH_Hidden_SacredSoil) && ActionReady(SacredSoil) && CanWeave() && RaidWideCasting();
+        return IsEnabled(CustomComboPreset.SCH_Raidwide_SacredSoil) && ActionReady(SacredSoil) && CanWeave() && RaidWideCasting();
     }
-    internal static bool HiddenExpedient()
+    internal static bool RaidwideExpedient()
     {
-        return IsEnabled(CustomComboPreset.SCH_Hidden_Expedient) && ActionReady(Expedient) && CanWeave() && RaidWideCasting();
+        return IsEnabled(CustomComboPreset.SCH_Raidwide_Expedient) && ActionReady(Expedient) && CanWeave() && RaidWideCasting();
     }
-    internal static bool HiddenSuccor()
+    internal static bool RaidwideSuccor()
     {
-        return IsEnabled(CustomComboPreset.SCH_Hidden_Succor_Raidwide) && ActionReady(OriginalHook(Succor)) && ShieldCheck && RaidWideCasting();
+        return IsEnabled(CustomComboPreset.SCH_Raidwide_Succor) && ActionReady(OriginalHook(Succor)) && ShieldCheck && RaidWideCasting();
     }
-    internal static bool HiddenRecitation()
+    internal static bool RaidwideRecitation()
     {
-        return Config.SCH_Hidden_Succor_Raidwide_Recitation&& ActionReady(Recitation);
+        return Config.SCH_Raidwide_Succor_Recitation&& ActionReady(Recitation);
     }
     #endregion
     

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -504,7 +504,7 @@ internal partial class WHM : Healer
             actionID is AfflatusSolace && gauge.BloodLily == 3
                 ? AfflatusMisery
                 : IsEnabled(Preset.WHM_Re_Solace)
-                  ? AfflatusSolace.Retarget(SimpleTarget.Stack.AllyToHeal)
+                  ? actionID.Retarget(SimpleTarget.Stack.AllyToHeal)
                   : actionID;
     }
 

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -1,8 +1,6 @@
 #region
 
 using System.Linq;
-using Dalamud.Game.ClientState.Objects.Types;
-using Dalamud.Game.ClientState.Statuses;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Data;
@@ -30,7 +28,7 @@ internal partial class WHM : Healer
         protected override uint Invoke(uint actionID)
         {
             var actionFound = StoneGlareList.Contains(actionID);
-           
+
             if (!actionFound)
                 return actionID;
 
@@ -38,7 +36,7 @@ internal partial class WHM : Healer
                 return OccultCrescent.BestPhantomAction();
 
             if (!InCombat()) return actionID;
-           
+
             #region Weaves
 
             if (CanWeave())
@@ -46,7 +44,8 @@ internal partial class WHM : Healer
                 if (Variant.CanRampart(Preset.WHM_DPS_Variant_Rampart))
                     return Variant.Rampart;
 
-                if (ActionReady(PresenceOfMind) && !HasStatusEffect(Buffs.SacredSight))
+                if (ActionReady(PresenceOfMind) &&
+                    !HasStatusEffect(Buffs.SacredSight))
                     return PresenceOfMind;
 
                 if (ActionReady(Assize))
@@ -81,7 +80,7 @@ internal partial class WHM : Healer
             if (BloodLilyReady)
                 return AfflatusMisery;
 
-            
+
             return actionID;
 
             #endregion
@@ -107,7 +106,8 @@ internal partial class WHM : Healer
                 if (ActionReady(Assize))
                     return Assize;
 
-                if (ActionReady(PresenceOfMind) && !HasStatusEffect(Buffs.SacredSight))
+                if (ActionReady(PresenceOfMind) &&
+                    !HasStatusEffect(Buffs.SacredSight))
                     return PresenceOfMind;
 
                 if (Role.CanLucidDream(7500))
@@ -136,11 +136,12 @@ internal partial class WHM : Healer
             if (BloodLilyReady &&
                 HasBattleTarget())
                 return AfflatusMisery;
-            
+
             var dotAction = OriginalHook(Aero);
             AeroList.TryGetValue(dotAction, out var dotDebuffID);
-            var target = SimpleTarget.DottableEnemy(dotAction, dotDebuffID,30, 3, 4);
-            
+            var target =
+                SimpleTarget.DottableEnemy(dotAction, dotDebuffID, 30, 3, 4);
+
             if (ActionReady(dotAction) && target != null)
                 return OriginalHook(Aero).Retarget(target);
 
@@ -151,7 +152,7 @@ internal partial class WHM : Healer
     }
 
     #endregion
-    
+
     #region DPS
 
     internal class WHM_ST_MainCombo : CustomCombo
@@ -162,10 +163,13 @@ internal partial class WHM : Healer
         {
             #region Button Selection
 
-            bool actionFound = Config.WHM_ST_MainCombo_Actions == 0 && StoneGlareList.Contains(actionID) ||
-                               Config.WHM_ST_MainCombo_Actions == 1 && AeroList.ContainsKey(actionID) ||
-                               Config.WHM_ST_MainCombo_Actions == 2 && actionID is Stone2;
-            
+            bool actionFound = Config.WHM_ST_MainCombo_Actions == 0 &&
+                               StoneGlareList.Contains(actionID) ||
+                               Config.WHM_ST_MainCombo_Actions == 1 &&
+                               AeroList.ContainsKey(actionID) ||
+                               Config.WHM_ST_MainCombo_Actions == 2 &&
+                               actionID is Stone2;
+
             if (!actionFound)
                 return actionID;
 
@@ -183,7 +187,7 @@ internal partial class WHM : Healer
                 return OccultCrescent.BestPhantomAction();
 
             if (!InCombat()) return actionID;
-            
+
             #region Special Feature Raidwide
 
             if (RaidwideTemperance())
@@ -192,7 +196,7 @@ internal partial class WHM : Healer
                 return Asylum.Retarget(actionID, SimpleTarget.Self);
             if (RaidwideLiturgyOfTheBell())
                 return LiturgyOfTheBell.Retarget(actionID, SimpleTarget.Self);
-           
+
             #endregion
 
             #region Weaves
@@ -203,7 +207,8 @@ internal partial class WHM : Healer
                     return Variant.Rampart;
 
                 if (IsEnabled(Preset.WHM_ST_MainCombo_PresenceOfMind) &&
-                    ActionReady(PresenceOfMind) && !HasStatusEffect(Buffs.SacredSight))
+                    ActionReady(PresenceOfMind) &&
+                    !HasStatusEffect(Buffs.SacredSight))
                     return PresenceOfMind;
 
                 if (IsEnabled(Preset.WHM_ST_MainCombo_Assize) &&
@@ -242,8 +247,8 @@ internal partial class WHM : Healer
             if (IsEnabled(Preset.WHM_ST_MainCombo_Misery_oGCD) &&
                 BloodLilyReady)
                 return AfflatusMisery;
-           
-            
+
+
             // Needed Because of Button Selection
             return OriginalHook(Stone1);
 
@@ -279,7 +284,7 @@ internal partial class WHM : Healer
                 return actionID;
 
             #endregion
-            
+
             #region Special Feature Raidwide
 
             if (RaidwideTemperance())
@@ -288,7 +293,7 @@ internal partial class WHM : Healer
                 return Asylum.Retarget([Holy, Holy3], SimpleTarget.Self);
             if (RaidwideLiturgyOfTheBell())
                 return LiturgyOfTheBell.Retarget([Holy, Holy3], SimpleTarget.Self);
-           
+
             #endregion
 
             #region Weaves
@@ -300,7 +305,8 @@ internal partial class WHM : Healer
                     return Assize;
 
                 if (IsEnabled(Preset.WHM_AoE_DPS_PresenceOfMind) &&
-                    ActionReady(PresenceOfMind) && !HasStatusEffect(Buffs.SacredSight))
+                    ActionReady(PresenceOfMind) &&
+                    !HasStatusEffect(Buffs.SacredSight))
                     return PresenceOfMind;
 
                 if (IsEnabled(Preset.WHM_AoE_DPS_Lucid) &&
@@ -333,11 +339,14 @@ internal partial class WHM : Healer
                 BloodLilyReady &&
                 HasBattleTarget())
                 return AfflatusMisery;
-           
+
             var dotAction = OriginalHook(Aero);
             AeroList.TryGetValue(dotAction, out var dotDebuffID);
-            var target = SimpleTarget.DottableEnemy(dotAction, dotDebuffID, Config.WHM_AoE_MainCombo_DoT_HPThreshold, Config.WHM_AoE_MainCombo_DoT_Reapply, Config.WHM_AoE_MainCombo_DoT_MaxTargets);
-            
+            var target = SimpleTarget.DottableEnemy(dotAction, dotDebuffID,
+                Config.WHM_AoE_MainCombo_DoT_HPThreshold,
+                Config.WHM_AoE_MainCombo_DoT_Reapply,
+                Config.WHM_AoE_MainCombo_DoT_MaxTargets);
+
             if (IsEnabled(Preset.WHM_AoE_MainCombo_DoT) &&
                 ActionReady(dotAction) && target != null)
                 return OriginalHook(Aero).Retarget([Holy, Holy3], target);
@@ -370,17 +379,8 @@ internal partial class WHM : Healer
                              GetRemainingCharges(ThinAir) >
                              Config.WHM_STHeals_ThinAir;
 
-
-            var canRegen = ActionReady(Regen) &&
-                             !JustUsedOn(Regen, healTarget) &&
-                             GetStatusEffectRemainingTime(Buffs.Regen, healTarget)
-                             <= Config.WHM_STHeals_RegenTimer && //Refresh Time Threshold
-                             GetTargetHPPercent(healTarget, Config.WHM_STHeals_IncludeShields)
-                             >= Config.WHM_STHeals_RegenHPLower &&
-                             GetTargetHPPercent(healTarget, Config.WHM_STHeals_IncludeShields)
-                             <= Config.WHM_STHeals_RegenHPUpper;  
             #endregion
-            
+
             #region Special Feature Raidwide
 
             if (RaidwideTemperance())
@@ -389,7 +389,7 @@ internal partial class WHM : Healer
                 return Asylum.Retarget(Cure, SimpleTarget.Self);
             if (RaidwideLiturgyOfTheBell())
                 return LiturgyOfTheBell.Retarget(Cure, SimpleTarget.Self);
-           
+
             #endregion
 
             #region Priority Cleansing
@@ -408,31 +408,35 @@ internal partial class WHM : Healer
             if (IsEnabled(Preset.WHM_STHeals_Lucid) && CanWeave() &&
                 Role.CanLucidDream(Config.WHM_STHeals_Lucid))
                 return Role.LucidDreaming;
-            
+
             // Divine Caress
-            if (IsEnabled(Preset.WHM_STHeals_Temperance) && HasStatusEffect(Buffs.DivineGrace) &&
+            if (IsEnabled(Preset.WHM_STHeals_Temperance) &&
+                HasStatusEffect(Buffs.DivineGrace) &&
                 (!Config.WHM_STHeals_TemperanceOptions[1] || !InBossEncounter()) &&
                 (!Config.WHM_STHeals_TemperanceOptions[0] || CanWeave()))
                 return OriginalHook(Temperance);
-            
+
             //Priority List
-            for(int i = 0; i < Config.WHM_ST_Heals_Priority.Count; i++)
+            for (int i = 0; i < Config.WHM_ST_Heals_Priority.Count; i++)
             {
                 int index = Config.WHM_ST_Heals_Priority.IndexOf(i + 1);
-                int config = GetMatchingConfigST(index, OptionalTarget, out uint spell, out bool enabled);
+                int config = GetMatchingConfigST(index, OptionalTarget,
+                    out uint spell, out bool enabled);
 
                 if (enabled)
                 {
-                    if (GetTargetHPPercent(healTarget, Config.WHM_STHeals_IncludeShields) <= config &&
+                    if (GetTargetHPPercent(healTarget,
+                            Config.WHM_STHeals_IncludeShields) <= config &&
                         ActionReady(spell))
                         return spell.RetargetIfEnabled(OptionalTarget, Cure);
                 }
             }
+
             if (LevelChecked(Cure2))
                 return IsEnabled(Preset.WHM_STHeals_ThinAir) && canThinAir
                     ? ThinAir
                     : Cure2.RetargetIfEnabled(OptionalTarget, Cure);
-            
+
             return Cure.RetargetIfEnabled(OptionalTarget);
         }
     }
@@ -452,8 +456,9 @@ internal partial class WHM : Healer
                              !HasStatusEffect(Buffs.ThinAir) &&
                              GetRemainingCharges(ThinAir) >
                              Config.WHM_AoEHeals_ThinAir;
+
             #endregion
-            
+
             #region Special Feature Raidwide
 
             if (RaidwideTemperance())
@@ -461,10 +466,10 @@ internal partial class WHM : Healer
             if (RaidwideAsylum())
                 return Asylum.Retarget(Medica1, SimpleTarget.Self);
             if (RaidwideLiturgyOfTheBell())
-                return LiturgyOfTheBell.Retarget(Medica1 ,SimpleTarget.Self);
-           
+                return LiturgyOfTheBell.Retarget(Medica1, SimpleTarget.Self);
+
             #endregion
-            
+
             if (IsEnabled(Preset.WHM_AoEHeals_Lucid) &&
                 CanWeave() &&
                 Role.CanLucidDream(Config.WHM_AoEHeals_Lucid))
@@ -474,19 +479,22 @@ internal partial class WHM : Healer
             if (IsEnabled(Preset.WHM_AoEHeals_Misery) &&
                 gauge.BloodLily == 3)
                 return AfflatusMisery;
-            
+
             //Priority List
-            for(int i = 0; i < Config.WHM_AoE_Heals_Priority.Count; i++)
+            for (int i = 0; i < Config.WHM_AoE_Heals_Priority.Count; i++)
             {
                 int index = Config.WHM_AoE_Heals_Priority.IndexOf(i + 1);
-                int config = GetMatchingConfigAoE(index, OptionalTarget, out uint spell, out bool enabled);
-                
-                if (enabled && GetPartyAvgHPPercent() <= config && ActionReady(spell))
-                    return IsEnabled(Preset.WHM_AoEHeals_ThinAir) && canThinAir && spell is Cure3 or Medica2 or Medica3?
-                        ThinAir:
-                        spell.RetargetIfEnabled(OptionalTarget, Medica1);
+                int config = GetMatchingConfigAoE(index, OptionalTarget,
+                    out uint spell, out bool enabled);
+
+                if (enabled && GetPartyAvgHPPercent() <= config &&
+                    ActionReady(spell))
+                    return IsEnabled(Preset.WHM_AoEHeals_ThinAir) && canThinAir &&
+                           spell is Cure3 or Medica2 or Medica3
+                        ? ThinAir
+                        : spell.RetargetIfEnabled(OptionalTarget, Medica1);
             }
-           
+
 
             return actionID;
         }
@@ -501,11 +509,9 @@ internal partial class WHM : Healer
         protected internal override Preset Preset => Preset.WHM_SolaceMisery;
 
         protected override uint Invoke(uint actionID) =>
-            actionID is AfflatusSolace && gauge.BloodLily == 3
-                ? AfflatusMisery
-                : IsEnabled(Preset.WHM_Re_Solace)
-                  ? actionID.Retarget(SimpleTarget.Stack.AllyToHeal)
-                  : actionID;
+            actionID is AfflatusSolace && gauge.BloodLily == 3 ? AfflatusMisery :
+                IsEnabled(Preset.WHM_Re_Solace) ?
+                    actionID.Retarget(SimpleTarget.Stack.AllyToHeal) : actionID;
     }
 
     internal class WHM_RaptureMisery : CustomCombo
@@ -522,15 +528,16 @@ internal partial class WHM : Healer
     {
         protected internal override Preset Preset => Preset.WHM_CureSync;
 
-        protected override uint Invoke(uint actionID) {
+        protected override uint Invoke(uint actionID)
+        {
             if (actionID is not Cure)
                 return actionID;
-            
+
             if (!LevelChecked(Cure2))
                 return IsEnabled(Preset.WHM_Re_Cure)
                     ? Cure.Retarget(Cure2, SimpleTarget.Stack.AllyToHeal)
                     : Cure;
-            
+
             return IsEnabled(Preset.WHM_Re_Cure)
                 ? Cure2.Retarget(SimpleTarget.Stack.AllyToHeal)
                 : Cure2;
@@ -550,17 +557,15 @@ internal partial class WHM : Healer
                 (ThinAir);
 
             if (HasStatusEffect(Role.Buffs.Swiftcast))
-                return IsEnabled(Preset.WHM_ThinAirRaise) && canThinAir
-                    ? ThinAir
-                    : IsEnabled(Preset.WHM_Raise_Retarget)
-                        ? Raise.Retarget(Role.Swiftcast,
-                            SimpleTarget.Stack.AllyToRaise)
-                        : Raise;
+                return IsEnabled(Preset.WHM_ThinAirRaise) && canThinAir ? ThinAir :
+                    IsEnabled(Preset.WHM_Raise_Retarget) ? Raise.Retarget(
+                        Role.Swiftcast,
+                        SimpleTarget.Stack.AllyToRaise) : Raise;
 
             return actionID;
         }
     }
-    
+
     internal class WHM_Mit_ST : CustomCombo
     {
         protected internal override Preset Preset => Preset.WHM_Mit_ST;
@@ -569,7 +574,7 @@ internal partial class WHM : Healer
         {
             if (actionID is not Aquaveil)
                 return actionID;
-            
+
             var healTarget = SimpleTarget.Stack.AllyToHeal;
             var benisonShield = GetStatusEffect(Buffs.DivineBenison, healTarget);
 
@@ -577,7 +582,7 @@ internal partial class WHM : Healer
                 return IsEnabled(Preset.WHM_Re_Aquaveil)
                     ? Aquaveil.Retarget(Aquaveil, SimpleTarget.Stack.AllyToHeal)
                     : Aquaveil;
-            
+
             if (Config.WHM_AquaveilOptions[0] &&
                 ActionReady(DivineBenison) &&
                 benisonShield == null)
@@ -586,17 +591,17 @@ internal partial class WHM : Healer
                     : DivineBenison;
 
             if (Config.WHM_AquaveilOptions[1] &&
-                ActionReady(Tetragrammaton) && 
+                ActionReady(Tetragrammaton) &&
                 GetTargetHPPercent(healTarget) < Config.WHM_Aquaveil_TetraThreshold)
                 return IsEnabled(Preset.WHM_Re_Tetragrammaton)
                     ? Tetragrammaton.Retarget(Aquaveil, SimpleTarget.Stack
-                    .AllyToHeal)
+                        .AllyToHeal)
                     : Tetragrammaton;
 
             return actionID;
         }
     }
-    
+
     internal class WHM_Mit_AoE : CustomCombo
     {
         protected internal override Preset Preset => Preset.WHM_Mit_AoE;
@@ -605,7 +610,7 @@ internal partial class WHM : Healer
         {
             if (actionID is not Asylum)
                 return actionID;
-            
+
             var asylumTarget =
                 (Config.WHM_AsylumOptions[0]
                     ? SimpleTarget.HardTarget.IfHostile()
@@ -628,23 +633,23 @@ internal partial class WHM : Healer
     internal class WHM_Retarget : CustomCombo
     {
         protected internal override Preset Preset => Preset.WHM_Retargets;
-        
+
         protected override uint Invoke(uint actionID)
         {
             var healStack = SimpleTarget.Stack.AllyToHeal;
-            
+
             if (IsEnabled(Preset.WHM_Re_Cure))
             {
                 Cure.Retarget(healStack, dontCull: true);
                 Cure2.Retarget(healStack, dontCull: true);
             }
-            
+
             if (IsEnabled(Preset.WHM_Re_Solace))
                 AfflatusSolace.Retarget(healStack, dontCull: true);
-            
+
             if (IsEnabled(Preset.WHM_Re_Aquaveil))
                 AfflatusSolace.Retarget(healStack, dontCull: true);
-            
+
             if (IsEnabled(Preset.WHM_Re_LiturgyOfTheBell))
             {
                 var bellTarget =
@@ -660,16 +665,16 @@ internal partial class WHM : Healer
 
             if (IsEnabled(Preset.WHM_Re_Cure3))
                 Cure3.Retarget(healStack, dontCull: true);
-            
+
             if (IsEnabled(Preset.WHM_Re_Benediction))
                 Benediction.Retarget(healStack, dontCull: true);
 
             if (IsEnabled(Preset.WHM_Re_Tetragrammaton))
                 Tetragrammaton.Retarget(healStack, dontCull: true);
-            
+
             if (IsEnabled(Preset.WHM_Re_Regen))
                 Regen.Retarget(healStack, dontCull: true);
-            
+
             if (IsEnabled(Preset.WHM_Re_DivineBenison))
                 DivineBenison.Retarget(healStack, dontCull: true);
 

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -335,7 +335,7 @@ internal partial class WHM : Healer
            
             var dotAction = OriginalHook(Aero);
             AeroList.TryGetValue(dotAction, out var dotDebuffID);
-            var target = SimpleTarget.DottableEnemy(dotAction, dotDebuffID, Config.WHM_AoE_MainCombo_DoT_Reapply, Config.WHM_AoE_MainCombo_DoT_MaxTargets);
+            var target = SimpleTarget.DottableEnemy(dotAction, dotDebuffID, 30,Config.WHM_AoE_MainCombo_DoT_Reapply, Config.WHM_AoE_MainCombo_DoT_MaxTargets);
             
             if (IsEnabled(CustomComboPreset.WHM_AoE_MainCombo_DoT) &&
                 ActionReady(dotAction) && target != null)

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -91,16 +91,15 @@ internal partial class WHM : Healer
             // Glare IV
             if (HasStatusEffect(Buffs.SacredSight))
                 return Glare4;
+            
+            // Blood Lily Spend
+            if (BloodLilyReady)
+                return AfflatusMisery;
 
             // Lily Heal Overcap
             if (ActionReady(AfflatusRapture) &&
                 (FullLily || AlmostFullLily))
                 return AfflatusRapture;
-
-            // Blood Lily Spend
-            if (BloodLilyReady)
-                return AfflatusMisery;
-
 
             return actionID;
 
@@ -150,14 +149,14 @@ internal partial class WHM : Healer
             // Glare IV
             if (HasStatusEffect(Buffs.SacredSight))
                 return OriginalHook(Glare4);
+            
+            if (BloodLilyReady &&
+                HasBattleTarget())
+                return AfflatusMisery;
 
             if (ActionReady(AfflatusRapture) &&
                 (FullLily || AlmostFullLily))
                 return AfflatusRapture;
-
-            if (BloodLilyReady &&
-                HasBattleTarget())
-                return AfflatusMisery;
 
             var dotAction = OriginalHook(Aero);
             AeroList.TryGetValue(dotAction, out var dotDebuffID);
@@ -279,17 +278,16 @@ internal partial class WHM : Healer
                 HasStatusEffect(Buffs.SacredSight))
                 return Glare4;
 
+            // Blood Lily Spend
+            if (IsEnabled(Preset.WHM_ST_MainCombo_Misery_oGCD) &&
+                BloodLilyReady)
+                return AfflatusMisery;
+            
             // Lily Heal Overcap
             if (IsEnabled(Preset.WHM_ST_MainCombo_LilyOvercap) &&
                 ActionReady(AfflatusRapture) &&
                 (FullLily || AlmostFullLily))
                 return AfflatusRapture;
-
-            // Blood Lily Spend
-            if (IsEnabled(Preset.WHM_ST_MainCombo_Misery_oGCD) &&
-                BloodLilyReady)
-                return AfflatusMisery;
-
 
             // Needed Because of Button Selection
             return OriginalHook(Stone1);
@@ -372,16 +370,16 @@ internal partial class WHM : Healer
             if (IsEnabled(Preset.WHM_AoE_DPS_GlareIV) &&
                 HasStatusEffect(Buffs.SacredSight))
                 return OriginalHook(Glare4);
+            
+            if (IsEnabled(Preset.WHM_AoE_DPS_Misery) &&
+                BloodLilyReady &&
+                HasBattleTarget())
+                return AfflatusMisery;
 
             if (IsEnabled(Preset.WHM_AoE_DPS_LilyOvercap) &&
                 ActionReady(AfflatusRapture) &&
                 (FullLily || AlmostFullLily))
                 return AfflatusRapture;
-
-            if (IsEnabled(Preset.WHM_AoE_DPS_Misery) &&
-                BloodLilyReady &&
-                HasBattleTarget())
-                return AfflatusMisery;
 
             var dotAction = OriginalHook(Aero);
             AeroList.TryGetValue(dotAction, out var dotDebuffID);

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Data;
+using WrathCombo.Extensions;
 
 // ReSharper disable AccessToStaticMemberViaDerivedType
 // ReSharper disable UnusedType.Global
@@ -21,8 +22,7 @@ internal partial class WHM : Healer
 
     internal class WHM_ST_Simple_DPS : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } =
-            CustomComboPreset.WHM_ST_Simple_DPS;
+        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_ST_Simple_DPS;
 
         protected override uint Invoke(uint actionID)
         {
@@ -87,8 +87,7 @@ internal partial class WHM : Healer
 
     internal class WHM_AoE_Simple_DPS : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } =
-            CustomComboPreset.WHM_AoE_Simple_DPS;
+        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_AoE_Simple_DPS;
 
         protected override uint Invoke(uint actionID)
         {
@@ -147,8 +146,7 @@ internal partial class WHM : Healer
 
     internal class WHM_ST_MainCombo : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } =
-            CustomComboPreset.WHM_ST_MainCombo;
+        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_ST_MainCombo;
 
         protected override uint Invoke(uint actionID)
         {
@@ -244,8 +242,7 @@ internal partial class WHM : Healer
 
     internal class WHM_AoE_DPS : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } =
-            CustomComboPreset.WHM_AoE_DPS;
+        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_AoE_DPS;
 
         private static int AssizeCount =>
             ActionWatching.CombatActions.Count(x => x == Assize);
@@ -338,8 +335,7 @@ internal partial class WHM : Healer
 
     internal class WHM_ST_Heals : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } =
-            CustomComboPreset.WHM_STHeals;
+        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_STHeals;
 
         protected override uint Invoke(uint actionID)
         {
@@ -424,8 +420,7 @@ internal partial class WHM : Healer
 
     internal class WHM_AoEHeals : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } =
-            CustomComboPreset.WHM_AoEHeals;
+        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_AoEHeals;
 
         protected override uint Invoke(uint actionID)
         {
@@ -484,8 +479,7 @@ internal partial class WHM : Healer
 
     internal class WHM_SolaceMisery : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } =
-            CustomComboPreset.WHM_SolaceMisery;
+        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_SolaceMisery;
 
         protected override uint Invoke(uint actionID) =>
             actionID is AfflatusSolace && gauge.BloodLily == 3
@@ -495,8 +489,7 @@ internal partial class WHM : Healer
 
     internal class WHM_RaptureMisery : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } =
-            CustomComboPreset.WHM_RaptureMisery;
+        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_RaptureMisery;
 
         protected override uint Invoke(uint actionID) =>
             actionID is AfflatusRapture && gauge.BloodLily == 3
@@ -506,8 +499,7 @@ internal partial class WHM : Healer
 
     internal class WHM_CureSync : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } =
-            CustomComboPreset.WHM_CureSync;
+        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_CureSync;
 
         protected override uint Invoke(uint actionID) =>
             actionID is Cure2 && !LevelChecked(Cure2)
@@ -517,8 +509,7 @@ internal partial class WHM : Healer
 
     internal class WHM_Raise : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } =
-            CustomComboPreset.WHM_Raise;
+        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_Raise;
 
         protected override uint Invoke(uint actionID)
         {
@@ -539,6 +530,58 @@ internal partial class WHM : Healer
             return actionID;
         }
     }
+    
+    
+    internal class WHM_Asylum : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_Asylum;
 
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not Asylum)
+                return actionID;
+            
+            var asylumTarget =
+                (Config.WHM_AsylumOptions[0]
+                    ? SimpleTarget.HardTarget.IfHostile()
+                    : null) ??
+                (Config.WHM_AsylumOptions[1]
+                    ? SimpleTarget.HardTarget.IfFriendly()
+                    : null) ??
+                SimpleTarget.Self;
+                
+            return IsEnabled(CustomComboPreset.WHM_Asylum)? Asylum.Retarget(asylumTarget) : actionID;
+        }
+    }
+    internal class WHM_LiturgyOfTheBell : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_LiturgyOfTheBell;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not LiturgyOfTheBell)
+                return actionID;
+            
+            var bellTarget =
+                (Config.WHM_LiturgyOfTheBellOptions[0]
+                    ? SimpleTarget.HardTarget.IfHostile()
+                    : null) ??
+                (Config.WHM_LiturgyOfTheBellOptions[1]
+                    ? SimpleTarget.HardTarget.IfFriendly()
+                    : null) ??
+                SimpleTarget.Self;
+                
+            return IsEnabled(CustomComboPreset.WHM_LiturgyOfTheBell)? LiturgyOfTheBell.Retarget(bellTarget) : actionID;
+        }
+    }
+    internal class WHM_Cure3 : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_Cure3;
+
+        protected override uint Invoke(uint actionID) =>
+            actionID is not Cure3
+                ? actionID
+                : actionID.Retarget(SimpleTarget.Stack.AllyToHeal, dontCull: true);
+    }
     #endregion
 }

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -63,6 +63,7 @@ internal partial class WHM : Healer
                     return Variant.Rampart;
 
                 if (ActionReady(PresenceOfMind) &&
+                    ActionWatching.NumberOfGcdsUsed >= 3 &&
                     !HasStatusEffect(Buffs.SacredSight))
                     return PresenceOfMind;
 
@@ -125,6 +126,7 @@ internal partial class WHM : Healer
                     return Assize;
 
                 if (ActionReady(PresenceOfMind) &&
+                    ActionWatching.NumberOfGcdsUsed >= 4 &&
                     !HasStatusEffect(Buffs.SacredSight))
                     return PresenceOfMind;
 
@@ -245,6 +247,7 @@ internal partial class WHM : Healer
 
                 if (IsEnabled(Preset.WHM_ST_MainCombo_PresenceOfMind) &&
                     ActionReady(PresenceOfMind) &&
+                    ActionWatching.NumberOfGcdsUsed >= 3 &&
                     !HasStatusEffect(Buffs.SacredSight))
                     return PresenceOfMind;
 
@@ -343,6 +346,7 @@ internal partial class WHM : Healer
 
                 if (IsEnabled(Preset.WHM_AoE_DPS_PresenceOfMind) &&
                     ActionReady(PresenceOfMind) &&
+                    ActionWatching.NumberOfGcdsUsed >= 4 &&
                     !HasStatusEffect(Buffs.SacredSight))
                     return PresenceOfMind;
 

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -335,7 +335,7 @@ internal partial class WHM : Healer
            
             var dotAction = OriginalHook(Aero);
             AeroList.TryGetValue(dotAction, out var dotDebuffID);
-            var target = SimpleTarget.DottableEnemy(dotAction, dotDebuffID, 30,Config.WHM_AoE_MainCombo_DoT_Reapply, Config.WHM_AoE_MainCombo_DoT_MaxTargets);
+            var target = SimpleTarget.DottableEnemy(dotAction, dotDebuffID, Config.WHM_AoE_MainCombo_DoT_HPThreshold, Config.WHM_AoE_MainCombo_DoT_Reapply, Config.WHM_AoE_MainCombo_DoT_MaxTargets);
             
             if (IsEnabled(CustomComboPreset.WHM_AoE_MainCombo_DoT) &&
                 ActionReady(dotAction) && target != null)

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -283,6 +283,12 @@ internal partial class WHM : Healer
                 Role.CanLucidDream(Config.WHM_STHeals_Lucid))
                 return Role.LucidDreaming;
             
+            // Divine Caress
+            if (IsEnabled(CustomComboPreset.WHM_STHeals_Temperance) && HasStatusEffect(Buffs.DivineGrace) &&
+                (!Config.WHM_STHeals_TemperanceOptions[1] || !InBossEncounter()) &&
+                (!Config.WHM_STHeals_TemperanceOptions[0] || CanWeave()))
+                return OriginalHook(Temperance);
+            
             //Priority List
             for(int i = 0; i < Config.WHM_ST_Heals_Priority.Count; i++)
             {
@@ -348,7 +354,7 @@ internal partial class WHM : Healer
             for(int i = 0; i < Config.WHM_AoE_Heals_Priority.Count; i++)
             {
                 int index = Config.WHM_AoE_Heals_Priority.IndexOf(i + 1);
-                int config = GetMatchingConfigAoE(index, out uint spell, out bool enabled);
+                int config = GetMatchingConfigAoE(index, OptionalTarget, out uint spell, out bool enabled);
                 
                 if (enabled && GetPartyAvgHPPercent() <= config && ActionReady(spell))
                     return IsEnabled(CustomComboPreset.WHM_AoEHeals_ThinAir) && canThinAir && spell is Cure3 or Medica2 or Medica3?

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -39,24 +39,6 @@ internal partial class WHM : Healer
 
             if (!InCombat()) return actionID;
 
-            #region Movement Options
-
-            if (IsMoving())
-            {
-                var dotAction = OriginalHook(Aero);
-                AeroList.TryGetValue(dotAction, out var dotDebuffID);
-                var target = SimpleTarget.DottableEnemy(
-                    dotAction, dotDebuffID, 0, 20, 99);
-                if (IsEnabled(Preset.WHM_ST_MainCombo_Move_DoT) &&
-                    target is not null)
-                    return dotAction.Retarget(StoneGlareList.ToArray(), target);
-
-                if (BloodLilyReady)
-                    return AfflatusMisery;
-            }
-
-            #endregion
-
             #region Weaves
 
             if (CanWeave())
@@ -100,6 +82,21 @@ internal partial class WHM : Healer
             if (ActionReady(AfflatusRapture) &&
                 (FullLily || AlmostFullLily))
                 return AfflatusRapture;
+            
+            #region Movement Options
+
+            if (IsMoving())
+            {
+                var dotAction = OriginalHook(Aero);
+                AeroList.TryGetValue(dotAction, out var dotDebuffID);
+                var target = SimpleTarget.DottableEnemy(
+                    dotAction, dotDebuffID, 0, 20, 99);
+                if (IsEnabled(Preset.WHM_ST_MainCombo_Move_DoT) &&
+                    target is not null)
+                    return dotAction.Retarget(StoneGlareList.ToArray(), target);
+            }
+
+            #endregion
 
             return actionID;
 
@@ -220,25 +217,6 @@ internal partial class WHM : Healer
 
             #endregion
 
-            #region Movement Options
-
-            if (IsMoving() && IsEnabled(Preset.WHM_ST_MainCombo_Movement))
-            {
-                var dotAction = OriginalHook(Aero);
-                AeroList.TryGetValue(dotAction, out var dotDebuffID);
-                var target = SimpleTarget.DottableEnemy(
-                    dotAction, dotDebuffID, 0, 30, 99);
-                if (IsEnabled(Preset.WHM_ST_MainCombo_Move_DoT) &&
-                    target is not null)
-                    return dotAction.Retarget(replacedAction, target);
-
-                if (IsEnabled(Preset.WHM_ST_MainCombo_Move_Lily) &&
-                    BloodLilyReady)
-                    return AfflatusMisery;
-            }
-
-            #endregion
-
             #region Weaves
 
             if (CanWeave())
@@ -288,6 +266,20 @@ internal partial class WHM : Healer
                 ActionReady(AfflatusRapture) &&
                 (FullLily || AlmostFullLily))
                 return AfflatusRapture;
+            
+            #region Movement Options
+
+            if (IsMoving())
+            {
+                var dotAction = OriginalHook(Aero);
+                AeroList.TryGetValue(dotAction, out var dotDebuffID);
+                var target = SimpleTarget.DottableEnemy(
+                    dotAction, dotDebuffID, 0, 30, 99);
+                if (IsEnabled(Preset.WHM_ST_MainCombo_Move_DoT) &&
+                    target is not null)
+                    return dotAction.Retarget(replacedAction, target);
+            }
+            #endregion
 
             // Needed Because of Button Selection
             return OriginalHook(Stone1);

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -165,7 +165,7 @@ internal partial class WHM : Healer
                 SimpleTarget.DottableEnemy(dotAction, dotDebuffID, 30, 3, 4);
 
             if (ActionReady(dotAction) && target != null)
-                return OriginalHook(Aero).Retarget(target);
+                return OriginalHook(Aero).Retarget([Holy, Holy3], target);
 
             #endregion
 
@@ -694,10 +694,10 @@ internal partial class WHM : Healer
 
         protected override uint Invoke(uint actionID)
         {
-            var healStack = SimpleTarget.Stack.AllyToHeal;
-            
             if (!EZ.Throttle("WHMRetargetingFeature", TS.FromSeconds(5)))
                 return actionID;
+            
+            var healStack = SimpleTarget.Stack.AllyToHeal;
 
             if (IsEnabled(Preset.WHM_Re_Cure))
             {
@@ -709,7 +709,7 @@ internal partial class WHM : Healer
                 AfflatusSolace.Retarget(healStack, dontCull: true);
 
             if (IsEnabled(Preset.WHM_Re_Aquaveil))
-                AfflatusSolace.Retarget(healStack, dontCull: true);
+                Aquaveil.Retarget(healStack, dontCull: true);
 
             if (IsEnabled(Preset.WHM_Re_LiturgyOfTheBell))
             {

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -154,25 +154,10 @@ internal partial class WHM : Healer
         {
             #region Button Selection
 
-            bool actionFound;
-
-            if (Config.WHM_ST_MainCombo_Adv &&
-                Config.WHM_ST_MainCombo_Adv_Actions.Count > 0)
-            {
-                var isStoneGlare = Config.WHM_ST_MainCombo_Adv_Actions[0] &&
-                                   StoneGlareList.Contains(actionID);
-                var isAero = Config.WHM_ST_MainCombo_Adv_Actions[1] &&
-                             AeroList.ContainsKey(actionID);
-                var isStone2 = Config.WHM_ST_MainCombo_Adv_Actions[2] &&
-                               actionID is Stone2;
-                actionFound = isStoneGlare || isAero || isStone2;
-            }
-            else
-            {
-                actionFound = StoneGlareList.Contains(actionID); //default handling
-            }
-
-            // If the action is not in the list, return the actionID
+            bool actionFound = Config.WHM_ST_MainCombo_Actions == 0 && StoneGlareList.Contains(actionID) ||
+                               Config.WHM_ST_MainCombo_Actions == 1 && AeroList.ContainsKey(actionID) ||
+                               Config.WHM_ST_MainCombo_Actions == 2 && actionID is Stone2;
+            
             if (!actionFound)
                 return actionID;
 

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -7,6 +7,7 @@ using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Data;
 using WrathCombo.Extensions;
+using Preset = WrathCombo.Combos.CustomComboPreset;
 
 // ReSharper disable AccessToStaticMemberViaDerivedType
 // ReSharper disable UnusedType.Global
@@ -24,7 +25,7 @@ internal partial class WHM : Healer
 
     internal class WHM_ST_Simple_DPS : CustomCombo
     {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_ST_Simple_DPS;
+        protected internal override Preset Preset => Preset.WHM_ST_Simple_DPS;
 
         protected override uint Invoke(uint actionID)
         {
@@ -42,7 +43,7 @@ internal partial class WHM : Healer
 
             if (CanWeave())
             {
-                if (Variant.CanRampart(CustomComboPreset.WHM_DPS_Variant_Rampart))
+                if (Variant.CanRampart(Preset.WHM_DPS_Variant_Rampart))
                     return Variant.Rampart;
 
                 if (ActionReady(PresenceOfMind) && !HasStatusEffect(Buffs.SacredSight))
@@ -55,7 +56,7 @@ internal partial class WHM : Healer
                     return Role.LucidDreaming;
 
                 if (Variant.CanSpiritDart(
-                        CustomComboPreset.WHM_DPS_Variant_SpiritDart))
+                        Preset.WHM_DPS_Variant_SpiritDart))
                     return Variant.SpiritDart;
             }
 
@@ -89,7 +90,7 @@ internal partial class WHM : Healer
 
     internal class WHM_AoE_Simple_DPS : CustomCombo
     {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_AoE_Simple_DPS;
+        protected internal override Preset Preset => Preset.WHM_AoE_Simple_DPS;
 
         protected override uint Invoke(uint actionID)
         {
@@ -112,10 +113,10 @@ internal partial class WHM : Healer
                 if (Role.CanLucidDream(7500))
                     return Role.LucidDreaming;
 
-                if (Variant.CanRampart(CustomComboPreset.WHM_DPS_Variant_Rampart))
+                if (Variant.CanRampart(Preset.WHM_DPS_Variant_Rampart))
                     return Variant.Rampart;
 
-                if (Variant.CanSpiritDart(CustomComboPreset
+                if (Variant.CanSpiritDart(Preset
                         .WHM_DPS_Variant_SpiritDart))
                     return Variant.SpiritDart;
             }
@@ -155,7 +156,7 @@ internal partial class WHM : Healer
 
     internal class WHM_ST_MainCombo : CustomCombo
     {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_ST_MainCombo;
+        protected internal override Preset Preset => Preset.WHM_ST_MainCombo;
 
         protected override uint Invoke(uint actionID)
         {
@@ -172,7 +173,7 @@ internal partial class WHM : Healer
 
             #region Opener
 
-            if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Opener))
+            if (IsEnabled(Preset.WHM_ST_MainCombo_Opener))
                 if (Opener().FullOpener(ref actionID))
                     return actionID;
 
@@ -198,23 +199,23 @@ internal partial class WHM : Healer
 
             if (CanWeave())
             {
-                if (Variant.CanRampart(CustomComboPreset.WHM_DPS_Variant_Rampart))
+                if (Variant.CanRampart(Preset.WHM_DPS_Variant_Rampart))
                     return Variant.Rampart;
 
-                if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_PresenceOfMind) &&
+                if (IsEnabled(Preset.WHM_ST_MainCombo_PresenceOfMind) &&
                     ActionReady(PresenceOfMind) && !HasStatusEffect(Buffs.SacredSight))
                     return PresenceOfMind;
 
-                if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Assize) &&
+                if (IsEnabled(Preset.WHM_ST_MainCombo_Assize) &&
                     ActionReady(Assize))
                     return Assize;
 
-                if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Lucid) &&
+                if (IsEnabled(Preset.WHM_ST_MainCombo_Lucid) &&
                     Role.CanLucidDream(Config.WHM_STDPS_Lucid))
                     return Role.LucidDreaming;
 
                 if (Variant.CanSpiritDart(
-                        CustomComboPreset.WHM_DPS_Variant_SpiritDart))
+                        Preset.WHM_DPS_Variant_SpiritDart))
                     return Variant.SpiritDart;
             }
 
@@ -223,22 +224,22 @@ internal partial class WHM : Healer
             #region GCDS and Casts
 
             // DoTs
-            if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_DoT) && NeedsDoT())
+            if (IsEnabled(Preset.WHM_ST_MainCombo_DoT) && NeedsDoT())
                 return OriginalHook(Aero);
 
             // Glare IV
-            if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_GlareIV) &&
+            if (IsEnabled(Preset.WHM_ST_MainCombo_GlareIV) &&
                 HasStatusEffect(Buffs.SacredSight))
                 return Glare4;
 
             // Lily Heal Overcap
-            if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_LilyOvercap) &&
+            if (IsEnabled(Preset.WHM_ST_MainCombo_LilyOvercap) &&
                 ActionReady(AfflatusRapture) &&
                 (FullLily || AlmostFullLily))
                 return AfflatusRapture;
 
             // Blood Lily Spend
-            if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Misery_oGCD) &&
+            if (IsEnabled(Preset.WHM_ST_MainCombo_Misery_oGCD) &&
                 BloodLilyReady)
                 return AfflatusMisery;
            
@@ -252,7 +253,7 @@ internal partial class WHM : Healer
 
     internal class WHM_AoE_DPS : CustomCombo
     {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_AoE_DPS;
+        protected internal override Preset Preset => Preset.WHM_AoE_DPS;
 
         private static int AssizeCount =>
             ActionWatching.CombatActions.Count(x => x == Assize);
@@ -268,12 +269,12 @@ internal partial class WHM : Healer
 
             #region Swiftcast Opener
 
-            if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_SwiftHoly) &&
+            if (IsEnabled(Preset.WHM_AoE_DPS_SwiftHoly) &&
                 ActionReady(Role.Swiftcast) &&
                 AssizeCount == 0 && !IsMoving() && InCombat())
                 return Role.Swiftcast;
 
-            if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_SwiftHoly) &&
+            if (IsEnabled(Preset.WHM_AoE_DPS_SwiftHoly) &&
                 WasLastAction(Role.Swiftcast))
                 return actionID;
 
@@ -294,22 +295,22 @@ internal partial class WHM : Healer
 
             if (CanWeave() || IsMoving())
             {
-                if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_Assize) &&
+                if (IsEnabled(Preset.WHM_AoE_DPS_Assize) &&
                     ActionReady(Assize))
                     return Assize;
 
-                if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_PresenceOfMind) &&
+                if (IsEnabled(Preset.WHM_AoE_DPS_PresenceOfMind) &&
                     ActionReady(PresenceOfMind) && !HasStatusEffect(Buffs.SacredSight))
                     return PresenceOfMind;
 
-                if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_Lucid) &&
+                if (IsEnabled(Preset.WHM_AoE_DPS_Lucid) &&
                     Role.CanLucidDream(Config.WHM_AoEDPS_Lucid))
                     return Role.LucidDreaming;
 
-                if (Variant.CanRampart(CustomComboPreset.WHM_DPS_Variant_Rampart))
+                if (Variant.CanRampart(Preset.WHM_DPS_Variant_Rampart))
                     return Variant.Rampart;
 
-                if (Variant.CanSpiritDart(CustomComboPreset
+                if (Variant.CanSpiritDart(Preset
                         .WHM_DPS_Variant_SpiritDart))
                     return Variant.SpiritDart;
             }
@@ -319,16 +320,16 @@ internal partial class WHM : Healer
             #region GCDS and Casts
 
             // Glare IV
-            if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_GlareIV) &&
+            if (IsEnabled(Preset.WHM_AoE_DPS_GlareIV) &&
                 HasStatusEffect(Buffs.SacredSight))
                 return OriginalHook(Glare4);
 
-            if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_LilyOvercap) &&
+            if (IsEnabled(Preset.WHM_AoE_DPS_LilyOvercap) &&
                 ActionReady(AfflatusRapture) &&
                 (FullLily || AlmostFullLily))
                 return AfflatusRapture;
 
-            if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_Misery) &&
+            if (IsEnabled(Preset.WHM_AoE_DPS_Misery) &&
                 BloodLilyReady &&
                 HasBattleTarget())
                 return AfflatusMisery;
@@ -337,7 +338,7 @@ internal partial class WHM : Healer
             AeroList.TryGetValue(dotAction, out var dotDebuffID);
             var target = SimpleTarget.DottableEnemy(dotAction, dotDebuffID, Config.WHM_AoE_MainCombo_DoT_HPThreshold, Config.WHM_AoE_MainCombo_DoT_Reapply, Config.WHM_AoE_MainCombo_DoT_MaxTargets);
             
-            if (IsEnabled(CustomComboPreset.WHM_AoE_MainCombo_DoT) &&
+            if (IsEnabled(Preset.WHM_AoE_MainCombo_DoT) &&
                 ActionReady(dotAction) && target != null)
                 return OriginalHook(Aero).Retarget([Holy, Holy3], target);
 
@@ -353,7 +354,7 @@ internal partial class WHM : Healer
 
     internal class WHM_ST_Heals : CustomCombo
     {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_STHeals;
+        protected internal override Preset Preset => Preset.WHM_STHeals;
 
         protected override uint Invoke(uint actionID)
         {
@@ -393,7 +394,7 @@ internal partial class WHM : Healer
 
             #region Priority Cleansing
 
-            if (IsEnabled(CustomComboPreset.WHM_STHeals_Esuna) &&
+            if (IsEnabled(Preset.WHM_STHeals_Esuna) &&
                 ActionReady(Role.Esuna) &&
                 GetTargetHPPercent(
                     healTarget, Config.WHM_STHeals_IncludeShields) >=
@@ -404,12 +405,12 @@ internal partial class WHM : Healer
 
             #endregion
 
-            if (IsEnabled(CustomComboPreset.WHM_STHeals_Lucid) && CanWeave() &&
+            if (IsEnabled(Preset.WHM_STHeals_Lucid) && CanWeave() &&
                 Role.CanLucidDream(Config.WHM_STHeals_Lucid))
                 return Role.LucidDreaming;
             
             // Divine Caress
-            if (IsEnabled(CustomComboPreset.WHM_STHeals_Temperance) && HasStatusEffect(Buffs.DivineGrace) &&
+            if (IsEnabled(Preset.WHM_STHeals_Temperance) && HasStatusEffect(Buffs.DivineGrace) &&
                 (!Config.WHM_STHeals_TemperanceOptions[1] || !InBossEncounter()) &&
                 (!Config.WHM_STHeals_TemperanceOptions[0] || CanWeave()))
                 return OriginalHook(Temperance);
@@ -428,7 +429,7 @@ internal partial class WHM : Healer
                 }
             }
             if (LevelChecked(Cure2))
-                return IsEnabled(CustomComboPreset.WHM_STHeals_ThinAir) && canThinAir
+                return IsEnabled(Preset.WHM_STHeals_ThinAir) && canThinAir
                     ? ThinAir
                     : Cure2.RetargetIfEnabled(OptionalTarget, Cure);
             
@@ -438,7 +439,7 @@ internal partial class WHM : Healer
 
     internal class WHM_AoEHeals : CustomCombo
     {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_AoEHeals;
+        protected internal override Preset Preset => Preset.WHM_AoEHeals;
 
         protected override uint Invoke(uint actionID)
         {
@@ -464,13 +465,13 @@ internal partial class WHM : Healer
            
             #endregion
             
-            if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Lucid) &&
+            if (IsEnabled(Preset.WHM_AoEHeals_Lucid) &&
                 CanWeave() &&
                 Role.CanLucidDream(Config.WHM_AoEHeals_Lucid))
                 return Role.LucidDreaming;
 
             // Blood Overcap
-            if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Misery) &&
+            if (IsEnabled(Preset.WHM_AoEHeals_Misery) &&
                 gauge.BloodLily == 3)
                 return AfflatusMisery;
             
@@ -481,7 +482,7 @@ internal partial class WHM : Healer
                 int config = GetMatchingConfigAoE(index, OptionalTarget, out uint spell, out bool enabled);
                 
                 if (enabled && GetPartyAvgHPPercent() <= config && ActionReady(spell))
-                    return IsEnabled(CustomComboPreset.WHM_AoEHeals_ThinAir) && canThinAir && spell is Cure3 or Medica2 or Medica3?
+                    return IsEnabled(Preset.WHM_AoEHeals_ThinAir) && canThinAir && spell is Cure3 or Medica2 or Medica3?
                         ThinAir:
                         spell.RetargetIfEnabled(OptionalTarget, Medica1);
             }
@@ -497,17 +498,19 @@ internal partial class WHM : Healer
 
     internal class WHM_SolaceMisery : CustomCombo
     {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_SolaceMisery;
+        protected internal override Preset Preset => Preset.WHM_SolaceMisery;
 
         protected override uint Invoke(uint actionID) =>
             actionID is AfflatusSolace && gauge.BloodLily == 3
                 ? AfflatusMisery
-                : actionID.RetargetIfEnabled(OptionalTarget);
+                : IsEnabled(Preset.WHM_Re_Solace)
+                  ? AfflatusSolace.Retarget(SimpleTarget.Stack.AllyToHeal)
+                  : AfflatusSolace;
     }
 
     internal class WHM_RaptureMisery : CustomCombo
     {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_RaptureMisery;
+        protected internal override Preset Preset => Preset.WHM_RaptureMisery;
 
         protected override uint Invoke(uint actionID) =>
             actionID is AfflatusRapture && gauge.BloodLily == 3
@@ -517,17 +520,26 @@ internal partial class WHM : Healer
 
     internal class WHM_CureSync : CustomCombo
     {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_CureSync;
+        protected internal override Preset Preset => Preset.WHM_CureSync;
 
-        protected override uint Invoke(uint actionID) =>
-            actionID is Cure2 && !LevelChecked(Cure2)
-                ? Cure.RetargetIfEnabled(OptionalTarget, Cure2)
-                : actionID.RetargetIfEnabled(OptionalTarget);
+        protected override uint Invoke(uint actionID) {
+            if (actionID is not Cure)
+                return actionID;
+            
+            if (!LevelChecked(Cure2))
+                return IsEnabled(Preset.WHM_Re_Cure)
+                    ? Cure.Retarget(Cure2, SimpleTarget.Stack.AllyToHeal)
+                    : Cure;
+            
+            return IsEnabled(Preset.WHM_Re_Cure)
+                ? Cure2.Retarget(SimpleTarget.Stack.AllyToHeal)
+                : Cure2;
+        }
     }
 
     internal class WHM_Raise : CustomCombo
     {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_Raise;
+        protected internal override Preset Preset => Preset.WHM_Raise;
 
         protected override uint Invoke(uint actionID)
         {
@@ -538,9 +550,9 @@ internal partial class WHM : Healer
                 (ThinAir);
 
             if (HasStatusEffect(Role.Buffs.Swiftcast))
-                return IsEnabled(CustomComboPreset.WHM_ThinAirRaise) && canThinAir
+                return IsEnabled(Preset.WHM_ThinAirRaise) && canThinAir
                     ? ThinAir
-                    : IsEnabled(CustomComboPreset.WHM_Raise_Retarget)
+                    : IsEnabled(Preset.WHM_Raise_Retarget)
                         ? Raise.Retarget(Role.Swiftcast,
                             SimpleTarget.Stack.AllyToRaise)
                         : Raise;
@@ -549,10 +561,45 @@ internal partial class WHM : Healer
         }
     }
     
-    
-    internal class WHM_Asylum : CustomCombo
+    internal class WHM_Mit_ST : CustomCombo
     {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_Asylum;
+        protected internal override Preset Preset => Preset.WHM_Mit_ST;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not Aquaveil)
+                return actionID;
+            
+            var healTarget = SimpleTarget.Stack.AllyToHeal;
+            var benisonShield = GetStatusEffect(Buffs.DivineBenison, healTarget);
+
+            if (ActionReady(Aquaveil))
+                return IsEnabled(Preset.WHM_Re_Aquaveil)
+                    ? Aquaveil.Retarget(Aquaveil, SimpleTarget.Stack.AllyToHeal)
+                    : Aquaveil;
+            
+            if (Config.WHM_AquaveilOptions[0] &&
+                ActionReady(DivineBenison) &&
+                benisonShield == null)
+                return IsEnabled(Preset.WHM_Re_DivineBenison)
+                    ? DivineBenison.Retarget(Aquaveil, SimpleTarget.Stack.AllyToHeal)
+                    : DivineBenison;
+
+            if (Config.WHM_AquaveilOptions[1] &&
+                ActionReady(Tetragrammaton) && 
+                GetTargetHPPercent(healTarget) < Config.WHM_Aquaveil_TetraThreshold)
+                return IsEnabled(Preset.WHM_Re_Tetragrammaton)
+                    ? Tetragrammaton.Retarget(Aquaveil, SimpleTarget.Stack
+                    .AllyToHeal)
+                    : Tetragrammaton;
+
+            return actionID;
+        }
+    }
+    
+    internal class WHM_Mit_AoE : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.WHM_Mit_AoE;
 
         protected override uint Invoke(uint actionID)
         {
@@ -568,111 +615,67 @@ internal partial class WHM : Healer
                     : null) ??
                 SimpleTarget.Self;
 
-            if (Config.WHM_AsylumOptions[2] &&
-                ActionReady(OriginalHook(Temperance)) &&
+            if (ActionReady(OriginalHook(Temperance)) &&
                 IsOnCooldown(Asylum))
                 return OriginalHook(Temperance);
 
-            return Asylum.Retarget(asylumTarget);
+            return IsEnabled(Preset.WHM_Re_Asylum)
+                ? Asylum.Retarget(Asylum, asylumTarget)
+                : Asylum;
         }
     }
-    internal class WHM_Aquaveil : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_Aquaveil;
 
+    internal class WHM_Retarget : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.WHM_Retargets;
+        
         protected override uint Invoke(uint actionID)
         {
-            IGameObject? healTarget = OptionalTarget ?? SimpleTarget.Stack.AllyToHeal;
-            Status? benisonShield = GetStatusEffect(Buffs.DivineBenison, healTarget);
+            var healStack = SimpleTarget.Stack.AllyToHeal;
             
-            if (actionID is not Aquaveil)
-                return actionID;
-
-            if (ActionReady(Aquaveil))
-                return actionID.RetargetIfEnabled(OptionalTarget);
+            if (IsEnabled(Preset.WHM_Re_Cure))
+            {
+                Cure.Retarget(healStack, dontCull: true);
+                Cure2.Retarget(healStack, dontCull: true);
+            }
             
-            if (Config.WHM_AquaveilOptions[0] &&
-                ActionReady(DivineBenison) &&
-                benisonShield == null)
-                return DivineBenison.RetargetIfEnabled(OptionalTarget, Aquaveil);
+            if (IsEnabled(Preset.WHM_Re_Solace))
+                AfflatusSolace.Retarget(healStack, dontCull: true);
+            
+            if (IsEnabled(Preset.WHM_Re_Aquaveil))
+                AfflatusSolace.Retarget(healStack, dontCull: true);
+            
+            if (IsEnabled(Preset.WHM_Re_LiturgyOfTheBell))
+            {
+                var bellTarget =
+                    (Config.WHM_LiturgyOfTheBellOptions[0]
+                        ? SimpleTarget.HardTarget.IfHostile()
+                        : null) ??
+                    (Config.WHM_LiturgyOfTheBellOptions[1]
+                        ? SimpleTarget.HardTarget.IfFriendly()
+                        : null) ??
+                    SimpleTarget.Self;
+                LiturgyOfTheBell.Retarget(bellTarget, dontCull: true);
+            }
 
-            if (Config.WHM_AquaveilOptions[1] &&
-                ActionReady(Tetragrammaton) && 
-                GetTargetHPPercent(healTarget) < Config.WHM_Aquaveil_TetraThreshold)
-                return Tetragrammaton.RetargetIfEnabled(OptionalTarget, Aquaveil);
+            if (IsEnabled(Preset.WHM_Re_Cure3))
+                Cure3.Retarget(healStack, dontCull: true);
+            
+            if (IsEnabled(Preset.WHM_Re_Benediction))
+                Benediction.Retarget(healStack, dontCull: true);
+
+            if (IsEnabled(Preset.WHM_Re_Tetragrammaton))
+                Tetragrammaton.Retarget(healStack, dontCull: true);
+            
+            if (IsEnabled(Preset.WHM_Re_Regen))
+                Regen.Retarget(healStack, dontCull: true);
+            
+            if (IsEnabled(Preset.WHM_Re_DivineBenison))
+                DivineBenison.Retarget(healStack, dontCull: true);
 
             return actionID;
         }
     }
-    internal class WHM_LiturgyOfTheBell : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_LiturgyOfTheBell;
 
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not LiturgyOfTheBell)
-                return actionID;
-            
-            var bellTarget =
-                (Config.WHM_LiturgyOfTheBellOptions[0]
-                    ? SimpleTarget.HardTarget.IfHostile()
-                    : null) ??
-                (Config.WHM_LiturgyOfTheBellOptions[1]
-                    ? SimpleTarget.HardTarget.IfFriendly()
-                    : null) ??
-                SimpleTarget.Self;
-                
-            return LiturgyOfTheBell.Retarget(bellTarget);
-        }
-    }
-    internal class WHM_Cure3 : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_Cure3;
-
-        protected override uint Invoke(uint actionID) =>
-            actionID is not Cure3
-                ? actionID
-                : actionID.RetargetIfEnabled(OptionalTarget);
-    }
-    
-    internal class WHM_Benediction : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_Benediction;
-
-        protected override uint Invoke(uint actionID) =>
-            actionID is not Benediction
-                ? actionID
-                : actionID.RetargetIfEnabled(OptionalTarget);
-    }
-    
-    internal class WHM_Tetragrammaton : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_Tetragrammaton;
-
-        protected override uint Invoke(uint actionID) =>
-            actionID is not Tetragrammaton
-                ? actionID
-                : actionID.RetargetIfEnabled(OptionalTarget);
-    }
-    
-    internal class WHM_Regen : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_Regen;
-
-        protected override uint Invoke(uint actionID) =>
-            actionID is not Regen
-                ? actionID
-                : actionID.RetargetIfEnabled(OptionalTarget);
-    }
-    
-    internal class WHM_DivineBenison : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.WHM_DivineBenison;
-
-        protected override uint Invoke(uint actionID) =>
-            actionID is not DivineBenison
-                ? actionID
-                : actionID.RetargetIfEnabled(OptionalTarget);
-    }
     #endregion
 }

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -163,12 +163,12 @@ internal partial class WHM : Healer
         {
             #region Button Selection
 
-            bool actionFound = Config.WHM_ST_MainCombo_Actions == 0 &&
-                               StoneGlareList.Contains(actionID) ||
-                               Config.WHM_ST_MainCombo_Actions == 1 &&
-                               AeroList.ContainsKey(actionID) ||
-                               Config.WHM_ST_MainCombo_Actions == 2 &&
-                               actionID is Stone2;
+            var actionFound = Config.WHM_ST_MainCombo_Actions == 0 &&
+                              StoneGlareList.Contains(actionID) ||
+                              Config.WHM_ST_MainCombo_Actions == 1 &&
+                              AeroList.ContainsKey(actionID) ||
+                              Config.WHM_ST_MainCombo_Actions == 2 &&
+                              actionID is Stone2;
 
             if (!actionFound)
                 return actionID;
@@ -417,11 +417,11 @@ internal partial class WHM : Healer
                 return OriginalHook(Temperance);
 
             //Priority List
-            for (int i = 0; i < Config.WHM_ST_Heals_Priority.Count; i++)
+            for (var i = 0; i < Config.WHM_ST_Heals_Priority.Count; i++)
             {
-                int index = Config.WHM_ST_Heals_Priority.IndexOf(i + 1);
-                int config = GetMatchingConfigST(index, OptionalTarget,
-                    out uint spell, out bool enabled);
+                var index = Config.WHM_ST_Heals_Priority.IndexOf(i + 1);
+                var config = GetMatchingConfigST(index, OptionalTarget,
+                    out var spell, out var enabled);
 
                 if (enabled)
                 {
@@ -481,11 +481,11 @@ internal partial class WHM : Healer
                 return AfflatusMisery;
 
             //Priority List
-            for (int i = 0; i < Config.WHM_AoE_Heals_Priority.Count; i++)
+            for (var i = 0; i < Config.WHM_AoE_Heals_Priority.Count; i++)
             {
-                int index = Config.WHM_AoE_Heals_Priority.IndexOf(i + 1);
-                int config = GetMatchingConfigAoE(index, OptionalTarget,
-                    out uint spell, out bool enabled);
+                var index = Config.WHM_AoE_Heals_Priority.IndexOf(i + 1);
+                var config = GetMatchingConfigAoE(index, OptionalTarget,
+                    out var spell, out var enabled);
 
                 if (enabled && GetPartyAvgHPPercent() <= config &&
                     ActionReady(spell))

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -234,7 +234,8 @@ internal partial class WHM : Healer
             if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Misery_oGCD) &&
                 BloodLilyReady)
                 return AfflatusMisery;
-
+           
+            
             // Needed Because of Button Selection
             return OriginalHook(Stone1);
 
@@ -324,6 +325,14 @@ internal partial class WHM : Healer
                 BloodLilyReady &&
                 HasBattleTarget())
                 return AfflatusMisery;
+           
+            var dotAction = OriginalHook(Aero);
+            AeroList.TryGetValue(dotAction, out var dotDebuffID);
+            var target = SimpleTarget.DottableEnemy(dotAction, dotDebuffID, 0f, 4);
+            
+            if (IsEnabled(CustomComboPreset.WHM_AoE_MainCombo_DoT) &&
+                ActionReady(dotAction) && target != null)
+                return OriginalHook(Aero).Retarget(target);
 
             #endregion
 

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -339,7 +339,7 @@ internal partial class WHM : Healer
             
             if (IsEnabled(CustomComboPreset.WHM_AoE_MainCombo_DoT) &&
                 ActionReady(dotAction) && target != null)
-                return OriginalHook(Aero).Retarget(target);
+                return OriginalHook(Aero).Retarget([Holy, Holy3], target);
 
             #endregion
 

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -328,7 +328,7 @@ internal partial class WHM : Healer
            
             var dotAction = OriginalHook(Aero);
             AeroList.TryGetValue(dotAction, out var dotDebuffID);
-            var target = SimpleTarget.DottableEnemy(dotAction, dotDebuffID, 0f, 4);
+            var target = SimpleTarget.DottableEnemy(dotAction, dotDebuffID, Config.WHM_AoE_MainCombo_DoT_Reapply, Config.WHM_AoE_MainCombo_DoT_MaxTargets);
             
             if (IsEnabled(CustomComboPreset.WHM_AoE_MainCombo_DoT) &&
                 ActionReady(dotAction) && target != null)

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -64,6 +64,17 @@ internal partial class WHM : Healer
                 return OccultCrescent.BestPhantomAction();
 
             if (!InCombat()) return actionID;
+            
+            #region Special Feature Raidwide
+
+            if (RaidwideTemperance())
+                return OriginalHook(Temperance);
+            if (RaidwideAsylum())
+                return Asylum.Retarget(actionID, SimpleTarget.Self);
+            if (RaidwideLiturgyOfTheBell())
+                return LiturgyOfTheBell.Retarget(actionID, SimpleTarget.Self);
+           
+            #endregion
 
             #region Weaves
 
@@ -149,6 +160,17 @@ internal partial class WHM : Healer
                 return actionID;
 
             #endregion
+            
+            #region Special Feature Raidwide
+
+            if (RaidwideTemperance())
+                return OriginalHook(Temperance);
+            if (RaidwideAsylum())
+                return Asylum.Retarget([Holy, Holy3], SimpleTarget.Self);
+            if (RaidwideLiturgyOfTheBell())
+                return LiturgyOfTheBell.Retarget([Holy, Holy3], SimpleTarget.Self);
+           
+            #endregion
 
             #region Weaves
 
@@ -232,6 +254,17 @@ internal partial class WHM : Healer
                              GetTargetHPPercent(healTarget, Config.WHM_STHeals_IncludeShields)
                              <= Config.WHM_STHeals_RegenHPUpper;  
             #endregion
+            
+            #region Special Feature Raidwide
+
+            if (RaidwideTemperance())
+                return OriginalHook(Temperance);
+            if (RaidwideAsylum())
+                return Asylum.Retarget(Cure, SimpleTarget.Self);
+            if (RaidwideLiturgyOfTheBell())
+                return LiturgyOfTheBell.Retarget(Cure, SimpleTarget.Self);
+           
+            #endregion
 
             #region Priority Cleansing
 
@@ -288,6 +321,17 @@ internal partial class WHM : Healer
                              !HasStatusEffect(Buffs.ThinAir) &&
                              GetRemainingCharges(ThinAir) >
                              Config.WHM_AoEHeals_ThinAir;
+            #endregion
+            
+            #region Special Feature Raidwide
+
+            if (RaidwideTemperance())
+                return OriginalHook(Temperance);
+            if (RaidwideAsylum())
+                return Asylum.Retarget(Medica1, SimpleTarget.Self);
+            if (RaidwideLiturgyOfTheBell())
+                return LiturgyOfTheBell.Retarget(Medica1 ,SimpleTarget.Self);
+           
             #endregion
             
             if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Lucid) &&

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -139,7 +139,7 @@ internal partial class WHM : Healer
             
             var dotAction = OriginalHook(Aero);
             AeroList.TryGetValue(dotAction, out var dotDebuffID);
-            var target = SimpleTarget.DottableEnemy(dotAction, dotDebuffID, 3, 4);
+            var target = SimpleTarget.DottableEnemy(dotAction, dotDebuffID,30, 3, 4);
             
             if (ActionReady(dotAction) && target != null)
                 return OriginalHook(Aero).Retarget(target);

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -17,6 +17,132 @@ namespace WrathCombo.Combos.PvE;
 
 internal partial class WHM : Healer
 {
+    #region Simple DPS
+
+    internal class WHM_ST_Simple_DPS : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } =
+            CustomComboPreset.WHM_ST_Simple_DPS;
+
+        protected override uint Invoke(uint actionID)
+        {
+            var actionFound = StoneGlareList.Contains(actionID);
+           
+            if (!actionFound)
+                return actionID;
+
+            if (OccultCrescent.ShouldUsePhantomActions())
+                return OccultCrescent.BestPhantomAction();
+
+            if (!InCombat()) return actionID;
+           
+            #region Weaves
+
+            if (CanWeave())
+            {
+                if (Variant.CanRampart(CustomComboPreset.WHM_DPS_Variant_Rampart))
+                    return Variant.Rampart;
+
+                if (ActionReady(PresenceOfMind) && !HasStatusEffect(Buffs.SacredSight))
+                    return PresenceOfMind;
+
+                if (ActionReady(Assize))
+                    return Assize;
+
+                if (Role.CanLucidDream(7500))
+                    return Role.LucidDreaming;
+
+                if (Variant.CanSpiritDart(
+                        CustomComboPreset.WHM_DPS_Variant_SpiritDart))
+                    return Variant.SpiritDart;
+            }
+
+            #endregion
+
+            #region GCDS and Casts
+
+            // DoTs
+            if (NeedsDoT())
+                return OriginalHook(Aero);
+
+            // Glare IV
+            if (HasStatusEffect(Buffs.SacredSight))
+                return Glare4;
+
+            // Lily Heal Overcap
+            if (ActionReady(AfflatusRapture) &&
+                (FullLily || AlmostFullLily))
+                return AfflatusRapture;
+
+            // Blood Lily Spend
+            if (BloodLilyReady)
+                return AfflatusMisery;
+
+            
+            return actionID;
+
+            #endregion
+        }
+    }
+
+    internal class WHM_AoE_Simple_DPS : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } =
+            CustomComboPreset.WHM_AoE_Simple_DPS;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not (Holy or Holy3))
+                return actionID;
+
+            if (OccultCrescent.ShouldUsePhantomActions())
+                return OccultCrescent.BestPhantomAction();
+
+            #region Weaves
+
+            if (CanWeave() || IsMoving())
+            {
+                if (ActionReady(Assize))
+                    return Assize;
+
+                if (ActionReady(PresenceOfMind) && !HasStatusEffect(Buffs.SacredSight))
+                    return PresenceOfMind;
+
+                if (Role.CanLucidDream(7500))
+                    return Role.LucidDreaming;
+
+                if (Variant.CanRampart(CustomComboPreset.WHM_DPS_Variant_Rampart))
+                    return Variant.Rampart;
+
+                if (Variant.CanSpiritDart(CustomComboPreset
+                        .WHM_DPS_Variant_SpiritDart))
+                    return Variant.SpiritDart;
+            }
+
+            #endregion
+
+            #region GCDS and Casts
+
+            // Glare IV
+            if (HasStatusEffect(Buffs.SacredSight))
+                return OriginalHook(Glare4);
+
+            if (ActionReady(AfflatusRapture) &&
+                (FullLily || AlmostFullLily))
+                return AfflatusRapture;
+
+            if (BloodLilyReady &&
+                HasBattleTarget())
+                return AfflatusMisery;
+
+            #endregion
+
+            return actionID;
+        }
+    }
+
+    #endregion
+    
     #region DPS
 
     internal class WHM_ST_MainCombo : CustomCombo

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -505,7 +505,7 @@ internal partial class WHM : Healer
                 ? AfflatusMisery
                 : IsEnabled(Preset.WHM_Re_Solace)
                   ? AfflatusSolace.Retarget(SimpleTarget.Stack.AllyToHeal)
-                  : AfflatusSolace;
+                  : actionID;
     }
 
     internal class WHM_RaptureMisery : CustomCombo

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -6,6 +6,8 @@ using WrathCombo.CustomComboNS;
 using WrathCombo.Data;
 using WrathCombo.Extensions;
 using Preset = WrathCombo.Combos.CustomComboPreset;
+using EZ = ECommons.Throttlers.EzThrottler;
+using TS = System.TimeSpan;
 
 // ReSharper disable AccessToStaticMemberViaDerivedType
 // ReSharper disable UnusedType.Global
@@ -693,6 +695,9 @@ internal partial class WHM : Healer
         protected override uint Invoke(uint actionID)
         {
             var healStack = SimpleTarget.Stack.AllyToHeal;
+            
+            if (!EZ.Throttle("WHMRetargetingFeature", TS.FromSeconds(5)))
+                return actionID;
 
             if (IsEnabled(Preset.WHM_Re_Cure))
             {

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -508,20 +508,35 @@ internal partial class WHM : Healer
     {
         protected internal override Preset Preset => Preset.WHM_SolaceMisery;
 
-        protected override uint Invoke(uint actionID) =>
-            actionID is AfflatusSolace && gauge.BloodLily == 3 ? AfflatusMisery :
-                IsEnabled(Preset.WHM_Re_Solace) ?
-                    actionID.Retarget(SimpleTarget.Stack.AllyToHeal) : actionID;
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not AfflatusSolace)
+                return actionID;
+
+            if (gauge.BloodLily == 3)
+                return AfflatusMisery;
+
+            if (IsEnabled(Preset.WHM_Re_Solace))
+                return AfflatusSolace.Retarget(SimpleTarget.Stack.AllyToHeal);
+
+            return actionID;
+        }
     }
 
     internal class WHM_RaptureMisery : CustomCombo
     {
         protected internal override Preset Preset => Preset.WHM_RaptureMisery;
 
-        protected override uint Invoke(uint actionID) =>
-            actionID is AfflatusRapture && gauge.BloodLily == 3
-                ? AfflatusMisery
-                : actionID;
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not AfflatusRapture)
+                return actionID;
+
+            if (gauge.BloodLily == 3)
+                return AfflatusMisery;
+
+            return actionID;
+        }
     }
 
     internal class WHM_CureSync : CustomCombo

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -246,53 +246,30 @@ internal partial class WHM : Healer
 
             #endregion
 
-            #region OGCD Tools
-
             if (IsEnabled(CustomComboPreset.WHM_STHeals_Lucid) && CanWeave() &&
                 Role.CanLucidDream(Config.WHM_STHeals_Lucid))
                 return Role.LucidDreaming;
-
-            // OGCD Priority List
-            foreach (var prio in Config.WHM_ST_Heals_Priority.Items.OrderBy(x => x))
+            
+            //Priority List
+            for(int i = 0; i < Config.WHM_ST_Heals_Priority.Count; i++)
             {
-                var index = Config.WHM_ST_Heals_Priority.IndexOf(prio);
-                var config = GetMatchingConfigST(index, OptionalTarget,
-                    out var spell, out var enabled);
+                int index = Config.WHM_ST_Heals_Priority.IndexOf(i + 1);
+                int config = GetMatchingConfigST(index, OptionalTarget, out uint spell, out bool enabled);
 
-                if (!enabled) continue;
-
-                if (GetTargetHPPercent(healTarget,
-                        Config.WHM_STHeals_IncludeShields) <= config &&
-                    ActionReady(spell))
-                    return spell
-                        .RetargetIfEnabled(OptionalTarget, Cure);
+                if (enabled)
+                {
+                    if (GetTargetHPPercent(healTarget, Config.WHM_STHeals_IncludeShields) <= config &&
+                        ActionReady(spell))
+                        return spell.RetargetIfEnabled(OptionalTarget, Cure);
+                }
             }
-
-            #endregion
-
-            #region GCD Tools
-
-            if (IsEnabled(CustomComboPreset.WHM_STHeals_Regen) && canRegen)
-                return Regen
-                    .RetargetIfEnabled(OptionalTarget, Cure);
-
-            if (IsEnabled(CustomComboPreset.WHM_STHeals_Solace) && CanLily &&
-                ActionReady(AfflatusSolace))
-                return AfflatusSolace
-                    .RetargetIfEnabled(OptionalTarget, Cure);
-
-            if (ActionReady(Cure2))
-            {
-                if (IsEnabled(CustomComboPreset.WHM_STHeals_ThinAir) && canThinAir)
-                    return ThinAir;
-                return Cure2
-                    .RetargetIfEnabled(OptionalTarget, Cure);
-            }
-
-            #endregion
-
-            return actionID
-                .RetargetIfEnabled(OptionalTarget, Cure);
+           
+            if (IsEnabled(CustomComboPreset.WHM_STHeals_ThinAir) && canThinAir)
+                return ThinAir;
+            
+            return LevelChecked(Cure2) ?
+                Cure2.RetargetIfEnabled(OptionalTarget, Cure):
+                Cure.RetargetIfEnabled(OptionalTarget);
         }
     }
 

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -135,6 +135,13 @@ internal partial class WHM : Healer
             if (BloodLilyReady &&
                 HasBattleTarget())
                 return AfflatusMisery;
+            
+            var dotAction = OriginalHook(Aero);
+            AeroList.TryGetValue(dotAction, out var dotDebuffID);
+            var target = SimpleTarget.DottableEnemy(dotAction, dotDebuffID, 3, 4);
+            
+            if (ActionReady(dotAction) && target != null)
+                return OriginalHook(Aero).Retarget(target);
 
             #endregion
 

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -7,6 +7,7 @@ using WrathCombo.Data;
 using WrathCombo.Window.Functions;
 using static WrathCombo.Extensions.UIntExtensions;
 using static WrathCombo.Window.Functions.UserConfig;
+using Preset = WrathCombo.Combos.CustomComboPreset;
 
 // ReSharper disable AccessToStaticMemberViaDerivedType
 // ReSharper disable GrammarMistakeInComment
@@ -23,13 +24,13 @@ internal partial class WHM
 {
     public static class Config
     {
-        internal static void Draw(CustomComboPreset preset)
+        internal static void Draw(Preset preset)
         {
             switch (preset)
             {
                 #region Single Target DPS
 
-                case CustomComboPreset.WHM_ST_MainCombo:
+                case Preset.WHM_ST_MainCombo:
                     DrawHorizontalRadioButton(WHM_ST_MainCombo_Actions, "On Stones/Glares", "Apply options to all Stones and Glares.", 0,
                         descriptionColor:ImGuiColors.DalamudWhite);
                     DrawHorizontalRadioButton(WHM_ST_MainCombo_Actions, "On Aeros/Dia", "Apply options to all Aeros And Dia.", 1,
@@ -38,11 +39,11 @@ internal partial class WHM
                         descriptionColor:ImGuiColors.DalamudWhite);
                     break;
 
-                case CustomComboPreset.WHM_ST_MainCombo_Opener:
+                case Preset.WHM_ST_MainCombo_Opener:
                     DrawBossOnlyChoice(WHM_Balance_Content);
                     break;
 
-                case CustomComboPreset.WHM_ST_MainCombo_DoT:
+                case Preset.WHM_ST_MainCombo_DoT:
                     DrawSliderInt(0, 100, WHM_ST_DPS_AeroOptionBoss,
                         targetStopUsingOnBossAtDescription,
                         itemWidth: medium);
@@ -84,7 +85,7 @@ internal partial class WHM
                     ImGui.Unindent();
                     break;
 
-                case CustomComboPreset.WHM_ST_MainCombo_Lucid:
+                case Preset.WHM_ST_MainCombo_Lucid:
                     DrawSliderInt(4000, 9500, WHM_STDPS_Lucid,
                         mpThresholdDescription,
                         itemWidth: medium, SliderIncrements.Hundreds);
@@ -94,13 +95,13 @@ internal partial class WHM
 
                 #region AoE DPS
 
-                case CustomComboPreset.WHM_AoE_DPS_Lucid:
+                case Preset.WHM_AoE_DPS_Lucid:
                     DrawSliderInt(4000, 9500, WHM_AoEDPS_Lucid,
                         mpThresholdDescription,
                         itemWidth: medium, SliderIncrements.Hundreds);
                     break;
                 
-                case CustomComboPreset.WHM_AoE_MainCombo_DoT:
+                case Preset.WHM_AoE_MainCombo_DoT:
                     DrawSliderInt(0, 100, WHM_AoE_MainCombo_DoT_HPThreshold,
                         targetStopUsingAtDescription);
                     ImGui.Indent();
@@ -116,13 +117,13 @@ internal partial class WHM
 
                 #region Single Target Heals
 
-                case CustomComboPreset.WHM_STHeals:
+                case Preset.WHM_STHeals:
                     DrawAdditionalBoolChoice(WHM_STHeals_IncludeShields,
                         "Include Shields in HP Percent Sliders",
                         "");
                     break;
                 
-                case CustomComboPreset.WHM_STHeals_Benediction:
+                case Preset.WHM_STHeals_Benediction:
                     DrawAdditionalBoolChoice(WHM_STHeals_BenedictionWeave,
                         weaveDescription, "");
                     DrawSliderInt(1, 100, WHM_STHeals_BenedictionHP,
@@ -131,7 +132,7 @@ internal partial class WHM
                         $"{Benediction.ActionName()} Priority: ");
                     break;
 
-                case CustomComboPreset.WHM_STHeals_Tetragrammaton:
+                case Preset.WHM_STHeals_Tetragrammaton:
                     DrawAdditionalBoolChoice(WHM_STHeals_TetraWeave,
                         weaveDescription, "");
                     DrawSliderInt(1, 100, WHM_STHeals_TetraHP,
@@ -140,7 +141,7 @@ internal partial class WHM
                         $"{Tetragrammaton.ActionName()} Priority: ");
                     break;
 
-                case CustomComboPreset.WHM_STHeals_Benison:
+                case Preset.WHM_STHeals_Benison:
                     DrawAdditionalBoolChoice(WHM_STHeals_BenisonWeave,
                         weaveDescription, "");
                     DrawSliderInt(0, 1, WHM_STHeals_BenisonCharges, 
@@ -151,7 +152,7 @@ internal partial class WHM
                         $"{DivineBenison.ActionName()} Priority: ");
                     break;
 
-                case CustomComboPreset.WHM_STHeals_Aquaveil:
+                case Preset.WHM_STHeals_Aquaveil:
                     DrawAdditionalBoolChoice(WHM_STHeals_AquaveilWeave,
                         weaveDescription, "");
                     DrawSliderInt(1, 100, WHM_STHeals_AquaveilHP,
@@ -160,14 +161,14 @@ internal partial class WHM
                         $"{Aquaveil.ActionName()} Priority: ");
                     break;
                 
-                case CustomComboPreset.WHM_STHeals_Solace:
+                case Preset.WHM_STHeals_Solace:
                     DrawSliderInt(1, 100, WHM_STHeals_SolaceHP,
                         targetStartUsingAtDescription);
                     DrawPriorityInput(WHM_ST_Heals_Priority, 9, 4,
                         $"{AfflatusSolace.ActionName()} Priority: ");
                     break;
 
-                case CustomComboPreset.WHM_STHeals_Regen:
+                case Preset.WHM_STHeals_Regen:
                     ImGui.Indent();
                     DrawRoundedSliderFloat(0f, 6f, WHM_STHeals_RegenTimer,
                         reapplyTimeRemainingDescription,
@@ -181,7 +182,7 @@ internal partial class WHM
                         $"{Regen.ActionName()} Priority: ");
                     break;
 
-                case CustomComboPreset.WHM_STHeals_Temperance:
+                case Preset.WHM_STHeals_Temperance:
                     DrawSliderInt(1, 100, WHM_STHeals_TemperanceHP,
                         targetStartUsingAtDescription);
                     DrawHorizontalMultiChoice(WHM_STHeals_TemperanceOptions,"Only Weave", weaveDescription, 2, 0);
@@ -190,7 +191,7 @@ internal partial class WHM
                         $"{Temperance.ActionName()} Priority: ");
                     break;
                 
-                case CustomComboPreset.WHM_STHeals_Asylum:
+                case Preset.WHM_STHeals_Asylum:
                     DrawSliderInt(1, 100, WHM_STHeals_AsylumHP,
                         targetStartUsingAtDescription);
                     DrawHorizontalMultiChoice(WHM_STHeals_AsylumOptions,"Only Weave", weaveDescription, 2, 0);
@@ -199,7 +200,7 @@ internal partial class WHM
                         $"{Asylum.ActionName()} Priority: ");
                     break;
                 
-                case CustomComboPreset.WHM_STHeals_LiturgyOfTheBell:
+                case Preset.WHM_STHeals_LiturgyOfTheBell:
                     DrawSliderInt(1, 100, WHM_STHeals_LiturgyOfTheBellHP,
                         targetStartUsingAtDescription);
                     DrawHorizontalMultiChoice(WHM_STHeals_LiturgyOfTheBellOptions,"Only Weave", weaveDescription, 2, 0);
@@ -208,18 +209,18 @@ internal partial class WHM
                         $"{LiturgyOfTheBell.ActionName()} Priority: ");
                     break;
                 
-                case CustomComboPreset.WHM_STHeals_ThinAir:
+                case Preset.WHM_STHeals_ThinAir:
                     DrawSliderInt(0, 1, WHM_STHeals_ThinAir,
                         chargesToKeepDescription);
                     break;
                 
-                case CustomComboPreset.WHM_STHeals_Lucid:
+                case Preset.WHM_STHeals_Lucid:
                     DrawSliderInt(4000, 9500, WHM_STHeals_Lucid,
                         mpThresholdDescription,
                         itemWidth: medium, SliderIncrements.Hundreds);
                     break;
 
-                case CustomComboPreset.WHM_STHeals_Esuna:
+                case Preset.WHM_STHeals_Esuna:
                     DrawSliderInt(0, 100, WHM_STHeals_Esuna,
                         targetStopUsingAtDescription);
                     break;
@@ -228,7 +229,7 @@ internal partial class WHM
 
                 #region AoE Heals
                 
-                case CustomComboPreset.WHM_AoEHeals_Medica2:
+                case Preset.WHM_AoEHeals_Medica2:
                     DrawSliderInt(1, 100, WHM_AoEHeals_Medica2HP,
                         partyStartUsingAtDescription);
                     ImGui.Indent();
@@ -240,7 +241,7 @@ internal partial class WHM
                         $"{Medica2.ActionName()} Priority: ");
                     break;
                 
-                case CustomComboPreset.WHM_AoEHeals_Cure3:
+                case Preset.WHM_AoEHeals_Cure3:
                     DrawSliderInt(1, 100, WHM_AoEHeals_Cure3HP,
                         partyStartUsingAtDescription);
                     DrawSliderInt(2, 8, WHM_AoEHeals_Cure3Allies,
@@ -252,7 +253,7 @@ internal partial class WHM
                         $"{Cure3.ActionName()} Priority: ");
                     break;
                 
-                case CustomComboPreset.WHM_AoEHeals_Plenary:
+                case Preset.WHM_AoEHeals_Plenary:
                     DrawSliderInt(1, 100, WHM_AoEHeals_PlenaryHP,
                         partyStartUsingAtDescription);
                     DrawAdditionalBoolChoice(WHM_AoEHeals_PlenaryWeave,
@@ -262,7 +263,7 @@ internal partial class WHM
                         $"{PlenaryIndulgence.ActionName()} Priority: ");
                     break;
                 
-                case CustomComboPreset.WHM_AoEHeals_Temperance:
+                case Preset.WHM_AoEHeals_Temperance:
                     DrawSliderInt(1, 100, WHM_AoEHeals_TemperanceHP, 
                         partyStartUsingAtDescription);
                     DrawAdditionalBoolChoice(WHM_AoEHeals_TemperanceWeave,
@@ -275,7 +276,7 @@ internal partial class WHM
                         $"{Temperance.ActionName()} Priority: ");
                     break;
                 
-                case CustomComboPreset.WHM_AoEHeals_Asylum:
+                case Preset.WHM_AoEHeals_Asylum:
                     DrawSliderInt(1, 100, WHM_AoEHeals_AsylumHP, 
                         partyStartUsingAtDescription);
                     DrawAdditionalBoolChoice(WHM_AoEHeals_AsylumWeave,
@@ -288,7 +289,7 @@ internal partial class WHM
                         $"{Asylum.ActionName()} Priority: ");
                     break;
                 
-                case CustomComboPreset.WHM_AoEHeals_LiturgyOfTheBell:
+                case Preset.WHM_AoEHeals_LiturgyOfTheBell:
                     DrawSliderInt(1, 100, WHM_AoEHeals_LiturgyHP, 
                         partyStartUsingAtDescription);
                     DrawAdditionalBoolChoice(WHM_AoEHeals_LiturgyWeave,
@@ -301,14 +302,14 @@ internal partial class WHM
                         $"{LiturgyOfTheBell.ActionName()} Priority: ");
                     break;
                 
-                case CustomComboPreset.WHM_AoEHeals_Rapture:
+                case Preset.WHM_AoEHeals_Rapture:
                     DrawSliderInt(1, 100, WHM_AoEHeals_RaptureHP,
                         partyStartUsingAtDescription);
                     DrawPriorityInput(WHM_AoE_Heals_Priority, 9, 6,
                         $"{AfflatusRapture.ActionName()} Priority: ");
                     break;
                 
-                case CustomComboPreset.WHM_AoEHeals_Assize:
+                case Preset.WHM_AoEHeals_Assize:
                     DrawSliderInt(1, 100, WHM_AoEHeals_AssizeHP,
                         partyStartUsingAtDescription);
                     DrawAdditionalBoolChoice(WHM_AoEHeals_AssizeWeave,
@@ -317,7 +318,7 @@ internal partial class WHM
                         $"{Assize.ActionName()} Priority: ");
                     break;
                 
-                case CustomComboPreset.WHM_AoEHeals_DivineCaress:
+                case Preset.WHM_AoEHeals_DivineCaress:
                     DrawSliderInt(1, 100, WHM_AoEHeals_DivineCaressHP,
                         partyStartUsingAtDescription);
                     DrawAdditionalBoolChoice(WHM_AoEHeals_DivineCaressWeave,
@@ -326,12 +327,12 @@ internal partial class WHM
                         $"{DivineCaress.ActionName()} Priority: ");
                     break;
 
-                case CustomComboPreset.WHM_AoEHeals_ThinAir:
+                case Preset.WHM_AoEHeals_ThinAir:
                     DrawSliderInt(0, 1, WHM_AoEHeals_ThinAir,
                         chargesToKeepDescription);
                     break;
 
-                case CustomComboPreset.WHM_AoEHeals_Lucid:
+                case Preset.WHM_AoEHeals_Lucid:
                     DrawSliderInt(4000, 9500, WHM_AoEHeals_Lucid,
                         mpThresholdDescription,
                         itemWidth: medium, SliderIncrements.Hundreds);
@@ -341,7 +342,7 @@ internal partial class WHM
 
                 #region Mitigation Features
 
-                case CustomComboPreset.WHM_Mit_ST:
+                case Preset.WHM_Mit_ST:
                     DrawHorizontalMultiChoice(WHM_AquaveilOptions,
                         "Include Divine Benison", "Will add Divine Benison for more mitigation.", 2, 0);
                     ImGui.NewLine();
@@ -360,7 +361,7 @@ internal partial class WHM
                 
                 #region Retargeting Features
                 
-                case CustomComboPreset.WHM_Re_Asylum:
+                case Preset.WHM_Re_Asylum:
                     ImGui.Indent();
                     ImGui.TextColored(ImGuiColors.DalamudGrey, "Options to try to Retarget Asylum to before Self:");
                     ImGui.Unindent();
@@ -370,7 +371,7 @@ internal partial class WHM
                         "Ally Hard Target", "Will place at hard target if ally", 3, 1);
                     break;
                 
-                case CustomComboPreset.WHM_Re_LiturgyOfTheBell:
+                case Preset.WHM_Re_LiturgyOfTheBell:
                     ImGui.Indent();
                     ImGui.TextColored(ImGuiColors.DalamudGrey, "Options to try to Retarget Asylum to before Self:");
                     ImGui.Unindent();

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -326,6 +326,20 @@ internal partial class WHM
                     break;
                 
                 #endregion
+                
+                #region StandAlone Features
+                
+                case CustomComboPreset.WHM_Asylum:
+                    DrawHorizontalMultiChoice(WHM_AsylumOptions,"Hardtarget Enemies", "Will place at hard target if enemy", 2, 0);
+                    DrawHorizontalMultiChoice(WHM_AsylumOptions,"Hardtarget Allies", "Will place at hard target if ally", 2, 1);
+                    break;
+                
+                case CustomComboPreset.WHM_LiturgyOfTheBell:
+                    DrawHorizontalMultiChoice(WHM_LiturgyOfTheBellOptions,"Hardtarget Enemies", "Will place at hard target if enemy", 2, 0);
+                    DrawHorizontalMultiChoice(WHM_LiturgyOfTheBellOptions,"Hardtarget Allies", "Will place at hard target if ally", 2, 1);
+                    break;
+                
+                #endregion
             }
         }
 
@@ -1062,6 +1076,30 @@ internal partial class WHM
             WHM_AoEHeals_AsylumDifficultyListSet =
                 ContentCheck.ListSet.Halved;
 
+        #endregion
+        
+        #region Standalone Features
+
+        /// <summary>
+        ///     Hard target Retargetting Options for Asylum Standalone Feature
+        /// </summary> 
+        /// <value>
+        ///     <b>Default</b>: True True
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_Asylum" />
+        internal static UserBoolArray WHM_AsylumOptions = 
+            new("WHM_AsylumOptions", [true, true]);
+        
+        /// <summary>
+        ///     Hard target Retargetting Options for LiturgyOfTheBell Standalone Feature
+        /// </summary> 
+        /// <value>
+        ///     <b>Default</b>: True True
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_LiturgyOfTheBell" />
+        internal static UserBoolArray WHM_LiturgyOfTheBellOptions = 
+            new ("WHM_LiturgyOfTheBellOptions", [true, true]);
+        
         #endregion
 
         #endregion

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -101,6 +101,15 @@ internal partial class WHM
                         mpThresholdDescription,
                         itemWidth: medium, SliderIncrements.Hundreds);
                     break;
+                
+                case CustomComboPreset.WHM_AoE_MainCombo_DoT:
+                    DrawRoundedSliderFloat(0, 5, WHM_AoE_MainCombo_DoT_Reapply,
+                        reapplyTimeRemainingDescription,
+                        itemWidth: little, digits: 1);
+                    DrawSliderInt(0, 10, WHM_AoE_MainCombo_DoT_MaxTargets,
+                        "Maximum number of targets to employ multi-dotting ",
+                        itemWidth: little);
+                    break;
 
                 #endregion
 
@@ -527,6 +536,30 @@ internal partial class WHM
         /// <seealso cref="CustomComboPreset.WHM_AoE_DPS_Lucid" />
         internal static UserInt WHM_AoEDPS_Lucid =
             new("WHM_AoE_Lucid", 6500);
+        
+        /// <summary>
+        ///     Reapplication Threshold for AoE Multidotting
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 0 <br />
+        ///     <b>Range</b>: 0 - 5<br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_AoE_MainCombo_DoT" />
+        internal static UserFloat WHM_AoE_MainCombo_DoT_Reapply =
+            new("WHM_AoE_MainCombo_DoT_Reapply", 0);
+        
+        /// <summary>
+        ///     Max Targets for AoE Multidotting
+        /// </summary> 
+        /// <value>
+        ///     <b>Default</b>: 4 <br />
+        ///     <b>Range</b>: 0 - 10<br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_AoE_MainCombo_DoT" />
+        internal static UserInt WHM_AoE_MainCombo_DoT_MaxTargets = 
+            new("WHM_AoE_MainCombo_DoT_MaxTargets", 4);
 
         #endregion
 

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -103,14 +103,15 @@ internal partial class WHM
                     break;
                 
                 case CustomComboPreset.WHM_AoE_MainCombo_DoT:
+                    DrawSliderInt(0, 100, WHM_AoE_MainCombo_DoT_HPThreshold,
+                        targetStopUsingAtDescription);
                     ImGui.Indent();
                     DrawRoundedSliderFloat(0, 5, WHM_AoE_MainCombo_DoT_Reapply,
                         reapplyTimeRemainingDescription,
                         itemWidth: little, digits: 1);
                     ImGui.Unindent();
                     DrawSliderInt(0, 10, WHM_AoE_MainCombo_DoT_MaxTargets,
-                        "Maximum number of targets to employ multi-dotting ",
-                        itemWidth: little);
+                        "Maximum number of targets to employ multi-dotting ");
                     break;
 
                 #endregion
@@ -550,6 +551,18 @@ internal partial class WHM
         /// <seealso cref="CustomComboPreset.WHM_AoE_MainCombo_DoT" />
         internal static UserFloat WHM_AoE_MainCombo_DoT_Reapply =
             new("WHM_AoE_MainCombo_DoT_Reapply", 0);
+        
+        /// <summary>
+        ///     Health Threshold to stop Multidotting
+        /// </summary> 
+        /// <value>
+        ///     <b>Default</b>: 50 <br />
+        ///     <b>Range</b>: 0 - 100<br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_AoE_MainCombo_DoT" />
+        internal static UserInt WHM_AoE_MainCombo_DoT_HPThreshold = 
+            new("WHM_AoE_MainCombo_DoT_HPThreshold", 50);
         
         /// <summary>
         ///     Max Targets for AoE Multidotting

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -103,9 +103,11 @@ internal partial class WHM
                     break;
                 
                 case CustomComboPreset.WHM_AoE_MainCombo_DoT:
+                    ImGui.Indent();
                     DrawRoundedSliderFloat(0, 5, WHM_AoE_MainCombo_DoT_Reapply,
                         reapplyTimeRemainingDescription,
                         itemWidth: little, digits: 1);
+                    ImGui.Unindent();
                     DrawSliderInt(0, 10, WHM_AoE_MainCombo_DoT_MaxTargets,
                         "Maximum number of targets to employ multi-dotting ",
                         itemWidth: little);

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -32,30 +32,12 @@ internal partial class WHM
                 #region Single Target DPS
 
                 case CustomComboPreset.WHM_ST_MainCombo:
-                    DrawAdditionalBoolChoice(WHM_ST_MainCombo_Adv,
-                        "Advanced Action Options",
-                        "Change how actions are handled",
-                        isConditionalChoice: true);
-
-                    if (WHM_ST_MainCombo_Adv)
-                    {
-                        ImGui.Indent();
-                        ImGui.Spacing();
-                        DrawHorizontalMultiChoice(WHM_ST_MainCombo_Adv_Actions,
-                            "On Stone/Glare",
-                            "Apply options to all Stones and Glares.",
-                            3, 0);
-                        DrawHorizontalMultiChoice(WHM_ST_MainCombo_Adv_Actions,
-                            "On Aero/Dia",
-                            "Apply options to Aeros and Dia.",
-                            3, 1);
-                        DrawHorizontalMultiChoice(WHM_ST_MainCombo_Adv_Actions,
-                            $"On {Stone2.ActionName()}",
-                            $"Apply options to On {Stone2.ActionName()}.",
-                            3, 2);
-                        ImGui.Unindent();
-                    }
-
+                    DrawHorizontalRadioButton(WHM_ST_MainCombo_Actions, "On Stones/Glares", "Apply options to all Stones and Glares.", 0,
+                        descriptionColor:ImGuiColors.DalamudWhite);
+                    DrawHorizontalRadioButton(WHM_ST_MainCombo_Actions, "On Aeros/Dia", "Apply options to all Aeros And Dia.", 1,
+                        descriptionColor:ImGuiColors.DalamudWhite);
+                    DrawHorizontalRadioButton(WHM_ST_MainCombo_Actions, "On Stone II", "Apply options to Stone II.", 2,
+                        descriptionColor:ImGuiColors.DalamudWhite);
                     break;
 
                 case CustomComboPreset.WHM_ST_MainCombo_Opener:
@@ -416,25 +398,14 @@ internal partial class WHM
         #region Single Target DPS
 
         /// <summary>
-        ///     Enable advanced replacement action options for single target combo.
+        ///     Button Selection for single target DPS.
         /// </summary>
         /// <value>
         ///     <b>Default</b>: false
         /// </value>
         /// <seealso cref="CustomComboPreset.WHM_ST_MainCombo" />
-        internal static UserBool WHM_ST_MainCombo_Adv =
-            new("WHM_ST_MainCombo_Adv");
-
-        /// <summary>
-        ///     Advanced action replacement options for main combo.
-        /// </summary>
-        /// <value>
-        ///     <b>Default</b>: [] <br />
-        ///     <b>Options</b>: Boolean array for action replacement selections
-        /// </value>
-        /// <seealso cref="CustomComboPreset.WHM_ST_MainCombo" />
-        public static UserBoolArray WHM_ST_MainCombo_Adv_Actions =
-            new("WHM_ST_MainCombo_Adv_Actions");
+        internal static UserInt WHM_ST_MainCombo_Actions =
+            new("WHM_ST_MainCombo_Actions");
 
         /// <summary>
         ///     Content type of Balance Opener.

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -249,6 +249,8 @@ internal partial class WHM
                 case CustomComboPreset.WHM_AoEHeals_Cure3:
                     DrawSliderInt(1, 100, WHM_AoEHeals_Cure3HP,
                         partyStartUsingAtDescription);
+                    DrawSliderInt(2, 8, WHM_AoEHeals_Cure3Allies,
+                        "Minimum Number of allies in range of Cure 3 target");
                     DrawSliderInt(1500, 8500, WHM_AoEHeals_Cure3MP,
                         "MP to be over",
                         sliderIncrement: 500);
@@ -318,7 +320,7 @@ internal partial class WHM
                     DrawAdditionalBoolChoice(WHM_AoEHeals_AssizeWeave,
                         weaveDescription, "");
                     DrawPriorityInput(WHM_AoE_Heals_Priority, 9, 7,
-                        $"{AfflatusRapture.ActionName()} Priority: ");
+                        $"{Assize.ActionName()} Priority: ");
                     break;
                 
                 case CustomComboPreset.WHM_AoEHeals_DivineCaress:
@@ -814,6 +816,19 @@ internal partial class WHM
         
         internal static UserInt WHM_AoEHeals_Cure3HP = 
             new("WHM_AoEHeals_Cure3HP", 100);
+        
+        /// <summary>
+        ///     Minimum Party Members In range of target to use Cure 3.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 2 <br />
+        ///     <b>Range</b>: 2 - 8 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_AoEHeals_Cure3" />
+        
+        internal static UserInt WHM_AoEHeals_Cure3Allies = 
+            new("WHM_AoEHeals_Cure3Allies", 2);
 
         /// <summary>
         ///     MP threshold to use Cure III.

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -399,7 +399,7 @@ internal partial class WHM
         
         /// Bar Description for Party HP%  Average to start using plus disable text
         private const string partyStartUsingAtDescription =
-            "Start using when below party average HP %. Set to 100 to disable this check";
+            "Start using when below party average HP% (100 = Disable check)";
 
         /// Bar Description for target HP% to start using plus disable text
         private const string targetStopUsingAtDescription =

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -190,10 +190,8 @@ internal partial class WHM
                 case CustomComboPreset.WHM_STHeals_Temperance:
                     DrawSliderInt(1, 100, WHM_STHeals_TemperanceHP,
                         targetStartUsingAtDescription);
-                    DrawDifficultyMultiChoice(WHM_STHeals_TemperanceDifficulty, WHM_STHeals_TemperanceDifficultyListSet,
-                        "Select what content difficulties Temperance should be used in:");
-                    DrawAdditionalBoolChoice(WHM_STHeals_TemperanceWeave,
-                        weaveDescription, "");
+                    DrawHorizontalMultiChoice(WHM_STHeals_TemperanceOptions,"Only Weave", weaveDescription, 2, 0);
+                    DrawHorizontalMultiChoice(WHM_STHeals_TemperanceOptions,"Not On Bosses", nonBossesDescription, 2, 1);
                     DrawPriorityInput(WHM_ST_Heals_Priority, 9, 6,
                         $"{Temperance.ActionName()} Priority: ");
                     break;
@@ -201,10 +199,8 @@ internal partial class WHM
                 case CustomComboPreset.WHM_STHeals_Asylum:
                     DrawSliderInt(1, 100, WHM_STHeals_AsylumHP,
                         targetStartUsingAtDescription);
-                    DrawDifficultyMultiChoice(WHM_STHeals_AsylumDifficulty, WHM_STHeals_AsylumDifficultyListSet,
-                        "Select what content difficulties Asylum should be used in:");
-                    DrawAdditionalBoolChoice(WHM_STHeals_AsylumWeave,
-                        weaveDescription, "");
+                    DrawHorizontalMultiChoice(WHM_STHeals_AsylumOptions,"Only Weave", weaveDescription, 2, 0);
+                    DrawHorizontalMultiChoice(WHM_STHeals_AsylumOptions,"Not On Bosses", nonBossesDescription, 2, 1);
                     DrawPriorityInput(WHM_ST_Heals_Priority, 9, 7,
                         $"{Asylum.ActionName()} Priority: ");
                     break;
@@ -212,10 +208,8 @@ internal partial class WHM
                 case CustomComboPreset.WHM_STHeals_LiturgyOfTheBell:
                     DrawSliderInt(1, 100, WHM_STHeals_LiturgyOfTheBellHP,
                         targetStartUsingAtDescription);
-                    DrawDifficultyMultiChoice(WHM_STHeals_LiturgyOfTheBellDifficulty, WHM_STHeals_LiturgyOfTheBellDifficultyListSet,
-                        "Select what content difficulties LiturgyOfTheBell should be used in:");
-                    DrawAdditionalBoolChoice(WHM_STHeals_LiturgyOfTheBellWeave,
-                        weaveDescription, "");
+                    DrawHorizontalMultiChoice(WHM_STHeals_LiturgyOfTheBellOptions,"Only Weave", weaveDescription, 2, 0);
+                    DrawHorizontalMultiChoice(WHM_STHeals_LiturgyOfTheBellOptions,"Not On Bosses", nonBossesDescription, 2, 1);
                     DrawPriorityInput(WHM_ST_Heals_Priority, 9, 8,
                         $"{LiturgyOfTheBell.ActionName()} Priority: ");
                     break;
@@ -239,60 +233,106 @@ internal partial class WHM
                 #endregion
 
                 #region AoE Heals
+                
+                case CustomComboPreset.WHM_AoEHeals_Medica2:
+                    DrawSliderInt(1, 100, WHM_AoEHeals_Medica2HP,
+                        partyStartUsingAtDescription);
+                    ImGui.Indent();
+                    DrawRoundedSliderFloat(0f, 6f, WHM_AoEHeals_MedicaTime,
+                        reapplyTimeRemainingDescription,
+                        itemWidth: little);
+                    ImGui.Unindent();
+                    DrawPriorityInput(WHM_AoE_Heals_Priority, 9, 0,
+                        $"{Medica2.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.WHM_AoEHeals_Cure3:
+                    DrawSliderInt(1, 100, WHM_AoEHeals_Cure3HP,
+                        partyStartUsingAtDescription);
+                    DrawSliderInt(1500, 8500, WHM_AoEHeals_Cure3MP,
+                        "MP to be over",
+                        sliderIncrement: 500);
+                    DrawPriorityInput(WHM_AoE_Heals_Priority, 9, 1,
+                        $"{Cure3.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.WHM_AoEHeals_Plenary:
+                    DrawSliderInt(1, 100, WHM_AoEHeals_PlenaryHP,
+                        partyStartUsingAtDescription);
+                    DrawAdditionalBoolChoice(WHM_AoEHeals_PlenaryWeave,
+                        weaveDescription,
+                        "");
+                    DrawPriorityInput(WHM_AoE_Heals_Priority, 9, 2,
+                        $"{PlenaryIndulgence.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.WHM_AoEHeals_Temperance:
+                    DrawSliderInt(1, 100, WHM_AoEHeals_TemperanceHP, 
+                        partyStartUsingAtDescription);
+                    DrawAdditionalBoolChoice(WHM_AoEHeals_TemperanceWeave,
+                        weaveDescription,
+                        "");
+                    DrawDifficultyMultiChoice(WHM_AoEHeals_TemperanceDifficulty,
+                        WHM_AoEHeals_TemperanceDifficultyListSet,
+                        "Select what content difficulties Temperance should be used in:");
+                    DrawPriorityInput(WHM_AoE_Heals_Priority, 9, 3,
+                        $"{Temperance.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.WHM_AoEHeals_Asylum:
+                    DrawSliderInt(1, 100, WHM_AoEHeals_AsylumHP, 
+                        partyStartUsingAtDescription);
+                    DrawAdditionalBoolChoice(WHM_AoEHeals_AsylumWeave,
+                        weaveDescription,
+                        "");
+                    DrawDifficultyMultiChoice(WHM_AoEHeals_AsylumDifficulty,
+                        WHM_AoEHeals_AsylumDifficultyListSet,
+                        "Select what content difficulties Asylum should be used in:");
+                    DrawPriorityInput(WHM_AoE_Heals_Priority, 9, 4,
+                        $"{Asylum.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.WHM_AoEHeals_LiturgyOfTheBell:
+                    DrawSliderInt(1, 100, WHM_AoEHeals_LiturgyHP, 
+                        partyStartUsingAtDescription);
+                    DrawAdditionalBoolChoice(WHM_AoEHeals_LiturgyWeave,
+                        weaveDescription,
+                        "");
+                    DrawDifficultyMultiChoice(WHM_AoEHeals_LiturgyDifficulty,
+                        WHM_AoEHeals_LiturgyDifficultyListSet,
+                        "Select what content difficulties LiturgyOfTheBell should be used in:");
+                    DrawPriorityInput(WHM_AoE_Heals_Priority, 9, 5,
+                        $"{LiturgyOfTheBell.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.WHM_AoEHeals_Rapture:
+                    DrawSliderInt(1, 100, WHM_AoEHeals_RaptureHP,
+                        partyStartUsingAtDescription);
+                    DrawPriorityInput(WHM_AoE_Heals_Priority, 9, 6,
+                        $"{AfflatusRapture.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.WHM_AoEHeals_Assize:
+                    DrawSliderInt(1, 100, WHM_AoEHeals_AssizeHP,
+                        partyStartUsingAtDescription);
+                    DrawAdditionalBoolChoice(WHM_AoEHeals_AssizeWeave,
+                        weaveDescription, "");
+                    DrawPriorityInput(WHM_AoE_Heals_Priority, 9, 7,
+                        $"{AfflatusRapture.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.WHM_AoEHeals_DivineCaress:
+                    DrawSliderInt(1, 100, WHM_AoEHeals_DivineCaressHP,
+                        partyStartUsingAtDescription);
+                    DrawAdditionalBoolChoice(WHM_AoEHeals_DivineCaressWeave,
+                        weaveDescription, "");
+                    DrawPriorityInput(WHM_AoE_Heals_Priority, 9, 8,
+                        $"{DivineCaress.ActionName()} Priority: ");
+                    break;
 
                 case CustomComboPreset.WHM_AoEHeals_ThinAir:
                     DrawSliderInt(0, 1, WHM_AoEHeals_ThinAir,
                         chargesToKeepDescription);
-                    break;
-
-                case CustomComboPreset.WHM_AoEHeals_Cure3:
-                    DrawSliderInt(1500, 8500, WHM_AoEHeals_Cure3MP,
-                        "MP to be over",
-                        sliderIncrement: 500);
-                    break;
-
-                case CustomComboPreset.WHM_AoEHeals_Assize:
-                    DrawAdditionalBoolChoice(WHM_AoEHeals_AssizeWeave,
-                        weaveDescription, "");
-                    break;
-
-                case CustomComboPreset.WHM_AoEHeals_Plenary:
-                    DrawAdditionalBoolChoice(WHM_AoEHeals_PlenaryWeave,
-                        weaveDescription,
-                        "");
-                    break;
-
-                case CustomComboPreset.WHM_AoEHeals_Temperance:
-                    DrawSliderInt(1, 100, WHM_AoEHeals_TemperanceHP,
-                        "Average party HP% to use at or below");
-                    DrawDifficultyMultiChoice(WHM_AoEHeals_TemperanceDifficulty,
-                        WHM_AoEHeals_TemperanceDifficultyListSet,
-                        "Select what content difficulties Temperance should be used in:");
-                    ImGui.Spacing();
-
-                    DrawAdditionalBoolChoice(WHM_AoEHeals_TemperanceWeave,
-                        weaveDescription,
-                        "");
-
-                    DrawAdditionalBoolChoice(WHM_AoEHeals_TemperanceRaidwide,
-                        "Also use for Raidwides",
-                        "Will also use for mitigation before raidwides (and a healing boost after them), if the party is low enough.",
-                        indentDescription: true);
-                    if (WHM_AoEHeals_TemperanceRaidwide)
-                    {
-                        ImGui.Indent();
-                        DrawDifficultyMultiChoice(WHM_AoEHeals_TemperanceRaidwideDifficulty,
-                            WHM_AoEHeals_TemperanceRaidwideDifficultyListSet,
-                            "Select what content difficulties the Raidwide option should apply to:");
-
-                        DrawAdditionalBoolChoice(WHM_AoEHeals_TemperanceRaidwidePrioritization,
-                            "Prioritize use for Raidwides",
-                            "Will ignore the Party HP% check for Raidwides, essentially using Temperance for mitigation.\n" +
-                            "Not advised in higher-end content.",
-                            indentDescription: true);
-                        ImGui.Unindent();
-                    }
-
                     break;
 
                 case CustomComboPreset.WHM_AoEHeals_Lucid:
@@ -300,52 +340,7 @@ internal partial class WHM
                         mpThresholdDescription,
                         itemWidth: medium, SliderIncrements.Hundreds);
                     break;
-
-                case CustomComboPreset.WHM_AoEHeals_Medica2:
-                    ImGui.Indent();
-                    DrawRoundedSliderFloat(0f, 6f, WHM_AoEHeals_MedicaTime,
-                        reapplyTimeRemainingDescription,
-                        itemWidth: little);
-                    ImGui.Unindent();
-                    break;
-
-                case CustomComboPreset.WHM_AoEHeals_LiturgyOfTheBell:
-                    DrawDifficultyMultiChoice(WHM_AoEHeals_LiturgyDifficulty, WHM_AoEHeals_LiturgyDifficultyListSet,
-                        "Select what content difficulties Liturgy of the Bell should be used in:");
-                    ImGui.NewLine();
-
-                    DrawAdditionalBoolChoice(WHM_AoEHeals_LiturgyRaidwideOnly,
-                        "Only use when a Raidwide is casting",
-                        "Will not use Liturgy of the Bell in the rotation unless we detect a Raidwide is casting.",
-                        indentDescription: true);
-
-                    if (WHM_AoEHeals_LiturgyRaidwideOnly)
-                    {
-                        ImGuiEx.Spacing(new Vector2(30f, 0f));
-                        ImGui.Text("Against what enemies should we check for Raidwides:");
-                        ImGui.NewLine();
-                        DrawRadioButton(
-                            WHM_AoEHeals_LiturgyRaidwideOnlyBoss, "All Enemies",
-                            "Will check for a Raidwide before using Bell at all times, on all enemies.",
-                            outputValue: (int)BossRequirement.Off, itemWidth: 125f,
-                            descriptionAsTooltip: true);
-                        DrawRadioButton(
-                            WHM_AoEHeals_LiturgyRaidwideOnlyBoss, "Only Bosses",
-                            "Will try to only check for Raidwide when fighting bosses.\n" +
-                            "(will use on cooldown versus regular enemies)\n" +
-                            "(Note: don't rely on this 100%, square sometimes marks enemies inconsistently)",
-                            outputValue: (int)BossRequirement.On, itemWidth: 125f,
-                            descriptionAsTooltip: true);
-                    }
-
-                    break;
-
-                case CustomComboPreset.WHM_AoEHeals_Asylum:
-                    DrawAdditionalBoolChoice(WHM_AoEHeals_AsylumRaidwideOnly,
-                        "Only use when a Raidwide is casting",
-                        "Will not use Asylum in the rotation unless we detect a Raidwide is casting.");
-                    break;
-
+                
                 #endregion
             }
         }
@@ -361,6 +356,10 @@ internal partial class WHM
         /// Bar Description for target HP% to start using plus disable text
         private const string targetStartUsingAtDescription =
             "Target HP% to use at or below (100 = Disable check)";
+        
+        /// Bar Description for Party HP%  Averageto start using plus disable text
+        private const string partyStartUsingAtDescription =
+            "Start using when below party average HP %. Set to 100 to disable this check";
 
         /// Bar Description for target HP% to start using plus disable text
         private const string targetStopUsingAtDescription =
@@ -386,8 +385,8 @@ internal partial class WHM
         private const string weaveDescription =
             "Only Weave";
 
-        private const string mouseoverCheckingDescription =
-            "Party UI Mouseover Checking";
+        private const string nonBossesDescription =
+            "Will not use on ST in Boss encounters.";
 
         /// <summary>
         ///     Whether abilities should be restricted to bosses or not.
@@ -704,14 +703,14 @@ internal partial class WHM
             new("WHM_STHeals_Lucid", 6500);
 
         /// <summary>
-        ///     Only use Temperance when weaving.
-        /// </summary>
+        ///     Weaving and boss selection options for Temperance.
+        /// </summary> 
         /// <value>
         ///     <b>Default</b>: false
         /// </value>
         /// <seealso cref="CustomComboPreset.WHM_STHeals_Temperance" />
-        internal static UserBool WHM_STHeals_TemperanceWeave =
-            new("WHM_STHeals_TemperanceWeave", false);
+        internal static UserBoolArray WHM_STHeals_TemperanceOptions =
+            new("WHM_STHeals_TemperanceOptions");
 
         /// <summary>
         ///     HP threshold to use Temperance.
@@ -726,34 +725,14 @@ internal partial class WHM
             new("WHM_STHeals_TemperanceHP", 75);
 
         /// <summary>
-        ///     Content difficulty selector for ST Temperance.
-        /// </summary>
-        /// <value>
-        ///     <b>Default</b>: <see cref="ContentCheck.BottomHalfContent" /> <br />
-        ///     <b>Options</b>: <see cref="ContentCheck.BottomHalfContent" />
-        ///     and/or <see cref="ContentCheck.TopHalfContent" />
-        /// </value>
-        /// <seealso cref="CustomComboPreset.WHM_STHeals_Temperance" />
-        internal static UserBoolArray WHM_STHeals_TemperanceDifficulty =
-            new("WHM_STHeals_TemperanceDifficulty", [true, false]);
-
-        /// <summary>
-        ///     Content difficulty list set for ST Temperance, set by
-        ///     <see cref="WHM_STHeals_TemperanceDifficulty" />.
-        /// </summary>
-        /// <seealso cref="CustomComboPreset.WHM_STHeals_Temperance" />
-        internal static readonly ContentCheck.ListSet
-            WHM_STHeals_TemperanceDifficultyListSet =
-                ContentCheck.ListSet.Halved;
-        /// <summary>
-        ///     Only use Asylum when weaving.
+        ///     Weaving and boss selection options for Asylum.
         /// </summary>
         /// <value>
         ///     <b>Default</b>: false
         /// </value>
         /// <seealso cref="CustomComboPreset.WHM_STHeals_Asylum" />
-        internal static UserBool WHM_STHeals_AsylumWeave =
-            new("WHM_STHeals_AsylumWeave", false);
+        internal static UserBoolArray WHM_STHeals_AsylumOptions =
+            new("WHM_STHeals_AsylumOptions");
 
         /// <summary>
         ///     HP threshold to use Asylum.
@@ -766,37 +745,16 @@ internal partial class WHM
         /// <seealso cref="CustomComboPreset.WHM_STHeals_Asylum" />
         internal static UserInt WHM_STHeals_AsylumHP =
             new("WHM_STHeals_AsylumHP", 75);
-
-        /// <summary>
-        ///     Content difficulty selector for ST Asylum
-        /// </summary>
-        /// <value>
-        ///     <b>Default</b>: <see cref="ContentCheck.BottomHalfContent" /> <br />
-        ///     <b>Options</b>: <see cref="ContentCheck.BottomHalfContent" />
-        ///     and/or <see cref="ContentCheck.TopHalfContent" />
-        /// </value>
-        /// <seealso cref="CustomComboPreset.WHM_STHeals_Asylum" />
-        internal static UserBoolArray WHM_STHeals_AsylumDifficulty =
-            new("WHM_STHeals_AsylumDifficulty", [true, false]);
-
-        /// <summary>
-        ///     Content difficulty list set for ST Asylum, set by
-        ///     <see cref="WHM_STHeals_AsylumDifficulty" />.
-        /// </summary>
-        /// <seealso cref="CustomComboPreset.WHM_STHeals_Asylum" />
-        internal static readonly ContentCheck.ListSet
-            WHM_STHeals_AsylumDifficultyListSet =
-                ContentCheck.ListSet.Halved;
         
         /// <summary>
-        ///     Only use LiturgyOfTheBell when weaving.
-        /// </summary>
+        ///     Weaving and boss selection options for LiturgyOfTheBell.
+        /// </summary> 
         /// <value>
         ///     <b>Default</b>: false
         /// </value>
         /// <seealso cref="CustomComboPreset.WHM_STHeals_LiturgyOfTheBell" />
-        internal static UserBool WHM_STHeals_LiturgyOfTheBellWeave =
-            new("WHM_STHeals_LiturgyOfTheBellWeave", false);
+        internal static UserBoolArray WHM_STHeals_LiturgyOfTheBellOptions =
+            new("WHM_STHeals_LiturgyOfTheBellOptions");
 
         /// <summary>
         ///     HP threshold to use LiturgyOfTheBell.
@@ -809,27 +767,6 @@ internal partial class WHM
         /// <seealso cref="CustomComboPreset.WHM_STHeals_LiturgyOfTheBell" />
         internal static UserInt WHM_STHeals_LiturgyOfTheBellHP =
             new("WHM_STHeals_LiturgyOfTheBellHP", 75);
-
-        /// <summary>
-        ///     Content difficulty selector for ST LiturgyOfTheBell.
-        /// </summary>
-        /// <value>
-        ///     <b>Default</b>: <see cref="ContentCheck.BottomHalfContent" /> <br />
-        ///     <b>Options</b>: <see cref="ContentCheck.BottomHalfContent" />
-        ///     and/or <see cref="ContentCheck.TopHalfContent" />
-        /// </value>
-        /// <seealso cref="CustomComboPreset.WHM_STHeals_Temperance" />
-        internal static UserBoolArray WHM_STHeals_LiturgyOfTheBellDifficulty =
-            new("WHM_STHeals_LiturgyOfTheBellDifficulty", [true, false]);
-
-        /// <summary>
-        ///     Content difficulty list set for ST LiturgyOfTheBell, set by
-        ///     <see cref="WHM_STHeals_TemperanceDifficulty" />.
-        /// </summary>
-        /// <seealso cref="CustomComboPreset.WHM_STHeals_Temperance" />
-        internal static readonly ContentCheck.ListSet
-            WHM_STHeals_LiturgyOfTheBellDifficultyListSet =
-                ContentCheck.ListSet.Halved;
 
         /// <summary>
         ///     HP threshold to stop using Esuna.
@@ -846,6 +783,12 @@ internal partial class WHM
         #endregion
 
         #region AoE Heals
+        
+        /// <summary>
+        ///     Priority order for AoE healing abilities.
+        /// </summary>
+        internal static UserIntArray WHM_AoE_Heals_Priority =
+            new("WHM_AoE_Heals_Priority");
 
         /// <summary>
         ///     Number of Thin Air charges to reserve in AoE healing.
@@ -858,6 +801,19 @@ internal partial class WHM
         /// <seealso cref="CustomComboPreset.WHM_AoEHeals_ThinAir" />
         internal static UserInt WHM_AoEHeals_ThinAir =
             new("WHM_AoE_ThinAir");
+        
+        /// <summary>
+        ///     Average party HP% threshold to use Cure3.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 100 <br />
+        ///     <b>Range</b>: 1 - 100 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_AoEHeals_Cure3" />
+        
+        internal static UserInt WHM_AoEHeals_Cure3HP = 
+            new("WHM_AoEHeals_Cure3HP", 100);
 
         /// <summary>
         ///     MP threshold to use Cure III.
@@ -872,6 +828,18 @@ internal partial class WHM
             new("WHM_AoE_Cure3MP");
 
         /// <summary>
+        ///     Average party HP% threshold to use Assize.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 100 <br />
+        ///     <b>Range</b>: 1 - 100 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_AoEHeals_Assize" />
+        internal static UserInt WHM_AoEHeals_AssizeHP = 
+            new("WHM_AoEHeals_AssizeHP", 100);
+        
+        /// <summary>
         ///     Only use Assize when weaving.
         /// </summary>
         /// <value>
@@ -880,6 +848,19 @@ internal partial class WHM
         /// <seealso cref="CustomComboPreset.WHM_AoEHeals_Assize" />
         internal static UserBool WHM_AoEHeals_AssizeWeave =
             new("WHM_AoEHeals_AssizeWeave");
+        
+        /// <summary>
+        ///     Average party HP% threshold to use Plenary.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 100 <br />
+        ///     <b>Range</b>: 1 - 100 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_AoEHeals_Plenary" />
+        
+        internal static UserInt WHM_AoEHeals_PlenaryHP = 
+            new("WHM_AoEHeals_PlenaryHP", 100);
 
         /// <summary>
         ///     Only use Plenary Indulgence when weaving.
@@ -900,16 +881,6 @@ internal partial class WHM
         /// <seealso cref="CustomComboPreset.WHM_AoEHeals_Temperance" />
         internal static UserBool WHM_AoEHeals_TemperanceWeave =
             new("WHM_AoEHeals_TemperanceWeave");
-
-        /// <summary>
-        ///     Will also use Temperance for Raidwides, if the party is low enough.
-        /// </summary>
-        /// <value>
-        ///     <b>Default</b>: false
-        /// </value>
-        /// <seealso cref="CustomComboPreset.WHM_AoEHeals_Temperance" />
-        internal static UserBool WHM_AoEHeals_TemperanceRaidwide =
-            new("WHM_AoEHeals_TemperanceRaidwide");
 
         /// <summary>
         ///     MP threshold to use Lucid Dreaming in AoE healing.
@@ -934,31 +905,77 @@ internal partial class WHM
         /// <seealso cref="CustomComboPreset.WHM_AoEHeals_Medica2" />
         internal static UserFloat WHM_AoEHeals_MedicaTime =
             new("WHM_AoEHeals_MedicaTime");
-
+        
         /// <summary>
-        ///     Only use Liturgy of the Bell vs a Raidwide.
+        ///     Average party HP% threshold to use Medica2.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 100 <br />
+        ///     <b>Range</b>: 1 - 100 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_AoEHeals_Medica2" />
+        
+        internal static UserInt WHM_AoEHeals_Medica2HP = 
+            new("WHM_AoEHeals_Medica2HP", 100);
+        
+        /// <summary>
+        ///     Average party HP% threshold to use Rapture.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 100 <br />
+        ///     <b>Range</b>: 1 - 100 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_AoEHeals_Rapture" />
+        
+        internal static UserInt WHM_AoEHeals_RaptureHP = 
+            new("WHM_AoEHeals_RaptureHP", 100);
+        
+        /// <summary>
+        ///     Average party HP% threshold to use Divine Caress.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 100 <br />
+        ///     <b>Range</b>: 1 - 100 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_AoEHeals_DivineCaress" />
+        
+        internal static UserInt WHM_AoEHeals_DivineCaressHP = 
+            new("WHM_AoEHeals_DivineCaressHP", 100);
+        
+        /// <summary>
+        ///     Only use Divine Caress when weaving.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: false
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_AoEHeals_DivineCaress" />
+        internal static UserBool WHM_AoEHeals_DivineCaressWeave =
+            new("WHM_AoEHeals_DivineCaressWeave");
+        
+        /// <summary>
+        ///     Average party HP% threshold to use LiturgyOfTheBell.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 30 <br />
+        ///     <b>Range</b>: 1 - 100 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_AoEHeals_LiturgyOfTheBell" />
+        internal static UserInt WHM_AoEHeals_LiturgyHP =
+            new("WHM_AoEHeals_LiturgyHP", 30);
+        
+        /// <summary>
+        ///     Only use Liturgy when weaving.
         /// </summary>
         /// <value>
         ///     <b>Default</b>: false
         /// </value>
         /// <seealso cref="CustomComboPreset.WHM_AoEHeals_LiturgyOfTheBell" />
-        internal static UserBool WHM_AoEHeals_LiturgyRaidwideOnly =
-            new("WHM_AoEHeals_LiturgyRaidwideOnly");
-
-        /// <summary>
-        ///     Boss Requirement for Liturgy of the Bell, to only check for raidwides
-        ///     in boss fights, or not.<br />
-        ///     Raidwides check controlled by
-        ///     <see cref="WHM_AoEHeals_LiturgyRaidwideOnly" />.
-        /// </summary>
-        /// <value>
-        ///     <b>Default</b>: <see cref="BossRequirement.On" /> <br />
-        ///     <b>Options</b>: <see cref="BossRequirement">BossRequirement Enum</see>
-        /// </value>
-        /// <seealso cref="CustomComboPreset.WHM_AoEHeals_LiturgyOfTheBell" />
-        public static readonly UserInt
-            WHM_AoEHeals_LiturgyRaidwideOnlyBoss =
-                new("WHM_AoEHeals_LiturgyRaidwideOnlyBoss", (int)BossRequirement.On);
+        internal static UserBool WHM_AoEHeals_LiturgyWeave =
+            new("WHM_AoEHeals_LiturgyWeave");
 
         /// <summary>
         ///     Content difficulty selector for Liturgy of the Bell.
@@ -1014,47 +1031,50 @@ internal partial class WHM
         internal static readonly ContentCheck.ListSet
             WHM_AoEHeals_TemperanceDifficultyListSet =
                 ContentCheck.ListSet.Halved;
-
+        
         /// <summary>
-        ///     Content difficulty selector for Temperance raidwide option.
+        ///     Average party HP% threshold to use Asylum.
         /// </summary>
         /// <value>
-        ///     <b>Default</b>: <see cref="ContentCheck.BottomHalfContent" /><br />
-        ///     <b>Options</b>: <see cref="ContentCheck.BottomHalfContent" />
-        ///     and/or <see cref="ContentCheck.TopHalfContent" />
+        ///     <b>Default</b>: 30 <br />
+        ///     <b>Range</b>: 1 - 100 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
         /// </value>
-        /// <seealso cref="CustomComboPreset.WHM_AoEHeals_Temperance" />
-        internal static UserBoolArray WHM_AoEHeals_TemperanceRaidwideDifficulty =
-            new("WHM_AoEHeals_TemperanceRaidwideDifficulty", [true, false]);
-
+        /// <seealso cref="CustomComboPreset.WHM_AoEHeals_Asylum" />
+        internal static UserInt WHM_AoEHeals_AsylumHP =
+            new("WHM_AoEHeals_AsylumHP", 30);
+        
         /// <summary>
-        ///     Content difficulty list set for Temperance raidwide option, set by
-        ///     <see cref="WHM_AoEHeals_TemperanceRaidwideDifficulty" />.
-        /// </summary>
-        /// <seealso cref="CustomComboPreset.WHM_AoEHeals_Temperance" />
-        internal static readonly ContentCheck.ListSet
-            WHM_AoEHeals_TemperanceRaidwideDifficultyListSet =
-                ContentCheck.ListSet.Halved;
-
-        /// <summary>
-        ///     Prioritizes Temperance for raidwides, by ignoring the HP% check then.
-        /// </summary>
-        /// <value>
-        ///     <b>Default</b>: false
-        /// </value>
-        /// <seealso cref="CustomComboPreset.WHM_AoEHeals_Temperance" />
-        internal static UserBool WHM_AoEHeals_TemperanceRaidwidePrioritization =
-            new("WHM_AoEHeals_TemperanceRaidwidePrioritization");
-
-        /// <summary>
-        ///     Only use Asylum vs a Raidwide.
+        ///     Only use Asylum when weaving.
         /// </summary>
         /// <value>
         ///     <b>Default</b>: false
         /// </value>
         /// <seealso cref="CustomComboPreset.WHM_AoEHeals_Asylum" />
-        internal static UserBool WHM_AoEHeals_AsylumRaidwideOnly =
-            new("WHM_AoEHeals_AsylumRaidwideOnly");
+        internal static UserBool WHM_AoEHeals_AsylumWeave =
+            new("WHM_AoEHeals_AsylumWeave");
+
+        /// <summary>
+        ///     Content difficulty selector for Asylum.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: <see cref="ContentCheck.BottomHalfContent" />
+        ///     and <see cref="ContentCheck.TopHalfContent" /><br />
+        ///     <b>Options</b>: <see cref="ContentCheck.BottomHalfContent" />
+        ///     and/or <see cref="ContentCheck.TopHalfContent" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_AoEHeals_Asylum" />
+        internal static UserBoolArray WHM_AoEHeals_AsylumDifficulty =
+            new("WHM_AoEHeals_AsylumDifficulty", [true, true]);
+
+        /// <summary>
+        ///     Content difficulty list set for Asylum, set by
+        ///     <see cref="WHM_AoEHeals_AsylumDifficulty" />.
+        /// </summary>
+        /// <seealso cref="CustomComboPreset.WHM_AoEHeals_Asylum" />
+        internal static readonly ContentCheck.ListSet
+            WHM_AoEHeals_AsylumDifficultyListSet =
+                ContentCheck.ListSet.Halved;
 
         #endregion
 

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -1,8 +1,6 @@
 ﻿#region
 
-using System.Numerics;
 using Dalamud.Interface.Colors;
-using ECommons.ImGuiMethods;
 using ImGuiNET;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
@@ -399,7 +397,7 @@ internal partial class WHM
         private const string targetStartUsingAtDescription =
             "Target HP% to use at or below (100 = Disable check)";
         
-        /// Bar Description for Party HP%  Averageto start using plus disable text
+        /// Bar Description for Party HP%  Average to start using plus disable text
         private const string partyStartUsingAtDescription =
             "Start using when below party average HP %. Set to 100 to disable this check";
 
@@ -553,7 +551,7 @@ internal partial class WHM
             new("WHM_AoE_Lucid", 6500);
         
         /// <summary>
-        ///     Reapplication Threshold for AoE Multidotting
+        ///     Reapplication Threshold for AoE Multi-DoTing
         /// </summary>
         /// <value>
         ///     <b>Default</b>: 0 <br />
@@ -565,7 +563,7 @@ internal partial class WHM
             new("WHM_AoE_MainCombo_DoT_Reapply", 0);
         
         /// <summary>
-        ///     Health Threshold to stop Multidotting
+        ///     Health Threshold to stop Multi-DoTing
         /// </summary> 
         /// <value>
         ///     <b>Default</b>: 50 <br />
@@ -577,7 +575,7 @@ internal partial class WHM
             new("WHM_AoE_MainCombo_DoT_HPThreshold", 50);
         
         /// <summary>
-        ///     Max Targets for AoE Multidotting
+        ///     Max Targets for AoE Multi-DoTing
         /// </summary> 
         /// <value>
         ///     <b>Default</b>: 4 <br />
@@ -1173,7 +1171,7 @@ internal partial class WHM
         #region Standalone Features
 
         /// <summary>
-        ///     Hard target Retargetting Options for Asylum Standalone Feature
+        ///     Hard target Retargeting Options for Asylum Standalone Feature
         /// </summary> 
         /// <value>
         ///     <b>Default</b>: True True
@@ -1183,7 +1181,8 @@ internal partial class WHM
             new("WHM_AsylumOptions", [true, true]);
         
         /// <summary>
-        ///     Hard target Retargetting Options for LiturgyOfTheBell Standalone Feature
+        ///     Hard target Retargeting Options for Liturgy Of The Bell
+        ///     Standalone Feature
         /// </summary> 
         /// <value>
         ///     <b>Default</b>: True True

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -340,34 +340,46 @@ internal partial class WHM
                     break;
                 
                 #endregion
-                
-                #region StandAlone Features
-                
-                case CustomComboPreset.WHM_Asylum:
-                    DrawHorizontalMultiChoice(WHM_AsylumOptions,
-                        "Hardtarget Enemies", "Will place at hard target if enemy", 3, 0);
-                    DrawHorizontalMultiChoice(WHM_AsylumOptions,
-                        "Hardtarget Allies", "Will place at hard target if ally", 3, 1);
-                    DrawHorizontalMultiChoice(WHM_AsylumOptions, 
-                        "Temperance Raidwide Mitigation Option", "Replace with Temperance when Asylum is on cooldown", 3, 2);
-                    break;
-                
-                case CustomComboPreset.WHM_LiturgyOfTheBell:
-                    DrawHorizontalMultiChoice(WHM_LiturgyOfTheBellOptions,
-                        "Hardtarget Enemies", "Will place at hard target if enemy", 2, 0);
-                    DrawHorizontalMultiChoice(WHM_LiturgyOfTheBellOptions,
-                        "Hardtarget Allies", "Will place at hard target if ally", 2, 1);
-                    break;
-                
-                case CustomComboPreset.WHM_Aquaveil:
+
+                #region Mitigation Features
+
+                case CustomComboPreset.WHM_Mit_ST:
                     DrawHorizontalMultiChoice(WHM_AquaveilOptions,
-                        "Divine Benison ST Mit Option", "Will add Divine Benison for ST Mit", 2, 0);
+                        "Include Divine Benison", "Will add Divine Benison for more mitigation.", 2, 0);
+                    ImGui.NewLine();
                     DrawHorizontalMultiChoice(WHM_AquaveilOptions,
-                        "Tetragrammaton ST Mit Option", "Will add Tetragrammaton to top off targets health", 2, 1);
+                        "Include Tetragrammaton", "Will add Tetragrammaton to top off targets health.", 2, 1);
                     if (WHM_AquaveilOptions[1])
                     {
-                        DrawSliderInt(0, 100, WHM_Aquaveil_TetraThreshold, "Will use if targets HP % is below set threshold");
+                        ImGui.Indent();
+                        DrawSliderInt(0, 100, WHM_Aquaveil_TetraThreshold,
+                            "Target HP% to use Tetra at or below (100 = Disable check)");
+                        ImGui.Unindent();
                     }
+                    break;
+
+                #endregion
+                
+                #region Retargeting Features
+                
+                case CustomComboPreset.WHM_Re_Asylum:
+                    ImGui.Indent();
+                    ImGui.TextColored(ImGuiColors.DalamudGrey, "Options to try to Retarget Asylum to before Self:");
+                    ImGui.Unindent();
+                    DrawHorizontalMultiChoice(WHM_AsylumOptions,
+                        "Enemy Hard Target", "Will place at hard target if enemy", 3, 0);
+                    DrawHorizontalMultiChoice(WHM_AsylumOptions,
+                        "Ally Hard Target", "Will place at hard target if ally", 3, 1);
+                    break;
+                
+                case CustomComboPreset.WHM_Re_LiturgyOfTheBell:
+                    ImGui.Indent();
+                    ImGui.TextColored(ImGuiColors.DalamudGrey, "Options to try to Retarget Asylum to before Self:");
+                    ImGui.Unindent();
+                    DrawHorizontalMultiChoice(WHM_LiturgyOfTheBellOptions,
+                        "Enemy Hard Target", "Will place at hard target if enemy", 2, 0);
+                    DrawHorizontalMultiChoice(WHM_LiturgyOfTheBellOptions,
+                        "Ally Hard Target", "Will place at hard target if ally", 2, 1);
                     break;
                     
                 
@@ -1166,7 +1178,7 @@ internal partial class WHM
         /// <value>
         ///     <b>Default</b>: True True
         /// </value>
-        /// <seealso cref="CustomComboPreset.WHM_Asylum" />
+        /// <seealso cref="CustomComboPreset.WHM_Re_Asylum" />
         internal static UserBoolArray WHM_AsylumOptions = 
             new("WHM_AsylumOptions", [true, true]);
         
@@ -1176,7 +1188,7 @@ internal partial class WHM
         /// <value>
         ///     <b>Default</b>: True True
         /// </value>
-        /// <seealso cref="CustomComboPreset.WHM_LiturgyOfTheBell" />
+        /// <seealso cref="CustomComboPreset.WHM_Re_LiturgyOfTheBell" />
         internal static UserBoolArray WHM_LiturgyOfTheBellOptions = 
             new ("WHM_LiturgyOfTheBellOptions", [true, true]);
         
@@ -1186,7 +1198,7 @@ internal partial class WHM
         /// <value>
         ///     <b>Default</b>: True True
         /// </value>
-        /// <seealso cref="CustomComboPreset.WHM_Aquaveil" />
+        /// <seealso cref="CustomComboPreset.WHM_Mit_ST" />
         internal static UserBoolArray WHM_AquaveilOptions = 
             new ("WHM_AquaveilOptions", [true, true]);
         
@@ -1198,7 +1210,7 @@ internal partial class WHM
         ///     <b>Range</b>: 0 - 100 <br />
         ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
         /// </value>
-        /// <seealso cref="CustomComboPreset.WHM_Aquaveil" />
+        /// <seealso cref="CustomComboPreset.WHM_Mit_ST" />
         internal static UserInt WHM_Aquaveil_TetraThreshold 
             = new("WHM_Aquaveil_TetraThreshold", 100);
         

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -129,6 +129,49 @@ internal partial class WHM
                         "Include Shields in HP Percent Sliders",
                         "");
                     break;
+                
+                case CustomComboPreset.WHM_STHeals_Benediction:
+                    DrawAdditionalBoolChoice(WHM_STHeals_BenedictionWeave,
+                        weaveDescription, "");
+                    DrawSliderInt(1, 100, WHM_STHeals_BenedictionHP,
+                        targetStartUsingAtDescription);
+                    DrawPriorityInput(WHM_ST_Heals_Priority, 9, 0,
+                        $"{Benediction.ActionName()} Priority: ");
+                    break;
+
+                case CustomComboPreset.WHM_STHeals_Tetragrammaton:
+                    DrawAdditionalBoolChoice(WHM_STHeals_TetraWeave,
+                        weaveDescription, "");
+                    DrawSliderInt(1, 100, WHM_STHeals_TetraHP,
+                        targetStartUsingAtDescription);
+                    DrawPriorityInput(WHM_ST_Heals_Priority, 9, 1,
+                        $"{Tetragrammaton.ActionName()} Priority: ");
+                    break;
+
+                case CustomComboPreset.WHM_STHeals_Benison:
+                    DrawAdditionalBoolChoice(WHM_STHeals_BenisonWeave,
+                        weaveDescription, "");
+                    DrawSliderInt(1, 100, WHM_STHeals_BenisonHP,
+                        targetStartUsingAtDescription);
+                    DrawPriorityInput(WHM_ST_Heals_Priority, 9, 2,
+                        $"{DivineBenison.ActionName()} Priority: ");
+                    break;
+
+                case CustomComboPreset.WHM_STHeals_Aquaveil:
+                    DrawAdditionalBoolChoice(WHM_STHeals_AquaveilWeave,
+                        weaveDescription, "");
+                    DrawSliderInt(1, 100, WHM_STHeals_AquaveilHP,
+                        targetStartUsingAtDescription);
+                    DrawPriorityInput(WHM_ST_Heals_Priority, 9, 3,
+                        $"{Aquaveil.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.WHM_STHeals_Solace:
+                    DrawSliderInt(1, 100, WHM_STHeals_SolaceHP,
+                        targetStartUsingAtDescription);
+                    DrawPriorityInput(WHM_ST_Heals_Priority, 9, 4,
+                        $"{AfflatusSolace.ActionName()} Priority: ");
+                    break;
 
                 case CustomComboPreset.WHM_STHeals_Regen:
                     ImGui.Indent();
@@ -140,53 +183,8 @@ internal partial class WHM
                         targetStopUsingAtDescription);
                     DrawSliderInt(0, 100, WHM_STHeals_RegenHPUpper,
                         targetStartUsingAtDescription);
-                    break;
-
-                case CustomComboPreset.WHM_STHeals_Benediction:
-                    DrawAdditionalBoolChoice(WHM_STHeals_BenedictionWeave,
-                        weaveDescription, "");
-                    DrawSliderInt(1, 100, WHM_STHeals_BenedictionHP,
-                        targetStartUsingAtDescription);
-                    DrawPriorityInput(WHM_ST_Heals_Priority, 5, 0,
-                        $"{Benediction.ActionName()} Priority: ");
-                    break;
-
-                case CustomComboPreset.WHM_STHeals_ThinAir:
-                    DrawSliderInt(0, 1, WHM_STHeals_ThinAir,
-                        chargesToKeepDescription);
-                    break;
-
-                case CustomComboPreset.WHM_STHeals_Tetragrammaton:
-                    DrawAdditionalBoolChoice(WHM_STHeals_TetraWeave,
-                        weaveDescription, "");
-                    DrawSliderInt(1, 100, WHM_STHeals_TetraHP,
-                        targetStartUsingAtDescription);
-                    DrawPriorityInput(WHM_ST_Heals_Priority, 5, 1,
-                        $"{Tetragrammaton.ActionName()} Priority: ");
-                    break;
-
-                case CustomComboPreset.WHM_STHeals_Benison:
-                    DrawAdditionalBoolChoice(WHM_STHeals_BenisonWeave,
-                        weaveDescription, "");
-                    DrawSliderInt(1, 100, WHM_STHeals_BenisonHP,
-                        targetStartUsingAtDescription);
-                    DrawPriorityInput(WHM_ST_Heals_Priority, 5, 2,
-                        $"{DivineBenison.ActionName()} Priority: ");
-                    break;
-
-                case CustomComboPreset.WHM_STHeals_Aquaveil:
-                    DrawAdditionalBoolChoice(WHM_STHeals_AquaveilWeave,
-                        weaveDescription, "");
-                    DrawSliderInt(1, 100, WHM_STHeals_AquaveilHP,
-                        targetStartUsingAtDescription);
-                    DrawPriorityInput(WHM_ST_Heals_Priority, 5, 3,
-                        $"{Aquaveil.ActionName()} Priority: ");
-                    break;
-
-                case CustomComboPreset.WHM_STHeals_Lucid:
-                    DrawSliderInt(4000, 9500, WHM_STHeals_Lucid,
-                        mpThresholdDescription,
-                        itemWidth: medium, SliderIncrements.Hundreds);
+                    DrawPriorityInput(WHM_ST_Heals_Priority, 9, 5,
+                        $"{Regen.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.WHM_STHeals_Temperance:
@@ -196,8 +194,41 @@ internal partial class WHM
                         "Select what content difficulties Temperance should be used in:");
                     DrawAdditionalBoolChoice(WHM_STHeals_TemperanceWeave,
                         weaveDescription, "");
-                    DrawPriorityInput(WHM_ST_Heals_Priority, 5, 4,
+                    DrawPriorityInput(WHM_ST_Heals_Priority, 9, 6,
                         $"{Temperance.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.WHM_STHeals_Asylum:
+                    DrawSliderInt(1, 100, WHM_STHeals_AsylumHP,
+                        targetStartUsingAtDescription);
+                    DrawDifficultyMultiChoice(WHM_STHeals_AsylumDifficulty, WHM_STHeals_AsylumDifficultyListSet,
+                        "Select what content difficulties Asylum should be used in:");
+                    DrawAdditionalBoolChoice(WHM_STHeals_AsylumWeave,
+                        weaveDescription, "");
+                    DrawPriorityInput(WHM_ST_Heals_Priority, 9, 7,
+                        $"{Asylum.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.WHM_STHeals_LiturgyOfTheBell:
+                    DrawSliderInt(1, 100, WHM_STHeals_LiturgyOfTheBellHP,
+                        targetStartUsingAtDescription);
+                    DrawDifficultyMultiChoice(WHM_STHeals_LiturgyOfTheBellDifficulty, WHM_STHeals_LiturgyOfTheBellDifficultyListSet,
+                        "Select what content difficulties LiturgyOfTheBell should be used in:");
+                    DrawAdditionalBoolChoice(WHM_STHeals_LiturgyOfTheBellWeave,
+                        weaveDescription, "");
+                    DrawPriorityInput(WHM_ST_Heals_Priority, 9, 8,
+                        $"{LiturgyOfTheBell.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.WHM_STHeals_ThinAir:
+                    DrawSliderInt(0, 1, WHM_STHeals_ThinAir,
+                        chargesToKeepDescription);
+                    break;
+                
+                case CustomComboPreset.WHM_STHeals_Lucid:
+                    DrawSliderInt(4000, 9500, WHM_STHeals_Lucid,
+                        mpThresholdDescription,
+                        itemWidth: medium, SliderIncrements.Hundreds);
                     break;
 
                 case CustomComboPreset.WHM_STHeals_Esuna:
@@ -568,6 +599,19 @@ internal partial class WHM
         /// <seealso cref="CustomComboPreset.WHM_STHeals_Benediction" />
         internal static UserInt WHM_STHeals_BenedictionHP =
             new("WHM_STHeals_BenedictionHP", 40);
+        
+        /// <summary>
+        ///     HP threshold to use Afflatus Solace.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 99 <br />
+        ///     <b>Range</b>: 1 - 100 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_STHeals_Solace" />
+        
+        internal static UserInt WHM_STHeals_SolaceHP = 
+            new("WHM_STHeals_SolaceHP", 80);
 
         /// <summary>
         ///     Number of Thin Air charges to reserve.
@@ -700,6 +744,91 @@ internal partial class WHM
         /// <seealso cref="CustomComboPreset.WHM_STHeals_Temperance" />
         internal static readonly ContentCheck.ListSet
             WHM_STHeals_TemperanceDifficultyListSet =
+                ContentCheck.ListSet.Halved;
+        /// <summary>
+        ///     Only use Asylum when weaving.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: false
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_STHeals_Asylum" />
+        internal static UserBool WHM_STHeals_AsylumWeave =
+            new("WHM_STHeals_AsylumWeave", false);
+
+        /// <summary>
+        ///     HP threshold to use Asylum.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 75 <br />
+        ///     <b>Range</b>: 1 - 100 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_STHeals_Asylum" />
+        internal static UserInt WHM_STHeals_AsylumHP =
+            new("WHM_STHeals_AsylumHP", 75);
+
+        /// <summary>
+        ///     Content difficulty selector for ST Asylum
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: <see cref="ContentCheck.BottomHalfContent" /> <br />
+        ///     <b>Options</b>: <see cref="ContentCheck.BottomHalfContent" />
+        ///     and/or <see cref="ContentCheck.TopHalfContent" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_STHeals_Asylum" />
+        internal static UserBoolArray WHM_STHeals_AsylumDifficulty =
+            new("WHM_STHeals_AsylumDifficulty", [true, false]);
+
+        /// <summary>
+        ///     Content difficulty list set for ST Asylum, set by
+        ///     <see cref="WHM_STHeals_AsylumDifficulty" />.
+        /// </summary>
+        /// <seealso cref="CustomComboPreset.WHM_STHeals_Asylum" />
+        internal static readonly ContentCheck.ListSet
+            WHM_STHeals_AsylumDifficultyListSet =
+                ContentCheck.ListSet.Halved;
+        
+        /// <summary>
+        ///     Only use LiturgyOfTheBell when weaving.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: false
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_STHeals_LiturgyOfTheBell" />
+        internal static UserBool WHM_STHeals_LiturgyOfTheBellWeave =
+            new("WHM_STHeals_LiturgyOfTheBellWeave", false);
+
+        /// <summary>
+        ///     HP threshold to use LiturgyOfTheBell.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 75 <br />
+        ///     <b>Range</b>: 1 - 100 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_STHeals_LiturgyOfTheBell" />
+        internal static UserInt WHM_STHeals_LiturgyOfTheBellHP =
+            new("WHM_STHeals_LiturgyOfTheBellHP", 75);
+
+        /// <summary>
+        ///     Content difficulty selector for ST LiturgyOfTheBell.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: <see cref="ContentCheck.BottomHalfContent" /> <br />
+        ///     <b>Options</b>: <see cref="ContentCheck.BottomHalfContent" />
+        ///     and/or <see cref="ContentCheck.TopHalfContent" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_STHeals_Temperance" />
+        internal static UserBoolArray WHM_STHeals_LiturgyOfTheBellDifficulty =
+            new("WHM_STHeals_LiturgyOfTheBellDifficulty", [true, false]);
+
+        /// <summary>
+        ///     Content difficulty list set for ST LiturgyOfTheBell, set by
+        ///     <see cref="WHM_STHeals_TemperanceDifficulty" />.
+        /// </summary>
+        /// <seealso cref="CustomComboPreset.WHM_STHeals_Temperance" />
+        internal static readonly ContentCheck.ListSet
+            WHM_STHeals_LiturgyOfTheBellDifficultyListSet =
                 ContentCheck.ListSet.Halved;
 
         /// <summary>

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -330,14 +330,32 @@ internal partial class WHM
                 #region StandAlone Features
                 
                 case CustomComboPreset.WHM_Asylum:
-                    DrawHorizontalMultiChoice(WHM_AsylumOptions,"Hardtarget Enemies", "Will place at hard target if enemy", 2, 0);
-                    DrawHorizontalMultiChoice(WHM_AsylumOptions,"Hardtarget Allies", "Will place at hard target if ally", 2, 1);
+                    DrawHorizontalMultiChoice(WHM_AsylumOptions,
+                        "Hardtarget Enemies", "Will place at hard target if enemy", 3, 0);
+                    DrawHorizontalMultiChoice(WHM_AsylumOptions,
+                        "Hardtarget Allies", "Will place at hard target if ally", 3, 1);
+                    DrawHorizontalMultiChoice(WHM_AsylumOptions, 
+                        "Temperance Raidwide Mitigation Option", "Replace with Temperance when Asylum is on cooldown", 3, 2);
                     break;
                 
                 case CustomComboPreset.WHM_LiturgyOfTheBell:
-                    DrawHorizontalMultiChoice(WHM_LiturgyOfTheBellOptions,"Hardtarget Enemies", "Will place at hard target if enemy", 2, 0);
-                    DrawHorizontalMultiChoice(WHM_LiturgyOfTheBellOptions,"Hardtarget Allies", "Will place at hard target if ally", 2, 1);
+                    DrawHorizontalMultiChoice(WHM_LiturgyOfTheBellOptions,
+                        "Hardtarget Enemies", "Will place at hard target if enemy", 2, 0);
+                    DrawHorizontalMultiChoice(WHM_LiturgyOfTheBellOptions,
+                        "Hardtarget Allies", "Will place at hard target if ally", 2, 1);
                     break;
+                
+                case CustomComboPreset.WHM_Aquaveil:
+                    DrawHorizontalMultiChoice(WHM_AquaveilOptions,
+                        "Divine Benison ST Mit Option", "Will add Divine Benison for ST Mit", 2, 0);
+                    DrawHorizontalMultiChoice(WHM_AquaveilOptions,
+                        "Tetragrammaton ST Mit Option", "Will add Tetragrammaton to top off targets health", 2, 1);
+                    if (WHM_AquaveilOptions[1])
+                    {
+                        DrawSliderInt(0, 100, WHM_Aquaveil_TetraThreshold, "Will use if targets HP % is below set threshold");
+                    }
+                    break;
+                    
                 
                 #endregion
             }
@@ -361,7 +379,7 @@ internal partial class WHM
 
         /// Bar Description for target HP% to start using plus disable text
         private const string targetStopUsingAtDescription =
-            " Non-Bosses HP% to stop using (0 = Use Always, 100 = Never)";
+            " Target HP% to stop using (0 = Use Always, 100 = Never)";
 
         /// Bar Description for target HP% to start using plus disable text
         private const string targetStopUsingOnBossAtDescription =
@@ -1099,6 +1117,28 @@ internal partial class WHM
         /// <seealso cref="CustomComboPreset.WHM_LiturgyOfTheBell" />
         internal static UserBoolArray WHM_LiturgyOfTheBellOptions = 
             new ("WHM_LiturgyOfTheBellOptions", [true, true]);
+        
+        /// <summary>
+        ///     Options for Aquaveil Standalone Feature
+        /// </summary> 
+        /// <value>
+        ///     <b>Default</b>: True True
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_Aquaveil" />
+        internal static UserBoolArray WHM_AquaveilOptions = 
+            new ("WHM_AquaveilOptions", [true, true]);
+        
+        /// <summary>
+        ///     Tetra threshold for Aquaveil standalone feature
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 100 <br />
+        ///     <b>Range</b>: 0 - 100 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_Aquaveil" />
+        internal static UserInt WHM_Aquaveil_TetraThreshold 
+            = new("WHM_Aquaveil_TetraThreshold", 100);
         
         #endregion
 

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -133,6 +133,8 @@ internal partial class WHM
                 case CustomComboPreset.WHM_STHeals_Benison:
                     DrawAdditionalBoolChoice(WHM_STHeals_BenisonWeave,
                         weaveDescription, "");
+                    DrawSliderInt(0, 1, WHM_STHeals_BenisonCharges, 
+                        chargesToKeepDescription);
                     DrawSliderInt(1, 100, WHM_STHeals_BenisonHP,
                         targetStartUsingAtDescription);
                     DrawPriorityInput(WHM_ST_Heals_Priority, 9, 2,
@@ -660,6 +662,18 @@ internal partial class WHM
         /// <seealso cref="CustomComboPreset.WHM_STHeals_Benison" />
         internal static UserBool WHM_STHeals_BenisonWeave =
             new("WHM_STHeals_BenisonWeave", false);
+        
+        /// <summary>
+        ///     Charges to keep of Divine Benison.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: 0 <br />
+        ///     <b>Range</b>: 0 - 1 <br />
+        ///     <b>Step</b>: <see cref="SliderIncrements.Ones" />
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_STHeals_Benison" />
+        internal static UserInt WHM_STHeals_BenisonCharges =
+            new("WHM_STHeals_BenisonCharges", 0);
 
         /// <summary>
         ///     HP threshold to use Divine Benison.

--- a/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
@@ -29,9 +29,9 @@ internal partial class WHM
     internal static bool NeedsDoT()
     {
         var dotAction = OriginalHook(Aero);
-        var hpThreshold = computeHpThreshold();
-
+        var hpThreshold = IsNotEnabled(CustomComboPreset.WHM_ST_Simple_DPS) ? computeHpThreshold(): 0;
         AeroList.TryGetValue(dotAction, out var dotDebuffID);
+        var dotRefresh = IsNotEnabled(CustomComboPreset.WHM_ST_Simple_DPS) ? Config.WHM_ST_MainCombo_DoT_Threshold : 2.5;
         var dotRemaining = GetStatusEffectRemainingTime(dotDebuffID, CurrentTarget);
 
         return ActionReady(dotAction) &&
@@ -39,7 +39,7 @@ internal partial class WHM
                !JustUsedOn(dotAction, CurrentTarget, 5f) &&
                HasBattleTarget() &&
                GetTargetHPPercent() > hpThreshold &&
-               dotRemaining <= Config.WHM_ST_MainCombo_DoT_Threshold;
+               dotRemaining <= dotRefresh;
     }
 
     internal static int computeHpThreshold()

--- a/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
@@ -60,6 +60,28 @@ internal partial class WHM
                 return !InBossEncounter() ? Config.WHM_ST_DPS_AeroOptionNonBoss : 0;
         }
     }
+    #region Raidwides
+    internal static bool RaidwideAsylum()
+    {
+        return IsEnabled(CustomComboPreset.WHM_Raidwide_Asylum) && 
+               ActionReady(Asylum) &&
+               CanWeave() && !RaidWideCasting();
+    }
+    internal static bool RaidwideTemperance()
+    {
+        return IsEnabled(CustomComboPreset.WHM_Raidwide_Temperance) && 
+               ActionReady(OriginalHook(Temperance)) && 
+               CanWeave() && !RaidWideCasting();
+    }
+    internal static bool RaidwideLiturgyOfTheBell()
+    {
+        return IsEnabled(CustomComboPreset.WHM_Raidwide_LiturgyOfTheBell) && 
+               ActionReady(LiturgyOfTheBell) &&
+               !HasStatusEffect(Buffs.LiturgyOfTheBell) && 
+               !RaidWideCasting() && CanWeave();
+    }
+    #endregion
+    
     #region Get ST Heals
     internal static int GetMatchingConfigST(int i, IGameObject? OptionalTarget, out uint action, out bool enabled)
     {

--- a/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
@@ -7,7 +7,6 @@ using Dalamud.Game.ClientState.Statuses;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
-using WrathCombo.Extensions;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 
 // ReSharper disable AccessToStaticMemberViaDerivedType
@@ -29,9 +28,13 @@ internal partial class WHM
     internal static bool NeedsDoT()
     {
         var dotAction = OriginalHook(Aero);
-        var hpThreshold = IsNotEnabled(CustomComboPreset.WHM_ST_Simple_DPS) ? computeHpThreshold(): 0;
+        var hpThreshold = IsNotEnabled(CustomComboPreset.WHM_ST_Simple_DPS)
+            ? computeHpThreshold()
+            : 0;
         AeroList.TryGetValue(dotAction, out var dotDebuffID);
-        var dotRefresh = IsNotEnabled(CustomComboPreset.WHM_ST_Simple_DPS) ? Config.WHM_ST_MainCombo_DoT_Threshold : 2.5;
+        var dotRefresh = IsNotEnabled(CustomComboPreset.WHM_ST_Simple_DPS)
+            ? Config.WHM_ST_MainCombo_DoT_Threshold
+            : 2.5;
         var dotRemaining = GetStatusEffectRemainingTime(dotDebuffID, CurrentTarget);
 
         return ActionReady(dotAction) &&
@@ -60,37 +63,20 @@ internal partial class WHM
                 return !InBossEncounter() ? Config.WHM_ST_DPS_AeroOptionNonBoss : 0;
         }
     }
-    #region Raidwides
-    internal static bool RaidwideAsylum()
-    {
-        return IsEnabled(CustomComboPreset.WHM_Raidwide_Asylum) && 
-               ActionReady(Asylum) &&
-               CanWeave() && RaidWideCasting();
-    }
-    internal static bool RaidwideTemperance()
-    {
-        return IsEnabled(CustomComboPreset.WHM_Raidwide_Temperance) && 
-               ActionReady(OriginalHook(Temperance)) && 
-               CanWeave() && RaidWideCasting();
-    }
-    internal static bool RaidwideLiturgyOfTheBell()
-    {
-        return IsEnabled(CustomComboPreset.WHM_Raidwide_LiturgyOfTheBell) && 
-               ActionReady(LiturgyOfTheBell) &&
-               !HasStatusEffect(Buffs.LiturgyOfTheBell) && 
-               RaidWideCasting() && CanWeave();
-    }
-    #endregion
-    
+
     #region Get ST Heals
-    internal static int GetMatchingConfigST(int i, IGameObject? OptionalTarget, out uint action, out bool enabled)
+
+    internal static int GetMatchingConfigST(int i, IGameObject? OptionalTarget,
+        out uint action, out bool enabled)
     {
         IGameObject? healTarget = OptionalTarget ?? SimpleTarget.Stack.AllyToHeal;
-        bool stopHot = Config.WHM_STHeals_RegenHPLower >= GetTargetHPPercent(healTarget, Config.WHM_STHeals_IncludeShields);
+        bool stopHot = Config.WHM_STHeals_RegenHPLower >=
+                       GetTargetHPPercent(healTarget,
+                           Config.WHM_STHeals_IncludeShields);
         float refreshTime = Config.WHM_STHeals_RegenTimer;
         Status? regenHoT = GetStatusEffect(Buffs.Regen, healTarget);
         Status? BenisonShield = GetStatusEffect(Buffs.DivineBenison, healTarget);
-        
+
         switch (i)
         {
             case 0:
@@ -107,7 +93,8 @@ internal partial class WHM
                 action = DivineBenison;
                 enabled = IsEnabled(CustomComboPreset.WHM_STHeals_Benison) &&
                           BenisonShield == null &&
-                          GetRemainingCharges(DivineBenison) > Config.WHM_STHeals_BenisonCharges &&
+                          GetRemainingCharges(DivineBenison) >
+                          Config.WHM_STHeals_BenisonCharges &&
                           (!Config.WHM_STHeals_BenisonWeave || CanWeave());
                 return Config.WHM_STHeals_BenisonHP;
             case 3:
@@ -117,35 +104,40 @@ internal partial class WHM
                 return Config.WHM_STHeals_AquaveilHP;
             case 4:
                 action = AfflatusSolace;
-                enabled = IsEnabled(CustomComboPreset.WHM_STHeals_Solace) && 
+                enabled = IsEnabled(CustomComboPreset.WHM_STHeals_Solace) &&
                           CanLily;
                 return Config.WHM_STHeals_SolaceHP;
             case 5:
                 action = Regen;
-                enabled = IsEnabled(CustomComboPreset.WHM_STHeals_Regen) && 
+                enabled = IsEnabled(CustomComboPreset.WHM_STHeals_Regen) &&
                           !stopHot &&
-                          (regenHoT is null || regenHoT.RemainingTime <= refreshTime);
+                          (regenHoT is null ||
+                           regenHoT.RemainingTime <= refreshTime);
                 return Config.WHM_STHeals_RegenHPUpper;
-            
+
             case 6:
                 action = OriginalHook(Temperance);
                 enabled = IsEnabled(CustomComboPreset.WHM_STHeals_Temperance) &&
-                          (!Config.WHM_STHeals_TemperanceOptions[1] || !InBossEncounter()) &&
+                          (!Config.WHM_STHeals_TemperanceOptions[1] ||
+                           !InBossEncounter()) &&
                           (!Config.WHM_STHeals_TemperanceOptions[0] || CanWeave());
                 return Config.WHM_STHeals_TemperanceHP;
-            
+
             case 7:
                 action = Asylum;
                 enabled = IsEnabled(CustomComboPreset.WHM_STHeals_Asylum) &&
-                          (!Config.WHM_STHeals_AsylumOptions[1] || !InBossEncounter()) &&
+                          (!Config.WHM_STHeals_AsylumOptions[1] ||
+                           !InBossEncounter()) &&
                           (!Config.WHM_STHeals_AsylumOptions[0] || CanWeave());
                 return Config.WHM_STHeals_AsylumHP;
             case 8:
                 action = LiturgyOfTheBell;
-                enabled = IsEnabled(CustomComboPreset.WHM_STHeals_LiturgyOfTheBell) &&
-                          !HasStatusEffect(Buffs.LiturgyOfTheBell) &&
-                          (!Config.WHM_STHeals_LiturgyOfTheBellOptions[1] || !InBossEncounter()) &&
-                          (!Config.WHM_STHeals_LiturgyOfTheBellOptions[0] || CanWeave());
+                enabled =
+                    IsEnabled(CustomComboPreset.WHM_STHeals_LiturgyOfTheBell) &&
+                    !HasStatusEffect(Buffs.LiturgyOfTheBell) &&
+                    (!Config.WHM_STHeals_LiturgyOfTheBellOptions[1] ||
+                     !InBossEncounter()) &&
+                    (!Config.WHM_STHeals_LiturgyOfTheBellOptions[0] || CanWeave());
                 return Config.WHM_STHeals_LiturgyOfTheBellHP;
         }
 
@@ -153,91 +145,126 @@ internal partial class WHM
         action = 0;
         return 0;
     }
+
     #endregion
-    
+
     #region Get Aoe Heals
-    public static int GetMatchingConfigAoE(int i, IGameObject? OptionalTarget, out uint action, out bool enabled)
+
+    public static int GetMatchingConfigAoE(int i, IGameObject? OptionalTarget,
+        out uint action, out bool enabled)
     {
-        IGameObject? healTarget = OptionalTarget ?? SimpleTarget.Stack.AllyToHeal;
-        bool medica3Check = !HasStatusEffect(Buffs.Medica3) ||
-                            GetStatusEffectRemainingTime(Buffs.Medica3) <= Config.WHM_AoEHeals_MedicaTime;
-        bool medica2Check = !HasStatusEffect(Buffs.Medica2) ||
-                            GetStatusEffectRemainingTime(Buffs.Medica2) <= Config.WHM_AoEHeals_MedicaTime;
-        
+        var medica3Check = !HasStatusEffect(Buffs.Medica3) ||
+                           GetStatusEffectRemainingTime(Buffs.Medica3) <=
+                           Config.WHM_AoEHeals_MedicaTime;
+        var medica2Check = !HasStatusEffect(Buffs.Medica2) ||
+                           GetStatusEffectRemainingTime(Buffs.Medica2) <=
+                           Config.WHM_AoEHeals_MedicaTime;
+
         switch (i)
         {
             case 0:
                 action = OriginalHook(Medica2);
                 enabled = IsEnabled(CustomComboPreset.WHM_AoEHeals_Medica2) &&
-                          (LevelChecked(Medica3) && medica3Check || 
+                          (LevelChecked(Medica3) && medica3Check ||
                            !LevelChecked(Medica3) && medica2Check);
                 return Config.WHM_AoEHeals_Medica2HP;
-            
+
             case 1:
                 action = Cure3;
                 enabled = IsEnabled(CustomComboPreset.WHM_AoEHeals_Cure3) &&
-                          NumberOfAlliesInRange(Cure3, OptionalTarget) 
+                          NumberOfAlliesInRange(Cure3, OptionalTarget)
                           >= Config.WHM_AoEHeals_Cure3Allies &&
                           (LocalPlayer.CurrentMp >= Config.WHM_AoEHeals_Cure3MP ||
                            HasStatusEffect(Buffs.ThinAir));
                 return Config.WHM_AoEHeals_Cure3HP;
-            
+
             case 2:
                 action = PlenaryIndulgence;
                 enabled = IsEnabled(CustomComboPreset.WHM_AoEHeals_Plenary) &&
                           (CanWeave() || !Config.WHM_AoEHeals_PlenaryWeave);
                 return Config.WHM_AoEHeals_PlenaryHP;
-            
+
             case 3:
                 action = Temperance;
                 enabled = IsEnabled(CustomComboPreset.WHM_AoEHeals_Temperance) &&
                           (CanWeave() || !Config.WHM_AoEHeals_TemperanceWeave) &&
                           !HasStatusEffect(Buffs.DivineGrace) &&
                           ContentCheck.IsInConfiguredContent(
-                            Config.WHM_AoEHeals_TemperanceDifficulty,
-                            Config.WHM_AoEHeals_TemperanceDifficultyListSet);
+                              Config.WHM_AoEHeals_TemperanceDifficulty,
+                              Config.WHM_AoEHeals_TemperanceDifficultyListSet);
                 return Config.WHM_AoEHeals_TemperanceHP;
-            
+
             case 4:
                 action = Asylum;
                 enabled = IsEnabled(CustomComboPreset.WHM_AoEHeals_Asylum) &&
-                          (CanWeave() || !Config.WHM_AoEHeals_AsylumWeave) && !IsMoving() &&
+                          (CanWeave() || !Config.WHM_AoEHeals_AsylumWeave) &&
+                          !IsMoving() &&
                           ContentCheck.IsInConfiguredContent(
                               Config.WHM_AoEHeals_AsylumDifficulty,
                               Config.WHM_AoEHeals_AsylumDifficultyListSet);
                 return Config.WHM_AoEHeals_AsylumHP;
-            
+
             case 5:
                 action = LiturgyOfTheBell;
-                enabled = IsEnabled(CustomComboPreset.WHM_AoEHeals_LiturgyOfTheBell) && 
-                          !HasStatusEffect(Buffs.LiturgyOfTheBell) && 
-                          (CanWeave() || !Config.WHM_AoEHeals_LiturgyWeave) &&
-                          ContentCheck.IsInConfiguredContent(
-                              Config.WHM_AoEHeals_LiturgyDifficulty,
-                              Config.WHM_AoEHeals_LiturgyDifficultyListSet);
+                enabled =
+                    IsEnabled(CustomComboPreset.WHM_AoEHeals_LiturgyOfTheBell) &&
+                    !HasStatusEffect(Buffs.LiturgyOfTheBell) &&
+                    (CanWeave() || !Config.WHM_AoEHeals_LiturgyWeave) &&
+                    ContentCheck.IsInConfiguredContent(
+                        Config.WHM_AoEHeals_LiturgyDifficulty,
+                        Config.WHM_AoEHeals_LiturgyDifficultyListSet);
                 return Config.WHM_AoEHeals_LiturgyHP;
-            
+
             case 6:
                 action = AfflatusRapture;
-                enabled = IsEnabled(CustomComboPreset.WHM_AoEHeals_Rapture) && CanLily;
+                enabled = IsEnabled(CustomComboPreset.WHM_AoEHeals_Rapture) &&
+                          CanLily;
                 return Config.WHM_AoEHeals_RaptureHP;
-            
+
             case 7:
                 action = Assize;
                 enabled = IsEnabled(CustomComboPreset.WHM_AoEHeals_Assize) &&
                           (!Config.WHM_AoEHeals_AssizeWeave || CanWeave());
                 return Config.WHM_AoEHeals_AssizeHP;
-            
+
             case 8:
                 action = DivineCaress;
                 enabled = IsEnabled(CustomComboPreset.WHM_AoEHeals_DivineCaress) &&
                           (!Config.WHM_AoEHeals_DivineCaressWeave || CanWeave());
                 return Config.WHM_AoEHeals_DivineCaressHP;
         }
+
         enabled = false;
         action = 0;
         return 0;
     }
+
+    #endregion
+
+    #region Raidwides
+
+    internal static bool RaidwideAsylum()
+    {
+        return IsEnabled(CustomComboPreset.WHM_Raidwide_Asylum) &&
+               ActionReady(Asylum) &&
+               CanWeave() && RaidWideCasting();
+    }
+
+    internal static bool RaidwideTemperance()
+    {
+        return IsEnabled(CustomComboPreset.WHM_Raidwide_Temperance) &&
+               ActionReady(OriginalHook(Temperance)) &&
+               CanWeave() && RaidWideCasting();
+    }
+
+    internal static bool RaidwideLiturgyOfTheBell()
+    {
+        return IsEnabled(CustomComboPreset.WHM_Raidwide_LiturgyOfTheBell) &&
+               ActionReady(LiturgyOfTheBell) &&
+               !HasStatusEffect(Buffs.LiturgyOfTheBell) &&
+               RaidWideCasting() && CanWeave();
+    }
+
     #endregion
 
     #region Variables

--- a/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
@@ -65,20 +65,20 @@ internal partial class WHM
     {
         return IsEnabled(CustomComboPreset.WHM_Raidwide_Asylum) && 
                ActionReady(Asylum) &&
-               CanWeave() && !RaidWideCasting();
+               CanWeave() && RaidWideCasting();
     }
     internal static bool RaidwideTemperance()
     {
         return IsEnabled(CustomComboPreset.WHM_Raidwide_Temperance) && 
                ActionReady(OriginalHook(Temperance)) && 
-               CanWeave() && !RaidWideCasting();
+               CanWeave() && RaidWideCasting();
     }
     internal static bool RaidwideLiturgyOfTheBell()
     {
         return IsEnabled(CustomComboPreset.WHM_Raidwide_LiturgyOfTheBell) && 
                ActionReady(LiturgyOfTheBell) &&
                !HasStatusEffect(Buffs.LiturgyOfTheBell) && 
-               !RaidWideCasting() && CanWeave();
+               RaidWideCasting() && CanWeave();
     }
     #endregion
     
@@ -155,8 +155,9 @@ internal partial class WHM
     #endregion
     
     #region Get Aoe Heals
-    public static int GetMatchingConfigAoE(int i, out uint action, out bool enabled)
+    public static int GetMatchingConfigAoE(int i, IGameObject? OptionalTarget, out uint action, out bool enabled)
     {
+        IGameObject? healTarget = OptionalTarget ?? SimpleTarget.Stack.AllyToHeal;
         bool medica3Check = !HasStatusEffect(Buffs.Medica3) ||
                             GetStatusEffectRemainingTime(Buffs.Medica3) <= Config.WHM_AoEHeals_MedicaTime;
         bool medica2Check = !HasStatusEffect(Buffs.Medica2) ||
@@ -174,6 +175,8 @@ internal partial class WHM
             case 1:
                 action = Cure3;
                 enabled = IsEnabled(CustomComboPreset.WHM_AoEHeals_Cure3) &&
+                          NumberOfAlliesInRange(Cure3, OptionalTarget) 
+                          >= Config.WHM_AoEHeals_Cure3Allies &&
                           (LocalPlayer.CurrentMp >= Config.WHM_AoEHeals_Cure3MP ||
                            HasStatusEffect(Buffs.ThinAir));
                 return Config.WHM_AoEHeals_Cure3HP;

--- a/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
@@ -107,6 +107,7 @@ internal partial class WHM
                 action = DivineBenison;
                 enabled = IsEnabled(CustomComboPreset.WHM_STHeals_Benison) &&
                           BenisonShield == null &&
+                          GetRemainingCharges(DivineBenison) > Config.WHM_STHeals_BenisonCharges &&
                           (!Config.WHM_STHeals_BenisonWeave || CanWeave());
                 return Config.WHM_STHeals_BenisonHP;
             case 3:

--- a/WrathCombo/Core/ActionRetargeting.cs
+++ b/WrathCombo/Core/ActionRetargeting.cs
@@ -173,7 +173,8 @@ public class ActionRetargeting : IDisposable
             showResolver: true, retarget: retarget);
 
         // Run the target resolver
-        RemoveRetarget(retarget.ID);
+        if (!retarget.DontCull)
+            RemoveRetarget(retarget.ID);
         try
         {
             target = retarget.Resolver.Invoke();

--- a/WrathCombo/CustomCombo/Functions/Target.cs
+++ b/WrathCombo/CustomCombo/Functions/Target.cs
@@ -10,7 +10,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using WrathCombo.Combos.PvE;
+using WrathCombo.Core;
 using WrathCombo.Data;
+using WrathCombo.Extensions;
 using WrathCombo.Services;
 using ObjectKind = Dalamud.Game.ClientState.Objects.Enums.ObjectKind;
 
@@ -216,36 +218,94 @@ internal abstract partial class CustomComboFunctions
     ///     Gets the number of enemies within range of an AoE action. <br/>
     ///     If the action requires a target, defaults to CurrentTarget unless specified.
     /// </summary>
-    public static int NumberOfEnemiesInRange(uint aoeSpell, IGameObject? target, bool checkIgnoredList = false)
+    /// <param name="aoeSpell">
+    ///     The Action ID to check. <br />
+    ///     This will be used to load up all required data from the Action Sheet.
+    /// </param>
+    /// <param name="target">
+    ///     Target for targeted AoE shapes (all but <see cref="SelfCircle"/>). <br />
+    ///     (Optional, defaults to false)
+    /// </param>
+    /// <param name="checkIgnoredList">
+    ///     Whether to check the 
+    ///     <see cref="PluginConfiguration.IgnoredNPCs"/> list. <br />
+    ///     (Optional, defaults to false)
+    /// </param>
+    /// <returns>
+    ///     Number of enemies within the specified action's range.
+    /// </returns>
+    public static int NumberOfEnemiesInRange
+        (uint aoeSpell, IGameObject? target = null, bool checkIgnoredList = false)
     {
         if (!ActionWatching.ActionSheet.TryGetValue(aoeSpell, out var sheetSpell))
             return 0;
 
-        if (sheetSpell.CanTargetHostile && ((target ??= CurrentTarget) is null || GetTargetDistance(target) > GetActionRange(sheetSpell.RowId)))
+        if (sheetSpell.CanTargetHostile &&
+            ((target ??= CurrentTarget) is null ||
+             GetTargetDistance(target) > GetActionRange(sheetSpell.RowId)))
             return 0;
 
-        int count = sheetSpell.CastType switch
+        var count = sheetSpell.CastType switch
         {
             1 => 1,
             2 => sheetSpell.CanTargetSelf
-                ? CanCircleAoe(sheetSpell.EffectRange, checkIgnoredList)
-                : CanRangedCircleAoe(target, sheetSpell.EffectRange, checkIgnoredList),
-            3 => CanConeAoe(target, sheetSpell.Range, checkIgnoredList),
-            4 => CanLineAoe(target, sheetSpell.Range, sheetSpell.XAxisModifier, checkIgnoredList),
-            _ => 0
+                ? NumberOfObjectsInRange<SelfCircle>(sheetSpell.EffectRange,
+                    checkIgnoredList: checkIgnoredList)
+                : NumberOfObjectsInRange<Circle>(sheetSpell.EffectRange, target,
+                    checkIgnoredList: checkIgnoredList),
+            3 => NumberOfObjectsInRange<Cone>(sheetSpell.Range, target,
+                checkIgnoredList: checkIgnoredList),
+            4 => NumberOfObjectsInRange<Line>(sheetSpell.Range, target,
+                sheetSpell.XAxisModifier, checkIgnoredList: checkIgnoredList),
+            _ => 0,
         };
 
         return count;
     }
 
-    /// <summary> Gets the number of enemies within a given range from the player. </summary>
-    public static int NumberOfEnemiesInRange(float range)
+    /// <summary>
+    ///     Gets the number of allies within range of an AoE action. <br/>
+    ///     If the action requires a target, defaults to CurrentTarget unless specified.
+    /// </summary>
+    /// <param name="aoeSpell">
+    ///     The Action ID to check. <br />
+    ///     This will be used to load up all required data from the Action Sheet.
+    /// </param>
+    /// <param name="target">
+    ///     Target for targeted AoE shapes (all but <see cref="SelfCircle"/>). <br />
+    ///     (Optional, defaults to false)
+    /// </param>
+    /// <returns>
+    ///     Number of allies within the specified action's range.
+    /// </returns>
+    public static int NumberOfAlliesInRange
+        (uint aoeSpell, IGameObject? target)
     {
-        return Svc.Objects.Count(o =>
-            o.ObjectKind == ObjectKind.BattleNpc &&
-            o.IsTargetable &&
-            o.IsHostile() &&
-            GetTargetDistance(o) <= range);
+        if (!ActionWatching.ActionSheet.TryGetValue(aoeSpell, out var sheetSpell))
+            return 0;
+
+        if (sheetSpell.CanTargetAlly &&
+            ((target ??= CurrentTarget) is null ||
+             GetTargetDistance(target) > GetActionRange(sheetSpell.RowId)))
+            return 0;
+
+        var count = sheetSpell.CastType switch
+        {
+            1 => 1,
+            2 => sheetSpell.CanTargetSelf
+                ? NumberOfObjectsInRange<SelfCircle>(sheetSpell.EffectRange,
+                    enemies: false)
+                : NumberOfObjectsInRange<Circle>(sheetSpell.EffectRange, target,
+                    enemies: false),
+            // No current cones or lines for allies, but may as well have them here
+            3 => NumberOfObjectsInRange<Cone>(sheetSpell.Range, target,
+                enemies: false),
+            4 => NumberOfObjectsInRange<Line>(sheetSpell.Range, target,
+                sheetSpell.XAxisModifier, enemies: false),
+            _ => 0,
+        };
+
+        return count;
     }
 
     /// <summary> Checks if an object is within line of sight of the player. </summary>
@@ -338,67 +398,117 @@ internal abstract partial class CustomComboFunctions
 
     #region Shape Checks
 
-    /// <summary> Gets the number of enemies within range of a point-blank AoE. </summary>
-    public static int CanCircleAoe(float effectRange, bool checkIgnoredList = false)
+    /// <summary>
+    ///     Gets the number of enemies within range of a specified AoE shape type.
+    /// </summary>
+    /// <typeparam name="T">
+    ///     The AoE shape type (<see cref="SelfCircle"/>,
+    ///     <see cref="Circle"/>, <see cref="Cone"/>, <see cref="Line"/>)<br />
+    ///     Types that implement <see cref="IAoeShape" />.
+    /// </typeparam>
+    /// <param name="size">
+    ///     The radius of the AoE (or length, for Line AoEs).
+    /// </param>
+    /// <param name="target">
+    ///     Target for targeted AoE shapes (all but <see cref="SelfCircle"/>). <br />
+    ///     (Optional, defaults to <see cref="CurrentTarget" />)
+    /// </param>
+    /// <param name="width">
+    ///     Width parameter - Only for Line AoEs.  <br />
+    ///     In the sheets, this column is labeled as "X Axis Modifier", and is
+    ///     usually 0-5. <br />
+    ///     (Optional, defaults to 0, which is the value for many Line AoEs)
+    /// </param>
+    /// <param name="checkIgnoredList">
+    ///     Whether to check the 
+    ///     <see cref="PluginConfiguration.IgnoredNPCs"/> list. <br />
+    ///     (Optional, defaults to false)
+    /// </param>
+    /// <param name="enemies">
+    ///     Whether enemy targets are what is searched;
+    ///     if <see langword="false" /> then will search for allies instead.
+    /// </param>
+    /// <returns>
+    ///     Number of enemies within the specified AoE shape.
+    /// </returns>
+    /// <remarks>
+    ///     In almost every situation you should instead use
+    ///     <see cref="NumberOfEnemiesInRange(uint, IGameObject?, bool)"/>.
+    /// </remarks>
+    internal static int NumberOfObjectsInRange<T>
+    (float size,
+        IGameObject? target = null,
+        float width = 0f,
+        bool checkIgnoredList = false,
+        bool enemies = true)
+        where T : IAoeShape
     {
-        if (LocalPlayer is not { } player) return 0;
+        // Bail if the player is not available
+        if (LocalPlayer is not { } player)
+            return 0;
+        
+        // Bail if the target is required and not available
+        if (typeof(T) != typeof(SelfCircle) && (target ??= CurrentTarget) is null)
+            return 0;
 
-        return Svc.Objects.Count(o => o.ObjectKind == ObjectKind.BattleNpc &&
-                                      o.IsTargetable &&
-                                      o.IsHostile() &&
-                                      !TargetIsInvincible(o) &&
-                                      (!checkIgnoredList || !Service.Configuration.IgnoredNPCs.ContainsKey(o.DataId)) &&
-                                      PointInCircle(o.Position - player.Position, effectRange + o.HitboxRadius));
-    }
+        // Get all possible enemies to search for the positions of
+        var targets = Svc.Objects.Where(IsValidTarget);
 
-    /// <summary> Gets the number of enemies within range of a targeted AoE. </summary>
-    public static int CanRangedCircleAoe(IGameObject? target, float effectRange, bool checkIgnoredList = false)
-    {
-        if (target is null) return 0;
+        // Circle AoEs positioned on self
+        if (typeof(T) == typeof(SelfCircle))
+            return targets.Count(o =>
+                PointInCircle(o.Position - player.Position,
+                    size + o.HitboxRadius));
 
-        return Svc.Objects.Count(o => o.ObjectKind == ObjectKind.BattleNpc &&
-                                      o.IsTargetable &&
-                                      o.IsHostile() &&
-                                      !TargetIsInvincible(o) &&
-                                      (!checkIgnoredList || !Service.Configuration.IgnoredNPCs.ContainsKey(o.DataId)) &&
-                                      PointInCircle(o.Position - target.Position, effectRange + o.HitboxRadius));
-    }
-
-    /// <summary> Gets the number of enemies within range of a cone AoE. </summary>
-    public static int CanConeAoe(IGameObject? target, float range, bool checkIgnoredList = false)
-    {
-        if (LocalPlayer is not { } player || target is null) return 0;
-
-        Vector3 direction = PositionalMath.GetDirection(player.Position, target.Position);
-
-        return Svc.Objects.Count(o => o.ObjectKind == ObjectKind.BattleNpc &&
-                                      o.IsTargetable &&
-                                      o.IsHostile() &&
-                                      !TargetIsInvincible(o) &&
-                                      GetTargetDistance(o) <= range &&
-                                      (!checkIgnoredList || !Service.Configuration.IgnoredNPCs.ContainsKey(o.DataId)) &&
-                                      PointInCone(o.Position - player.Position, direction, 45f));
-    }
-
-    /// <summary> Gets the number of enemies within range of a line AoE. </summary>
-    public static int CanLineAoe(IGameObject? target, float range, float xAxisModifier, bool checkIgnoredList = false)
-    {
-        if (LocalPlayer is not { } player || target is null) return 0;
-
-        float halfLength = range * 0.5f;
-        float halfWidth = xAxisModifier * 0.5f;
-        float rotation = PositionalMath.GetRotation(player.Position, target.Position);
-
-        return Svc.Objects.Count(o => o.ObjectKind == ObjectKind.BattleNpc &&
-                                      o.IsTargetable &&
-                                      o.IsHostile() &&
-                                      !TargetIsInvincible(o) &&
-                                      GetTargetDistance(o) <= range &&
-                                      (!checkIgnoredList || !Service.Configuration.IgnoredNPCs.ContainsKey(o.DataId)) &&
-                                      HitboxInRect(o, rotation, halfLength, halfWidth));
+        // Circle AoEs centered on a target
+        if (typeof(T) == typeof(Circle))
+            return targets.Count(o => 
+                PointInCircle(o.Position - target.Position,
+                    size + o.HitboxRadius));
+        
+        // Cone AoEs
+        if (typeof(T) == typeof(Cone))
+            return targets.Count(o =>
+                GetTargetDistance(o) <= size &&
+                PointInCone(o.Position - player.Position,
+                    PositionalMath.GetDirection(player.Position, target.Position),
+                    45f));
+        
+        // Line AoEs
+        if (typeof(T) == typeof(Line))
+            return targets.Count(o =>
+                GetTargetDistance(o) <= size &&
+                HitboxInRect(o,
+                    PositionalMath.GetRotation(player.Position, target.Position),
+                    size * 0.5f, width * 0.5f));
+        
+        // If it was not a supported type
+        return 0;
+        
+        bool IsValidTarget(IGameObject o)
+        {
+            if (!enemies)
+                return o is IBattleChara &&
+                       o.IsTargetable &&
+                       o.IsWithinRange(60f) &&
+                       o.IsFriendly();
+            
+            return o is { ObjectKind: ObjectKind.BattleNpc, IsTargetable: true } &&
+                   o.IsWithinRange(60f) &&
+                   o.IsHostile() &&
+                   !TargetIsInvincible(o) &&
+                   (!checkIgnoredList ||
+                    !Service.Configuration.IgnoredNPCs.ContainsKey(o.DataId));
+        }
     }
 
     #region Shape Helpers
+    
+    public interface IAoeShape { }
+    public struct SelfCircle : IAoeShape { }
+    public struct Circle : IAoeShape { }
+    public struct Cone : IAoeShape { }
+    public struct Line : IAoeShape { }
 
     #region Point in Circle
     public static bool PointInCircle(Vector3 offsetFromOrigin, float radius)

--- a/WrathCombo/CustomCombo/Functions/Target.cs
+++ b/WrathCombo/CustomCombo/Functions/Target.cs
@@ -116,7 +116,7 @@ internal abstract partial class CustomComboFunctions
     /// </returns>
     public static bool CanInterruptEnemy(float? minCastPercent = null, IGameObject? optionalTarget = null)
     {
-        if ((optionalTarget ?? CurrentTarget) is not IBattleChara chara || !chara.IsCasting || !chara.IsCastInterruptible)
+        if ((optionalTarget ?? CurrentTarget) is not IBattleChara { IsCasting: true } chara || !chara.IsCastInterruptible)
             return false;
 
         float minThreshold = Math.Clamp(minCastPercent ?? (float)Service.Configuration.InterruptDelay, 0f, 1f);
@@ -224,7 +224,7 @@ internal abstract partial class CustomComboFunctions
     /// </param>
     /// <param name="target">
     ///     Target for targeted AoE shapes (all but <see cref="SelfCircle"/>). <br />
-    ///     (Optional, defaults to false)
+    ///     (Optional, defaults to <see cref="CurrentTarget" />)
     /// </param>
     /// <param name="checkIgnoredList">
     ///     Whether to check the 
@@ -273,13 +273,13 @@ internal abstract partial class CustomComboFunctions
     /// </param>
     /// <param name="target">
     ///     Target for targeted AoE shapes (all but <see cref="SelfCircle"/>). <br />
-    ///     (Optional, defaults to false)
+    ///     (Optional, defaults to <see cref="CurrentTarget" />)
     /// </param>
     /// <returns>
     ///     Number of allies within the specified action's range.
     /// </returns>
     public static int NumberOfAlliesInRange
-        (uint aoeSpell, IGameObject? target)
+        (uint aoeSpell, IGameObject? target = null)
     {
         if (!ActionWatching.ActionSheet.TryGetValue(aoeSpell, out var sheetSpell))
             return 0;

--- a/WrathCombo/CustomCombo/SimpleTarget.cs
+++ b/WrathCombo/CustomCombo/SimpleTarget.cs
@@ -369,7 +369,7 @@ internal static class SimpleTarget
     public static IGameObject? DottableEnemy
     (uint dotAction,
         ushort dotDebuff,
-        uint minHPPercent = 10,
+        int minHPPercent = 10,
         float reapplyThreshold = 1,
         int maxNumberOfEnemiesInRange = 3)
     {

--- a/WrathCombo/CustomCombo/SimpleTarget.cs
+++ b/WrathCombo/CustomCombo/SimpleTarget.cs
@@ -384,7 +384,7 @@ internal static class SimpleTarget
         return Svc.Objects
             .OfType<IBattleChara>()
             .Where(x => x.IsHostile() && x.IsTargetable && x.CanUseOn(dotAction) &&
-                        x.CurrentHp / x.MaxHp * 100u > minHP &&
+                        x.CurrentHp * 100u / x.MaxHp > minHP &&
                         !CustomComboFunctions.JustUsedOn(dotAction, x) &&
                         CustomComboFunctions.GetStatusEffectRemainingTime
                             (dotDebuff, x) <= reapplyThreshold &&

--- a/WrathCombo/CustomCombo/SimpleTarget.cs
+++ b/WrathCombo/CustomCombo/SimpleTarget.cs
@@ -369,6 +369,7 @@ internal static class SimpleTarget
     public static IGameObject? DottableEnemy
     (uint dotAction,
         ushort dotDebuff,
+        uint minHP = 10, // 10%
         float reapplyThreshold = 1,
         int maxNumberOfEnemiesInRange = 3)
     {
@@ -383,6 +384,7 @@ internal static class SimpleTarget
         return Svc.Objects
             .OfType<IBattleChara>()
             .Where(x => x.IsHostile() && x.IsTargetable && x.CanUseOn(dotAction) &&
+                        x.CurrentHp / x.MaxHp * 100u > minHP &&
                         !CustomComboFunctions.JustUsedOn(dotAction, x) &&
                         CustomComboFunctions.GetStatusEffectRemainingTime
                             (dotDebuff, x) <= reapplyThreshold &&

--- a/WrathCombo/CustomCombo/SimpleTarget.cs
+++ b/WrathCombo/CustomCombo/SimpleTarget.cs
@@ -369,7 +369,7 @@ internal static class SimpleTarget
     public static IGameObject? DottableEnemy
     (uint dotAction,
         ushort dotDebuff,
-        uint minHP = 10, // 10%
+        uint minHPPercent = 10,
         float reapplyThreshold = 1,
         int maxNumberOfEnemiesInRange = 3)
     {
@@ -384,7 +384,7 @@ internal static class SimpleTarget
         return Svc.Objects
             .OfType<IBattleChara>()
             .Where(x => x.IsHostile() && x.IsTargetable && x.CanUseOn(dotAction) &&
-                        x.CurrentHp * 100u / x.MaxHp > minHP &&
+                        x.CurrentHp * 100u / x.MaxHp > minHPPercent &&
                         !CustomComboFunctions.JustUsedOn(dotAction, x) &&
                         CustomComboFunctions.GetStatusEffectRemainingTime
                             (dotDebuff, x) <= reapplyThreshold &&

--- a/WrathCombo/CustomCombo/SimpleTarget.cs
+++ b/WrathCombo/CustomCombo/SimpleTarget.cs
@@ -366,7 +366,7 @@ internal static class SimpleTarget
             .OrderByDescending(x => Svc.Targets.Target?.GameObjectId == x.GameObjectId)
             .FirstOrDefault();
 
-    public static IGameObject? DoTableEnemy
+    public static IGameObject? DottableEnemy
     (uint dotAction,
         ushort dotDebuff,
         float reapplyThreshold = 0,
@@ -388,7 +388,8 @@ internal static class SimpleTarget
                             (dotDebuff, x) <= reapplyThreshold &&
                         CustomComboFunctions.CanApplyStatus(x, dotDebuff) &&
                         x.IsWithinRange(action.Range))
-            .OrderByDescending(x => x.CurrentHp / x.MaxHp * 100)
+            .OrderBy(x => CustomComboFunctions.GetStatusEffectRemainingTime(dotDebuff, x))
+            .ThenByDescending(x => x.CurrentHp / x.MaxHp * 100)
             .FirstOrDefault();
     }
 

--- a/WrathCombo/CustomCombo/SimpleTarget.cs
+++ b/WrathCombo/CustomCombo/SimpleTarget.cs
@@ -369,20 +369,21 @@ internal static class SimpleTarget
     public static IGameObject? DottableEnemy
     (uint dotAction,
         ushort dotDebuff,
-        float reapplyThreshold = 0,
-        int maxTargetsToKeepDoTed = 3)
+        float reapplyThreshold = 1,
+        int maxNumberOfEnemiesInRange = 3)
     {
         var action = ActionSheet[dotAction];
         var numberOfEnemiesInRange = Svc.Objects
             .OfType<IBattleChara>()
             .Count(x => x.IsHostile() && x.IsTargetable && x.IsWithinRange(15f));
 
-        if (numberOfEnemiesInRange >= maxTargetsToKeepDoTed)
+        if (numberOfEnemiesInRange > maxNumberOfEnemiesInRange)
             return null;
 
         return Svc.Objects
             .OfType<IBattleChara>()
             .Where(x => x.IsHostile() && x.IsTargetable && x.CanUseOn(dotAction) &&
+                        !CustomComboFunctions.JustUsedOn(dotAction, x) &&
                         CustomComboFunctions.GetStatusEffectRemainingTime
                             (dotDebuff, x) <= reapplyThreshold &&
                         CustomComboFunctions.CanApplyStatus(x, dotDebuff) &&

--- a/WrathCombo/CustomCombo/SimpleTarget.cs
+++ b/WrathCombo/CustomCombo/SimpleTarget.cs
@@ -388,7 +388,7 @@ internal static class SimpleTarget
                             (dotDebuff, x) <= reapplyThreshold &&
                         CustomComboFunctions.CanApplyStatus(x, dotDebuff) &&
                         x.IsWithinRange(action.Range))
-            .OrderBy(x => x.CurrentHp / x.MaxHp * 100)
+            .OrderByDescending(x => x.CurrentHp / x.MaxHp * 100)
             .FirstOrDefault();
     }
 

--- a/WrathCombo/CustomCombo/SimpleTarget.cs
+++ b/WrathCombo/CustomCombo/SimpleTarget.cs
@@ -373,12 +373,11 @@ internal static class SimpleTarget
         int maxTargetsToKeepDoTed = 3)
     {
         var action = ActionSheet[dotAction];
-        var numberOfEnemiesWithDoT = Svc.Objects
+        var numberOfEnemiesInRange = Svc.Objects
             .OfType<IBattleChara>()
-            .Count(x => x.IsHostile() && x.IsTargetable &&
-                        CustomComboFunctions.HasStatusEffect(dotDebuff, x));
+            .Count(x => x.IsHostile() && x.IsTargetable && x.IsWithinRange(15f));
 
-        if (numberOfEnemiesWithDoT >= maxTargetsToKeepDoTed)
+        if (numberOfEnemiesInRange >= maxTargetsToKeepDoTed)
             return null;
 
         return Svc.Objects

--- a/WrathCombo/Data/StatusCache.cs
+++ b/WrathCombo/Data/StatusCache.cs
@@ -150,7 +150,7 @@ namespace WrathCombo.Data
                     if (targetID is 2350) return !HasStatusEffect(398);
 
                     // Allagan Bomb
-                    if (targetID is 2407) return NumberOfEnemiesInRange(30) > 1;
+                    if (targetID is 2407) return NumberOfObjectsInRange<SelfCircle>(30) > 1;
 
                     return false;
                 case 1248:  // Jeuno 1 Ark Angels

--- a/WrathCombo/Extensions/GameObjectExtensions.cs
+++ b/WrathCombo/Extensions/GameObjectExtensions.cs
@@ -153,12 +153,11 @@ public static class GameObjectExtensions
         Svc.Objects
             .Any(x => x.GameObjectId == obj.GameObjectId) ? obj : null;
 
-
     /// <summary>
     ///     Can be chained onto a <see cref="IGameObject" /> to make it return
     ///     <see langword="null" /> if the target cannot be affected by the action.
     /// </summary>
-    public unsafe static IGameObject? IfCanUseOn(this IGameObject? obj, uint actionId) =>
+    public static unsafe IGameObject? IfCanUseOn(this IGameObject? obj, uint actionId) =>
         obj != null && ActionManager.CanUseActionOnTarget(actionId, obj.Struct()) ? obj : null;
 
     #endregion
@@ -262,6 +261,13 @@ public static class GameObjectExtensions
         obj != null &&
         Svc.Objects
             .Any(x => x.GameObjectId == obj.GameObjectId);
+
+    /// <summary>
+    ///     Can be chained onto a <see cref="IGameObject" /> to make it a quick
+    ///     boolean check for if the object can be affected by the action.
+    /// </summary>
+    public static unsafe bool CanUseOn(this IGameObject? obj, uint actionId) =>
+        obj != null && ActionManager.CanUseActionOnTarget(actionId, obj.Struct());
 
     #endregion
 


### PR DESCRIPTION
- WHM Update
  - Simple DPS Modes Added for ST and AOE
  - Updated how ST advanced selects its button replacement  
  - Added Priority List spell selection to ST and AOE Healing
  - ! Raidwide Detection Features, is utilized in all 4 advance combos  
  - ! ST Movement Options
  - ! AoE Multi-dotting Option
    - Set target threshold, Health Threshold, and Refresh time
  - ! ST and AoE Mitigation Features on Asylum and Aquaveil for manual healers
  - Retargeting Standalone Features added
    - Cure 1 and 2
    - Afflatus Solace
    - Aquaveil
    - Asylum
    - Liturgy of the Bell
    - Cure 3
    - Benediction
    - Regen
    - Tetragrammaton
    - Divine Benison
    
- SCH and AST Update
  - ! Raidwide Detection Features, is utilized in all 4 advance combos
  - ! AoE Multi-dotting Option
    - Set target threshold, Health Threshold, and Refresh time
     
