### PR TITLE
[Core] Add `NumberOfAlliesInRange` Method, refactor `Can[Shape]Aoe` Methods

### DIFF
--- a/WrathCombo/Combos/PvE/ALL/Roles/RoleActions.cs
+++ b/WrathCombo/Combos/PvE/ALL/Roles/RoleActions.cs
@@ -88,7 +88,7 @@ internal static partial class RoleActions
             ActionReady(SecondWind) && PlayerHealthPercentageHp() <= healthPercent;
 
         public static bool CanArmsLength(int enemyCount, All.Enums.BossAvoidance avoidanceSetting) =>
-            ActionReady(ArmsLength) && CanCircleAoe(7) >= enemyCount &&
+            ActionReady(ArmsLength) && NumberOfEnemiesInRange(ArmsLength) >= enemyCount &&
             ((int)avoidanceSetting == (int)All.Enums.BossAvoidance.Off || !InBossEncounter());
     }
 
@@ -192,7 +192,7 @@ internal static partial class RoleActions
 
         public static bool CanReprisal(int healthPercent = 100, int? enemyCount = null, bool checkTargetForDebuff = true) =>
             (checkTargetForDebuff && !HasStatusEffect(Debuffs.Reprisal, CurrentTarget, true) || !checkTargetForDebuff) &&
-            (enemyCount is null ? InActionRange(Reprisal) : CanCircleAoe(5) >= enemyCount) &&
+            (enemyCount is null ? InActionRange(Reprisal) : NumberOfEnemiesInRange(Reprisal) >= enemyCount) &&
             ActionReady(Reprisal) && PlayerHealthPercentageHp() <= healthPercent && CanApplyStatus(CurrentTarget, Debuffs.Reprisal);
 
         public static bool CanShirk() =>

--- a/WrathCombo/Combos/PvE/Content/Variant/VariantActions.cs
+++ b/WrathCombo/Combos/PvE/Content/Variant/VariantActions.cs
@@ -70,6 +70,6 @@ internal static partial class Variant
 
     internal static bool CanUltimatum(CustomComboPreset preset, WeaveTypes weave = WeaveTypes.None) =>
         IsEnabled(preset) && ActionReady(VariantUltimatum)
-        && CanCircleAoe(5) > 0 && CheckWeave(weave);
+        && NumberOfEnemiesInRange(VariantUltimatum) > 0 && CheckWeave(weave);
 }
 #endregion

--- a/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
@@ -50,7 +50,7 @@ internal partial class DNC
     ///     <see cref="TechnicalFinish4" />, <see cref="FinishingMove" />,
     ///     and <see cref="Tillana" />.
     /// </remarks>
-    private static bool EnemyIn15Yalms => CanCircleAoe(15, true) > 0;
+    private static bool EnemyIn15Yalms => NumberOfEnemiesInRange(FinishingMove) > 0;
 
     /// <summary>
     ///     Checks if any enemy is within 8 yalms.
@@ -58,7 +58,7 @@ internal partial class DNC
     /// <remarks>
     ///     This is used for <see cref="Improvisation" />.
     /// </remarks>
-    private static bool EnemyIn8Yalms => CanCircleAoe(8, true) > 0;
+    private static bool EnemyIn8Yalms => NumberOfEnemiesInRange(Improvisation) > 0;
 
     /// <summary>
     ///     Logic to pick different openers.

--- a/WrathCombo/Combos/PvE/DRK/DRK.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK.cs
@@ -56,7 +56,7 @@ internal partial class DRK : Tank
             var skipBecauseOpener =
                 IsEnabled(Preset.DRK_ST_BalanceOpener) &&
                 Opener().HasCooldowns() &&
