### PR TITLE
[SAM] Add bosscheck meikyo usage

### DIFF
--- a/WrathCombo/Combos/PvE/SAM/SAM_Config.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM_Config.cs
@@ -44,6 +44,15 @@ internal partial class SAM
                     }
                     break;
 
+                case CustomComboPreset.SAM_ST_CDs_MeikyoShisui:
+                    DrawHorizontalRadioButton(SAM_ST_Meikyo_Suboption,
+                        "Use The Balance Logic in all content", $"Uses {MeikyoShisui.ActionName()} logic regardless of content.", 0);
+
+                    DrawHorizontalRadioButton(SAM_ST_Meikyo_Suboption,
+                        "Use The Balance logic only in Boss encounters", $"Only uses {MeikyoShisui.ActionName()} logic when in Boss encounters." +
+                                                                         $"\nWill use Meikyo every minute regardless of sen count outside of boss encounters.", 1);
+                    break;
+
                 case CustomComboPreset.SAM_ST_ComboHeals:
                     DrawSliderInt(0, 100, SAM_STSecondWindThreshold,
                         $"{Role.SecondWind.ActionName()} HP percentage threshold");
@@ -141,6 +150,7 @@ internal partial class SAM
             SAM_Opener_PrePullDelay = new("SAM_Opener_PrePullDelay", 13),
             SAM_ST_KenkiOvercapAmount = new("SAM_ST_KenkiOvercapAmount", 65),
             SAM_ST_Higanbana_Suboption = new("SAM_ST_Higanbana_Suboption", 1),
+            SAM_ST_Meikyo_Suboption = new("SAM_ST_Meikyo_Suboption", 1),
             SAM_ST_Higanbana_HP_Threshold = new("SAM_ST_Higanbana_HP_Threshold", 0),
             SAM_ST_Higanbana_Refresh = new("SAM_ST_Higanbana_Refresh", 15),
             SAM_ST_ExecuteThreshold = new("SAM_ST_ExecuteThreshold", 1),

--- a/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
@@ -46,36 +46,45 @@ internal partial class SAM
         if (ActionReady(MeikyoShisui) && !HasStatusEffect(Buffs.Tendo) && !HasStatusEffect(Buffs.MeikyoShisui) &&
             (JustUsed(Gekko) || JustUsed(Kasha) || JustUsed(Yukikaze)))
         {
-            if (EnhancedSenei)
+            if ((SAM_ST_Meikyo_Suboption == 0 || InBossEncounter() ||
+                 IsEnabled(CustomComboPreset.SAM_ST_SimpleMode) && InBossEncounter()))
             {
-                //if no opener
-                if ((IsEnabled(CustomComboPreset.SAM_ST_Opener) && SAM_Balance_Content == 1 && !InBossEncounter() ||
-                     IsNotEnabled(CustomComboPreset.SAM_ST_Opener)) &&
-                    meikyoUsed < 1 && !HasStatusEffect(Buffs.TsubameReady))
-                    return true;
-
-                if (HasStatusEffect(Buffs.TsubameReady))
+                if (EnhancedSenei)
                 {
-                    switch (gcd)
+                    //if no opener
+                    if ((IsEnabled(CustomComboPreset.SAM_ST_Opener) && SAM_Balance_Content == 1 && !InBossEncounter() ||
+                         IsNotEnabled(CustomComboPreset.SAM_ST_Opener)) &&
+                        meikyoUsed < 1 && !HasStatusEffect(Buffs.TsubameReady))
+                        return true;
+
+                    if (HasStatusEffect(Buffs.TsubameReady))
                     {
-                        //2.14 GCD
-                        case >= 2.09f when GetCooldownRemainingTime(Senei) <= 10 &&
-                                           (meikyoUsed % 7 is 1 or 2 && SenCount is 3 ||
-                                            meikyoUsed % 7 is 3 or 4 && SenCount is 2 ||
-                                            meikyoUsed % 7 is 5 or 6 && SenCount is 1):
-                        //2.08 gcd
-                        case <= 2.08f when GetCooldownRemainingTime(Senei) <= 10 && SenCount is 3:
-                            return true;
+                        switch (gcd)
+                        {
+                            //2.14 GCD
+                            case >= 2.09f when GetCooldownRemainingTime(Senei) <= 10 &&
+                                               (meikyoUsed % 7 is 1 or 2 && SenCount is 3 ||
+                                                meikyoUsed % 7 is 3 or 4 && SenCount is 2 ||
+                                                meikyoUsed % 7 is 5 or 6 && SenCount is 1):
+                            //2.08 gcd
+                            case <= 2.08f when GetCooldownRemainingTime(Senei) <= 10 && SenCount is 3:
+                                return true;
+                        }
                     }
+
+                    // reset meikyo
+                    if (gcd >= 2.09f && meikyoUsed % 7 is 0 && JustUsed(Yukikaze))
+                        return true;
                 }
 
-                // reset meikyo
-                if (gcd >= 2.09f && meikyoUsed % 7 is 0 && JustUsed(Yukikaze))
+
+                //Pre Enhanced Senei
+                if (!EnhancedSenei && ActionReady(MeikyoShisui) && !HasStatusEffect(Buffs.TsubameReady))
                     return true;
             }
 
-            //Pre Enhanced Senei
-            if (!EnhancedSenei && ActionReady(MeikyoShisui) && !HasStatusEffect(Buffs.TsubameReady))
+            if (IsEnabled(CustomComboPreset.SAM_ST_SimpleMode) && !InBossEncounter() ||
+                SAM_ST_Meikyo_Suboption == 1 && !InBossEncounter())
                 return true;
         }
 

--- a/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
@@ -77,7 +77,6 @@ internal partial class SAM
                         return true;
                 }
 
-
                 //Pre Enhanced Senei
                 if (!EnhancedSenei && ActionReady(MeikyoShisui) && !HasStatusEffect(Buffs.TsubameReady))
                     return true;


### PR DESCRIPTION
Add bosscheck to meikyo usage.

Makes it so that u can choose wether to always use the balance logic, or not use it in non boss content.
(its like Queen logic of MCH)