-                NumberOfEnemiesInRange(20) < 2; // don't skip if add-pulling
+                NumberOfObjectsInRange<SelfCircle>(20) < 2; // don't skip if add-pulling
             if (IsEnabled(Preset.DRK_ST_RangedUptime) &&
                 ActionReady(Unmend) &&
                 !InMeleeRange() &&

--- a/WrathCombo/CustomCombo/Functions/Target.cs
+++ b/WrathCombo/CustomCombo/Functions/Target.cs
@@ -10,7 +10,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using WrathCombo.Combos.PvE;
+using WrathCombo.Core;
 using WrathCombo.Data;
+using WrathCombo.Extensions;
 using WrathCombo.Services;
 using ObjectKind = Dalamud.Game.ClientState.Objects.Enums.ObjectKind;
 
@@ -216,36 +218,49 @@ internal abstract partial class CustomComboFunctions
     ///     Gets the number of enemies within range of an AoE action. <br/>
     ///     If the action requires a target, defaults to CurrentTarget unless specified.
     /// </summary>
-    public static int NumberOfEnemiesInRange(uint aoeSpell, IGameObject? target, bool checkIgnoredList = false)
+    /// <param name="aoeSpell">
+    ///     The Action ID to check. <br />
+    ///     This will be used to load up all required data from the Action Sheet.
+    /// </param>
+    /// <param name="target">
+    ///     Target for targeted AoE shapes (all but <see cref="SelfCircle"/>). <br />
+    ///     (Optional, defaults to false)
+    /// </param>
+    /// <param name="checkIgnoredList">
+    ///     Whether to check the 
+    ///     <see cref="PluginConfiguration.IgnoredNPCs"/> list. <br />
+    ///     (Optional, defaults to false)
+    /// </param>
+    /// <returns>
+    ///     Number of enemies within the specified action's range.
+    /// </returns>
+    public static int NumberOfEnemiesInRange
+        (uint aoeSpell, IGameObject? target = null, bool checkIgnoredList = false)
     {
         if (!ActionWatching.ActionSheet.TryGetValue(aoeSpell, out var sheetSpell))
             return 0;
 
-        if (sheetSpell.CanTargetHostile && ((target ??= CurrentTarget) is null || GetTargetDistance(target) > GetActionRange(sheetSpell.RowId)))
+        if (sheetSpell.CanTargetHostile &&
+            ((target ??= CurrentTarget) is null ||
+             GetTargetDistance(target) > GetActionRange(sheetSpell.RowId)))
             return 0;
 
-        int count = sheetSpell.CastType switch
+        var count = sheetSpell.CastType switch
         {
             1 => 1,
             2 => sheetSpell.CanTargetSelf
-                ? CanCircleAoe(sheetSpell.EffectRange, checkIgnoredList)
-                : CanRangedCircleAoe(target, sheetSpell.EffectRange, checkIgnoredList),
-            3 => CanConeAoe(target, sheetSpell.Range, checkIgnoredList),
-            4 => CanLineAoe(target, sheetSpell.Range, sheetSpell.XAxisModifier, checkIgnoredList),
-            _ => 0
+                ? NumberOfObjectsInRange<SelfCircle>(sheetSpell.EffectRange,
+                    checkIgnoredList: checkIgnoredList)
+                : NumberOfObjectsInRange<Circle>(sheetSpell.EffectRange, target,
+                    checkIgnoredList: checkIgnoredList),
+            3 => NumberOfObjectsInRange<Cone>(sheetSpell.Range, target,
+                checkIgnoredList: checkIgnoredList),
+            4 => NumberOfObjectsInRange<Line>(sheetSpell.Range, target,
+                sheetSpell.XAxisModifier, checkIgnoredList: checkIgnoredList),
+            _ => 0,
         };
 
         return count;
-    }
-
-    /// <summary> Gets the number of enemies within a given range from the player. </summary>
-    public static int NumberOfEnemiesInRange(float range)
-    {
-        return Svc.Objects.Count(o =>
-            o.ObjectKind == ObjectKind.BattleNpc &&
-            o.IsTargetable &&
-            o.IsHostile() &&
-            GetTargetDistance(o) <= range);
     }
 
     /// <summary> Checks if an object is within line of sight of the player. </summary>
@@ -338,67 +353,111 @@ internal abstract partial class CustomComboFunctions
 
     #region Shape Checks
 
-    /// <summary> Gets the number of enemies within range of a point-blank AoE. </summary>
-    public static int CanCircleAoe(float effectRange, bool checkIgnoredList = false)
+    /// <summary>
+    ///     Gets the number of enemies within range of a specified AoE shape type.
+    /// </summary>
+    /// <typeparam name="T">
+    ///     The AoE shape type (<see cref="SelfCircle"/>,
+    ///     <see cref="Circle"/>, <see cref="Cone"/>, <see cref="Line"/>)<br />
+    ///     Types that implement <see cref="IAoeShape" />.
+    /// </typeparam>
+    /// <param name="size">
+    ///     The radius of the AoE (or length, for Line AoEs).
+    /// </param>
+    /// <param name="target">
+    ///     Target for targeted AoE shapes (all but <see cref="SelfCircle"/>). <br />
+    ///     (Optional, defaults to <see cref="CurrentTarget" />)
+    /// </param>
+    /// <param name="width">
+    ///     Width parameter - Only for Line AoEs.  <br />
+    ///     In the sheets, this column is labeled as "X Axis Modifier", and is
+    ///     usually 0-5. <br />
+    ///     (Optional, defaults to 0, which is the value for many Line AoEs)
+    /// </param>
+    /// <param name="checkIgnoredList">
+    ///     Whether to check the 
+    ///     <see cref="PluginConfiguration.IgnoredNPCs"/> list. <br />
+    ///     (Optional, defaults to false)
+    /// </param>
+    /// <param name="enemies">
+    ///     Whether enemy targets are what is searched;
+    ///     if <see langword="false" /> then will search for allies instead.
+    /// </param>
+    /// <returns>
+    ///     Number of enemies within the specified AoE shape.
+    /// </returns>
+    /// <remarks>
+    ///     In almost every situation you should instead use
+    ///     <see cref="NumberOfEnemiesInRange(uint, IGameObject?, bool)"/>.
+    /// </remarks>
+    internal static int NumberOfObjectsInRange<T>
+    (float size,
+        IGameObject? target = null,
+        float width = 0f,
+        bool checkIgnoredList = false,
+        bool enemies = true)
+        where T : IAoeShape
     {
-        if (LocalPlayer is not { } player) return 0;
+        // Bail if the player is not available
+        if (LocalPlayer is not { } player)
+            return 0;
+        
+        // Bail if the target is required and not available
+        if (typeof(T) != typeof(SelfCircle) && (target ??= CurrentTarget) is null)
+            return 0;
 
-        return Svc.Objects.Count(o => o.ObjectKind == ObjectKind.BattleNpc &&
-                                      o.IsTargetable &&
-                                      o.IsHostile() &&
-                                      !TargetIsInvincible(o) &&
-                                      (!checkIgnoredList || !Service.Configuration.IgnoredNPCs.ContainsKey(o.DataId)) &&
-                                      PointInCircle(o.Position - player.Position, effectRange + o.HitboxRadius));
-    }
+        // Get all possible enemies to search for the positions of
+        var targets = Svc.Objects.Where(IsValidTarget);
 
-    /// <summary> Gets the number of enemies within range of a targeted AoE. </summary>
-    public static int CanRangedCircleAoe(IGameObject? target, float effectRange, bool checkIgnoredList = false)
-    {
-        if (target is null) return 0;
+        // Circle AoEs positioned on self
+        if (typeof(T) == typeof(SelfCircle))
+            return targets.Count(o =>
+                PointInCircle(o.Position - player.Position,
+                    size + o.HitboxRadius));
 
-        return Svc.Objects.Count(o => o.ObjectKind == ObjectKind.BattleNpc &&
-                                      o.IsTargetable &&
-                                      o.IsHostile() &&
-                                      !TargetIsInvincible(o) &&
-                                      (!checkIgnoredList || !Service.Configuration.IgnoredNPCs.ContainsKey(o.DataId)) &&
-                                      PointInCircle(o.Position - target.Position, effectRange + o.HitboxRadius));
-    }
-
-    /// <summary> Gets the number of enemies within range of a cone AoE. </summary>
-    public static int CanConeAoe(IGameObject? target, float range, bool checkIgnoredList = false)
-    {
-        if (LocalPlayer is not { } player || target is null) return 0;
-
-        Vector3 direction = PositionalMath.GetDirection(player.Position, target.Position);
-
-        return Svc.Objects.Count(o => o.ObjectKind == ObjectKind.BattleNpc &&
-                                      o.IsTargetable &&
-                                      o.IsHostile() &&
-                                      !TargetIsInvincible(o) &&
-                                      GetTargetDistance(o) <= range &&
-                                      (!checkIgnoredList || !Service.Configuration.IgnoredNPCs.ContainsKey(o.DataId)) &&
-                                      PointInCone(o.Position - player.Position, direction, 45f));
-    }
-
-    /// <summary> Gets the number of enemies within range of a line AoE. </summary>
-    public static int CanLineAoe(IGameObject? target, float range, float xAxisModifier, bool checkIgnoredList = false)
-    {
-        if (LocalPlayer is not { } player || target is null) return 0;
-
-        float halfLength = range * 0.5f;
-        float halfWidth = xAxisModifier * 0.5f;
-        float rotation = PositionalMath.GetRotation(player.Position, target.Position);
-
-        return Svc.Objects.Count(o => o.ObjectKind == ObjectKind.BattleNpc &&
-                                      o.IsTargetable &&
-                                      o.IsHostile() &&
-                                      !TargetIsInvincible(o) &&
-                                      GetTargetDistance(o) <= range &&
-                                      (!checkIgnoredList || !Service.Configuration.IgnoredNPCs.ContainsKey(o.DataId)) &&
-                                      HitboxInRect(o, rotation, halfLength, halfWidth));
+        // Circle AoEs centered on a target
+        if (typeof(T) == typeof(Circle))
+            return targets.Count(o => 
+                PointInCircle(o.Position - target.Position,
+                    size + o.HitboxRadius));
+        
+        // Cone AoEs
+        if (typeof(T) == typeof(Cone))
+            return targets.Count(o =>
+                GetTargetDistance(o) <= size &&
+                PointInCone(o.Position - player.Position,
+                    PositionalMath.GetDirection(player.Position, target.Position),
+                    45f));
+        
+        // Line AoEs
+        if (typeof(T) == typeof(Line))
+            return targets.Count(o =>
+                GetTargetDistance(o) <= size &&
+                HitboxInRect(o,
+                    PositionalMath.GetRotation(player.Position, target.Position),
+                    size * 0.5f, width * 0.5f));
+        
+        // If it was not a supported type
+        return 0;
+        
+        bool IsValidTarget(IGameObject o)
+        {
+            return o is { ObjectKind: ObjectKind.BattleNpc, IsTargetable: true } &&
+                   o.IsWithinRange(60f) &&
+                   o.IsHostile() &&
+                   !TargetIsInvincible(o) &&
+                   (!checkIgnoredList ||
+                    !Service.Configuration.IgnoredNPCs.ContainsKey(o.DataId));
+        }
     }
 
     #region Shape Helpers
+    
+    public interface IAoeShape { }
+    public struct SelfCircle : IAoeShape { }
+    public struct Circle : IAoeShape { }
+    public struct Cone : IAoeShape { }
+    public struct Line : IAoeShape { }
 
     #region Point in Circle
     public static bool PointInCircle(Vector3 offsetFromOrigin, float radius)

--- a/WrathCombo/Data/StatusCache.cs
+++ b/WrathCombo/Data/StatusCache.cs
@@ -150,7 +150,7 @@ namespace WrathCombo.Data
                     if (targetID is 2350) return !HasStatusEffect(398);
 
                     // Allagan Bomb
-                    if (targetID is 2407) return NumberOfEnemiesInRange(30) > 1;
+                    if (targetID is 2407) return NumberOfObjectsInRange<SelfCircle>(30) > 1;
 
                     return false;
                 case 1248:  // Jeuno 1 Ark Angels


### PR DESCRIPTION
- [X] Refactored `Can[Shape]Aoe` Methods into a more appropriately named and reduced duplicate code `NumberOfObjectsInRange<IAoeShape>` Method
  - [X] Refactored old usages of `Can[ShapeAoe]` Methods to use `NumberOfEnemiesInRange` checks instead, where appropriate, or the new `NumberOfObjectsInRange<IAoeShape>` Method
- [X] Adds a new `NumberOfAlliesInRange` Method, for use with the few friendly-targeted AoE abilities (e.g. `Cure III`)