### PR TITLE
[Various] Edewen DPS Classes Small Cleanups and Additions

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -4295,7 +4295,7 @@ public enum CustomComboPreset
     PCT_ST_Advanced_Openers = 20006,
 
     [ParentCombo(PCT_ST_AdvancedMode)]
-    [CustomComboInfo("Optimal Burst Window Feature", "Uses an optimized rotation for burst window for Level 100", PCT.JobID)]
+    [CustomComboInfo("Optimal Burst Window Feature", "Uses an optimized rotation for standard burst window", PCT.JobID)]
     PCT_ST_AdvancedMode_Burst_Phase = 20010,
 
     [ParentCombo(PCT_ST_AdvancedMode)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5464,6 +5464,10 @@ public enum CustomComboPreset
     RDM_Riposte = 13403,
     
     [ParentCombo(RDM_Riposte)]
+    [CustomComboInfo("Riposte OGCD Weave Options", "Weave the following OGCDS in the melee combo", RDM.JobID)]
+    RDM_Riposte_Weaves = 134230,
+    
+    [ParentCombo(RDM_Riposte)]
     [CustomComboInfo("Gap-Close with Corps-a-corps Option",
         "Use Corp-a-corps when out of melee range and you have enough mana or Magicked Swordplay to start the melee combo", RDM.JobID)]
     RDM_Riposte_GapCloser = 13424,
@@ -5479,6 +5483,10 @@ public enum CustomComboPreset
     [ReplaceSkill(RDM.Moulinet)]
     [CustomComboInfo("Moulinet Melee Combo", "Replaces Moulinet with the basic melee aoe combo.", RDM.JobID)]
     RDM_Moulinet= 13425,
+    
+    [ParentCombo(RDM_Moulinet)]
+    [CustomComboInfo("Moulinet OGCD Weave Options", "Weave the following OGCDS in the melee combo", RDM.JobID)]
+    RDM_Moulinet_Weaves = 13431,
     
     [ParentCombo(RDM_Moulinet)]
     [CustomComboInfo("Gap-Close with Corps-a-corps Option",
@@ -5557,7 +5565,7 @@ public enum CustomComboPreset
     [CustomComboInfo("Cure on Vercure Option", "Replaces Vercure with Variant Cure.", RDM.JobID)]
     RDM_Variant_Cure2 = 13417,
     
-    //Last Used 13423
+    //Last Used 13431
     #endregion
 
     #endregion

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1422,7 +1422,7 @@ public enum CustomComboPreset
 
     [ParentCombo(BRD_ST_AdvMode)]
     [CustomComboInfo("oGcd Option",
-        "Weave Sidewinder, Empyreal arrow, Rain of death, and Pitch perfect when available.", BRD.JobID)]
+        "Weave Sidewinder, Empyreal arrow, Bloodletter, and Pitch perfect when available.", BRD.JobID)]
     BRD_ST_Adv_oGCD = 3038,
 
     [ParentCombo(BRD_ST_AdvMode)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5536,16 +5536,6 @@ public enum CustomComboPreset
     [CustomComboInfo("OGCDs One Button Feature",
         "Replaces Fleche with Contre Sixte, Vice of Thorns, Prefulgence, Engagement, and 1 charge of Corps-a-corps.", RDM.JobID)]
     RDM_OGCDs = 13420,
-    
-    [ParentCombo(RDM_OGCDs)]
-    [CustomComboInfo("Engagement Pooling Option",
-        "Will not spend both Engagement Charges unless you have Embolden.", RDM.JobID)]
-    RDM_OGCDs_EngagementPool = 13421,
-    
-    [ParentCombo(RDM_OGCDs)]
-    [CustomComboInfo("Corps-a-corps Melee only Option",
-        "Needs to be in melee range to use Corps-a-corps.", RDM.JobID)]
-    RDM_OGCDs_CorpsMelee = 13422,
 
     [Variant]
     [VariantParent(RDM_ST_DPS, RDM_ST_SimpleMode, RDM_AoE_DPS, RDM_AoE_SimpleMode)]

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -1,283 +1,36 @@
 using Dalamud.Game.ClientState.JobGauge.Enums;
-using WrathCombo.Combos.PvE.Content;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Data;
+using Preset = WrathCombo.Combos.CustomComboPreset;
 using static WrathCombo.Combos.PvE.BRD.Config;
 namespace WrathCombo.Combos.PvE;
 
 internal partial class BRD : PhysicalRanged
 {
-    #region Smaller features
-
-    internal class BRD_StraightShotUpgrade : CustomCombo
+    #region Simple Modes
+    internal class BRD_AoE_SimpleMode : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_StraightShotUpgrade;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not (HeavyShot or BurstShot))
-                return actionID;
-
-            if (IsEnabled(CustomComboPreset.BRD_DoTMaintainance) &&
-                InCombat())
-            {
-                if (UseIronJaws())
-                    return IronJaws;
-
-                if (ApplyBlueDot())
-                    return OriginalHook(Windbite);
-
-                if (ApplyPurpleDot())
-                    return OriginalHook(VenomousBite);
-            }
-
-            if (IsEnabled(CustomComboPreset.BRD_ApexST))
-            {
-                if (gauge.SoulVoice == 100)
-                    return ApexArrow;
-
-                if (HasStatusEffect(Buffs.BlastArrowReady))
-                    return BlastArrow;
-            }
-
-            if (HasStatusEffect(Buffs.HawksEye) || HasStatusEffect(Buffs.Barrage))
-                return OriginalHook(StraightShot);
-
-            return actionID;
-        }
-    }
-
-    internal class BRD_IronJaws : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_IronJaws;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not IronJaws)
-                return actionID;
-
-            if (UseIronJaws())
-                return IronJaws;
-
-            if (ApplyBlueDot())
-                return OriginalHook(Windbite);
-
-            if (ApplyPurpleDot())
-                return OriginalHook(VenomousBite);
-
-            // Apex Option
-            if (IsEnabled(CustomComboPreset.BRD_IronJawsApex))
-            {
-                if (LevelChecked(BlastArrow) && HasStatusEffect(Buffs.BlastArrowReady))
-                    return BlastArrow;
-
-                if (gauge.SoulVoice == 100)
-                    return ApexArrow;
-            }
-            return actionID;
-        }
-    }
-
-    internal class BRD_IronJaws_Alternate : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_IronJaws_Alternate;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not IronJaws)
-                return actionID;
-
-            if (UseIronJaws())
-                return IronJaws;
-
-            return LevelChecked(Windbite) && BlueRemaining <= PurpleRemaining ?
-                OriginalHook(Windbite) :
-                OriginalHook(VenomousBite);
-        }
-    }
-
-    internal class BRD_AoE_oGCD : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_AoE_oGCD;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not RainOfDeath)
-                return actionID;
-
-            if (IsEnabled(CustomComboPreset.BRD_AoE_oGCD_Songs) && (gauge.SongTimer < 1 || SongArmy))
-            {
-                if (ActionReady(WanderersMinuet))
-                    return WanderersMinuet;
-
-                if (ActionReady(MagesBallad))
-                    return MagesBallad;
-
-                if (ActionReady(ArmysPaeon))
-                    return ArmysPaeon;
-            }
-
-            if (ActionReady(EmpyrealArrow))
-                return EmpyrealArrow;
-
-            if (PitchPerfected())
-                return OriginalHook(PitchPerfect);
-
-            if (ActionReady(RainOfDeath))
-                return RainOfDeath;
-
-            if (ActionReady(Sidewinder))
-                return Sidewinder;
-
-            return actionID;
-        }
-    }
-
-    internal class BRD_ST_oGCD : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_ST_oGCD;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not (Bloodletter or HeartbreakShot))
-                return actionID;
-
-            if (IsEnabled(CustomComboPreset.BRD_ST_oGCD_Songs) && (gauge.SongTimer < 1 || SongArmy))
-            {
-                if (ActionReady(WanderersMinuet))
-                    return WanderersMinuet;
-
-                if (ActionReady(MagesBallad))
-                    return MagesBallad;
-
-                if (ActionReady(ArmysPaeon))
-                    return ArmysPaeon;
-            }
-
-            if (PitchPerfected())
-                return OriginalHook(PitchPerfect);
-
-            if (ActionReady(EmpyrealArrow))
-                return EmpyrealArrow;
-
-            if (ActionReady(Sidewinder))
-                return Sidewinder;
-
-            if (ActionReady(Bloodletter))
-                return OriginalHook(Bloodletter);
-
-            return actionID;
-        }
-    }
-
-    internal class BRD_AoE_Combo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_AoE_Combo;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not (QuickNock or Ladonsbite))
-                return actionID;
-
-            if (IsEnabled(CustomComboPreset.BRD_Apex))
-            {
-                if (gauge.SoulVoice == 100)
-                    return ApexArrow;
-
-                if (HasStatusEffect(Buffs.BlastArrowReady))
-                    return BlastArrow;
-            }
-
-            if (IsEnabled(CustomComboPreset.BRD_AoE_Combo) && ActionReady(WideVolley) && HasStatusEffect(Buffs.HawksEye))
-                return OriginalHook(WideVolley);
-
-            return actionID;
-        }
-    }
-
-    internal class BRD_Buffs : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_Buffs;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not Barrage)
-                return actionID;
-
-            if (ActionReady(RagingStrikes))
-                return RagingStrikes;
-
-            if (ActionReady(BattleVoice))
-                return BattleVoice;
-
-            if (ActionReady(RadiantFinale))
-                return RadiantFinale;
-
-            return actionID;
-        }
-    }
-
-    internal class BRD_OneButtonSongs : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_OneButtonSongs;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not WanderersMinuet)
-                return actionID;
-
-            if (ActionReady(WanderersMinuet) || gauge.Song == Song.Wanderer && SongTimerInSeconds > 11)
-                return WanderersMinuet;
-
-            if (ActionReady(MagesBallad) || gauge.Song == Song.Mage && SongTimerInSeconds > 2)
-                return MagesBallad;
-
-            if (ActionReady(ArmysPaeon) || gauge.Song == Song.Army && SongTimerInSeconds > 2)
-                return ArmysPaeon;
-
-            return actionID;
-        }
-    }
-
-    #endregion
-
-    #region Advanced Modes
-
-    internal class BRD_AoE_AdvMode : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_AoE_AdvMode;
-
+        protected internal override Preset Preset => Preset.BRD_AoE_SimpleMode;
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not (Ladonsbite or QuickNock))
                 return actionID;
 
-            #region Variables
-            bool ragingEnabled = IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs_Raging);
-            bool battleVoiceEnabled = IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs_Battlevoice);
-            bool barrageEnabled = IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs_Barrage);
-            bool radiantEnabled = IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs_RadiantFinale);
-            bool allBuffsEnabled = radiantEnabled && battleVoiceEnabled && ragingEnabled && barrageEnabled;
-            int buffThreshold = BRD_AoE_Adv_Buffs_SubOption == 1 || !InBossEncounter() ? BRD_AoE_Adv_Buffs_Threshold : 0;
-
-            #endregion
-
             #region Special Content
-
-            if (Variant.CanCure(CustomComboPreset.BRD_Variant_Cure, Config.BRD_VariantCure))
+            if (Variant.CanCure(Preset.BRD_Variant_Cure, 50))
                 return Variant.Cure;
 
-            if (Variant.CanRampart(CustomComboPreset.BRD_Variant_Rampart, WeaveTypes.Weave))
+            if (Variant.CanRampart(Preset.BRD_Variant_Rampart, WeaveTypes.Weave))
                 return Variant.Rampart;
-                
+            
             if (OccultCrescent.ShouldUsePhantomActions())
                 return OccultCrescent.BestPhantomAction();
             #endregion
 
             #region Songs
-
-            if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Songs) && InCombat() && (CanBardWeave || !BardHasTarget))
+            // Limit optimisation to when you are high enough level to benefit from it.
+            if (InCombat() && (CanBardWeave || !BardHasTarget))
             {
                 if (SongChangePitchPerfect())
                     return PitchPerfect;
@@ -298,8 +51,297 @@ internal partial class BRD : PhysicalRanged
             #endregion
 
             #region Buffs
+            if (CanBardWeave)
+            {
+                if (!SongNone && LevelChecked(MagesBallad))
+                {
+                    if (UseRadiantBuff())
+                        return RadiantFinale;
 
-            if (IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs) && CanBardWeave && GetTargetHPPercent() > buffThreshold)
+                    if (UseBattleVoiceBuff())
+                        return BattleVoice;
+
+                    if (UseRagingStrikesBuff())
+                        return RagingStrikes;
+
+                    if (UseBarrageBuff())
+                        return Barrage;
+                }
+
+                if (!LevelChecked(MagesBallad))
+                {
+                    if (ActionReady(RadiantFinale))
+                        return RadiantFinale;
+
+                    if (ActionReady(BattleVoice))
+                        return BattleVoice;
+
+                    if (ActionReady(RagingStrikes))
+                        return RagingStrikes;
+
+                    if (ActionReady(Barrage))
+                        return Barrage;
+                }
+            }
+            #endregion
+
+            #region OGCDS and Selfcare
+            if (CanBardWeave)
+            {
+                if (ActionReady(EmpyrealArrow))
+                    return EmpyrealArrow;
+
+                if (PitchPerfected())
+                    return OriginalHook(PitchPerfect);
+
+                if (ActionReady(Sidewinder) && UsePooledSidewinder())
+                    return Sidewinder;
+
+                if (Role.CanHeadGraze(true, WeaveTypes.DelayWeave))
+                    return Role.HeadGraze;
+
+                if (ActionReady(RainOfDeath) && UsePooledBloodRain())
+                    return OriginalHook(RainOfDeath);
+
+                if (!LevelChecked(RainOfDeath) && !(WasLastAction(Bloodletter) && BloodletterCharges > 0))
+                    return OriginalHook(Bloodletter);
+
+                if (Role.CanSecondWind(40))
+                    return Role.SecondWind;
+
+                if (ActionReady(TheWardensPaeon))
+                {
+                    if (HasCleansableDebuff(LocalPlayer))
+                        return TheWardensPaeon;
+
+                    else if (WardenResolver() is not null)
+                        return TheWardensPaeon.Retarget([Ladonsbite, QuickNock], WardenResolver);
+                }
+            }
+            #endregion
+
+            #region GCDS
+            if (HasStatusEffect(Buffs.Barrage))
+                return OriginalHook(WideVolley);
+
+            if (HasStatusEffect(Buffs.BlastArrowReady))
+                return BlastArrow;
+
+            if (UsePooledApex())
+                return ApexArrow;
+
+            if (HasStatusEffect(Buffs.ResonantArrowReady))
+                return ResonantArrow;
+
+            if (HasStatusEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16 && HasStatusEffect(Buffs.RagingStrikes))
+                return OriginalHook(RadiantEncore);
+
+            if (HasStatusEffect(Buffs.HawksEye) && ActionReady(WideVolley))
+                return OriginalHook(WideVolley);
+            #endregion
+
+            return actionID;
+        }
+    }
+
+    internal class BRD_ST_SimpleMode : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.BRD_ST_SimpleMode;
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not (HeavyShot or BurstShot))
+                return actionID;
+
+            #region Special Content
+            if (Variant.CanCure(Preset.BRD_Variant_Cure, 50))
+                return Variant.Cure;
+
+            if (Variant.CanRampart(Preset.BRD_Variant_Rampart, WeaveTypes.Weave))
+                return Variant.Rampart;
+            
+            if (OccultCrescent.ShouldUsePhantomActions())
+                return OccultCrescent.BestPhantomAction();
+            #endregion
+
+            #region Songs
+            // Limit optimisation to when you are high enough level to benefit from it.
+            if (InCombat() && (CanBardWeave || !BardHasTarget))
+            {
+                if (SongChangePitchPerfect())
+                    return PitchPerfect;
+
+                if (SongChangeEmpyreal())
+                    return EmpyrealArrow;
+
+                if (WandererSong())
+                    return WanderersMinuet;
+
+                if (MagesSong())
+                    return MagesBallad;
+
+                if (ArmySong())
+                    return ArmysPaeon;
+
+            }
+            #endregion
+
+            #region Buffs
+            if (CanBardWeave)
+            {
+                if (!SongNone && LevelChecked(MagesBallad))
+                {
+                    if (UseRadiantBuff())
+                        return RadiantFinale;
+
+                    if (UseBattleVoiceBuff())
+                        return BattleVoice;
+
+                    if (UseRagingStrikesBuff())
+                        return RagingStrikes;
+
+                    if (UseBarrageBuff())
+                        return Barrage;
+                }
+
+                if (!LevelChecked(MagesBallad))
+                {
+                    if (ActionReady(RadiantFinale))
+                        return RadiantFinale;
+
+                    if (ActionReady(BattleVoice))
+                        return BattleVoice;
+
+                    if (ActionReady(RagingStrikes))
+                        return RagingStrikes;
+
+                    if (ActionReady(Barrage))
+                        return Barrage;
+                }
+            }
+            #endregion
+
+            #region OGCDS
+            if (CanBardWeave)
+            {
+                if (ActionReady(EmpyrealArrow))
+                    return EmpyrealArrow;
+
+                if (PitchPerfected())
+                    return OriginalHook(PitchPerfect);
+
+                if (ActionReady(Sidewinder) && UsePooledSidewinder())
+                    return Sidewinder;
+
+                if (Role.CanHeadGraze(true, WeaveTypes.DelayWeave))
+                    return Role.HeadGraze;
+
+                if (ActionReady(Bloodletter) && UsePooledBloodRain())
+                    return OriginalHook(Bloodletter);
+
+                if (Role.CanSecondWind(40))
+                    return Role.SecondWind;
+
+                if (ActionReady(TheWardensPaeon))
+                {
+                    if (HasCleansableDebuff(LocalPlayer))
+                        return TheWardensPaeon;
+                    else if (WardenResolver() is not null)
+                        return TheWardensPaeon.Retarget([HeavyShot, BurstShot], WardenResolver);
+                }
+            }
+            #endregion
+
+            #region Dot Management
+            if (UseIronJaws())
+                return IronJaws;
+
+            if (ApplyBlueDot())
+                return OriginalHook(Windbite);
+
+            if (ApplyPurpleDot())
+                return OriginalHook(VenomousBite);
+
+            if (RagingJawsRefresh() && RagingStrikesDuration < 6)
+                return IronJaws;
+            #endregion
+
+            #region GCDS
+            if (HasStatusEffect(Buffs.Barrage))
+                return OriginalHook(StraightShot);
+
+            if (HasStatusEffect(Buffs.BlastArrowReady))
+                return BlastArrow;
+
+            if (UsePooledApex())
+                return ApexArrow;
+
+            if (HasStatusEffect(Buffs.ResonantArrowReady))
+                return ResonantArrow;
+
+            if (HasStatusEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16 && HasStatusEffect(Buffs.RagingStrikes))
+                return OriginalHook(RadiantEncore);
+
+            if (HasStatusEffect(Buffs.HawksEye))
+                return OriginalHook(StraightShot);
+            #endregion
+
+            return actionID;
+        }
+    }
+    #endregion
+
+    #region Advanced Modes
+    internal class BRD_AoE_AdvMode : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.BRD_AoE_AdvMode;
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not (Ladonsbite or QuickNock))
+                return actionID;
+
+            #region Variables
+            bool ragingEnabled = IsEnabled(Preset.BRD_AoE_Adv_Buffs_Raging);
+            bool battleVoiceEnabled = IsEnabled(Preset.BRD_AoE_Adv_Buffs_Battlevoice);
+            bool barrageEnabled = IsEnabled(Preset.BRD_AoE_Adv_Buffs_Barrage);
+            bool radiantEnabled = IsEnabled(Preset.BRD_AoE_Adv_Buffs_RadiantFinale);
+            bool allBuffsEnabled = radiantEnabled && battleVoiceEnabled && ragingEnabled && barrageEnabled;
+            int buffThreshold = BRD_AoE_Adv_Buffs_SubOption == 1 || !InBossEncounter() ? BRD_AoE_Adv_Buffs_Threshold : 0;
+            #endregion
+
+            #region Special Content
+            if (Variant.CanCure(Preset.BRD_Variant_Cure, BRD_VariantCure))
+                return Variant.Cure;
+
+            if (Variant.CanRampart(Preset.BRD_Variant_Rampart, WeaveTypes.Weave))
+                return Variant.Rampart;
+                
+            if (OccultCrescent.ShouldUsePhantomActions())
+                return OccultCrescent.BestPhantomAction();
+            #endregion
+
+            #region Songs
+            if (IsEnabled(Preset.BRD_AoE_Adv_Songs) && InCombat() && (CanBardWeave || !BardHasTarget))
+            {
+                if (SongChangePitchPerfect())
+                    return PitchPerfect;
+
+                if (SongChangeEmpyreal())
+                    return EmpyrealArrow;
+
+                if (WandererSong())
+                    return WanderersMinuet;
+
+                if (MagesSong())
+                    return MagesBallad;
+
+                if (ArmySong())
+                    return ArmysPaeon;
+
+            }
+            #endregion
+
+            #region Buffs
+            if (IsEnabled(Preset.BRD_AoE_Adv_Buffs) && CanBardWeave && GetTargetHPPercent() > buffThreshold)
             {
                 if (allBuffsEnabled && !SongNone && LevelChecked(MagesBallad))
                 {
@@ -331,13 +373,11 @@ internal partial class BRD : PhysicalRanged
                         return Barrage;
                 }
             }
-
             #endregion
 
             #region OGCDS
-
-            if (CanBardWeave && IsEnabled(CustomComboPreset.BRD_AoE_Adv_oGCD) &&
-               (!BuffTime || !IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs)))
+            if (CanBardWeave && IsEnabled(Preset.BRD_AoE_Adv_oGCD) &&
+               (!BuffTime || !IsEnabled(Preset.BRD_AoE_Adv_Buffs)))
             {
                 if (ActionReady(EmpyrealArrow))
                     return EmpyrealArrow;
@@ -346,60 +386,56 @@ internal partial class BRD : PhysicalRanged
                     return OriginalHook(PitchPerfect);
 
                 if (ActionReady(Sidewinder) &&
-                    (IsEnabled(CustomComboPreset.BRD_AoE_Pooling) && UsePooledSidewinder() || !IsEnabled(CustomComboPreset.BRD_AoE_Pooling)))
+                    (IsEnabled(Preset.BRD_AoE_Pooling) && UsePooledSidewinder() || !IsEnabled(Preset.BRD_AoE_Pooling)))
                     return Sidewinder;
 
-                if (Role.CanHeadGraze(CustomComboPreset.BRD_AoE_Adv_Interrupt, WeaveTypes.DelayWeave))
+                if (Role.CanHeadGraze(Preset.BRD_AoE_Adv_Interrupt, WeaveTypes.DelayWeave))
                     return Role.HeadGraze;
 
                 if (ActionReady(RainOfDeath) &&
-                    (IsEnabled(CustomComboPreset.BRD_AoE_Pooling) && UsePooledBloodRain() || !IsEnabled(CustomComboPreset.BRD_AoE_Pooling)))
+                    (IsEnabled(Preset.BRD_AoE_Pooling) && UsePooledBloodRain() || !IsEnabled(Preset.BRD_AoE_Pooling)))
                     return OriginalHook(RainOfDeath);
 
                 if (!LevelChecked(RainOfDeath) && !WasLastAction(Bloodletter) && BloodletterCharges > 0)
                     return OriginalHook(Bloodletter);
             }
-
             #endregion
 
             #region Self Care
-
             if (CanBardWeave)
             {
-                if (IsEnabled(CustomComboPreset.BRD_AoE_SecondWind) && Role.CanSecondWind(Config.BRD_STSecondWindThreshold))
+                if (IsEnabled(Preset.BRD_AoE_SecondWind) && Role.CanSecondWind(BRD_STSecondWindThreshold))
                     return Role.SecondWind;
                
-                if (IsEnabled(CustomComboPreset.BRD_AoE_Wardens) && ActionReady(TheWardensPaeon))
+                if (IsEnabled(Preset.BRD_AoE_Wardens) && ActionReady(TheWardensPaeon))
                 {
                     if (HasCleansableDebuff(LocalPlayer))
                         return TheWardensPaeon;
 
-                    else if (IsEnabled(CustomComboPreset.BRD_AoE_WardensAuto) && WardenResolver() is not null)
+                    else if (IsEnabled(Preset.BRD_AoE_WardensAuto) && WardenResolver() is not null)
                         return TheWardensPaeon.Retarget([Ladonsbite, QuickNock], WardenResolver);
                 }                   
             }
-
             #endregion
 
             #region GCDS
-
             if (HasStatusEffect(Buffs.Barrage))
                 return OriginalHook(WideVolley);
 
-            if (IsEnabled(CustomComboPreset.BRD_AoE_BuffsEncore) && HasStatusEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16 &&
+            if (IsEnabled(Preset.BRD_AoE_BuffsEncore) && HasStatusEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16 &&
                (HasStatusEffect(Buffs.RagingStrikes) || !ragingEnabled))
                 return OriginalHook(RadiantEncore);
 
-            if (IsEnabled(CustomComboPreset.BRD_AoE_ApexArrow))
+            if (IsEnabled(Preset.BRD_AoE_ApexArrow))
             {
                 if (HasStatusEffect(Buffs.BlastArrowReady))
                     return BlastArrow;
 
-                if (IsEnabled(CustomComboPreset.BRD_AoE_ApexPooling) && UsePooledApex() || !IsEnabled(CustomComboPreset.BRD_AoE_ApexPooling) && gauge.SoulVoice == 100)
+                if (IsEnabled(Preset.BRD_AoE_ApexPooling) && UsePooledApex() || !IsEnabled(Preset.BRD_AoE_ApexPooling) && gauge.SoulVoice == 100)
                     return ApexArrow;
             }
 
-            if (IsEnabled(CustomComboPreset.BRD_AoE_BuffsResonant))
+            if (IsEnabled(Preset.BRD_AoE_BuffsResonant))
             {
                 if (HasStatusEffect(Buffs.ResonantArrowReady))
                     return ResonantArrow;
@@ -407,7 +443,6 @@ internal partial class BRD : PhysicalRanged
 
             if (HasStatusEffect(Buffs.HawksEye) && ActionReady(WideVolley))
                 return OriginalHook(WideVolley);
-
             #endregion
 
             return actionID;
@@ -416,27 +451,25 @@ internal partial class BRD : PhysicalRanged
 
     internal class BRD_ST_AdvMode : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_ST_AdvMode;
+        protected internal override Preset Preset => Preset.BRD_ST_AdvMode;
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not (HeavyShot or BurstShot))
                 return actionID;
 
             #region Variables
-            int ragingJawsRenewTime = Config.BRD_RagingJawsRenewTime;
-            bool ragingEnabled = IsEnabled(CustomComboPreset.BRD_Adv_Buffs_Raging);
-            bool battleVoiceEnabled = IsEnabled(CustomComboPreset.BRD_Adv_Buffs_Battlevoice);
-            bool barrageEnabled = IsEnabled(CustomComboPreset.BRD_Adv_Buffs_Barrage);
-            bool radiantEnabled = IsEnabled(CustomComboPreset.BRD_Adv_Buffs_RadiantFinale);
+            int ragingJawsRenewTime = BRD_RagingJawsRenewTime;
+            bool ragingEnabled = IsEnabled(Preset.BRD_Adv_Buffs_Raging);
+            bool battleVoiceEnabled = IsEnabled(Preset.BRD_Adv_Buffs_Battlevoice);
+            bool barrageEnabled = IsEnabled(Preset.BRD_Adv_Buffs_Barrage);
+            bool radiantEnabled = IsEnabled(Preset.BRD_Adv_Buffs_RadiantFinale);
             bool allBuffsEnabled = radiantEnabled && battleVoiceEnabled && ragingEnabled && barrageEnabled;
             int dotThreshold = BRD_Adv_DoT_SubOption == 1 || !InBossEncounter() ? BRD_Adv_DoT_Threshold : 0;
             int buffThreshold = BRD_Adv_Buffs_SubOption == 1 || !InBossEncounter() ? BRD_Adv_Buffs_Threshold : 0;
-
             #endregion
             
             #region Opener
-
-            if (IsEnabled(CustomComboPreset.BRD_ST_Adv_Balance_Standard) && HasBattleTarget() &&
+            if (IsEnabled(Preset.BRD_ST_Adv_Balance_Standard) && HasBattleTarget() &&
                 Opener().FullOpener(ref actionID))
             {
                 if (ActionWatching.GetAttackType(Opener().CurrentOpenerAction) != ActionWatching.ActionAttackType.Ability && CanBardWeave)
@@ -453,21 +486,18 @@ internal partial class BRD : PhysicalRanged
             #endregion
 
             #region Special Content
-
-            if (Variant.CanCure(CustomComboPreset.BRD_Variant_Cure, Config.BRD_VariantCure))
+            if (Variant.CanCure(Preset.BRD_Variant_Cure, BRD_VariantCure))
                 return Variant.Cure;
 
-            if (Variant.CanRampart(CustomComboPreset.BRD_Variant_Rampart, WeaveTypes.Weave))
+            if (Variant.CanRampart(Preset.BRD_Variant_Rampart, WeaveTypes.Weave))
                 return Variant.Rampart;
             
             if (OccultCrescent.ShouldUsePhantomActions())
                 return OccultCrescent.BestPhantomAction();
-
             #endregion
 
             #region Songs
-
-            if (IsEnabled(CustomComboPreset.BRD_Adv_Song) && InCombat())
+            if (IsEnabled(Preset.BRD_Adv_Song) && InCombat())
             {
                 if (SongChangePitchPerfect())
                     return PitchPerfect;
@@ -485,12 +515,10 @@ internal partial class BRD : PhysicalRanged
                     return ArmysPaeon;
 
             }
-
             #endregion
 
             #region Buffs
-
-            if (IsEnabled(CustomComboPreset.BRD_Adv_Buffs) && CanBardWeave && GetTargetHPPercent() > buffThreshold)
+            if (IsEnabled(Preset.BRD_Adv_Buffs) && CanBardWeave && GetTargetHPPercent() > buffThreshold)
             {
                 if (allBuffsEnabled && !SongNone && LevelChecked(MagesBallad))
                 {                    
@@ -525,9 +553,8 @@ internal partial class BRD : PhysicalRanged
             #endregion
 
             #region OGCD
-
-            if (CanBardWeave && IsEnabled(CustomComboPreset.BRD_ST_Adv_oGCD) &&
-                (!BuffTime || !IsEnabled(CustomComboPreset.BRD_Adv_Buffs)))
+            if (CanBardWeave && IsEnabled(Preset.BRD_ST_Adv_oGCD) &&
+                (!BuffTime || !IsEnabled(Preset.BRD_Adv_Buffs)))
             {
                 if (ActionReady(EmpyrealArrow))
                     return EmpyrealArrow;
@@ -536,46 +563,42 @@ internal partial class BRD : PhysicalRanged
                     return OriginalHook(PitchPerfect);
 
                 if (ActionReady(Sidewinder) && 
-                    (IsEnabled(CustomComboPreset.BRD_Adv_Pooling) && UsePooledSidewinder() || !IsEnabled(CustomComboPreset.BRD_Adv_Pooling)))
+                    (IsEnabled(Preset.BRD_Adv_Pooling) && UsePooledSidewinder() || !IsEnabled(Preset.BRD_Adv_Pooling)))
                     return Sidewinder;
 
-                if (Role.CanHeadGraze(CustomComboPreset.BRD_Adv_Interrupt, WeaveTypes.DelayWeave))
+                if (Role.CanHeadGraze(Preset.BRD_Adv_Interrupt, WeaveTypes.DelayWeave))
                     return Role.HeadGraze;
 
                 if (ActionReady(Bloodletter) &&
-                    (IsEnabled(CustomComboPreset.BRD_Adv_Pooling) && UsePooledBloodRain() || !IsEnabled(CustomComboPreset.BRD_Adv_Pooling)))
+                    (IsEnabled(Preset.BRD_Adv_Pooling) && UsePooledBloodRain() || !IsEnabled(Preset.BRD_Adv_Pooling)))
                     return OriginalHook(Bloodletter);
             }
-
             #endregion
 
             #region Self Care
-
             if (CanBardWeave || !InCombat())
             {
-                if (IsEnabled(CustomComboPreset.BRD_ST_SecondWind) && Role.CanSecondWind(Config.BRD_STSecondWindThreshold))
+                if (IsEnabled(Preset.BRD_ST_SecondWind) && Role.CanSecondWind(BRD_STSecondWindThreshold))
                     return Role.SecondWind;
 
-                if (IsEnabled(CustomComboPreset.BRD_ST_Wardens) && ActionReady(TheWardensPaeon))
+                if (IsEnabled(Preset.BRD_ST_Wardens) && ActionReady(TheWardensPaeon))
                 {
                     if (HasCleansableDebuff(LocalPlayer))
                         return TheWardensPaeon;
 
-                    else if (IsEnabled(CustomComboPreset.BRD_ST_WardensAuto) && WardenResolver() is not null)
+                    else if (IsEnabled(Preset.BRD_ST_WardensAuto) && WardenResolver() is not null)
                         return TheWardensPaeon.Retarget([HeavyShot, BurstShot], WardenResolver);
                 }
             }
-
             #endregion
 
             #region Dot Management
-
-            if (IsEnabled(CustomComboPreset.BRD_Adv_DoT) && GetTargetHPPercent() > dotThreshold)
+            if (IsEnabled(Preset.BRD_Adv_DoT) && GetTargetHPPercent() > dotThreshold)
             {
-                if (IsEnabled(CustomComboPreset.BRD_Adv_IronJaws) && UseIronJaws())
+                if (IsEnabled(Preset.BRD_Adv_IronJaws) && UseIronJaws())
                     return IronJaws;
 
-                if (IsEnabled(CustomComboPreset.BRD_Adv_ApplyDots))
+                if (IsEnabled(Preset.BRD_Adv_ApplyDots))
                 {
                     if (ApplyBlueDot())
                         return OriginalHook(Windbite);
@@ -583,309 +606,84 @@ internal partial class BRD : PhysicalRanged
                     if (ApplyPurpleDot())
                         return OriginalHook(VenomousBite);
                 }   
-                if (IsEnabled(CustomComboPreset.BRD_Adv_RagingJaws) && RagingJawsRefresh() && RagingStrikesDuration < ragingJawsRenewTime)
+                if (IsEnabled(Preset.BRD_Adv_RagingJaws) && RagingJawsRefresh() && RagingStrikesDuration < ragingJawsRenewTime)
                     return IronJaws;
             }
-            
-
             #endregion
 
             #region GCDS
-
             if (HasStatusEffect(Buffs.Barrage))
                 return OriginalHook(StraightShot);
 
-            if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore) && HasStatusEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16 && 
+            if (IsEnabled(Preset.BRD_Adv_BuffsEncore) && HasStatusEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16 && 
                (HasStatusEffect(Buffs.RagingStrikes) || !ragingEnabled))
                 return OriginalHook(RadiantEncore);
 
-            if (IsEnabled(CustomComboPreset.BRD_ST_ApexArrow))
+            if (IsEnabled(Preset.BRD_ST_ApexArrow))
             {
                 if (HasStatusEffect(Buffs.BlastArrowReady))
                     return BlastArrow;
 
-                if (IsEnabled(CustomComboPreset.BRD_Adv_ApexPooling) && UsePooledApex() || !IsEnabled(CustomComboPreset.BRD_Adv_ApexPooling) && gauge.SoulVoice == 100)
+                if (IsEnabled(Preset.BRD_Adv_ApexPooling) && UsePooledApex() || !IsEnabled(Preset.BRD_Adv_ApexPooling) && gauge.SoulVoice == 100)
                     return ApexArrow;
             }
 
-            if (IsEnabled(CustomComboPreset.BRD_Adv_BuffsResonant) && HasStatusEffect(Buffs.ResonantArrowReady))
+            if (IsEnabled(Preset.BRD_Adv_BuffsResonant) && HasStatusEffect(Buffs.ResonantArrowReady))
                 return ResonantArrow;
 
             if (HasStatusEffect(Buffs.HawksEye))
                 return OriginalHook(StraightShot);
-
             #endregion
 
             return actionID;
         }
     }
-
     #endregion
-
-    #region Simple Modes
-
-    internal class BRD_AoE_SimpleMode : CustomCombo
+    
+    #region Smaller features
+    internal class BRD_StraightShotUpgrade : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_AoE_SimpleMode;
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not (Ladonsbite or QuickNock))
-                return actionID;
-
-            #region Special Content
-
-            if (Variant.CanCure(CustomComboPreset.BRD_Variant_Cure, 50))
-                return Variant.Cure;
-
-            if (Variant.CanRampart(CustomComboPreset.BRD_Variant_Rampart, WeaveTypes.Weave))
-                return Variant.Rampart;
-            
-            if (OccultCrescent.ShouldUsePhantomActions())
-                return OccultCrescent.BestPhantomAction();
-
-            #endregion
-
-
-            #region Songs
-
-            // Limit optimisation to when you are high enough level to benefit from it.
-            if (InCombat() && (CanBardWeave || !BardHasTarget))
-            {
-                if (SongChangePitchPerfect())
-                    return PitchPerfect;
-
-                if (SongChangeEmpyreal())
-                    return EmpyrealArrow;
-
-                if (WandererSong())
-                    return WanderersMinuet;
-
-                if (MagesSong())
-                    return MagesBallad;
-
-                if (ArmySong())
-                    return ArmysPaeon;
-
-            }
-
-            #endregion
-
-            #region Buffs
-
-            if (CanBardWeave)
-            {
-                if (!SongNone && LevelChecked(MagesBallad))
-                {
-                    if (UseRadiantBuff())
-                        return RadiantFinale;
-
-                    if (UseBattleVoiceBuff())
-                        return BattleVoice;
-
-                    if (UseRagingStrikesBuff())
-                        return RagingStrikes;
-
-                    if (UseBarrageBuff())
-                        return Barrage;
-                }
-
-                if (!LevelChecked(MagesBallad))
-                {
-                    if (ActionReady(RadiantFinale))
-                        return RadiantFinale;
-
-                    if (ActionReady(BattleVoice))
-                        return BattleVoice;
-
-                    if (ActionReady(RagingStrikes))
-                        return RagingStrikes;
-
-                    if (ActionReady(Barrage))
-                        return Barrage;
-                }
-            }
-
-            #endregion
-
-            #region OGCDS and Selfcare
-
-            if (CanBardWeave)
-            {
-                if (ActionReady(EmpyrealArrow))
-                    return EmpyrealArrow;
-
-                if (PitchPerfected())
-                    return OriginalHook(PitchPerfect);
-
-                if (ActionReady(Sidewinder) && UsePooledSidewinder())
-                    return Sidewinder;
-
-                if (Role.CanHeadGraze(true, WeaveTypes.DelayWeave))
-                    return Role.HeadGraze;
-
-                if (ActionReady(RainOfDeath) && UsePooledBloodRain())
-                    return OriginalHook(RainOfDeath);
-
-                if (!LevelChecked(RainOfDeath) && !(WasLastAction(Bloodletter) && BloodletterCharges > 0))
-                    return OriginalHook(Bloodletter);
-
-                if (Role.CanSecondWind(40))
-                    return Role.SecondWind;
-
-                if (ActionReady(TheWardensPaeon))
-                {
-                    if (HasCleansableDebuff(LocalPlayer))
-                        return TheWardensPaeon;
-
-                    else if (WardenResolver() is not null)
-                        return TheWardensPaeon.Retarget([Ladonsbite, QuickNock], WardenResolver);
-                }
-            }
-
-            #endregion
-
-            #region GCDS
-
-            if (HasStatusEffect(Buffs.Barrage))
-                return OriginalHook(WideVolley);
-
-            if (HasStatusEffect(Buffs.BlastArrowReady))
-                return BlastArrow;
-
-            if (UsePooledApex())
-                return ApexArrow;
-
-            if (HasStatusEffect(Buffs.ResonantArrowReady))
-                return ResonantArrow;
-
-            if (HasStatusEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16 && HasStatusEffect(Buffs.RagingStrikes))
-                return OriginalHook(RadiantEncore);
-
-            if (HasStatusEffect(Buffs.HawksEye) && ActionReady(WideVolley))
-                return OriginalHook(WideVolley);
-
-            #endregion
-
-            return actionID;
-        }
-    }
-
-    internal class BRD_ST_SimpleMode : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_ST_SimpleMode;
+        protected internal override Preset Preset => Preset.BRD_StraightShotUpgrade;
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not (HeavyShot or BurstShot))
                 return actionID;
 
-            #region Special Content
-
-            if (Variant.CanCure(CustomComboPreset.BRD_Variant_Cure, 50))
-                return Variant.Cure;
-
-            if (Variant.CanRampart(CustomComboPreset.BRD_Variant_Rampart, WeaveTypes.Weave))
-                return Variant.Rampart;
-            
-            if (OccultCrescent.ShouldUsePhantomActions())
-                return OccultCrescent.BestPhantomAction();
-
-            #endregion
-
-            #region Songs
-
-            // Limit optimisation to when you are high enough level to benefit from it.
-            if (InCombat() && (CanBardWeave || !BardHasTarget))
+            if (IsEnabled(Preset.BRD_DoTMaintainance) &&
+                InCombat())
             {
-                if (SongChangePitchPerfect())
-                    return PitchPerfect;
+                if (UseIronJaws())
+                    return IronJaws;
 
-                if (SongChangeEmpyreal())
-                    return EmpyrealArrow;
+                if (ApplyBlueDot())
+                    return OriginalHook(Windbite);
 
-                if (WandererSong())
-                    return WanderersMinuet;
-
-                if (MagesSong())
-                    return MagesBallad;
-
-                if (ArmySong())
-                    return ArmysPaeon;
-
+                if (ApplyPurpleDot())
+                    return OriginalHook(VenomousBite);
             }
 
-            #endregion
-
-            #region Buffs
-
-            if (CanBardWeave)
+            if (IsEnabled(Preset.BRD_ApexST))
             {
-                if (!SongNone && LevelChecked(MagesBallad))
-                {
-                    if (UseRadiantBuff())
-                        return RadiantFinale;
+                if (gauge.SoulVoice == 100)
+                    return ApexArrow;
 
-                    if (UseBattleVoiceBuff())
-                        return BattleVoice;
-
-                    if (UseRagingStrikesBuff())
-                        return RagingStrikes;
-
-                    if (UseBarrageBuff())
-                        return Barrage;
-                }
-
-                if (!LevelChecked(MagesBallad))
-                {
-                    if (ActionReady(RadiantFinale))
-                        return RadiantFinale;
-
-                    if (ActionReady(BattleVoice))
-                        return BattleVoice;
-
-                    if (ActionReady(RagingStrikes))
-                        return RagingStrikes;
-
-                    if (ActionReady(Barrage))
-                        return Barrage;
-                }
+                if (HasStatusEffect(Buffs.BlastArrowReady))
+                    return BlastArrow;
             }
 
-            #endregion
+            if (HasStatusEffect(Buffs.HawksEye) || HasStatusEffect(Buffs.Barrage))
+                return OriginalHook(StraightShot);
 
-            #region OGCDS
-
-            if (CanBardWeave)
-            {
-                if (ActionReady(EmpyrealArrow))
-                    return EmpyrealArrow;
-
-                if (PitchPerfected())
-                    return OriginalHook(PitchPerfect);
-
-                if (ActionReady(Sidewinder) && UsePooledSidewinder())
-                    return Sidewinder;
-
-                if (Role.CanHeadGraze(true, WeaveTypes.DelayWeave))
-                    return Role.HeadGraze;
-
-                if (ActionReady(Bloodletter) && UsePooledBloodRain())
-                    return OriginalHook(Bloodletter);
-
-                if (Role.CanSecondWind(40))
-                    return Role.SecondWind;
-
-                if (ActionReady(TheWardensPaeon))
-                {
-                    if (HasCleansableDebuff(LocalPlayer))
-                        return TheWardensPaeon;
-                    else if (WardenResolver() is not null)
-                        return TheWardensPaeon.Retarget([HeavyShot, BurstShot], WardenResolver);
-                }
-            }
-
-            #endregion
-
-            #region Dot Management
+            return actionID;
+        }
+    }
+    internal class BRD_IronJaws : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.BRD_IronJaws;
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not IronJaws)
+                return actionID;
 
             if (UseIronJaws())
                 return IronJaws;
@@ -896,37 +694,166 @@ internal partial class BRD : PhysicalRanged
             if (ApplyPurpleDot())
                 return OriginalHook(VenomousBite);
 
-            if (RagingJawsRefresh() && RagingStrikesDuration < 6)
+            // Apex Option
+            if (IsEnabled(Preset.BRD_IronJawsApex))
+            {
+                if (LevelChecked(BlastArrow) && HasStatusEffect(Buffs.BlastArrowReady))
+                    return BlastArrow;
+
+                if (gauge.SoulVoice == 100)
+                    return ApexArrow;
+            }
+            return actionID;
+        }
+    }
+    internal class BRD_IronJaws_Alternate : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.BRD_IronJaws_Alternate;
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not IronJaws)
+                return actionID;
+
+            if (UseIronJaws())
                 return IronJaws;
 
+            return LevelChecked(Windbite) && BlueRemaining <= PurpleRemaining ?
+                OriginalHook(Windbite) :
+                OriginalHook(VenomousBite);
+        }
+    }
+    internal class BRD_AoE_oGCD : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.BRD_AoE_oGCD;
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not RainOfDeath)
+                return actionID;
 
-            #endregion
+            if (IsEnabled(Preset.BRD_AoE_oGCD_Songs) && (gauge.SongTimer < 1 || SongArmy))
+            {
+                if (ActionReady(WanderersMinuet))
+                    return WanderersMinuet;
 
-            #region GCDS
+                if (ActionReady(MagesBallad))
+                    return MagesBallad;
 
-            if (HasStatusEffect(Buffs.Barrage))
-                return OriginalHook(StraightShot);
+                if (ActionReady(ArmysPaeon))
+                    return ArmysPaeon;
+            }
 
-            if (HasStatusEffect(Buffs.BlastArrowReady))
-                return BlastArrow;
+            if (ActionReady(EmpyrealArrow))
+                return EmpyrealArrow;
 
-            if (UsePooledApex())
-                return ApexArrow;
+            if (PitchPerfected())
+                return OriginalHook(PitchPerfect);
 
-            if (HasStatusEffect(Buffs.ResonantArrowReady))
-                return ResonantArrow;
+            if (ActionReady(RainOfDeath))
+                return RainOfDeath;
 
-            if (HasStatusEffect(Buffs.RadiantEncoreReady) && RadiantFinaleDuration < 16 && HasStatusEffect(Buffs.RagingStrikes))
-                return OriginalHook(RadiantEncore);
-
-            if (HasStatusEffect(Buffs.HawksEye))
-                return OriginalHook(StraightShot);
-
-            #endregion
+            if (ActionReady(Sidewinder))
+                return Sidewinder;
 
             return actionID;
         }
     }
+    internal class BRD_ST_oGCD : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.BRD_ST_oGCD;
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not (Bloodletter or HeartbreakShot))
+                return actionID;
 
+            if (IsEnabled(Preset.BRD_ST_oGCD_Songs) && (gauge.SongTimer < 1 || SongArmy))
+            {
+                if (ActionReady(WanderersMinuet))
+                    return WanderersMinuet;
+
+                if (ActionReady(MagesBallad))
+                    return MagesBallad;
+
+                if (ActionReady(ArmysPaeon))
+                    return ArmysPaeon;
+            }
+
+            if (PitchPerfected())
+                return OriginalHook(PitchPerfect);
+
+            if (ActionReady(EmpyrealArrow))
+                return EmpyrealArrow;
+
+            if (ActionReady(Sidewinder))
+                return Sidewinder;
+
+            if (ActionReady(Bloodletter))
+                return OriginalHook(Bloodletter);
+
+            return actionID;
+        }
+    }
+    internal class BRD_AoE_Combo : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.BRD_AoE_Combo;
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not (QuickNock or Ladonsbite))
+                return actionID;
+
+            if (IsEnabled(Preset.BRD_Apex))
+            {
+                if (gauge.SoulVoice == 100)
+                    return ApexArrow;
+
+                if (HasStatusEffect(Buffs.BlastArrowReady))
+                    return BlastArrow;
+            }
+
+            if (IsEnabled(Preset.BRD_AoE_Combo) && ActionReady(WideVolley) && HasStatusEffect(Buffs.HawksEye))
+                return OriginalHook(WideVolley);
+
+            return actionID;
+        }
+    }
+    internal class BRD_Buffs : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.BRD_Buffs;
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not Barrage)
+                return actionID;
+
+            if (ActionReady(RagingStrikes))
+                return RagingStrikes;
+
+            if (ActionReady(BattleVoice))
+                return BattleVoice;
+
+            if (ActionReady(RadiantFinale))
+                return RadiantFinale;
+
+            return actionID;
+        }
+    }
+    internal class BRD_OneButtonSongs : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.BRD_OneButtonSongs;
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not WanderersMinuet)
+                return actionID;
+
+            if (ActionReady(WanderersMinuet) || gauge.Song == Song.Wanderer && SongTimerInSeconds > 11)
+                return WanderersMinuet;
+
+            if (ActionReady(MagesBallad) || gauge.Song == Song.Mage && SongTimerInSeconds > 2)
+                return MagesBallad;
+
+            if (ActionReady(ArmysPaeon) || gauge.Song == Song.Army && SongTimerInSeconds > 2)
+                return ArmysPaeon;
+
+            return actionID;
+        }
+    }
     #endregion
 }

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -18,7 +18,7 @@ internal partial class BRD : PhysicalRanged
                 return actionID;
 
             #region Special Content
-            if (Variant.CanCure(Preset.BRD_Variant_Cure, 50))
+            if (Variant.CanCure(Preset.BRD_Variant_Cure, BRD_VariantCure))
                 return Variant.Cure;
 
             if (Variant.CanRampart(Preset.BRD_Variant_Rampart, WeaveTypes.Weave))
@@ -153,7 +153,7 @@ internal partial class BRD : PhysicalRanged
                 return actionID;
 
             #region Special Content
-            if (Variant.CanCure(Preset.BRD_Variant_Cure, 50))
+            if (Variant.CanCure(Preset.BRD_Variant_Cure, BRD_VariantCure))
                 return Variant.Cure;
 
             if (Variant.CanRampart(Preset.BRD_Variant_Rampart, WeaveTypes.Weave))

--- a/WrathCombo/Combos/PvE/BRD/BRD_Config.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Config.cs
@@ -2,13 +2,14 @@ using Dalamud.Interface.Colors;
 using ImGuiNET;
 using WrathCombo.CustomComboNS.Functions;
 using static WrathCombo.Window.Functions.UserConfig;
-
+using Preset = WrathCombo.Combos.CustomComboPreset;
 namespace WrathCombo.Combos.PvE;
 
 internal partial class BRD
 {
     internal static class Config
     {
+        #region Options
         public static UserInt
             BRD_RagingJawsRenewTime = new("ragingJawsRenewTime"),            
             BRD_STSecondWindThreshold = new("BRD_STSecondWindThreshold"),
@@ -22,101 +23,81 @@ internal partial class BRD
             BRD_Adv_Buffs_SubOption = new ("BRD_Adv_Buffs_SubOption", 1),
             BRD_AoE_Adv_Buffs_Threshold = new("BRD_AoE_Adv_Buffs_Threshold", 1),
             BRD_AoE_Adv_Buffs_SubOption = new("BRD_AoE_Adv_Buffs_SubOption", 1);
-
-        internal static void Draw(CustomComboPreset preset)
+        #endregion
+        
+        internal static void Draw(Preset preset)
         {
             switch (preset)
             {
-                case CustomComboPreset.BRD_ST_Adv_Balance_Standard:
+                #region Single Target
+                case Preset.BRD_ST_Adv_Balance_Standard:
                     DrawRadioButton(BRD_Adv_Opener_Selection, "Standard Opener", "", 0);
                     DrawRadioButton(BRD_Adv_Opener_Selection, "2.48 Adjusted Standard Opener", "", 1);
                     DrawRadioButton(BRD_Adv_Opener_Selection, "2.49 Standard Comfy", "", 2);
-
                     ImGui.Indent();
                     DrawBossOnlyChoice(BRD_Balance_Content);
                     ImGui.Unindent();
                     break;
 
-                case CustomComboPreset.BRD_Adv_RagingJaws:
+                case Preset.BRD_Adv_RagingJaws:
                     DrawSliderInt(3, 10, BRD_RagingJawsRenewTime,
                         "Remaining time (In seconds). Recommended 5, increase little by little if refresh is outside of radiant window");
-
                     break;
 
-
-                case CustomComboPreset.BRD_Adv_DoT:
-
+                case Preset.BRD_Adv_DoT:
                     DrawSliderInt(0, 100, BRD_Adv_DoT_Threshold,
                         $"Stop using Dots on targets below this HP % (0% = always use, 100% = never use).");
-
                     ImGui.Indent();
-
                     ImGui.TextColored(ImGuiColors.DalamudYellow, "Select what kind of enemies the HP check should be applied to:");
-
                     DrawHorizontalRadioButton(BRD_Adv_DoT_SubOption,
                         "Non-boss Encounters Only", $"Applies HP check to Non-Boss Encounters only", 0);
-
                     DrawHorizontalRadioButton(BRD_Adv_DoT_SubOption,
                         "All Content", $"Applies HP Check to All Content", 1);
-
                     ImGui.Unindent();
-
                     break;
 
-                case CustomComboPreset.BRD_Adv_Buffs:
-
+                case Preset.BRD_Adv_Buffs:
                     DrawSliderInt(0, 100, BRD_Adv_Buffs_Threshold,
                        $"Stop using Buffs on targets below this HP % (0% = always use, 100% = never use).");
-
                     ImGui.Indent();
-
                     ImGui.TextColored(ImGuiColors.DalamudYellow, "Select what kind of enemies the HP check should be applied to:");
-
                     DrawHorizontalRadioButton(BRD_Adv_Buffs_SubOption,
                         "Non-boss Encounters Only", $"Applies HP check to Non-Boss Encounters only", 0);
-
                     DrawHorizontalRadioButton(BRD_Adv_Buffs_SubOption,
                         "All Content", $"Applies HP Check to All Content", 1);
-
                     ImGui.Unindent();
-
                     break;
-
-                case CustomComboPreset.BRD_AoE_Adv_Buffs:
-
-                    DrawSliderInt(0, 100, BRD_AoE_Adv_Buffs_Threshold,
-                        $"Stop using Buffs on targets below this HP % (0% = always use, 100% = never use).");
-
-                    ImGui.Indent();
-
-                    ImGui.TextColored(ImGuiColors.DalamudYellow, "Select what kind of enemies the HP check should be applied to:");
-
-                    DrawHorizontalRadioButton(BRD_AoE_Adv_Buffs_SubOption,
-                        "Non-boss Encounters Only", $"Applies HP check to Non-Boss Encounters only", 0);
-
-                    DrawHorizontalRadioButton(BRD_AoE_Adv_Buffs_SubOption,
-                        "All Content", $"Applies HP Check to All Content", 1);
-
-                    ImGui.Unindent();
-
-                    break;
-
-                case CustomComboPreset.BRD_ST_SecondWind:
+                
+                case Preset.BRD_ST_SecondWind:
                     DrawSliderInt(0, 100, BRD_STSecondWindThreshold,
                         "HP percent threshold to use Second Wind below.");
+                    break;
+                #endregion
 
+                #region AOE
+                case Preset.BRD_AoE_Adv_Buffs:
+                    DrawSliderInt(0, 100, BRD_AoE_Adv_Buffs_Threshold,
+                        $"Stop using Buffs on targets below this HP % (0% = always use, 100% = never use).");
+                    ImGui.Indent();
+                    ImGui.TextColored(ImGuiColors.DalamudYellow, "Select what kind of enemies the HP check should be applied to:");
+                    DrawHorizontalRadioButton(BRD_AoE_Adv_Buffs_SubOption,
+                        "Non-boss Encounters Only", $"Applies HP check to Non-Boss Encounters only", 0);
+                    DrawHorizontalRadioButton(BRD_AoE_Adv_Buffs_SubOption,
+                        "All Content", $"Applies HP Check to All Content", 1);
+                    ImGui.Unindent();
                     break;
 
-                case CustomComboPreset.BRD_AoE_SecondWind:
+                case Preset.BRD_AoE_SecondWind:
                     DrawSliderInt(0, 100, BRD_AoESecondWindThreshold,
                         "HP percent threshold to use Second Wind below.");
-
                     break;
-
-                case CustomComboPreset.BRD_Variant_Cure:
+                #endregion
+                
+                #region Standalone
+                case Preset.BRD_Variant_Cure:
                     DrawSliderInt(1, 100, BRD_VariantCure, "HP% to be at or under", 200);
-
                     break;
+                #endregion
             }
         }
     }

--- a/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
@@ -1,30 +1,23 @@
 ﻿#region Dependencies
-
 using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Game.ClientState.Statuses;
-using ECommons.DalamudServices;
-using ECommons.GameHelpers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
-using WrathCombo.Data;
 using WrathCombo.Extensions;
+using static WrathCombo.Combos.PvE.BRD.Config;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
-
-
 #endregion
 
 namespace WrathCombo.Combos.PvE;
-
 internal partial class BRD
 {
     #region Variables
-
     // Gauge Stuff
     internal static BRDGauge? gauge = GetJobGauge<BRDGauge>();
     internal static int SongTimerInSeconds => gauge.SongTimer / 1000;
@@ -95,7 +88,7 @@ internal partial class BRD
             if (BuffWindow && RagingStrikesDuration < 18 || RagingCD > 30)
                     return true;
             
-           return false;
+            return false;
         }
 
         //Bloodletter & Rain of Death Logic
@@ -114,38 +107,26 @@ internal partial class BRD
         #endregion
 
         #region Dot Management
-
         //Iron Jaws dot refreshing
         internal static bool UseIronJaws()
         {
-            if (ActionReady(IronJaws) && Purple is not null && Blue is not null &&
-                    (PurpleRemaining < 4 || BlueRemaining < 4))
-                return true;
-            return false;
+            return ActionReady(IronJaws) && Purple is not null && Blue is not null &&
+                   (PurpleRemaining < 4 || BlueRemaining < 4);
         }
-
         //Blue dot application and low level refresh
         internal static bool ApplyBlueDot()
         {
-            if (ActionReady(Windbite) && DebuffCapCanBlue && (Blue is null || !CanIronJaws && BlueRemaining < 4))
-                return true;
-            return false;
+            return ActionReady(Windbite) && DebuffCapCanBlue && (Blue is null || !CanIronJaws && BlueRemaining < 4);
         }
-
         //Purple dot application and low level refresh
         internal static bool ApplyPurpleDot()
         {
-            if (ActionReady(VenomousBite) && DebuffCapCanPurple && (Purple is null || !CanIronJaws && PurpleRemaining < 4))
-                return true;
-            return false;
+            return ActionReady(VenomousBite) && DebuffCapCanPurple && (Purple is null || !CanIronJaws && PurpleRemaining < 4);
         }
-
         //Raging jaws option dot refresh for snapshot
         internal static bool RagingJawsRefresh()
         {
-            if (ActionReady(IronJaws) && HasStatusEffect(Buffs.RagingStrikes) && PurpleRemaining < 35 && BlueRemaining < 35)
-                return true;
-            return false;
+            return ActionReady(IronJaws) && HasStatusEffect(Buffs.RagingStrikes) && PurpleRemaining < 35 && BlueRemaining < 35;
         }
         #endregion
 
@@ -153,105 +134,80 @@ internal partial class BRD
         //RadiantFinale Buff
         internal static bool UseRadiantBuff()
         {
-            if (ActionReady(RadiantFinale) && RagingCD < 2.2 && CanWeaveDelayed && !HasStatusEffect(Buffs.RadiantEncoreReady))
-                return true;
-            return false;
+            return ActionReady(RadiantFinale) && RagingCD < 2.2 && CanWeaveDelayed && !HasStatusEffect(Buffs.RadiantEncoreReady);
         } 
-
         //BattleVoice Buff
         internal static bool UseBattleVoiceBuff()
         {
-            if (ActionReady(BattleVoice) && (HasStatusEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale)))
-                return true;
-            return false;
+            return ActionReady(BattleVoice) && (HasStatusEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale));
         }
-    
         //RagingStrikes Buff
         internal static bool UseRagingStrikesBuff()
         {
-            if (ActionReady(RagingStrikes) && (JustUsed(BattleVoice) || !LevelChecked(BattleVoice) || HasStatusEffect(Buffs.BattleVoice)))
-                return true;
-            return false;
-
+            return ActionReady(RagingStrikes) && (JustUsed(BattleVoice) || !LevelChecked(BattleVoice) || HasStatusEffect(Buffs.BattleVoice));
         } 
-
         //Barrage Buff
         internal static bool UseBarrageBuff()
         {
-            if (ActionReady(Barrage) && HasStatusEffect(Buffs.RagingStrikes) && !HasStatusEffect(Buffs.ResonantArrowReady))
-                return true;
+            return ActionReady(Barrage) && HasStatusEffect(Buffs.RagingStrikes) && !HasStatusEffect(Buffs.ResonantArrowReady);
+        }
+        #endregion
+    
+        #region Songs
+        internal static bool WandererSong()
+        {
+            if (ActionReady(WanderersMinuet))
+            {
+                if (SongNone) // No song, use wanderer first
+                   return true;
+                    
+                if (SongArmy && (CanWeaveDelayed || !BardHasTarget) && (SongTimerInSeconds <= 12 || gauge.Repertoire == 4)) //Transition to wanderer as soon as it is ready
+                    return true;
+            }
             return false;
         }
-    #endregion
-
-        #region Songs
-
-    internal static bool WandererSong()
-    {
-        if (ActionReady(WanderersMinuet))
+        internal static bool MagesSong()
         {
-            if (SongNone) // No song, use wanderer first
-               return true;
-                
-            if (SongArmy && (CanWeaveDelayed || !BardHasTarget) && (SongTimerInSeconds <= 12 || gauge.Repertoire == 4)) //Transition to wanderer as soon as it is ready
-                return true;
+            if (ActionReady(MagesBallad) && (CanBardWeave || !BardHasTarget))
+            {
+                if (SongNone && !ActionReady(WanderersMinuet)) //No song, Use Mages if wanderer is on cd or not aquaired yet
+                    return true;
+
+                if (SongWanderer && SongTimerInSeconds <= 3 && gauge.Repertoire == 0) //Swap to mages after wanderer and no pitch perfect to spend
+                    return true;
+            }
+            return false;
         }
-        return false;
-    }
-    internal static bool MagesSong()
-    {
-        if (ActionReady(MagesBallad) && (CanBardWeave || !BardHasTarget))
+        internal static bool ArmySong()
         {
-            if (SongNone && !ActionReady(WanderersMinuet)) //No song, Use Mages if wanderer is on cd or not aquaired yet
-                return true;
+            if (ActionReady(ArmysPaeon) && (CanBardWeave || !BardHasTarget))
+            {
+                if (SongNone && !ActionReady(MagesBallad) && !ActionReady(WanderersMinuet)) //No song, Use army as last resort
+                    return true;
 
-            if (SongWanderer && SongTimerInSeconds <= 3 && gauge.Repertoire == 0) //Swap to mages after wanderer and no pitch perfect to spend
-                return true;
+                if (SongMage && SongTimerInSeconds <= 3) //Transition to army after mages
+                    return true;
+            }
+            return false;
         }
-        return false;
-    }
-
-    internal static bool ArmySong()
-    {
-        if (ActionReady(ArmysPaeon) && (CanBardWeave || !BardHasTarget))
+        internal static bool SongChangeEmpyreal()
         {
-            if (SongNone && !ActionReady(MagesBallad) && !ActionReady(WanderersMinuet)) //No song, Use army as last resort
-                return true;
-
-            if (SongMage && SongTimerInSeconds <= 3) //Transition to army after mages
-                return true;
+            return SongMage && SongTimerInSeconds <= 3 && ActionReady(ArmysPaeon) && ActionReady(EmpyrealArrow) && BardHasTarget && CanBardWeave; // Uses Empyreal before transiitoning to Army if possible
         }
-        return false;
-    }
-
-    internal static bool SongChangeEmpyreal()
-    {
-        if (SongMage && SongTimerInSeconds <= 3 && ActionReady(ArmysPaeon) && ActionReady(EmpyrealArrow) && BardHasTarget && CanBardWeave) // Uses Empyreal before transiitoning to Army if possible
-            return true;
-        
-        return false;
-    }
-
-    internal static bool SongChangePitchPerfect()
-    {
-        if (SongWanderer && SongTimerInSeconds <= 3 && gauge.Repertoire > 0 && BardHasTarget && CanBardWeave) // Dumps the Pitch perfect stacks before transition to mages
-            return true;
-
-        return false;
-    }
-    #endregion
+        internal static bool SongChangePitchPerfect()
+        {
+            return SongWanderer && SongTimerInSeconds <= 3 && gauge.Repertoire > 0 && BardHasTarget && CanBardWeave; // Dumps the Pitch perfect stacks before transition to mages
+        }
+        #endregion
 
         #region Warden Resolver
         [ActionRetargeting.TargetResolver]
         private static IGameObject? WardenResolver() =>
-         GetPartyMembers()
-              .Select(member => member.BattleChara)
-              .Where(member => member.IsNotThePlayer() && !member.IsDead && member.IsCleansable() && InActionRange(TheWardensPaeon, member))          
-              .FirstOrDefault();
+            GetPartyMembers()
+                .Select(member => member.BattleChara)          
+                .FirstOrDefault(member => member.IsNotThePlayer() && !member.IsDead && member.IsCleansable() && InActionRange(TheWardensPaeon, member));
         #endregion
-
-
-
+        
     #endregion
 
     #region ID's
@@ -329,7 +285,6 @@ internal partial class BRD
     #endregion
 
     #region Openers
-
     public static BRDStandard Opener1 = new();
     public static BRDAdjusted Opener2 = new();
     public static BRDComfy Opener3 = new();
@@ -337,13 +292,11 @@ internal partial class BRD
     {
         if (IsEnabled(CustomComboPreset.BRD_ST_AdvMode))
         {
-            if (Config.BRD_Adv_Opener_Selection == 0 && Opener1.LevelChecked) return Opener1;
-            if (Config.BRD_Adv_Opener_Selection == 1 && Opener2.LevelChecked) return Opener2;
-            if (Config.BRD_Adv_Opener_Selection == 2 && Opener3.LevelChecked) return Opener3;
+            if (BRD_Adv_Opener_Selection == 0 && Opener1.LevelChecked) return Opener1;
+            if (BRD_Adv_Opener_Selection == 1 && Opener2.LevelChecked) return Opener2;
+            if (BRD_Adv_Opener_Selection == 2 && Opener3.LevelChecked) return Opener3;
         }
-
-        if (Opener1.LevelChecked) return Opener1;
-        return WrathOpener.Dummy;
+        return Opener1.LevelChecked ? Opener1 : WrathOpener.Dummy;
     }
 
     internal class BRDStandard : WrathOpener
@@ -370,21 +323,17 @@ internal partial class BRD
             IronJaws,
             BurstShot
         ];
-
         public override List<(int[], uint, Func<bool>)> SubstitutionSteps { get; set; } =
         [
             ([6, 9, 16, 17, 19], RefulgentArrow, () => HasStatusEffect(Buffs.HawksEye))
         ];
-
         public override List<int> DelayedWeaveSteps { get; set; } =
         [
             5
         ];
         public override int MinOpenerLevel => 100;
         public override int MaxOpenerLevel => 109;
-
-        internal override UserData ContentCheckConfig => Config.BRD_Balance_Content;
-
+        internal override UserData ContentCheckConfig => BRD_Balance_Content;
         public override bool HasCooldowns() =>
             IsOffCooldown(WanderersMinuet) &&
             IsOffCooldown(BattleVoice) &&
@@ -393,7 +342,6 @@ internal partial class BRD
             IsOffCooldown(Barrage) &&
             IsOffCooldown(Sidewinder);
     }
-
     internal class BRDAdjusted : WrathOpener
     {
         public override List<uint> OpenerActions { get; set; } =
@@ -419,22 +367,17 @@ internal partial class BRD
             IronJaws,
             BurstShot
         ];
-
         public override List<(int[], uint, Func<bool>)> SubstitutionSteps { get; set; } =
         [
             ([7, 10, 17, 18, 20], RefulgentArrow, () => HasStatusEffect(Buffs.HawksEye))
         ];
-
         public override List<int> DelayedWeaveSteps { get; set; } =
         [
             6
         ];
-
         public override int MinOpenerLevel => 100;
         public override int MaxOpenerLevel => 109;
-
-        internal override UserData ContentCheckConfig => Config.BRD_Balance_Content;
-
+        internal override UserData ContentCheckConfig => BRD_Balance_Content;
         public override bool HasCooldowns() =>
             IsOffCooldown(WanderersMinuet) &&
             IsOffCooldown(BattleVoice) &&
@@ -443,7 +386,6 @@ internal partial class BRD
             IsOffCooldown(Barrage) &&
             IsOffCooldown(Sidewinder);
     }
-
     internal class BRDComfy : WrathOpener
     {
         public override List<uint> OpenerActions { get; set; } =
@@ -469,17 +411,13 @@ internal partial class BRD
             IronJaws,
             BurstShot
         ];
-
         public override List<(int[], uint, Func<bool>)> SubstitutionSteps { get; set; } =
         [
             ([7, 10, 16, 18, 20], RefulgentArrow, () => HasStatusEffect(Buffs.HawksEye))
         ];
-
         public override int MinOpenerLevel => 100;
         public override int MaxOpenerLevel => 109;
-
-        internal override UserData ContentCheckConfig => Config.BRD_Balance_Content;
-
+        internal override UserData ContentCheckConfig => BRD_Balance_Content;
         public override bool HasCooldowns() =>
             IsOffCooldown(WanderersMinuet) &&
             IsOffCooldown(BattleVoice) &&
@@ -488,6 +426,5 @@ internal partial class BRD
             IsOffCooldown(Barrage) &&
             IsOffCooldown(Sidewinder);
     }
-
     #endregion
 }

--- a/WrathCombo/Combos/PvE/PCT/PCT.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT.cs
@@ -28,9 +28,9 @@ internal partial class PCT : Caster
             }
             #endregion
 
-            #region Burst Window lvl 100 only
-            if (BurstPhaseReady)
-                return BurstWindow(actionID);
+            #region Burst Window
+            if (HasStatusEffect(Buffs.StarryMuse))
+                return BurstWindowStandard(actionID);
             #endregion
             
             #region Special Content
@@ -47,34 +47,33 @@ internal partial class PCT : Caster
             #endregion
 
             #region OGCD
-            // General Weaves
-            if (InCombat() && CanWeave())
+            
+            if (InCombat())
             {
-                // ScenicMuse pre-100
-                if (ScenicMuseReady && !LevelChecked(StarPrism))
+                // SubtractivePalette
+                if (PaletteReady && CanWeave())
+                    return SubtractivePalette;
+                
+                if (ScenicMuseReady && CanDelayedWeave())
                     return OriginalHook(ScenicMuse);
 
                 // LivingMuse
-                if (LivingMuseReady &&
+                if (LivingMuseReady  && CanWeave() &&
                     (!PortraitReady || GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)) &&
                     (!LevelChecked(ScenicMuse) || ScenicCD > GetCooldownChargeRemainingTime(LivingMuse)))
                     return OriginalHook(LivingMuse);
 
                 // SteelMuse
-                if (SteelMuseReady &&
+                if (SteelMuseReady && CanWeave() &&
                     (SteelCD < ScenicCD || GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
                     !LevelChecked(ScenicMuse)))
                     return OriginalHook(SteelMuse);
 
                 // Portrait Mog or Madeen
-                if (PortraitReady &&
+                if (PortraitReady && CanWeave() &&
                     IsOffCooldown(OriginalHook(MogoftheAges)) &&
                     (ScenicCD >= 60 || !LevelChecked(ScenicMuse)))
                     return OriginalHook(MogoftheAges);
-
-                // SubtractivePalette
-                if (PaletteReady)
-                    return SubtractivePalette;
 
                 //LucidDreaming
                 if (Role.CanLucidDream(PCT_ST_AdvancedMode_LucidOption))
@@ -144,7 +143,7 @@ internal partial class PCT : Caster
                 return RainbowDrip;
 
             //Comet in Black
-            if (CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint)
+            if (CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint && ScenicCD > 10)
                 return OriginalHook(CometinBlack);
 
             //Hammer Stamp Combo
@@ -230,8 +229,8 @@ internal partial class PCT : Caster
             #endregion
 
             #region Burst Window
-            if (burstPhaseEnabled && BurstPhaseReady)
-                return BurstWindow(actionID);
+            if (burstPhaseEnabled && HasStatusEffect(Buffs.StarryMuse))
+                return BurstWindowStandard(actionID);
             #endregion
             
             #region Special Content
@@ -249,33 +248,33 @@ internal partial class PCT : Caster
 
             #region OGCD
             // General Weaves
-            if (InCombat() && CanWeave())
+            if (InCombat())
             {
+                // SubtractivePalette
+                if (paletteEnabled && CanWeave() && PaletteReady)
+                    return SubtractivePalette;
+                
                 // ScenicMuse
-                if (scenicMuseEnabled && ScenicMuseReady && (!burstPhaseEnabled || !LevelChecked(StarPrism)))
+                if (scenicMuseEnabled && ScenicMuseReady && CanDelayedWeave())
                     return OriginalHook(ScenicMuse);
                     
                 // LivingMuse
-                if (livingMuseEnabled && LivingMuseReady && 
+                if (livingMuseEnabled && LivingMuseReady && CanWeave() &&
                     (!PortraitReady || GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)) &&
                     (!LevelChecked(ScenicMuse) || ScenicCD > GetCooldownChargeRemainingTime(LivingMuse)))
                     return OriginalHook(LivingMuse);
                         
                 // SteelMuse
-                if (steelMuseEnabled && SteelMuseReady &&
+                if (steelMuseEnabled && SteelMuseReady && CanWeave() &&
                     (SteelCD < ScenicCD || GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
                     !LevelChecked(ScenicMuse)))
                     return OriginalHook(SteelMuse);
                     
                 // Portrait Mog or Madeen
-                if (portraitEnabled && PortraitReady && 
+                if (portraitEnabled && PortraitReady && CanWeave() &&
                     IsOffCooldown(OriginalHook(MogoftheAges)) && 
                     (ScenicCD >= 60 || !LevelChecked(ScenicMuse)))
                     return OriginalHook(MogoftheAges);
-                    
-                // SubtractivePalette
-                if (paletteEnabled && PaletteReady)
-                    return SubtractivePalette;
                         
                 //LucidDreaming
                 if (lucidDreamingEnabled && Role.CanLucidDream(PCT_ST_AdvancedMode_LucidOption))
@@ -345,7 +344,7 @@ internal partial class PCT : Caster
                 return RainbowDrip;
 
             //Comet in Black
-            if (cometEnabled && CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint)
+            if (cometEnabled && CometinBlack.LevelChecked() && HasStatusEffect(Buffs.MonochromeTones) && HasPaint && ScenicCD > 10)
                 return OriginalHook(CometinBlack);
 
             //Hammer Stamp Combo

--- a/WrathCombo/Combos/PvE/PCT/PCT.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT.cs
@@ -1,18 +1,16 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Types;
-using WrathCombo.Combos.PvE.Content;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Extensions;
-
+using Preset = WrathCombo.Combos.CustomComboPreset;
+using static WrathCombo.Combos.PvE.PCT.Config;
 namespace WrathCombo.Combos.PvE;
 
 internal partial class PCT : Caster
 {
-
     #region Single Target Combos
     internal class PCT_ST_SimpleMode : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PCT_ST_SimpleMode;
-
+        protected internal override Preset Preset => Preset.PCT_ST_SimpleMode;
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not FireInRed)
@@ -33,16 +31,15 @@ internal partial class PCT : Caster
             #region Burst Window lvl 100 only
             if (BurstPhaseReady)
                 return BurstWindow(actionID);
-
             #endregion
             
             #region Special Content
             // Variant Cure
-            if (Variant.CanCure(CustomComboPreset.PCT_Variant_Cure, Config.PCT_VariantCure))
+            if (Variant.CanCure(Preset.PCT_Variant_Cure, PCT_VariantCure))
                 return Variant.Cure;
 
             // Variant Rampart
-            if (Variant.CanRampart(CustomComboPreset.PCT_Variant_Rampart, WeaveTypes.Weave))
+            if (Variant.CanRampart(Preset.PCT_Variant_Rampart, WeaveTypes.Weave))
                 return Variant.Rampart;
             
             if (OccultCrescent.ShouldUsePhantomActions())
@@ -80,7 +77,7 @@ internal partial class PCT : Caster
                     return SubtractivePalette;
 
                 //LucidDreaming
-                if (Role.CanLucidDream(Config.PCT_ST_AdvancedMode_LucidOption))
+                if (Role.CanLucidDream(PCT_ST_AdvancedMode_LucidOption))
                     return Role.LucidDreaming;
             }
             #endregion
@@ -96,7 +93,6 @@ internal partial class PCT : Caster
                 if (LandscapeMotifReady)
                     return OriginalHook(LandscapeMotif);
             }
-
             #endregion
 
             #region Moving
@@ -121,11 +117,9 @@ internal partial class PCT : Caster
                     (CreatureMotifReady || WeaponMotifReady || LandscapeMotifReady))
                     return Role.Swiftcast;
             }
-
             #endregion
 
             #region Pre_Burst Motifs
-
             //Prepare for Burst
             if (GetCooldownRemainingTime(ScenicMuse) <= 20)
             {
@@ -138,11 +132,9 @@ internal partial class PCT : Caster
                 if (WeaponMotifReady && GetTargetHPPercent() > 10)
                     return OriginalHook(WeaponMotif);
             }
-
             #endregion
 
             #region GCDs
-
             //StarPrism
             if (HasStatusEffect(Buffs.Starstruck))
                 return StarPrism;
@@ -181,51 +173,43 @@ internal partial class PCT : Caster
             return actionID;
             #endregion
         }
-
     }   
-
     internal class PCT_ST_AdvancedMode : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PCT_ST_AdvancedMode;
-
+        protected internal override Preset Preset => Preset.PCT_ST_AdvancedMode;
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not FireInRed)
                 return actionID;
 
             #region Enables and Configs
-           
-            int creatureStop = Config.PCT_ST_CreatureStop;
-            int landscapeStop = Config.PCT_ST_LandscapeStop;
-            int weaponStop = Config.PCT_ST_WeaponStop;
+            int creatureStop = PCT_ST_CreatureStop;
+            int landscapeStop = PCT_ST_LandscapeStop;
+            int weaponStop = PCT_ST_WeaponStop;
 
-            bool prepullEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_PrePullMotifs);
-            bool openerEnabled = IsEnabled(CustomComboPreset.PCT_ST_Advanced_Openers);
-            bool burstPhaseEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_Phase);
-            bool noTargetMotifEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_NoTargetMotifs);
-            bool scenicMuseEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_ScenicMuse);
-            bool livingMuseEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LivingMuse);
-            bool steelMuseEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SteelMuse);
-            bool portraitEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MogOfTheAges);
-            bool paletteEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SubtractivePalette);
-            bool lucidDreamingEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LucidDreaming);
-            bool swiftMotifEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SwiftMotifs);
-            bool hammerMovementEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HammerStampCombo);
-            bool cometMovementEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_CometinBlack);
-            bool holyMovementEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HolyInWhite);
-            bool swiftcastMotifMovementEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SwitfcastOption);
-            bool landscapeMotifEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif);
-            bool creatureMotifEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif);
-            bool weaponMotifEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif);
-            bool starPrismEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_StarPrism);
-            bool rainbowDripEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_RainbowDrip);
-            bool cometEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CometinBlack);
-            bool hammerEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_HammerStampCombo);
-            bool blizzardComboEnabled = IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_BlizzardInCyan);
-
-
-
-
+            bool prepullEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_PrePullMotifs);
+            bool openerEnabled = IsEnabled(Preset.PCT_ST_Advanced_Openers);
+            bool burstPhaseEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_Burst_Phase);
+            bool noTargetMotifEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_NoTargetMotifs);
+            bool scenicMuseEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_ScenicMuse);
+            bool livingMuseEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_LivingMuse);
+            bool steelMuseEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_SteelMuse);
+            bool portraitEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_MogOfTheAges);
+            bool paletteEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_SubtractivePalette);
+            bool lucidDreamingEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_LucidDreaming);
+            bool swiftMotifEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_SwiftMotifs);
+            bool hammerMovementEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_MovementOption_HammerStampCombo);
+            bool cometMovementEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_MovementOption_CometinBlack);
+            bool holyMovementEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_MovementOption_HolyInWhite);
+            bool swiftcastMotifMovementEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_SwitfcastOption);
+            bool landscapeMotifEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_LandscapeMotif);
+            bool creatureMotifEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_CreatureMotif);
+            bool weaponMotifEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_WeaponMotif);
+            bool starPrismEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_StarPrism);
+            bool rainbowDripEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_RainbowDrip);
+            bool cometEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_CometinBlack);
+            bool hammerEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_HammerStampCombo);
+            bool blizzardComboEnabled = IsEnabled(Preset.PCT_ST_AdvancedMode_BlizzardInCyan);
             #endregion
 
             #region Prepull
@@ -241,25 +225,22 @@ internal partial class PCT : Caster
             #endregion
 
             #region Opener
-
             if (openerEnabled && Opener().FullOpener(ref actionID))
                 return actionID;
-
             #endregion
 
             #region Burst Window
             if (burstPhaseEnabled && BurstPhaseReady)
                 return BurstWindow(actionID);
-
             #endregion
             
             #region Special Content
             // Variant Cure
-            if (Variant.CanCure(CustomComboPreset.PCT_Variant_Cure, Config.PCT_VariantCure))
+            if (Variant.CanCure(Preset.PCT_Variant_Cure, PCT_VariantCure))
                 return Variant.Cure;
 
             // Variant Rampart
-            if (Variant.CanRampart(CustomComboPreset.PCT_Variant_Rampart, WeaveTypes.Weave))
+            if (Variant.CanRampart(Preset.PCT_Variant_Rampart, WeaveTypes.Weave))
                 return Variant.Rampart;
             
             if (OccultCrescent.ShouldUsePhantomActions())
@@ -297,7 +278,7 @@ internal partial class PCT : Caster
                     return SubtractivePalette;
                         
                 //LucidDreaming
-                if (lucidDreamingEnabled && Role.CanLucidDream(Config.PCT_ST_AdvancedMode_LucidOption))
+                if (lucidDreamingEnabled && Role.CanLucidDream(PCT_ST_AdvancedMode_LucidOption))
                     return Role.LucidDreaming;
             }
             #endregion
@@ -313,7 +294,6 @@ internal partial class PCT : Caster
                 if (LandscapeMotifReady && GetTargetHPPercent() > landscapeStop)
                     return OriginalHook(LandscapeMotif);
             }
-
             #endregion
 
             #region Moving
@@ -338,11 +318,9 @@ internal partial class PCT : Caster
                     (CreatureMotifReady || WeaponMotifReady || LandscapeMotifReady))
                     return Role.Swiftcast;
             }
-
             #endregion
 
             #region Pre_Burst Motifs
-
             //Prepare for Burst
             if (GetCooldownRemainingTime(ScenicMuse) <= 20)
             {
@@ -355,11 +333,9 @@ internal partial class PCT : Caster
                 if (weaponMotifEnabled && WeaponMotifReady && GetTargetHPPercent() > weaponStop)
                     return OriginalHook(WeaponMotif);
             }
-
             #endregion
 
             #region GCDs
-
             //StarPrism
             if (starPrismEnabled && HasStatusEffect(Buffs.Starstruck))
                 return StarPrism;
@@ -399,27 +375,23 @@ internal partial class PCT : Caster
             #endregion
         }
     }
-
     #endregion
 
     #region AOE Combos
 
     internal class PCT_AoE_SimpleMode : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PCT_AoE_SimpleMode;
-
+        protected internal override Preset Preset => Preset.PCT_AoE_SimpleMode;
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not FireIIinRed)
                 return actionID;
 
             #region Enables and Configs
-
-            int creatureStop = 10;
-            int landscapeStop = 10;
-            int weaponStop = 10;
-            int holdPaintCharges = 2;
-
+            const int creatureStop = 10;
+            const int landscapeStop = 10;
+            const int weaponStop = 10;
+            const int holdPaintCharges = 2;
             #endregion
 
             #region Prepull
@@ -436,11 +408,11 @@ internal partial class PCT : Caster
 
             #region Special Content
             // Variant Cure
-            if (Variant.CanCure(CustomComboPreset.PCT_Variant_Cure, Config.PCT_VariantCure))
+            if (Variant.CanCure(Preset.PCT_Variant_Cure, PCT_VariantCure))
                 return Variant.Cure;
 
             // Variant Rampart
-            if (Variant.CanRampart(CustomComboPreset.PCT_Variant_Rampart, WeaveTypes.Weave))
+            if (Variant.CanRampart(Preset.PCT_Variant_Rampart, WeaveTypes.Weave))
                 return Variant.Rampart;
             
             if (OccultCrescent.ShouldUsePhantomActions())
@@ -478,7 +450,7 @@ internal partial class PCT : Caster
                     return SubtractivePalette;
 
                 //LucidDreaming
-                if (Role.CanLucidDream(Config.PCT_ST_AdvancedMode_LucidOption))
+                if (Role.CanLucidDream(PCT_ST_AdvancedMode_LucidOption))
                     return Role.LucidDreaming;
             }
             #endregion
@@ -494,7 +466,6 @@ internal partial class PCT : Caster
                 if (LandscapeMotifReady && GetTargetHPPercent() > landscapeStop)
                     return OriginalHook(LandscapeMotif);
             }
-
             #endregion
 
             #region Moving
@@ -519,11 +490,9 @@ internal partial class PCT : Caster
                     (CreatureMotifReady || WeaponMotifReady || LandscapeMotifReady))
                     return Role.Swiftcast;
             }
-
             #endregion
 
             #region Pre_Burst Motifs
-
             //Prepare for Burst
             if (GetCooldownRemainingTime(ScenicMuse) <= 20)
             {
@@ -536,11 +505,9 @@ internal partial class PCT : Caster
                 if (WeaponMotifReady && GetTargetHPPercent() > weaponStop)
                     return OriginalHook(WeaponMotif);
             }
-
             #endregion
 
             #region GCDs
-
             //StarPrism
             if (HasStatusEffect(Buffs.Starstruck))
                 return StarPrism;
@@ -581,51 +548,45 @@ internal partial class PCT : Caster
                 return OriginalHook(HolyInWhite);
 
             return actionID;
-
             #endregion
-
         }
     }
-
     internal class PCT_AoE_AdvancedMode : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PCT_AoE_AdvancedMode;
-
+        protected internal override Preset Preset => Preset.PCT_AoE_AdvancedMode;
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not FireIIinRed)
                 return actionID;
 
             #region Enables and Configs
+            int creatureStop = PCT_AoE_CreatureStop;
+            int landscapeStop = PCT_AoE_LandscapeStop;
+            int weaponStop = PCT_AoE_WeaponStop;
+            int holdPaintCharges = PCT_AoE_AdvancedMode_HolyinWhiteOption;
 
-            int creatureStop = Config.PCT_AoE_CreatureStop;
-            int landscapeStop = Config.PCT_AoE_LandscapeStop;
-            int weaponStop = Config.PCT_AoE_WeaponStop;
-            int holdPaintCharges = Config.PCT_AoE_AdvancedMode_HolyinWhiteOption;
-
-            bool prepullEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_PrePullMotifs);
-            bool noTargetMotifEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_NoTargetMotifs);
-            bool scenicMuseEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_ScenicMuse);
-            bool livingMuseEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LivingMuse);
-            bool steelMuseEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SteelMuse);
-            bool portraitEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MogOfTheAges);
-            bool paletteEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SubtractivePalette);
-            bool lucidDreamingEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LucidDreaming);
-            bool swiftMotifEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SwiftMotifs);
-            bool hammerMovementEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HammerStampCombo);
-            bool cometMovementEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_CometinBlack);
-            bool holyMovementEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HolyInWhite);
-            bool swiftcastMotifMovementEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SwitfcastOption);
-            bool landscapeMotifEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LandscapeMotif);
-            bool creatureMotifEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CreatureMotif);
-            bool weaponMotifEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_WeaponMotif);
-            bool starPrismEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_StarPrism);
-            bool rainbowDripEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_RainbowDrip);
-            bool cometEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CometinBlack);
-            bool hammerEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_HammerStampCombo);
-            bool blizzardComboEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_BlizzardInCyan);
-            bool holyInWhiteEnabled = IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_HolyinWhite);
-
+            bool prepullEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_PrePullMotifs);
+            bool noTargetMotifEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_NoTargetMotifs);
+            bool scenicMuseEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_ScenicMuse);
+            bool livingMuseEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_LivingMuse);
+            bool steelMuseEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_SteelMuse);
+            bool portraitEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_MogOfTheAges);
+            bool paletteEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_SubtractivePalette);
+            bool lucidDreamingEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_LucidDreaming);
+            bool swiftMotifEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_SwiftMotifs);
+            bool hammerMovementEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_MovementOption_HammerStampCombo);
+            bool cometMovementEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_MovementOption_CometinBlack);
+            bool holyMovementEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_MovementOption_HolyInWhite);
+            bool swiftcastMotifMovementEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_SwitfcastOption);
+            bool landscapeMotifEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_LandscapeMotif);
+            bool creatureMotifEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_CreatureMotif);
+            bool weaponMotifEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_WeaponMotif);
+            bool starPrismEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_StarPrism);
+            bool rainbowDripEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_RainbowDrip);
+            bool cometEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_CometinBlack);
+            bool hammerEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_HammerStampCombo);
+            bool blizzardComboEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_BlizzardInCyan);
+            bool holyInWhiteEnabled = IsEnabled(Preset.PCT_AoE_AdvancedMode_HolyinWhite);
             #endregion
 
             #region Prepull
@@ -642,11 +603,11 @@ internal partial class PCT : Caster
 
             #region Special Content
             // Variant Cure
-            if (Variant.CanCure(CustomComboPreset.PCT_Variant_Cure, Config.PCT_VariantCure))
+            if (Variant.CanCure(Preset.PCT_Variant_Cure, PCT_VariantCure))
                 return Variant.Cure;
 
             // Variant Rampart
-            if (Variant.CanRampart(CustomComboPreset.PCT_Variant_Rampart, WeaveTypes.Weave))
+            if (Variant.CanRampart(Preset.PCT_Variant_Rampart, WeaveTypes.Weave))
                 return Variant.Rampart;
             
             if (OccultCrescent.ShouldUsePhantomActions())
@@ -684,7 +645,7 @@ internal partial class PCT : Caster
                     return SubtractivePalette;
 
                 //LucidDreaming
-                if (lucidDreamingEnabled && Role.CanLucidDream(Config.PCT_ST_AdvancedMode_LucidOption))
+                if (lucidDreamingEnabled && Role.CanLucidDream(PCT_ST_AdvancedMode_LucidOption))
                     return Role.LucidDreaming;
             }
             #endregion
@@ -700,7 +661,6 @@ internal partial class PCT : Caster
                 if (LandscapeMotifReady && GetTargetHPPercent() > landscapeStop)
                     return OriginalHook(LandscapeMotif);
             }
-
             #endregion
 
             #region Moving
@@ -725,11 +685,9 @@ internal partial class PCT : Caster
                     (CreatureMotifReady || WeaponMotifReady || LandscapeMotifReady))
                     return Role.Swiftcast;
             }
-
             #endregion
 
             #region Pre_Burst Motifs
-
             //Prepare for Burst
             if (GetCooldownRemainingTime(ScenicMuse) <= 20)
             {
@@ -742,11 +700,9 @@ internal partial class PCT : Caster
                 if (weaponMotifEnabled && WeaponMotifReady && GetTargetHPPercent() > weaponStop)
                     return OriginalHook(WeaponMotif);
             }
-
             #endregion
 
             #region GCDs
-
             //StarPrism
             if (starPrismEnabled && HasStatusEffect(Buffs.Starstruck))
                 return StarPrism;
@@ -787,85 +743,72 @@ internal partial class PCT : Caster
                 return OriginalHook(HolyInWhite);
 
             return actionID;
-
             #endregion
         }
     }
-
     #endregion
 
     #region Smaller Features
-
     internal class CombinedAetherhues : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.CombinedAetherhues;
-
+        protected internal override Preset Preset => Preset.CombinedAetherhues;
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not (FireInRed or FireIIinRed))
                 return actionID;
 
-            int choice = Config.CombinedAetherhueChoices;
+            int choice = CombinedAetherhueChoices;
 
             if (actionID == FireInRed && choice is 0 or 1)
             {
                 if (HasStatusEffect(Buffs.SubtractivePalette))
                     return OriginalHook(BlizzardinCyan);
             }
-
             if (actionID == FireIIinRed && choice is 0 or 2)
             {
                 if (HasStatusEffect(Buffs.SubtractivePalette))
                     return OriginalHook(BlizzardIIinCyan);
             }
-
             return actionID;
         }
     }
-
     internal class CombinedMotifs : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.CombinedMotifs;
-
+        protected internal override Preset Preset => Preset.CombinedMotifs;
         protected override uint Invoke(uint actionID)
         {
             PCTGauge gauge = GetJobGauge<PCTGauge>();
 
             if (actionID == CreatureMotif)
             {
-                if ((Config.CombinedMotifsMog && gauge.MooglePortraitReady) || (Config.CombinedMotifsMadeen && gauge.MadeenPortraitReady && IsOffCooldown(OriginalHook(MogoftheAges))))
+                if ((CombinedMotifsMog && gauge.MooglePortraitReady) || (CombinedMotifsMadeen && gauge.MadeenPortraitReady && IsOffCooldown(OriginalHook(MogoftheAges))))
                     return OriginalHook(MogoftheAges);
 
                 if (gauge.CreatureMotifDrawn)
                     return OriginalHook(LivingMuse);
             }
-
             if (actionID == WeaponMotif)
             {
-                if (Config.CombinedMotifsWeapon && HasStatusEffect(Buffs.HammerTime))
+                if (CombinedMotifsWeapon && HasStatusEffect(Buffs.HammerTime))
                     return OriginalHook(HammerStamp);
 
                 if (gauge.WeaponMotifDrawn)
                     return OriginalHook(SteelMuse);
             }
-
             if (actionID == LandscapeMotif)
             {
-                if (Config.CombinedMotifsLandscape && HasStatusEffect(Buffs.Starstruck))
+                if (CombinedMotifsLandscape && HasStatusEffect(Buffs.Starstruck))
                     return OriginalHook(StarPrism);
 
                 if (gauge.LandscapeMotifDrawn)
                     return OriginalHook(ScenicMuse);
             }
-
             return actionID;
         }
     }
-
     internal class CombinedPaint : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.CombinedPaint;
-
+        protected internal override Preset Preset => Preset.CombinedPaint;
         protected override uint Invoke(uint actionID)
         {
             if (actionID != HolyInWhite)
@@ -875,6 +818,5 @@ internal partial class PCT : Caster
             return actionID;
         }
     }
-
     #endregion
 }

--- a/WrathCombo/Combos/PvE/PCT/PCT_Config.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT_Config.cs
@@ -2,6 +2,8 @@ using ImGuiNET;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Extensions;
 using WrathCombo.Window.Functions;
+using Preset = WrathCombo.Combos.CustomComboPreset;
+using static WrathCombo.Window.Functions.UserConfig;
 
 namespace WrathCombo.Combos.PvE;
 
@@ -9,6 +11,7 @@ internal partial class PCT
 {
     internal static class Config
     {
+        #region Options
         public static UserInt
             CombinedAetherhueChoices = new("CombinedAetherhueChoices"),
             PCT_ST_AdvancedMode_LucidOption = new("PCT_ST_AdvancedMode_LucidOption", 6500),
@@ -25,108 +28,101 @@ internal partial class PCT
             PCT_Balance_Content = new("PCT_Balance_Content", 1);
 
         public static UserBool
-            WhiteHyperphantasiaOption = new("WhiteHyperphantasiaOption"),
-            BlackHyperphantasiaOption = new("BlackHyperphantasiaOption"),
             CombinedMotifsMog = new("CombinedMotifsMog"),
             CombinedMotifsMadeen = new("CombinedMotifsMadeen"),
             CombinedMotifsWeapon = new("CombinedMotifsWeapon"),
             CombinedMotifsLandscape = new("CombinedMotifsLandscape");
-
-
-        internal static void Draw(CustomComboPreset preset)
+        #endregion
+    
+        internal static void Draw(Preset preset)
         {
             switch (preset)
             {
-                case CustomComboPreset.PCT_ST_Advanced_Openers:
+                #region Single Target
+                case Preset.PCT_ST_Advanced_Openers:
                     ImGui.Indent();
-                    UserConfig.DrawHorizontalRadioButton(PCT_Opener_Choice, $"2nd GCD {StarryMuse.ActionName()}", "", 0);
-                    UserConfig.DrawHorizontalRadioButton(PCT_Opener_Choice, $"3rd GCD {StarryMuse.ActionName()}", "", 1);
-
+                    DrawHorizontalRadioButton(PCT_Opener_Choice, $"2nd GCD {StarryMuse.ActionName()}", "",
+                        0);
+                    DrawHorizontalRadioButton(PCT_Opener_Choice, $"3rd GCD {StarryMuse.ActionName()}", "",
+                        1);
                     ImGui.NewLine();
-                    UserConfig.DrawBossOnlyChoice(PCT_Balance_Content);
+                    DrawBossOnlyChoice(PCT_Balance_Content);
                     ImGui.Unindent();
                     break;
-                case CustomComboPreset.CombinedAetherhues:
-                    UserConfig.DrawRadioButton(CombinedAetherhueChoices, "Both Single Target & AoE",
-                        $"Replaces both {FireInRed.ActionName()} & {FireIIinRed.ActionName()}", 0);
 
-                    UserConfig.DrawRadioButton(CombinedAetherhueChoices, "Single Target Only",
-                        $"Replace only {FireInRed.ActionName()}", 1);
-
-                    UserConfig.DrawRadioButton(CombinedAetherhueChoices, "AoE Only",
-                        $"Replace only {FireIIinRed.ActionName()}", 2);
-
+                case Preset.PCT_ST_AdvancedMode_LucidDreaming:
+                    DrawSliderInt(0, 10000, PCT_ST_AdvancedMode_LucidOption,
+                        "Add Lucid Dreaming when below this MP", sliderIncrement: SliderIncrements.Hundreds);
                     break;
 
-                case CustomComboPreset.CombinedMotifs:
-                    UserConfig.DrawAdditionalBoolChoice(CombinedMotifsMog, $"{MogoftheAges.ActionName()} Feature",
-                        $"Add {MogoftheAges.ActionName()} when fully drawn and off cooldown.");
+                case Preset.PCT_ST_AdvancedMode_LandscapeMotif:
+                    DrawSliderInt(0, 10, PCT_ST_LandscapeStop, "Health % to stop Drawing Motif");
+                    break;
 
-                    UserConfig.DrawAdditionalBoolChoice(CombinedMotifsMadeen,
+                case Preset.PCT_ST_AdvancedMode_CreatureMotif:
+                    DrawSliderInt(0, 10, PCT_ST_CreatureStop, "Health % to stop Drawing Motif");
+                    break;
+
+                case Preset.PCT_ST_AdvancedMode_WeaponMotif:
+                    DrawSliderInt(0, 10, PCT_ST_WeaponStop, "Health % to stop Drawing Motif");
+                    break;
+
+                #endregion
+
+                #region AoE
+                case Preset.PCT_AoE_AdvancedMode_HolyinWhite:
+                    DrawSliderInt(0, 5, PCT_AoE_AdvancedMode_HolyinWhiteOption,
+                        "How many charges to keep ready? (0 = Use all)");
+                    break;
+
+                case Preset.PCT_AoE_AdvancedMode_LucidDreaming:
+                    DrawSliderInt(0, 10000, PCT_AoE_AdvancedMode_LucidOption,
+                        "Add Lucid Dreaming when below this MP", sliderIncrement: SliderIncrements.Hundreds);
+                    break;
+
+                case Preset.PCT_AoE_AdvancedMode_LandscapeMotif:
+                    DrawSliderInt(0, 10, PCT_AoE_LandscapeStop, "Health % to stop Drawing Motif");
+                    break;
+
+                case Preset.PCT_AoE_AdvancedMode_CreatureMotif:
+                    DrawSliderInt(0, 10, PCT_AoE_CreatureStop, "Health % to stop Drawing Motif");
+                    break;
+
+                case Preset.PCT_AoE_AdvancedMode_WeaponMotif:
+                    DrawSliderInt(0, 10, PCT_AoE_WeaponStop, "Health % to stop Drawing Motif");
+                    break;
+
+                #endregion
+
+                #region Standalone
+                case Preset.CombinedAetherhues:
+                    DrawRadioButton(CombinedAetherhueChoices, "Both Single Target & AoE",
+                        $"Replaces both {FireInRed.ActionName()} & {FireIIinRed.ActionName()}", 0);
+                    DrawRadioButton(CombinedAetherhueChoices, "Single Target Only",
+                        $"Replace only {FireInRed.ActionName()}", 1);
+                    DrawRadioButton(CombinedAetherhueChoices, "AoE Only",
+                        $"Replace only {FireIIinRed.ActionName()}", 2);
+                    break;
+
+                case Preset.CombinedMotifs:
+                    DrawAdditionalBoolChoice(CombinedMotifsMog, $"{MogoftheAges.ActionName()} Feature",
+                        $"Add {MogoftheAges.ActionName()} when fully drawn and off cooldown.");
+                    DrawAdditionalBoolChoice(CombinedMotifsMadeen,
                         $"{RetributionoftheMadeen.ActionName()} Feature",
                         $"Add {RetributionoftheMadeen.ActionName()} when fully drawn and off cooldown.");
-
-                    UserConfig.DrawAdditionalBoolChoice(CombinedMotifsWeapon, $"{HammerStamp.ActionName()} Feature",
+                    DrawAdditionalBoolChoice(CombinedMotifsWeapon, $"{HammerStamp.ActionName()} Feature",
                         $"Add {HammerStamp.ActionName()} when under the effect of {Buffs.HammerTime.StatusName()}.");
-
-                    UserConfig.DrawAdditionalBoolChoice(CombinedMotifsLandscape, $"{StarPrism.ActionName()} Feature",
+                    DrawAdditionalBoolChoice(CombinedMotifsLandscape, $"{StarPrism.ActionName()} Feature",
                         $"Add {StarPrism.ActionName()} when under the effect of {Buffs.Starstruck.StatusName()}.");
                     break;
 
-                case CustomComboPreset.PCT_ST_AdvancedMode_LucidDreaming:
-                    UserConfig.DrawSliderInt(0, 10000, PCT_ST_AdvancedMode_LucidOption,
-                        "Add Lucid Dreaming when below this MP", sliderIncrement: SliderIncrements.Hundreds);
-
+                case Preset.PCT_Variant_Cure:
+                    DrawSliderInt(1, 100, PCT_VariantCure, "HP% to be at or under", 200);
                     break;
 
-                case CustomComboPreset.PCT_AoE_AdvancedMode_HolyinWhite:
-                    UserConfig.DrawSliderInt(0, 5, PCT_AoE_AdvancedMode_HolyinWhiteOption,
-                        "How many charges to keep ready? (0 = Use all)");
-
-                    break;
-
-                case CustomComboPreset.PCT_AoE_AdvancedMode_LucidDreaming:
-                    UserConfig.DrawSliderInt(0, 10000, PCT_AoE_AdvancedMode_LucidOption,
-                        "Add Lucid Dreaming when below this MP", sliderIncrement: SliderIncrements.Hundreds);
-
-                    break;
-
-                case CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif:
-                    UserConfig.DrawSliderInt(0, 10, PCT_ST_LandscapeStop, "Health % to stop Drawing Motif");
-
-                    break;
-
-                case CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif:
-                    UserConfig.DrawSliderInt(0, 10, PCT_ST_CreatureStop, "Health % to stop Drawing Motif");
-
-                    break;
-
-                case CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif:
-                    UserConfig.DrawSliderInt(0, 10, PCT_ST_WeaponStop, "Health % to stop Drawing Motif");
-
-                    break;
-
-                case CustomComboPreset.PCT_AoE_AdvancedMode_LandscapeMotif:
-                    UserConfig.DrawSliderInt(0, 10, PCT_AoE_LandscapeStop, "Health % to stop Drawing Motif");
-
-                    break;
-
-                case CustomComboPreset.PCT_AoE_AdvancedMode_CreatureMotif:
-                    UserConfig.DrawSliderInt(0, 10, PCT_AoE_CreatureStop, "Health % to stop Drawing Motif");
-
-                    break;
-
-                case CustomComboPreset.PCT_AoE_AdvancedMode_WeaponMotif:
-                    UserConfig.DrawSliderInt(0, 10, PCT_AoE_WeaponStop, "Health % to stop Drawing Motif");
-
-                    break;
-
-                case CustomComboPreset.PCT_Variant_Cure:
-                    UserConfig.DrawSliderInt(1, 100, PCT_VariantCure, "HP% to be at or under", 200);
-
-                    break;
-                
+                #endregion
             }
         }
     }
+    
 }

--- a/WrathCombo/Combos/PvE/PCT/PCT_Helper.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT_Helper.cs
@@ -6,6 +6,8 @@ using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 using WrathCombo.Extensions;
+using Preset = WrathCombo.Combos.CustomComboPreset;
+using static WrathCombo.Combos.PvE.PCT.Config;
 #endregion
 
 namespace WrathCombo.Combos.PvE;
@@ -13,11 +15,8 @@ namespace WrathCombo.Combos.PvE;
 internal partial class PCT
 {
     #region Variables
-
     // Gauge Stuff
     internal static PCTGauge gauge = GetJobGauge<PCTGauge>();
-
-
     //Useful Bools
     internal static bool ScenicMuseReady => gauge.LandscapeMotifDrawn && ActionReady(ScenicMuse);
     internal static bool LivingMuseReady => ActionReady(LivingMuse) && gauge.CreatureMotifDrawn;
@@ -30,14 +29,9 @@ internal partial class PCT
                                             (HasStatusEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50 && ScenicCD > 40 || gauge.PalleteGauge == 100);
     internal static bool HasPaint => gauge.Paint > 0;
     internal static bool BurstPhaseReady => LevelChecked(StarPrism) && InCombat() && (ScenicCD <= 5 || HasStatusEffect(Buffs.StarryMuse) && gauge.PalleteGauge >= 50);
-
-
-
     //Buff Tracking
     internal static float ScenicCD => GetCooldownRemainingTime(StarryMuse);
     internal static float SteelCD => GetCooldownRemainingTime(StrikingMuse);
-
-
     #endregion
 
     #region Functions
@@ -48,18 +42,15 @@ internal partial class PCT
     {
         if (GetStatusEffectStacks(Buffs.Hyperphantasia) > 0 && HasStatusEffect(Buffs.Inspiration) && HasPaint)
         {
-            if ((IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HolyInWhite) || IsEnabled(CustomComboPreset.PCT_ST_SimpleMode)) 
+            if ((IsEnabled(Preset.PCT_ST_AdvancedMode_MovementOption_HolyInWhite) || IsEnabled(Preset.PCT_ST_SimpleMode)) 
                 && HolyInWhite.LevelChecked())
                 return true;
-
-            if ((IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_CometinBlack) || IsEnabled(CustomComboPreset.PCT_ST_SimpleMode)) 
+            if ((IsEnabled(Preset.PCT_ST_AdvancedMode_MovementOption_CometinBlack) || IsEnabled(Preset.PCT_ST_SimpleMode)) 
                 && CometinBlack.LevelChecked())
                 return true;
         }
         return false;
     }
-
-
     internal static uint BurstWindow(uint actionId)
     {
         if (LandscapeMotifReady) //Emergency Landscape Paint if someone started a fight with no motifs.
@@ -81,7 +72,6 @@ internal partial class PCT
             if (ScenicMuseReady && (CanDelayedWeave() || !CanWeave()) && IsOffCooldown(ScenicMuse)) // The !canweave option is specifically so that it can minimize drift IF it does not catch the delayed weave in time.
                 return OriginalHook(ScenicMuse);            
         }
-
         if (HyperPhantasiaMovementPaint() && IsMoving())
             return HasStatusEffect(Buffs.MonochromeTones) ? OriginalHook(CometinBlack) : OriginalHook(HolyInWhite);
 
@@ -123,8 +113,6 @@ internal partial class PCT
         }
         return actionId;
     }
-
-   
     #endregion
 
     #region ID's
@@ -195,7 +183,6 @@ internal partial class PCT
     #endregion
 
     #region Openers
-
     internal static PCTopenerMaxLevel1 Opener1 = new();
     internal static PCTopenerMaxLevel2 Opener2 = new();
 
@@ -203,15 +190,12 @@ internal partial class PCT
 
     internal static WrathOpener Opener()
     {
-        if (Opener1.LevelChecked && Config.PCT_Opener_Choice == 0)
+        if (Opener1.LevelChecked && PCT_Opener_Choice == 0)
             return Opener1;
-
-        if (Opener2.LevelChecked && Config.PCT_Opener_Choice == 1)
+        if (Opener2.LevelChecked && PCT_Opener_Choice == 1)
             return Opener2;
-
         return WrathOpener.Dummy;
     }
-
     public static bool HasMotifs()
     {
 
@@ -226,12 +210,10 @@ internal partial class PCT
 
         return true;
     }
-
     internal class PCTopenerMaxLevel1 : WrathOpener
     {
         //2nd GCD Starry Opener
         public override int MinOpenerLevel => 100;
-
         public override int MaxOpenerLevel => 109;
         public override List<uint> OpenerActions { get; set; } =
         [
@@ -256,7 +238,7 @@ internal partial class PCT
             ClawMotif,
             ClawedMuse,//20
         ];
-        internal override UserData? ContentCheckConfig => Config.PCT_Balance_Content;
+        internal override UserData? ContentCheckConfig => PCT_Balance_Content;
 
         public override List<(int[] Steps, uint NewAction, Func<bool> Condition)> SubstitutionSteps { get; set; } =
 [
@@ -290,12 +272,10 @@ internal partial class PCT
             return true;
         }
     }
-
     internal class PCTopenerMaxLevel2 : WrathOpener
     {
         //3rd GCD Starry Opener
         public override int MinOpenerLevel => 100;
-
         public override int MaxOpenerLevel => 109;
         public override List<uint> OpenerActions { get; set; } =
         [
@@ -322,7 +302,7 @@ internal partial class PCT
             ClawMotif,
             ClawedMuse
         ];
-        internal override UserData? ContentCheckConfig => Config.PCT_Balance_Content;
+        internal override UserData? ContentCheckConfig => PCT_Balance_Content;
 
         public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } = [([18], () => !HasStatusEffect(Buffs.RainbowBright))];
 
@@ -357,7 +337,6 @@ internal partial class PCT
 
             return true;
         }
-        
     }
 #endregion
 }

--- a/WrathCombo/Combos/PvE/RDM/RDM.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM.cs
@@ -556,6 +556,25 @@ internal partial class RDM : Caster
                 (HasEnoughManaToStartStandalone || CanMagickedSwordplay) && !InMeleeRange()) 
                 return Corpsacorps;
             
+            if (IsEnabled(Preset.RDM_Riposte_Weaves) && CanWeave())
+            {
+                if (RDM_Riposte_Weaves_Options[0] && ActionReady(Fleche))
+                    return Fleche;
+                if (RDM_Riposte_Weaves_Options[1] && ActionReady(ContreSixte))
+                    return ContreSixte;
+                if (RDM_Riposte_Weaves_Options[2] && HasStatusEffect(Buffs.ThornedFlourish))
+                    return ViceOfThorns;
+                if (RDM_Riposte_Weaves_Options[3] && CanPrefulgence)
+                    return Prefulgence;
+                if (RDM_Riposte_Weaves_Options[4] && InMeleeRange() &&
+                    GetRemainingCharges(Engagement) > RDM_Riposte_Weaves_Options_EngagementCharges)
+                    return Engagement;
+                if (RDM_Riposte_Weaves_Options[5] &&
+                    GetRemainingCharges(Corpsacorps) > RDM_Riposte_Weaves_Options_CorpsCharges && 
+                    (InMeleeRange() || GetTargetDistance() <= RDM_Riposte_Weaves_Options_Corpsacorps_Distance))
+                    return Corpsacorps;
+            }
+            
             if (IsEnabled(Preset.RDM_Riposte_Finisher))
             {
                 if (ComboAction is Scorch && LevelChecked(Resolution) || ComboAction is Verholy or Verflare && LevelChecked(Scorch)) 
@@ -593,6 +612,25 @@ internal partial class RDM : Caster
             if (IsEnabled(Preset.RDM_Moulinet_GapCloser) && ActionReady(Corpsacorps) && 
                 (HasEnoughManaToStartStandalone || CanMagickedSwordplay) && !InMeleeRange()) 
                 return Corpsacorps;
+            
+            if (IsEnabled(Preset.RDM_Moulinet_Weaves) && CanWeave())
+            {
+                if (RDM_Moulinet_Weaves_Options[0] && ActionReady(Fleche))
+                    return Fleche;
+                if (RDM_Moulinet_Weaves_Options[1] && ActionReady(ContreSixte))
+                    return ContreSixte;
+                if (RDM_Moulinet_Weaves_Options[2] && HasStatusEffect(Buffs.ThornedFlourish))
+                    return ViceOfThorns;
+                if (RDM_Moulinet_Weaves_Options[3] && CanPrefulgence)
+                    return Prefulgence;
+                if (RDM_Moulinet_Weaves_Options[4] && InMeleeRange() &&
+                    GetRemainingCharges(Engagement) > RDM_Moulinet_Weaves_Options_EngagementCharges)
+                    return Engagement;
+                if (RDM_Moulinet_Weaves_Options[5] &&
+                    GetRemainingCharges(Corpsacorps) > RDM_Moulinet_Weaves_Options_CorpsCharges && 
+                    (InMeleeRange() || GetTargetDistance() <= RDM_Moulinet_Weaves_Options_Corpsacorps_Distance))
+                    return Corpsacorps;
+            }
             
             if (IsEnabled(Preset.RDM_Moulinet_Finisher))
             {

--- a/WrathCombo/Combos/PvE/RDM/RDM.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM.cs
@@ -1,7 +1,8 @@
 using System;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
-using WrathCombo.Data;
+using Preset = WrathCombo.Combos.CustomComboPreset;
+using static WrathCombo.Combos.PvE.RDM.Config;
 
 namespace WrathCombo.Combos.PvE;
 
@@ -10,7 +11,8 @@ internal partial class RDM : Caster
     #region Simple Modes
     internal class RDM_ST_SimpleMode : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_ST_SimpleMode;
+        protected internal override Preset Preset => Preset.RDM_ST_SimpleMode;
+
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not (Jolt or Jolt2 or Jolt3))
@@ -20,10 +22,10 @@ internal partial class RDM : Caster
             if (OccultCrescent.ShouldUsePhantomActions())
                 return OccultCrescent.BestPhantomAction();
                 
-            if (Variant.CanCure(CustomComboPreset.RDM_Variant_Cure, Config.RDM_VariantCure))
+            if (Variant.CanCure(Preset.RDM_Variant_Cure, RDM_VariantCure))
                 return Variant.Cure;
 
-            if (Variant.CanRampart(CustomComboPreset.RDM_Variant_Rampart))
+            if (Variant.CanRampart(Preset.RDM_Variant_Rampart))
                 return Variant.Rampart;
 
             #endregion
@@ -111,7 +113,8 @@ internal partial class RDM : Caster
     
     internal class RDM_AoE_SimpleMode : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_AoE_SimpleMode;
+        protected internal override Preset Preset => Preset.RDM_AoE_SimpleMode;
+
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not (Scatter or Impact))
@@ -121,10 +124,10 @@ internal partial class RDM : Caster
             if (OccultCrescent.ShouldUsePhantomActions())
                 return OccultCrescent.BestPhantomAction();
                 
-            if (Variant.CanCure(CustomComboPreset.RDM_Variant_Cure, Config.RDM_VariantCure))
+            if (Variant.CanCure(Preset.RDM_Variant_Cure, RDM_VariantCure))
                 return Variant.Cure;
 
-            if (Variant.CanRampart(CustomComboPreset.RDM_Variant_Rampart))
+            if (Variant.CanRampart(Preset.RDM_Variant_Rampart))
                 return Variant.Rampart;
             #endregion
             
@@ -177,7 +180,7 @@ internal partial class RDM : Caster
             if (HasManaStacks) 
                 return UseHolyFlare(actionID);
             
-            if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo))
+            if (IsEnabled(Preset.RDM_AoE_MeleeCombo))
             {
                 if (ActionReady(Moulinet) && HasBattleTarget() && GetTargetDistance() < 8 && 
                     (CanMagickedSwordplay ||HasEnoughManaToStart || ComboAction is EnchantedMoulinet or Moulinet or EnchantedMoulinetDeux && HasEnoughManaForCombo))
@@ -211,14 +214,15 @@ internal partial class RDM : Caster
     #region Advanced Modes
     internal class RDM_ST_DPS : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_ST_DPS;
+        protected internal override Preset Preset => Preset.RDM_ST_DPS;
+
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not (Jolt or Jolt2 or Jolt3))
                 return actionID;
             
             #region Opener
-            if (IsEnabled(CustomComboPreset.RDM_Balance_Opener) && HasBattleTarget() &&
+            if (IsEnabled(Preset.RDM_Balance_Opener) && HasBattleTarget() &&
                 Opener().FullOpener(ref actionID)) 
                 return actionID;
             #endregion
@@ -227,56 +231,56 @@ internal partial class RDM : Caster
             if (OccultCrescent.ShouldUsePhantomActions())
                 return OccultCrescent.BestPhantomAction();
                 
-            if (Variant.CanCure(CustomComboPreset.RDM_Variant_Cure, Config.RDM_VariantCure))
+            if (Variant.CanCure(Preset.RDM_Variant_Cure, RDM_VariantCure))
                 return Variant.Cure;
 
-            if (Variant.CanRampart(CustomComboPreset.RDM_Variant_Rampart))
+            if (Variant.CanRampart(Preset.RDM_Variant_Rampart))
                 return Variant.Rampart;
             #endregion
 
             #region OGCDs
             if (CanWeave())
             {
-                if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_GapCloser) && 
+                if (IsEnabled(Preset.RDM_ST_MeleeCombo_GapCloser) && 
                     ActionReady(Corpsacorps) && (HasEnoughManaToStart || CanMagickedSwordplay) && !InMeleeRange()) 
                     return Corpsacorps;
                  
-                if (IsEnabled(CustomComboPreset.RDM_ST_Manafication) && ActionReady(Manafication) && (EmboldenCD <= 5 || HasEmbolden) && !CanPrefulgence) 
+                if (IsEnabled(Preset.RDM_ST_Manafication) && ActionReady(Manafication) && (EmboldenCD <= 5 || HasEmbolden) && !CanPrefulgence) 
                     return Manafication;
                 
-                if (IsEnabled(CustomComboPreset.RDM_ST_Embolden) && ActionReady(Embolden) && !HasEmbolden) 
+                if (IsEnabled(Preset.RDM_ST_Embolden) && ActionReady(Embolden) && !HasEmbolden) 
                     return Embolden;
                 
-                if (IsEnabled(CustomComboPreset.RDM_ST_ContreSixte) && ActionReady(ContreSixte)) 
+                if (IsEnabled(Preset.RDM_ST_ContreSixte) && ActionReady(ContreSixte)) 
                     return ContreSixte;
                 
-                if (IsEnabled(CustomComboPreset.RDM_ST_Fleche) && ActionReady(Fleche)) 
+                if (IsEnabled(Preset.RDM_ST_Fleche) && ActionReady(Fleche)) 
                     return Fleche;
                 
-                if (IsEnabled(CustomComboPreset.RDM_ST_Engagement) && CanEngagement && (IsNotEnabled(CustomComboPreset.RDM_ST_Engagement_Pooling) || PoolEngagement))  
+                if (IsEnabled(Preset.RDM_ST_Engagement) && CanEngagement && (IsNotEnabled(Preset.RDM_ST_Engagement_Pooling) || PoolEngagement))  
                     return Engagement;
                 
-                if (IsEnabled(CustomComboPreset.RDM_ST_Corpsacorps) && CanCorps && 
-                    GetTargetDistance()<= Config.RDM_ST_Corpsacorps_Distance &&
-                    TimeStoodStill >= TimeSpan.FromSeconds(Config.RDM_ST_Corpsacorps_Time))
+                if (IsEnabled(Preset.RDM_ST_Corpsacorps) && CanCorps && 
+                    GetTargetDistance()<= RDM_ST_Corpsacorps_Distance &&
+                    TimeStoodStill >= TimeSpan.FromSeconds(RDM_ST_Corpsacorps_Time))
                     return Corpsacorps;
                 
-                if (IsEnabled(CustomComboPreset.RDM_ST_Prefulgence) && CanPrefulgence)
+                if (IsEnabled(Preset.RDM_ST_Prefulgence) && CanPrefulgence)
                     return Prefulgence;
                 
-                if (IsEnabled(CustomComboPreset.RDM_ST_ViceOfThorns) && CanViceOfThorns)
+                if (IsEnabled(Preset.RDM_ST_ViceOfThorns) && CanViceOfThorns)
                     return ViceOfThorns;
                 
-                if (IsEnabled(CustomComboPreset.RDM_ST_Lucid) && Role.CanLucidDream(Config.RDM_ST_Lucid_Threshold))
+                if (IsEnabled(Preset.RDM_ST_Lucid) && Role.CanLucidDream(RDM_ST_Lucid_Threshold))
                     return Role.LucidDreaming;
                 
-                if (IsEnabled(CustomComboPreset.RDM_ST_Acceleration) && 
-                    (CanAcceleration && GetRemainingCharges(Acceleration) > Config.RDM_ST_Acceleration_Charges || 
-                    CanAccelerationMovement && IsEnabled(CustomComboPreset.RDM_ST_Acceleration_Movement))) 
+                if (IsEnabled(Preset.RDM_ST_Acceleration) && 
+                    (CanAcceleration && GetRemainingCharges(Acceleration) > RDM_ST_Acceleration_Charges || 
+                    CanAccelerationMovement && IsEnabled(Preset.RDM_ST_Acceleration_Movement))) 
                     return Acceleration;
                 
-                if (IsEnabled(CustomComboPreset.RDM_ST_Swiftcast) && 
-                    (!IsEnabled(CustomComboPreset.RDM_ST_SwiftcastMovement) && CanSwiftcast || CanSwiftcastMovement))
+                if (IsEnabled(Preset.RDM_ST_Swiftcast) && 
+                    (!IsEnabled(Preset.RDM_ST_SwiftcastMovement) && CanSwiftcast || CanSwiftcastMovement))
                     return Role.Swiftcast;
             }
             #endregion
@@ -285,12 +289,12 @@ internal partial class RDM : Caster
             if (ComboAction is Scorch && LevelChecked(Resolution) || ComboAction is Verholy or Verflare && LevelChecked(Scorch)) 
                 return actionID;
 
-            if (IsEnabled(CustomComboPreset.RDM_ST_HolyFlare) && HasManaStacks) 
+            if (IsEnabled(Preset.RDM_ST_HolyFlare) && HasManaStacks) 
                 return UseHolyFlare(actionID);
             
-            if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo) )
+            if (IsEnabled(Preset.RDM_ST_MeleeCombo) )
             {
-                if ((InMeleeRange() || IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_MeleeCheck)) && (HasEnoughManaForCombo || CanMagickedSwordplay))
+                if ((InMeleeRange() || IsEnabled(Preset.RDM_ST_MeleeCombo_MeleeCheck)) && (HasEnoughManaForCombo || CanMagickedSwordplay))
                 {
                     if (ComboAction is Zwerchhau or EnchantedZwerchhau && LevelChecked(Redoublement)) 
                         return EnchantedRedoublement;
@@ -298,7 +302,7 @@ internal partial class RDM : Caster
                         return EnchantedZwerchhau;
                 }
                 
-                if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_IncludeRiposte) && ActionReady(EnchantedRiposte) && 
+                if (IsEnabled(Preset.RDM_ST_MeleeCombo_IncludeRiposte) && ActionReady(EnchantedRiposte) && 
                     InMeleeRange() && !HasDualcast && !HasAccelerate && !HasSwiftcast &&
                     (HasEnoughManaToStart || CanMagickedSwordplay)) 
                     return EnchantedRiposte;
@@ -306,13 +310,13 @@ internal partial class RDM : Caster
             #endregion
             
             #region GCD Casts
-            if (IsEnabled(CustomComboPreset.RDM_ST_ThunderAero) && CanInstantCast)
+            if (IsEnabled(Preset.RDM_ST_ThunderAero) && CanInstantCast)
                 return UseInstantCastST(actionID);
             
             if (CanGrandImpact) 
                 return GrandImpact;
 
-            if (IsEnabled(CustomComboPreset.RDM_ST_FireStone))
+            if (IsEnabled(Preset.RDM_ST_FireStone))
             {
                 if (UseVerStone())
                     return Verstone;
@@ -327,7 +331,8 @@ internal partial class RDM : Caster
    
     internal class RDM_AoE_DPS : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_AoE_DPS;
+        protected internal override Preset Preset => Preset.RDM_AoE_DPS;
+
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not (Scatter or Impact))
@@ -337,56 +342,56 @@ internal partial class RDM : Caster
             if (OccultCrescent.ShouldUsePhantomActions())
                 return OccultCrescent.BestPhantomAction();
                 
-            if (Variant.CanCure(CustomComboPreset.RDM_Variant_Cure, Config.RDM_VariantCure))
+            if (Variant.CanCure(Preset.RDM_Variant_Cure, RDM_VariantCure))
                 return Variant.Cure;
 
-            if (Variant.CanRampart(CustomComboPreset.RDM_Variant_Rampart))
+            if (Variant.CanRampart(Preset.RDM_Variant_Rampart))
                 return Variant.Rampart;
             #endregion
 
             #region OGCDs
             if (CanWeave())
             {
-                if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo_GapCloser) && 
+                if (IsEnabled(Preset.RDM_AoE_MeleeCombo_GapCloser) && 
                     ActionReady(Corpsacorps) && (HasEnoughManaToStart || CanMagickedSwordplay) && !InMeleeRange()) 
                     return Corpsacorps;
                  
-                if (IsEnabled(CustomComboPreset.RDM_AoE_Manafication) && ActionReady(Manafication) && (EmboldenCD <= 5 || HasEmbolden) && !CanPrefulgence) 
+                if (IsEnabled(Preset.RDM_AoE_Manafication) && ActionReady(Manafication) && (EmboldenCD <= 5 || HasEmbolden) && !CanPrefulgence) 
                     return Manafication;
                 
-                if (IsEnabled(CustomComboPreset.RDM_AoE_Embolden) && ActionReady(Embolden) && !HasEmbolden) 
+                if (IsEnabled(Preset.RDM_AoE_Embolden) && ActionReady(Embolden) && !HasEmbolden) 
                     return Embolden;
                 
-                if (IsEnabled(CustomComboPreset.RDM_AoE_ContreSixte) && ActionReady(ContreSixte)) 
+                if (IsEnabled(Preset.RDM_AoE_ContreSixte) && ActionReady(ContreSixte)) 
                     return ContreSixte;
                 
-                if (IsEnabled(CustomComboPreset.RDM_AoE_Fleche) && ActionReady(Fleche)) 
+                if (IsEnabled(Preset.RDM_AoE_Fleche) && ActionReady(Fleche)) 
                     return Fleche;
                 
-                if (IsEnabled(CustomComboPreset.RDM_AoE_Engagement) && CanEngagement && (IsNotEnabled(CustomComboPreset.RDM_AoE_Engagement_Pooling) || PoolEngagement))  
+                if (IsEnabled(Preset.RDM_AoE_Engagement) && CanEngagement && (IsNotEnabled(Preset.RDM_AoE_Engagement_Pooling) || PoolEngagement))  
                     return Engagement;
 
-                if (IsEnabled(CustomComboPreset.RDM_AoE_Corpsacorps) && CanCorps &&
-                    GetTargetDistance() <= Config.RDM_AoE_Corpsacorps_Distance &&
-                    TimeStoodStill >= TimeSpan.FromSeconds(Config.RDM_AoE_Corpsacorps_Time))
+                if (IsEnabled(Preset.RDM_AoE_Corpsacorps) && CanCorps &&
+                    GetTargetDistance() <= RDM_AoE_Corpsacorps_Distance &&
+                    TimeStoodStill >= TimeSpan.FromSeconds(RDM_AoE_Corpsacorps_Time))
                     return Corpsacorps;
                     
-                if (IsEnabled(CustomComboPreset.RDM_AoE_Prefulgence) && CanPrefulgence)
+                if (IsEnabled(Preset.RDM_AoE_Prefulgence) && CanPrefulgence)
                     return Prefulgence;
                 
-                if (IsEnabled(CustomComboPreset.RDM_AoE_ViceOfThorns) && CanViceOfThorns)
+                if (IsEnabled(Preset.RDM_AoE_ViceOfThorns) && CanViceOfThorns)
                     return ViceOfThorns;
                 
-                if (IsEnabled(CustomComboPreset.RDM_AoE_Lucid) && Role.CanLucidDream(Config.RDM_AoE_Lucid_Threshold))
+                if (IsEnabled(Preset.RDM_AoE_Lucid) && Role.CanLucidDream(RDM_AoE_Lucid_Threshold))
                     return Role.LucidDreaming;
                 
-                if (IsEnabled(CustomComboPreset.RDM_AoE_Acceleration) && 
-                    (CanAcceleration && GetRemainingCharges(Acceleration) > Config.RDM_AoE_Acceleration_Charges || 
-                    CanAccelerationMovement && IsEnabled(CustomComboPreset.RDM_AoE_Acceleration_Movement))) 
+                if (IsEnabled(Preset.RDM_AoE_Acceleration) && 
+                    (CanAcceleration && GetRemainingCharges(Acceleration) > RDM_AoE_Acceleration_Charges || 
+                    CanAccelerationMovement && IsEnabled(Preset.RDM_AoE_Acceleration_Movement))) 
                     return Acceleration;
                 
-                if (IsEnabled(CustomComboPreset.RDM_AoE_Swiftcast) && 
-                    (!IsEnabled(CustomComboPreset.RDM_AoE_SwiftcastMovement) && CanSwiftcast || CanSwiftcastMovement))
+                if (IsEnabled(Preset.RDM_AoE_Swiftcast) && 
+                    (!IsEnabled(Preset.RDM_AoE_SwiftcastMovement) && CanSwiftcast || CanSwiftcastMovement))
                     return Role.Swiftcast;
             }
             #endregion
@@ -395,13 +400,13 @@ internal partial class RDM : Caster
             if (ComboAction is Scorch && LevelChecked(Resolution) || ComboAction is Verholy or Verflare && LevelChecked(Scorch)) 
                 return actionID;
             
-            if (IsEnabled(CustomComboPreset.RDM_AoE_HolyFlare) && HasManaStacks) 
+            if (IsEnabled(Preset.RDM_AoE_HolyFlare) && HasManaStacks) 
                 return UseHolyFlare(actionID);   
 
-            if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo))
+            if (IsEnabled(Preset.RDM_AoE_MeleeCombo))
             {
                 if (ActionReady(Moulinet) && 
-                    (IsNotEnabled(CustomComboPreset.RDM_AoE_MeleeCombo_Target) && !HasBattleTarget() || HasBattleTarget() && GetTargetDistance() < 8) && 
+                    (IsNotEnabled(Preset.RDM_AoE_MeleeCombo_Target) && !HasBattleTarget() || HasBattleTarget() && GetTargetDistance() < 8) && 
                     (CanMagickedSwordplay ||HasEnoughManaToStart || ComboAction is EnchantedMoulinet or Moulinet or EnchantedMoulinetDeux && HasEnoughManaForCombo))
                     return OriginalHook(Moulinet);
                 
@@ -421,7 +426,7 @@ internal partial class RDM : Caster
             if (CanGrandImpact) 
                 return GrandImpact;
             
-            if (IsEnabled(CustomComboPreset.RDM_AoE_ThunderAero) && !CanInstantCast)
+            if (IsEnabled(Preset.RDM_AoE_ThunderAero) && !CanInstantCast)
                 return UseThunderAeroAoE(actionID);
 
             return !LevelChecked(Scatter) ? UseInstantCastST(actionID) : actionID;
@@ -433,7 +438,7 @@ internal partial class RDM : Caster
     #region Standalone Features
     internal class RDM_VariantVerCure : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_Variant_Cure2;
+        protected internal override Preset Preset => Preset.RDM_Variant_Cure2;
 
         protected override uint Invoke(uint actionID) =>
             actionID is Vercure && Variant.CanCure(Preset, 100)
@@ -443,7 +448,8 @@ internal partial class RDM : Caster
     
     internal class RDM_Verraise : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_Raise;
+        protected internal override Preset Preset => Preset.RDM_Raise;
+
         protected override uint Invoke(uint actionID)
         {
             /*
@@ -458,8 +464,8 @@ internal partial class RDM : Caster
             if (actionID != Role.Swiftcast)
                 return actionID;
 
-            if (Variant.CanRaise(CustomComboPreset.RDM_Variant_Raise))
-                return IsEnabled(CustomComboPreset.RDM_Raise_Retarget)
+            if (Variant.CanRaise(Preset.RDM_Variant_Raise))
+                return IsEnabled(Preset.RDM_Raise_Retarget)
                     ? Variant.Raise.Retarget(Role.Swiftcast,
                         SimpleTarget.Stack.AllyToRaise)
                     : Variant.Raise;
@@ -468,15 +474,15 @@ internal partial class RDM : Caster
             {
                 bool schwifty = HasStatusEffect(Role.Buffs.Swiftcast);
                 if (schwifty || HasStatusEffect(Buffs.Dualcast))
-                    return IsEnabled(CustomComboPreset.RDM_Raise_Retarget)
+                    return IsEnabled(Preset.RDM_Raise_Retarget)
                         ? Verraise.Retarget(Role.Swiftcast,
                             SimpleTarget.Stack.AllyToRaise)
                         : Verraise;
-                if (IsEnabled(CustomComboPreset.RDM_Raise_Vercure) &&
+                if (IsEnabled(Preset.RDM_Raise_Vercure) &&
                     !schwifty &&
                     ActionReady(Vercure) &&
                     IsOnCooldown(Role.Swiftcast))
-                    return IsEnabled(CustomComboPreset.RDM_Raise_Retarget)
+                    return IsEnabled(Preset.RDM_Raise_Retarget)
                         ? Vercure.Retarget(Role.Swiftcast,
                             SimpleTarget.Stack.AllyToHeal)
                         : Vercure;
@@ -489,7 +495,7 @@ internal partial class RDM : Caster
     
     internal class RDM_VerAero : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_VerAero;
+        protected internal override Preset Preset => Preset.RDM_VerAero;
 
         protected override uint Invoke(uint actionID)
         {
@@ -502,7 +508,7 @@ internal partial class RDM : Caster
             if (HasManaStacks)
                 return UseHolyFlare(actionID);
 
-            if (IsEnabled(CustomComboPreset.RDM_VerAero_Stone) && CanVerStone)
+            if (IsEnabled(Preset.RDM_VerAero_Stone) && CanVerStone)
                 return Verstone;
 
             if (!HasDualcast && !HasSwiftcast)
@@ -514,7 +520,7 @@ internal partial class RDM : Caster
 
     internal class RDM_VerThunder : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_VerThunder;
+        protected internal override Preset Preset => Preset.RDM_VerThunder;
 
         protected override uint Invoke(uint actionID)
         {
@@ -527,7 +533,7 @@ internal partial class RDM : Caster
             if (HasManaStacks) 
                 return UseHolyFlare(actionID);
 
-            if (IsEnabled(CustomComboPreset.RDM_VerThunder_Fire) && CanVerFire) 
+            if (IsEnabled(Preset.RDM_VerThunder_Fire) && CanVerFire) 
                 return Verfire;
         
             if (!HasDualcast && !HasSwiftcast)
@@ -539,18 +545,18 @@ internal partial class RDM : Caster
     
     internal class RDM_ST_Melee_Combo : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_Riposte;
+        protected internal override Preset Preset => Preset.RDM_Riposte;
 
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not Riposte)
                 return actionID;
             
-            if (IsEnabled(CustomComboPreset.RDM_Riposte_GapCloser) && ActionReady(Corpsacorps) && 
+            if (IsEnabled(Preset.RDM_Riposte_GapCloser) && ActionReady(Corpsacorps) && 
                 (HasEnoughManaToStartStandalone || CanMagickedSwordplay) && !InMeleeRange()) 
                 return Corpsacorps;
             
-            if (IsEnabled(CustomComboPreset.RDM_Riposte_Finisher))
+            if (IsEnabled(Preset.RDM_Riposte_Finisher))
             {
                 if (ComboAction is Scorch && LevelChecked(Resolution) || ComboAction is Verholy or Verflare && LevelChecked(Scorch)) 
                     return OriginalHook(Jolt);
@@ -568,7 +574,7 @@ internal partial class RDM : Caster
                     return EnchantedZwerchhau;
             }
             
-            if (IsEnabled(CustomComboPreset.RDM_Riposte_NoWaste) && !HasEnoughManaToStartStandalone && !CanMagickedSwordplay)
+            if (IsEnabled(Preset.RDM_Riposte_NoWaste) && !HasEnoughManaToStartStandalone && !CanMagickedSwordplay)
                 return All.SavageBlade;
 
             return actionID;
@@ -577,18 +583,18 @@ internal partial class RDM : Caster
     
     internal class RDM_AOE_Melee_Combo : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_Moulinet;
+        protected internal override Preset Preset => Preset.RDM_Moulinet;
 
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not Moulinet)
                 return actionID;
             
-            if (IsEnabled(CustomComboPreset.RDM_Moulinet_GapCloser) && ActionReady(Corpsacorps) && 
+            if (IsEnabled(Preset.RDM_Moulinet_GapCloser) && ActionReady(Corpsacorps) && 
                 (HasEnoughManaToStartStandalone || CanMagickedSwordplay) && !InMeleeRange()) 
                 return Corpsacorps;
             
-            if (IsEnabled(CustomComboPreset.RDM_Moulinet_Finisher))
+            if (IsEnabled(Preset.RDM_Moulinet_Finisher))
             {
                 if (ComboAction is Scorch && LevelChecked(Resolution) || ComboAction is Verholy or Verflare && LevelChecked(Scorch)) 
                     return OriginalHook(Jolt);
@@ -597,7 +603,7 @@ internal partial class RDM : Caster
                     return UseHolyFlare(actionID);
             }
             
-            if (IsEnabled(CustomComboPreset.RDM_Moulinet_NoWaste) && 
+            if (IsEnabled(Preset.RDM_Moulinet_NoWaste) && 
                 ComboAction is not (Moulinet or EnchantedMoulinet or EnchantedMoulinetDeux) && !HasEnoughManaToStartStandalone && !CanMagickedSwordplay)
                 return All.SavageBlade;
             
@@ -607,7 +613,8 @@ internal partial class RDM : Caster
 
     internal class RDM_CorpsDisplacement : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_CorpsDisplacement;
+        protected internal override Preset Preset => Preset.RDM_CorpsDisplacement;
+
         protected override uint Invoke(uint actionID) =>
             actionID is Displacement
             && LevelChecked(Displacement)
@@ -617,7 +624,7 @@ internal partial class RDM : Caster
 
     internal class RDM_EmboldenProtection: CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_EmboldenProtection;
+        protected internal override Preset Preset => Preset.RDM_EmboldenProtection;
 
         protected override uint Invoke(uint actionID)
         {
@@ -627,7 +634,7 @@ internal partial class RDM : Caster
             if (CanViceOfThorns)
                 return ViceOfThorns;
             
-            if (IsEnabled(CustomComboPreset.RDM_EmboldenManafication) && ActionReady(Manafication) &&
+            if (IsEnabled(Preset.RDM_EmboldenManafication) && ActionReady(Manafication) &&
                 (IsOnCooldown(Embolden) || HasStatusEffect(Buffs.Embolden, SimpleTarget.Self, true)))
                 return Manafication;
 
@@ -640,14 +647,14 @@ internal partial class RDM : Caster
 
     internal class RDM_MagickProtection : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_MagickProtection;
+        protected internal override Preset Preset => Preset.RDM_MagickProtection;
 
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not MagickBarrier)
                 return actionID;
             
-            if (IsEnabled(CustomComboPreset.RDM_MagickBarrierAddle))
+            if (IsEnabled(Preset.RDM_MagickBarrierAddle))
             {
                 if (Role.CanAddle() && CanNotMagickBarrier || 
                     GetCooldownRemainingTime(Role.Addle) < GetCooldownRemainingTime(MagickBarrier))
@@ -657,7 +664,7 @@ internal partial class RDM : Caster
             if (ActionReady(MagickBarrier) && HasStatusEffect(Buffs.MagickBarrier, anyOwner: true))
                 return All.SavageBlade;
             
-            if (IsEnabled(CustomComboPreset.RDM_MagickBarrierAddle) && GetCooldownRemainingTime(Role.Addle) < GetCooldownRemainingTime(MagickBarrier))
+            if (IsEnabled(Preset.RDM_MagickBarrierAddle) && GetCooldownRemainingTime(Role.Addle) < GetCooldownRemainingTime(MagickBarrier))
                 return Role.Addle;
             
             return actionID;
@@ -666,7 +673,7 @@ internal partial class RDM : Caster
     
     internal class RDM_OGCDs : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_OGCDs;
+        protected internal override Preset Preset => Preset.RDM_OGCDs;
 
         protected override uint Invoke(uint actionID)
         {
@@ -676,24 +683,29 @@ internal partial class RDM : Caster
             if (ActionReady(Fleche))
                 return Fleche;
             
-            if (ActionReady(ContreSixte)) 
+            if (RDM_OGCDs_Options[0] &&
+                ActionReady(ContreSixte)) 
                 return ContreSixte;
             
-            if (HasStatusEffect(Buffs.ThornedFlourish))
+            if (RDM_OGCDs_Options[1] &&
+                HasStatusEffect(Buffs.ThornedFlourish))
                 return ViceOfThorns;
             
-            if (CanPrefulgence)
+            if (RDM_OGCDs_Options[2] &&
+                CanPrefulgence)
                 return Prefulgence;
                 
-            if (GetRemainingCharges(Engagement) == 2 || 
-                (HasEmbolden || !LevelChecked(Embolden) || IsNotEnabled(CustomComboPreset.RDM_OGCDs_EngagementPool)) & HasCharges(Engagement) ||
-                GetRemainingCharges(Engagement) == 1 && GetCooldownChargeRemainingTime(Engagement) < EmboldenCD)
+            if (RDM_OGCDs_Options[3] &&
+                InMeleeRange() &&
+                GetRemainingCharges(Engagement) > RDM_OGCDs_Options_EngagementCharges)
                 return Engagement;
                 
-            if (GetRemainingCharges(Corpsacorps) == 2 && (InMeleeRange() || IsNotEnabled(CustomComboPreset.RDM_OGCDs_CorpsMelee)))
+            if (RDM_OGCDs_Options[4] &&
+                GetRemainingCharges(Corpsacorps) > RDM_OGCDs_Options_CorpsCharges && 
+                (InMeleeRange() || GetTargetDistance() <= RDM_OGCDs_Options_Corpsacorps_Distance))
                 return Corpsacorps;
 
-            return GetCooldownRemainingTime(ContreSixte) < GetCooldownRemainingTime(Fleche) ? ContreSixte : actionID;
+            return RDM_OGCDs_Options[0] && GetCooldownRemainingTime(ContreSixte) < GetCooldownRemainingTime(Fleche) ? ContreSixte : actionID;
         }
     }
     #endregion 

--- a/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
@@ -4,12 +4,14 @@ using WrathCombo.CustomComboNS.Functions;
 using static WrathCombo.Extensions.UIntExtensions;
 using static WrathCombo.Window.Functions.SliderIncrements;
 using static WrathCombo.Window.Functions.UserConfig;
+using Preset = WrathCombo.Combos.CustomComboPreset;
 
 namespace WrathCombo.Combos.PvE;
 internal partial class RDM
 {
     internal static class Config
     {
+        #region Options
         public static UserInt
             RDM_VariantCure = new("RDM_VariantCure"),
             RDM_ST_Lucid_Threshold = new("RDM_LucidDreaming_Threshold", 6500),
@@ -21,13 +23,22 @@ internal partial class RDM
             RDM_ST_Corpsacorps_Time = new("RDM_ST_Corpsacorps_Time", 0),
             RDM_AoE_Corpsacorps_Distance = new("RDM_AoE_Corpsacorps_Distance", 25),
             RDM_AoE_Corpsacorps_Time = new("RDM_AoE_Corpsacorps_Time", 0),
-            RDM_Opener_Selection = new("RDM_Opener_Selection", 0);
+            RDM_Opener_Selection = new("RDM_Opener_Selection", 0),
+            RDM_OGCDs_Options_CorpsCharges = new("RDM_OGCDs_Options_CorpsCharges", 0),
+            RDM_OGCDs_Options_EngagementCharges = new("RDM_OGCDs_Options_EngagementCharges", 0),
+            RDM_OGCDs_Options_Corpsacorps_Distance = new("RDM_OGCDs_Options_Corpsacorps_Distance", 25);
+        
+        internal static UserBoolArray
+            RDM_OGCDs_Options = new("RDM_OGCDs_Options");
+        
+        #endregion
 
-        internal static void Draw(CustomComboPreset preset)
+        internal static void Draw(Preset preset)
         {
             switch (preset)
             {
-                case CustomComboPreset.RDM_Balance_Opener:
+                #region Single Target
+                case Preset.RDM_Balance_Opener:
                     DrawHorizontalRadioButton(RDM_Opener_Selection, "Standard Opener", "Balance Standard Opener", 0);
                     DrawHorizontalRadioButton(RDM_Opener_Selection, "GapClosing Adjusted Standard Opener", "Shifts the melee a little bit to put a gapcloser in", 1);
 
@@ -36,13 +47,13 @@ internal partial class RDM
                     ImGui.Unindent();
                     break;
                 
-                case CustomComboPreset.RDM_Variant_Cure:
+                case Preset.RDM_Variant_Cure:
                     DrawSliderInt(1, 100, RDM_VariantCure, "HP% to be at or under", 200);
                     break;
 
-                case CustomComboPreset.RDM_ST_MeleeCombo:
-                    if (P.IPCSearch.AutoActions[CustomComboPreset.RDM_ST_DPS] == true && 
-                        CustomComboFunctions.IsNotEnabled(CustomComboPreset.RDM_ST_MeleeCombo_IncludeRiposte))
+                case Preset.RDM_ST_MeleeCombo:
+                    if (P.IPCSearch.AutoActions[Preset.RDM_ST_DPS] == true && 
+                        CustomComboFunctions.IsNotEnabled(Preset.RDM_ST_MeleeCombo_IncludeRiposte))
                     {
                         ImGui.Indent();
                         ImGui.TextColored(ImGuiColors.DalamudRed, "WARNING: RIPOSTE IS NOT ENABLED.");
@@ -51,36 +62,60 @@ internal partial class RDM
                     }
                     break;
                 
-                case CustomComboPreset.RDM_ST_Corpsacorps:
+                case Preset.RDM_ST_Corpsacorps:
                     DrawSliderInt(0, 25, RDM_ST_Corpsacorps_Distance,
                         " Use when Distance from target is less than or equal to:");
                     
                     DrawSliderInt(0, 3, RDM_ST_Corpsacorps_Time,
                         " How long you need to be stationary to use. Zero to disable");
                     break;
+                #endregion
                 
-                case CustomComboPreset.RDM_AoE_Corpsacorps:
+                #region AOE
+                case Preset.RDM_AoE_Corpsacorps:
                     DrawSliderInt(0, 25, RDM_AoE_Corpsacorps_Distance,
                         " Use when Distance from target is less than or equal to:");
                     DrawSliderInt(0, 3, RDM_AoE_Corpsacorps_Time,
                         " How long you need to be stationary to use. Zero to disable");
                     break;
 
-                case CustomComboPreset.RDM_ST_Lucid:
+                case Preset.RDM_ST_Lucid:
                     DrawSliderInt(0, 10000, RDM_ST_Lucid_Threshold, $"Add {Role.LucidDreaming.ActionName()} when below this MP", sliderIncrement: Hundreds);
                     break;
 
-                case CustomComboPreset.RDM_AoE_Lucid:
+                case Preset.RDM_AoE_Lucid:
                     DrawSliderInt(0, 10000, RDM_AoE_Lucid_Threshold, $"Add {Role.LucidDreaming.ActionName()} when below this MP", sliderIncrement: Hundreds);
                     break;
                 
-                case CustomComboPreset.RDM_ST_Acceleration:
+                case Preset.RDM_ST_Acceleration:
                     DrawSliderInt(0, 1, RDM_ST_Acceleration_Charges, "How many charges to keep ready\n (0 = Use All)");
                     break;
 
-                case CustomComboPreset.RDM_AoE_Acceleration:
+                case Preset.RDM_AoE_Acceleration:
                     DrawSliderInt(0, 1, RDM_AoE_Acceleration_Charges, "How many charges to keep ready?\n (0 = Use All)");
                     break;
+                #endregion
+                
+                #region Standalones
+                case Preset.RDM_OGCDs:
+                    DrawHorizontalMultiChoice(RDM_OGCDs_Options,"Contre Sixte", "Adds to the OGCD button", 5, 0);
+                    DrawHorizontalMultiChoice(RDM_OGCDs_Options,"Vice Of Thorns", "Adds to the OGCD button", 5, 1);
+                    DrawHorizontalMultiChoice(RDM_OGCDs_Options,"Prefulgence", "Adds to the OGCD button", 5, 2);
+                    DrawHorizontalMultiChoice(RDM_OGCDs_Options,"Engagement", "Adds to the OGCD button", 5, 3);
+                    DrawHorizontalMultiChoice(RDM_OGCDs_Options,"Corps-a-corps", "Adds to the OGCD button", 5, 4);
+
+                    if (RDM_OGCDs_Options[3])
+                    {
+                        DrawSliderInt(0, 1, RDM_OGCDs_Options_EngagementCharges, "How many charges of Engagement to keep for manual use");
+                    }
+                    
+                    if (RDM_OGCDs_Options[4])
+                    {
+                        DrawSliderInt(0, 1, RDM_OGCDs_Options_CorpsCharges, "How many charges of Corps to keep for manual use");
+                        DrawSliderInt(0, 25, RDM_OGCDs_Options_Corpsacorps_Distance, "Use Corps when distance is less than or equal to:");
+                    }
+                    break;
+                #endregion
             }
         }
     }

--- a/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
@@ -24,12 +24,20 @@ internal partial class RDM
             RDM_AoE_Corpsacorps_Distance = new("RDM_AoE_Corpsacorps_Distance", 25),
             RDM_AoE_Corpsacorps_Time = new("RDM_AoE_Corpsacorps_Time", 0),
             RDM_Opener_Selection = new("RDM_Opener_Selection", 0),
+            RDM_Riposte_Weaves_Options_EngagementCharges = new ("RDM_Riposte_Weaves_Options_EngagementCharges", 0),
+            RDM_Riposte_Weaves_Options_CorpsCharges = new ("RDM_Riposte_Weaves_Options_CorpsCharges", 0),
+            RDM_Riposte_Weaves_Options_Corpsacorps_Distance = new ("RDM_Riposte_Weaves_Options_Corpsacorps_Distance", 25),
+            RDM_Moulinet_Weaves_Options_EngagementCharges = new("RDM_Moulinet_Weaves_Options_EngagementCharges", 0),
+            RDM_Moulinet_Weaves_Options_CorpsCharges = new("RDM_Moulinet_Weaves_Options_CorpsCharges", 0),
+            RDM_Moulinet_Weaves_Options_Corpsacorps_Distance = new("RDM_Moulinet_Weaves_Options_Corpsacorps_Distance", 25),
             RDM_OGCDs_Options_CorpsCharges = new("RDM_OGCDs_Options_CorpsCharges", 0),
             RDM_OGCDs_Options_EngagementCharges = new("RDM_OGCDs_Options_EngagementCharges", 0),
             RDM_OGCDs_Options_Corpsacorps_Distance = new("RDM_OGCDs_Options_Corpsacorps_Distance", 25);
         
         internal static UserBoolArray
-            RDM_OGCDs_Options = new("RDM_OGCDs_Options");
+            RDM_OGCDs_Options = new("RDM_OGCDs_Options"),
+            RDM_Riposte_Weaves_Options = new("RDM_Riposte_Weaves_Options"),
+            RDM_Moulinet_Weaves_Options = new("RDM_Moulinet_Weaves_Options");
         
         #endregion
 
@@ -97,6 +105,46 @@ internal partial class RDM
                 #endregion
                 
                 #region Standalones
+                case Preset.RDM_Riposte_Weaves:
+                    DrawHorizontalMultiChoice(RDM_Riposte_Weaves_Options,"Fleche", "Adds to the OGCD button", 6, 0);
+                    DrawHorizontalMultiChoice(RDM_Riposte_Weaves_Options,"Contre Sixte", "Adds to the OGCD button", 6, 1);
+                    DrawHorizontalMultiChoice(RDM_Riposte_Weaves_Options,"Vice Of Thorns", "Adds to the OGCD button", 6, 2);
+                    DrawHorizontalMultiChoice(RDM_Riposte_Weaves_Options,"Prefulgence", "Adds to the OGCD button", 6, 3);
+                    DrawHorizontalMultiChoice(RDM_Riposte_Weaves_Options,"Engagement", "Adds to the OGCD button", 6, 4);
+                    DrawHorizontalMultiChoice(RDM_Riposte_Weaves_Options,"Corps-a-corps", "Adds to the OGCD button", 6, 5);
+
+                    if (RDM_Riposte_Weaves_Options[4])
+                    {
+                        DrawSliderInt(0, 1, RDM_Riposte_Weaves_Options_EngagementCharges, "How many charges of Engagement to keep for manual use");
+                    }
+                    
+                    if (RDM_Riposte_Weaves_Options[5])
+                    {
+                        DrawSliderInt(0, 1, RDM_Riposte_Weaves_Options_CorpsCharges, "How many charges of Corps to keep for manual use");
+                        DrawSliderInt(0, 25, RDM_Riposte_Weaves_Options_Corpsacorps_Distance, "Use Corps when distance is less than or equal to:");
+                    }
+                    break;
+                
+                case Preset.RDM_Moulinet_Weaves:
+                    DrawHorizontalMultiChoice(RDM_Moulinet_Weaves_Options,"Fleche", "Adds to the OGCD button", 6, 0);
+                    DrawHorizontalMultiChoice(RDM_Moulinet_Weaves_Options,"Contre Sixte", "Adds to the OGCD button", 6, 1);
+                    DrawHorizontalMultiChoice(RDM_Moulinet_Weaves_Options,"Vice Of Thorns", "Adds to the OGCD button", 6, 2);
+                    DrawHorizontalMultiChoice(RDM_Moulinet_Weaves_Options,"Prefulgence", "Adds to the OGCD button", 6, 3);
+                    DrawHorizontalMultiChoice(RDM_Moulinet_Weaves_Options,"Engagement", "Adds to the OGCD button", 6, 4);
+                    DrawHorizontalMultiChoice(RDM_Moulinet_Weaves_Options,"Corps-a-corps", "Adds to the OGCD button", 6, 5);
+
+                    if (RDM_Moulinet_Weaves_Options[4])
+                    {
+                        DrawSliderInt(0, 1, RDM_Moulinet_Weaves_Options_EngagementCharges, "How many charges of Engagement to keep for manual use");
+                    }
+                    
+                    if (RDM_Moulinet_Weaves_Options[5])
+                    {
+                        DrawSliderInt(0, 1, RDM_Moulinet_Weaves_Options_CorpsCharges, "How many charges of Corps to keep for manual use");
+                        DrawSliderInt(0, 25, RDM_Moulinet_Weaves_Options_Corpsacorps_Distance, "Use Corps when distance is less than or equal to:");
+                    }
+                    break;
+                    
                 case Preset.RDM_OGCDs:
                     DrawHorizontalMultiChoice(RDM_OGCDs_Options,"Contre Sixte", "Adds to the OGCD button", 5, 0);
                     DrawHorizontalMultiChoice(RDM_OGCDs_Options,"Vice Of Thorns", "Adds to the OGCD button", 5, 1);

--- a/WrathCombo/Combos/PvE/RDM/RDM_Helper.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM_Helper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
+using static WrathCombo.Combos.PvE.RDM.Config;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 #endregion
 
@@ -252,8 +253,8 @@ internal partial class RDM
     internal static GapClosing Opener2 = new();
     internal static WrathOpener Opener()
     {
-        if (Config.RDM_Opener_Selection == 0 && Opener1.LevelChecked) return Opener1;
-        if (Config.RDM_Opener_Selection == 1 && Opener2.LevelChecked) return Opener2;
+        if (RDM_Opener_Selection == 0 && Opener1.LevelChecked) return Opener1;
+        if (RDM_Opener_Selection == 1 && Opener2.LevelChecked) return Opener2;
         
         return  (Opener1.LevelChecked) ? Opener1 : WrathOpener.Dummy;
     }
@@ -306,7 +307,7 @@ internal partial class RDM
             ([1], Jolt3, () => PartyInCombat() && !Player.Object.IsCasting)
         ];
 
-        internal override UserData? ContentCheckConfig => Config.RDM_BalanceOpener_Content;
+        internal override UserData? ContentCheckConfig => RDM_BalanceOpener_Content;
 
             public override bool HasCooldowns()
             {
@@ -368,7 +369,7 @@ internal partial class RDM
             ([1], Jolt3, () => PartyInCombat() && !Player.Object.IsCasting)
         ];
 
-        internal override UserData? ContentCheckConfig => Config.RDM_BalanceOpener_Content;
+        internal override UserData? ContentCheckConfig => RDM_BalanceOpener_Content;
 
         public override bool HasCooldowns()
         {

--- a/WrathCombo/Combos/PvE/SMN/SMN.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN.cs
@@ -1,33 +1,32 @@
 using Dalamud.Game.ClientState.JobGauge.Types;
 using System.Linq;
-using WrathCombo.Combos.PvE.Content;
 using WrathCombo.Core;
 using WrathCombo.Extensions;
 using WrathCombo.CustomComboNS;
+using Preset = WrathCombo.Combos.CustomComboPreset;
+using static WrathCombo.Combos.PvE.SMN.Config;
 
 namespace WrathCombo.Combos.PvE;
 
 internal partial class SMN : Caster
 {
     #region Small Features
-
     internal class SMN_Raise : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SMN_Raise;
-
+        protected internal override Preset Preset => Preset.SMN_Raise;
         protected override uint Invoke(uint actionID)
         {
             if (actionID != Role.Swiftcast)
                 return actionID;
 
-            if (Variant.CanRaise(CustomComboPreset.SMN_Variant_Raise))
-                return IsEnabled(CustomComboPreset.SMN_Raise_Retarget)
+            if (Variant.CanRaise(Preset.SMN_Variant_Raise))
+                return IsEnabled(Preset.SMN_Raise_Retarget)
                     ? Variant.Raise.Retarget(Role.Swiftcast,
                         SimpleTarget.Stack.AllyToRaise)
                     : Variant.Raise;
 
             if (IsOnCooldown(Role.Swiftcast))
-                return IsEnabled(CustomComboPreset.SMN_Raise_Retarget)
+                return IsEnabled(Preset.SMN_Raise_Retarget)
                     ? Resurrection.Retarget(Role.Swiftcast,
                         SimpleTarget.Stack.AllyToRaise)
                     : Resurrection;
@@ -36,8 +35,7 @@ internal partial class SMN : Caster
     }
     internal class SMN_Searing : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SMN_Searing;
-
+        protected internal override Preset Preset => Preset.SMN_Searing;
         protected override uint Invoke(uint actionID)
         {
             if (actionID != SearingLight)
@@ -46,15 +44,12 @@ internal partial class SMN : Caster
             if (HasStatusEffect(Buffs.RubysGlimmer))
                 return SearingFlash;
 
-            if (HasStatusEffect(Buffs.SearingLight, anyOwner: true))
-                return 11;
-
-            return actionID;
+            return HasStatusEffect(Buffs.SearingLight, anyOwner: true) ? 11 : actionID;
         }
     }
     internal class SMN_RuinMobility : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SMN_RuinMobility;
+        protected internal override Preset Preset => Preset.SMN_RuinMobility;
 
         protected override uint Invoke(uint actionID)
         {
@@ -62,15 +57,12 @@ internal partial class SMN : Caster
                 return actionID;
             bool furtherRuin = HasStatusEffect(Buffs.FurtherRuin);
 
-            if (!furtherRuin)
-                return Ruin3;
-            return actionID;
+            return !furtherRuin ? Ruin3 : actionID;
         }
     }
-
     internal class SMN_EDFester : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SMN_EDFester;
+        protected internal override Preset Preset => Preset.SMN_EDFester;
 
         protected override uint Invoke(uint actionID)
         {
@@ -78,7 +70,7 @@ internal partial class SMN : Caster
                 return actionID;
 
             SMNGauge gauge = GetJobGauge<SMNGauge>();
-            if (HasStatusEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergyDrain) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SMN_EDFester_Ruin4))
+            if (HasStatusEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergyDrain) && !gauge.HasAetherflowStacks && IsEnabled(Preset.SMN_EDFester_Ruin4))
                 return Ruin4;
 
             if (LevelChecked(EnergyDrain) && !gauge.HasAetherflowStacks)
@@ -87,11 +79,9 @@ internal partial class SMN : Caster
             return actionID;
         }
     }
-
     internal class SMN_ESPainflare : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SMN_ESPainflare;
-
+        protected internal override Preset Preset => Preset.SMN_ESPainflare;
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not Painflare)
@@ -102,23 +92,18 @@ internal partial class SMN : Caster
             if (!LevelChecked(Painflare) || gauge.HasAetherflowStacks)
                 return actionID;
 
-            if (HasStatusEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergySiphon) && IsEnabled(CustomComboPreset.SMN_ESPainflare_Ruin4))
+            if (HasStatusEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergySiphon) && IsEnabled(Preset.SMN_ESPainflare_Ruin4))
                 return Ruin4;
 
             if (LevelChecked(EnergySiphon))
                 return EnergySiphon;
 
-            if (LevelChecked(EnergyDrain))
-                return EnergyDrain;
-
-            return actionID;
+            return LevelChecked(EnergyDrain) ? EnergyDrain : actionID;
         }
     }
-
     internal class SMN_CarbuncleReminder : CustomCombo
     {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.SMN_CarbuncleReminder;
-
+        protected internal override Preset Preset => Preset.SMN_CarbuncleReminder;
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not (Ruin or Ruin2 or Ruin3 or DreadwyrmTrance or
@@ -127,16 +112,13 @@ internal partial class SMN : Caster
                  PreciousBrilliance or Gemshine))
                 return actionID;
 
-            if (NeedToSummon)
-                return SummonCarbuncle;
-
-            return actionID;
+            return NeedToSummon ? SummonCarbuncle : actionID;
         }
     }
 
     internal class SMN_Egi_AstralFlow : CustomCombo
     {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.SMN_Egi_AstralFlow;
+        protected internal override Preset Preset => Preset.SMN_Egi_AstralFlow;
 
         protected override uint Invoke(uint actionID)
         {
@@ -150,7 +132,7 @@ internal partial class SMN : Caster
     }
     internal class SMN_DemiAbilities : CustomCombo
     {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.SMN_DemiAbilities;
+        protected internal override Preset Preset => Preset.SMN_DemiAbilities;
 
         protected override uint Invoke(uint actionID)
         {
@@ -176,14 +158,12 @@ internal partial class SMN : Caster
             return actionID;
         }
     }
-
     #endregion
 
     #region Simple
     internal class SMN_Simple_Combo : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SMN_ST_Simple_Combo;
-
+        protected internal override Preset Preset => Preset.SMN_ST_Simple_Combo;
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not (Ruin or Ruin2 or Ruin3))
@@ -197,10 +177,10 @@ internal partial class SMN : Caster
             #endregion
 
             #region Special Content
-            if (Variant.CanCure(CustomComboPreset.SMN_Variant_Cure, Config.SMN_VariantCure))
+            if (Variant.CanCure(Preset.SMN_Variant_Cure, SMN_VariantCure))
                 return Variant.Cure;
 
-            if (Variant.CanRampart(CustomComboPreset.SMN_Variant_Rampart, WeaveTypes.Weave))
+            if (Variant.CanRampart(Preset.SMN_Variant_Rampart, WeaveTypes.Weave))
                 return Variant.Rampart;
             
             if (OccultCrescent.ShouldUsePhantomActions())
@@ -214,7 +194,7 @@ internal partial class SMN : Caster
                  if (ActionReady(OriginalHook(EnkindleBahamut)))
                     return OriginalHook(EnkindleBahamut);
 
-                if (ActionReady(AstralFlow) && DemiNotPheonix)
+                 if (ActionReady(AstralFlow) && DemiNotPheonix)
                     return OriginalHook(AstralFlow);
             }
 
@@ -357,11 +337,9 @@ internal partial class SMN : Caster
             return actionID;
         }
     }
-
     internal class SMN_Simple_Combo_AoE : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SMN_AoE_Simple_Combo;
-
+        protected internal override Preset Preset => Preset.SMN_AoE_Simple_Combo;
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not (Outburst or Tridisaster))
@@ -375,10 +353,10 @@ internal partial class SMN : Caster
             #endregion
 
             #region Special Content
-            if (Variant.CanCure(CustomComboPreset.SMN_Variant_Cure, Config.SMN_VariantCure))
+            if (Variant.CanCure(Preset.SMN_Variant_Cure, SMN_VariantCure))
                 return Variant.Cure;
 
-            if (Variant.CanRampart(CustomComboPreset.SMN_Variant_Rampart, WeaveTypes.Weave))
+            if (Variant.CanRampart(Preset.SMN_Variant_Rampart, WeaveTypes.Weave))
                 return Variant.Rampart;
             
             if (OccultCrescent.ShouldUsePhantomActions())
@@ -539,11 +517,10 @@ internal partial class SMN : Caster
     #region Advanced
     internal class SMN_ST_Advanced_Combo : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SMN_ST_Advanced_Combo;
-
+        protected internal override Preset Preset => Preset.SMN_ST_Advanced_Combo;
         protected override uint Invoke(uint actionID)
         {
-            bool allRuins = Config.SMN_ST_Advanced_Combo_AltMode == 0;
+            bool allRuins = SMN_ST_Advanced_Combo_AltMode == 0;
             bool actionFound = allRuins && AllRuinsList.Contains(actionID) ||
                                !allRuins && NotRuin3List.Contains(actionID);
             if (!actionFound)
@@ -553,26 +530,26 @@ internal partial class SMN : Caster
                 return SummonCarbuncle;
 
             #region Variables
-            int lucidThreshold = Config.SMN_ST_Lucid;
-            int swiftcastPhase = Config.SMN_ST_SwiftcastPhase;
-            bool TitanAstralFlow = IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_Egi_AstralFlow) && Config.SMN_ST_Egi_AstralFlow[0];
-            bool IfritAstralFlowCyclone = IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_Egi_AstralFlow) && Config.SMN_ST_Egi_AstralFlow[1];
-            bool IfritAstralFlowStrike = IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_Egi_AstralFlow) && Config.SMN_ST_Egi_AstralFlow[3];
-            bool GarudaAstralFlow = IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_Egi_AstralFlow) && Config.SMN_ST_Egi_AstralFlow[2];
+            int lucidThreshold = SMN_ST_Lucid;
+            int swiftcastPhase = SMN_ST_SwiftcastPhase;
+            bool TitanAstralFlow = IsEnabled(Preset.SMN_ST_Advanced_Combo_Egi_AstralFlow) && SMN_ST_Egi_AstralFlow[0];
+            bool IfritAstralFlowCyclone = IsEnabled(Preset.SMN_ST_Advanced_Combo_Egi_AstralFlow) && SMN_ST_Egi_AstralFlow[1];
+            bool IfritAstralFlowStrike = IsEnabled(Preset.SMN_ST_Advanced_Combo_Egi_AstralFlow) && SMN_ST_Egi_AstralFlow[3];
+            bool GarudaAstralFlow = IsEnabled(Preset.SMN_ST_Advanced_Combo_Egi_AstralFlow) && SMN_ST_Egi_AstralFlow[2];
             var dontWaitForSearing = SearingCD > (Gauge.SummonTimerRemaining / 1000f) + GCDTotal;
             var replacedActions = allRuins ? AllRuinsList.ToArray() : NotRuin3List.ToArray();
             #endregion
 
             #region Opener
-            if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_Balance_Opener) &&
+            if (IsEnabled(Preset.SMN_ST_Advanced_Combo_Balance_Opener) &&
                 Opener().FullOpener(ref actionID))
                 return actionID;
             #endregion
 
             #region Special Content
-            if (Variant.CanCure(CustomComboPreset.SMN_Variant_Cure, Config.SMN_VariantCure))
+            if (Variant.CanCure(Preset.SMN_Variant_Cure, SMN_VariantCure))
                 return Variant.Cure;
-            if (Variant.CanRampart(CustomComboPreset.SMN_Variant_Rampart, WeaveTypes.Weave))
+            if (Variant.CanRampart(Preset.SMN_Variant_Rampart, WeaveTypes.Weave))
                 return Variant.Rampart;
             if (OccultCrescent.ShouldUsePhantomActions())
                 return OccultCrescent.BestPhantomAction();
@@ -580,7 +557,7 @@ internal partial class SMN : Caster
 
             #region OGCD
             //Emergency Demi Attack Dump, Probably not needed anymore without burst delay selection
-            if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_DemiSummons_Attacks) && DemiExists && Gauge.SummonTimerRemaining <= 2500)
+            if (IsEnabled(Preset.SMN_ST_Advanced_Combo_DemiSummons_Attacks) && DemiExists && Gauge.SummonTimerRemaining <= 2500)
             {
                 if (ActionReady(OriginalHook(EnkindleBahamut)))
                     return OriginalHook(EnkindleBahamut);
@@ -592,9 +569,9 @@ internal partial class SMN : Caster
             if (SummonerWeave)
             {
                 // Searing Light
-                if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_SearingLight) && ActionReady(SearingLight) && !HasStatusEffect(Buffs.SearingLight, anyOwner: true))
+                if (IsEnabled(Preset.SMN_ST_Advanced_Combo_SearingLight) && ActionReady(SearingLight) && !HasStatusEffect(Buffs.SearingLight, anyOwner: true))
                 {
-                    if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_SearingLight_Burst) && TraitLevelChecked(Traits.EnhancedDreadwyrmTrance))
+                    if (IsEnabled(Preset.SMN_ST_Advanced_Combo_SearingLight_Burst) && TraitLevelChecked(Traits.EnhancedDreadwyrmTrance))
                     {
                         if (DemiExists)
                             return SearingLight;
@@ -604,9 +581,9 @@ internal partial class SMN : Caster
                 }
 
                 // Energy Drain
-                if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_EDFester) && !Gauge.HasAetherflowStacks && ActionReady(EnergyDrain))
+                if (IsEnabled(Preset.SMN_ST_Advanced_Combo_EDFester) && !Gauge.HasAetherflowStacks && ActionReady(EnergyDrain))
                 {
-                    if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_oGCDPooling) && LevelChecked(SearingLight))
+                    if (IsEnabled(Preset.SMN_ST_Advanced_Combo_oGCDPooling) && LevelChecked(SearingLight))
                     {
                         if (HasStatusEffect(Buffs.SearingLight, anyOwner: true) || SearingCD > 30)
                             return OriginalHook(EnergyDrain);
@@ -616,7 +593,7 @@ internal partial class SMN : Caster
                 }
 
                 // Demi Nuke
-                if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_DemiSummons_Attacks) && DemiExists && (HasStatusEffect(Buffs.SearingLight, anyOwner: true) || dontWaitForSearing) && (GetCooldown(EnergyDrain).CooldownRemaining >= 3 || !ActionReady(Fester)))
+                if (IsEnabled(Preset.SMN_ST_Advanced_Combo_DemiSummons_Attacks) && DemiExists && (HasStatusEffect(Buffs.SearingLight, anyOwner: true) || dontWaitForSearing) && (GetCooldown(EnergyDrain).CooldownRemaining >= 3 || !ActionReady(Fester)))
                 {
                     if (ActionReady(OriginalHook(EnkindleBahamut)))
                         return OriginalHook(EnkindleBahamut);
@@ -626,9 +603,9 @@ internal partial class SMN : Caster
                         if (DemiNotPheonix)
                             return OriginalHook(AstralFlow);
 
-                        if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_DemiSummons_Rekindle) && DemiPheonix)
+                        if (IsEnabled(Preset.SMN_ST_Advanced_Combo_DemiSummons_Rekindle) && DemiPheonix)
                         {
-                            if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_DemiSummons_Rekindle_Retarget))
+                            if (IsEnabled(Preset.SMN_ST_Advanced_Combo_DemiSummons_Rekindle_Retarget))
                                 return OriginalHook(AstralFlow).Retarget(replacedActions,
                                     SimpleTarget.TargetsTarget.IfInParty() ??
                                     SimpleTarget.AnyTank.IfMissingHP() ??
@@ -640,9 +617,9 @@ internal partial class SMN : Caster
                 }
 
                 // Fester Logic
-                if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_EDFester) && ActionReady(Fester) && !HasStatusEffect(Buffs.TitansFavor))
+                if (IsEnabled(Preset.SMN_ST_Advanced_Combo_EDFester) && ActionReady(Fester) && !HasStatusEffect(Buffs.TitansFavor))
                 {
-                    if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_oGCDPooling) && LevelChecked(SearingLight))
+                    if (IsEnabled(Preset.SMN_ST_Advanced_Combo_oGCDPooling) && LevelChecked(SearingLight))
                     {
                         if (HasStatusEffect(Buffs.SearingLight, anyOwner: true))
                             return OriginalHook(Fester);
@@ -652,30 +629,30 @@ internal partial class SMN : Caster
                 }
 
                 // Searing Flash
-                if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_SearingFlash) && HasStatusEffect(Buffs.RubysGlimmer))
+                if (IsEnabled(Preset.SMN_ST_Advanced_Combo_SearingFlash) && HasStatusEffect(Buffs.RubysGlimmer))
                     return SearingFlash;
 
                 // Lux Solaris
-                if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_DemiSummons_LuxSolaris) && ActionReady(LuxSolaris) &&
+                if (IsEnabled(Preset.SMN_ST_Advanced_Combo_DemiSummons_LuxSolaris) && ActionReady(LuxSolaris) &&
                     (PlayerHealthPercentageHp() < 100 || (GetStatusEffectRemainingTime(Buffs.RefulgentLux) is < 3 and > 0)))
                     return OriginalHook(LuxSolaris);
 
                 // Self Shield Overcap
-                if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_Radiant) &&
+                if (IsEnabled(Preset.SMN_ST_Advanced_Combo_Radiant) &&
                     !HasStatusEffect(Buffs.SearingLight) && !HasStatusEffect(Buffs.TitansFavor) &&
                     GetRemainingCharges(RadiantAegis) == 2 && ActionReady(RadiantAegis))
                     return RadiantAegis;
 
                 // Lucid Dreaming
-                if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_Lucid) && Role.CanLucidDream(lucidThreshold))
+                if (IsEnabled(Preset.SMN_ST_Advanced_Combo_Lucid) && Role.CanLucidDream(lucidThreshold))
                     return Role.LucidDreaming;
             }
             #endregion
 
             #region Demi Summon
             // Demi
-            if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_DemiSummons) && PartyInCombat() && ActionReady(OriginalHook(Aethercharge)))
-                return IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_SearingLight_Burst) && SearingBurstDriftCheck
+            if (IsEnabled(Preset.SMN_ST_Advanced_Combo_DemiSummons) && PartyInCombat() && ActionReady(OriginalHook(Aethercharge)))
+                return IsEnabled(Preset.SMN_ST_Advanced_Combo_SearingLight_Burst) && SearingBurstDriftCheck
                     ? OriginalHook(Ruin)
                     : OriginalHook(Aethercharge);
             #endregion
@@ -686,7 +663,7 @@ internal partial class SMN : Caster
                 if (TitanAstralFlow && ActionReady(AstralFlow) && SummonerWeave)
                     return OriginalHook(AstralFlow);
 
-                if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_EgiSummons_Attacks) && GemshineReady)
+                if (IsEnabled(Preset.SMN_ST_Advanced_Combo_EgiSummons_Attacks) && GemshineReady)
                     return OriginalHook(Gemshine);
             }
             #endregion
@@ -696,7 +673,7 @@ internal partial class SMN : Caster
             {               
                 if (GarudaAstralFlow && HasStatusEffect(Buffs.GarudasFavor))
                 {
-                    if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_DemiEgiMenu_SwiftcastEgi) && swiftcastPhase is 1 or 3 && Role.CanSwiftcast()) // Forced Swiftcast option
+                    if (IsEnabled(Preset.SMN_ST_Advanced_Combo_DemiEgiMenu_SwiftcastEgi) && swiftcastPhase is 1 or 3 && Role.CanSwiftcast()) // Forced Swiftcast option
                         return Role.Swiftcast;
                     
                     if (!IsMoving() || HasStatusEffect(Role.Buffs.Swiftcast))
@@ -705,15 +682,15 @@ internal partial class SMN : Caster
 
                 #region Special Ruin 3 rule lvl 54 - 72
                 // Use Ruin III instead of Emerald Ruin III if enabled and Ruin Mastery III is not active
-                if (IsEnabled(CustomComboPreset.SMN_ST_Ruin3_Emerald_Ruin3) && !TraitLevelChecked(Traits.RuinMastery3) && LevelChecked(Ruin3) && !IsMoving())                
+                if (IsEnabled(Preset.SMN_ST_Ruin3_Emerald_Ruin3) && !TraitLevelChecked(Traits.RuinMastery3) && LevelChecked(Ruin3) && !IsMoving())                
                     return Ruin3;
                
                 #endregion
 
-                if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_EgiSummons_Attacks) && GemshineReady)
+                if (IsEnabled(Preset.SMN_ST_Advanced_Combo_EgiSummons_Attacks) && GemshineReady)
                     return OriginalHook(Gemshine);
 
-                if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_Ruin4) && HasStatusEffect(Buffs.FurtherRuin) && IsMoving())
+                if (IsEnabled(Preset.SMN_ST_Advanced_Combo_Ruin4) && HasStatusEffect(Buffs.FurtherRuin) && IsMoving())
                     return Ruin4;
             }
             #endregion
@@ -721,27 +698,27 @@ internal partial class SMN : Caster
             #region Ifrit Phase
             if (IsIfritAttuned || OriginalHook(AstralFlow) is CrimsonCyclone or CrimsonStrike)
             {
-                if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_DemiEgiMenu_SwiftcastEgi) && swiftcastPhase is 2 or 3 && Role.CanSwiftcast())
+                if (IsEnabled(Preset.SMN_ST_Advanced_Combo_DemiEgiMenu_SwiftcastEgi) && swiftcastPhase is 2 or 3 && Role.CanSwiftcast())
                     return Role.Swiftcast;
 
-                if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_EgiSummons_Attacks) && GemshineReady && 
+                if (IsEnabled(Preset.SMN_ST_Advanced_Combo_EgiSummons_Attacks) && GemshineReady && 
                     (!IsMoving() || HasStatusEffect(Role.Buffs.Swiftcast)))
                     return OriginalHook(Gemshine);
 
                 if (IfritAstralFlowCyclone && HasStatusEffect(Buffs.IfritsFavor) &&
-                    GetTargetDistance() <= Config.SMN_ST_CrimsonCycloneMeleeDistance  //Melee Check
+                    GetTargetDistance() <= SMN_ST_CrimsonCycloneMeleeDistance  //Melee Check
                    || IfritAstralFlowStrike && HasStatusEffect(Buffs.CrimsonStrike) && InMeleeRange()) //After Strike
                     return OriginalHook(AstralFlow);
 
-                if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_Ruin4) && HasStatusEffect(Buffs.FurtherRuin) && !HasStatusEffect(Role.Buffs.Swiftcast))
+                if (IsEnabled(Preset.SMN_ST_Advanced_Combo_Ruin4) && HasStatusEffect(Buffs.FurtherRuin) && !HasStatusEffect(Role.Buffs.Swiftcast))
                     return Ruin4;
             }
             #endregion
 
             #region Egi Priority
-            foreach (var prio in Config.SMN_ST_Egi_Priority.Items.OrderBy(x => x))
+            foreach (var prio in SMN_ST_Egi_Priority.Items.OrderBy(x => x))
             {
-                var index = Config.SMN_ST_Egi_Priority.IndexOf(prio);
+                var index = SMN_ST_Egi_Priority.IndexOf(prio);
                 var config = GetMatchingConfigST(index, OptionalTarget,
                     out var spell, out var enabled);
 
@@ -753,7 +730,7 @@ internal partial class SMN : Caster
             #endregion
 
             #region Ruin 4 Dump
-            if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_Ruin4) && !IsAttunedAny  && DemiNone && HasStatusEffect(Buffs.FurtherRuin))
+            if (IsEnabled(Preset.SMN_ST_Advanced_Combo_Ruin4) && !IsAttunedAny  && DemiNone && HasStatusEffect(Buffs.FurtherRuin))
                 return Ruin4;
             #endregion
 
@@ -763,8 +740,7 @@ internal partial class SMN : Caster
 
     internal class SMN_Advanced_Combo_AoE : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SMN_AoE_Advanced_Combo;
-
+        protected internal override Preset Preset => Preset.SMN_AoE_Advanced_Combo;
         protected override uint Invoke(uint actionID)
         {
             if (actionID is not (Outburst or Tridisaster))
@@ -774,20 +750,20 @@ internal partial class SMN : Caster
                 return SummonCarbuncle;
 
             #region Variables
-            int lucidThreshold = Config.SMN_AoE_Lucid;
-            int swiftcastPhase = Config.SMN_AoE_SwiftcastPhase;
-            bool TitanAstralFlow = IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_Egi_AstralFlow) && Config.SMN_AoE_Egi_AstralFlow[0];
-            bool IfritAstralFlowCyclone = IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_Egi_AstralFlow) && Config.SMN_AoE_Egi_AstralFlow[1];
-            bool IfritAstralFlowStrike = IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_Egi_AstralFlow) && Config.SMN_AoE_Egi_AstralFlow[3];
-            bool GarudaAstralFlow = IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_Egi_AstralFlow) && Config.SMN_AoE_Egi_AstralFlow[2];
+            int lucidThreshold = SMN_AoE_Lucid;
+            int swiftcastPhase = SMN_AoE_SwiftcastPhase;
+            bool TitanAstralFlow = IsEnabled(Preset.SMN_AoE_Advanced_Combo_Egi_AstralFlow) && SMN_AoE_Egi_AstralFlow[0];
+            bool IfritAstralFlowCyclone = IsEnabled(Preset.SMN_AoE_Advanced_Combo_Egi_AstralFlow) && SMN_AoE_Egi_AstralFlow[1];
+            bool IfritAstralFlowStrike = IsEnabled(Preset.SMN_AoE_Advanced_Combo_Egi_AstralFlow) && SMN_AoE_Egi_AstralFlow[3];
+            bool GarudaAstralFlow = IsEnabled(Preset.SMN_AoE_Advanced_Combo_Egi_AstralFlow) && SMN_AoE_Egi_AstralFlow[2];
             var dontWaitForSearing = SearingCD > (Gauge.SummonTimerRemaining / 1000f) + GCDTotal;
             #endregion
 
             #region Special Content
-            if (Variant.CanCure(CustomComboPreset.SMN_Variant_Cure, Config.SMN_VariantCure))
+            if (Variant.CanCure(Preset.SMN_Variant_Cure, SMN_VariantCure))
                 return Variant.Cure;
 
-            if (Variant.CanRampart(CustomComboPreset.SMN_Variant_Rampart, WeaveTypes.Weave))
+            if (Variant.CanRampart(Preset.SMN_Variant_Rampart, WeaveTypes.Weave))
                 return Variant.Rampart;
             
             if (OccultCrescent.ShouldUsePhantomActions())
@@ -796,7 +772,7 @@ internal partial class SMN : Caster
 
             #region OGCD
             //Emergency Demi Attack Dump, Probably not needed anymore without burst delay selection
-            if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_DemiSummons_Attacks) && DemiExists && Gauge.SummonTimerRemaining <= 2500)
+            if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_DemiSummons_Attacks) && DemiExists && Gauge.SummonTimerRemaining <= 2500)
             {
                 if (ActionReady(OriginalHook(EnkindleBahamut)))
                     return OriginalHook(EnkindleBahamut);
@@ -808,9 +784,9 @@ internal partial class SMN : Caster
             if (SummonerWeave)
             {
                 // Searing Light
-                if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_SearingLight) && ActionReady(SearingLight) && !HasStatusEffect(Buffs.SearingLight, anyOwner: true))
+                if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_SearingLight) && ActionReady(SearingLight) && !HasStatusEffect(Buffs.SearingLight, anyOwner: true))
                 {
-                    if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_SearingLight_Burst) && TraitLevelChecked(Traits.EnhancedDreadwyrmTrance))
+                    if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_SearingLight_Burst) && TraitLevelChecked(Traits.EnhancedDreadwyrmTrance))
                     {
                         if (DemiExists)
                             return SearingLight;
@@ -820,9 +796,9 @@ internal partial class SMN : Caster
                 }
 
                 // Energy Drain
-                if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_ESPainflare) && !Gauge.HasAetherflowStacks && ActionReady(EnergyDrain))
+                if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_ESPainflare) && !Gauge.HasAetherflowStacks && ActionReady(EnergyDrain))
                 {
-                    if (IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_oGCDPooling) && LevelChecked(SearingLight))
+                    if (IsEnabled(Preset.SMN_ST_Advanced_Combo_oGCDPooling) && LevelChecked(SearingLight))
                     {
                         if (HasStatusEffect(Buffs.SearingLight, anyOwner: true) || SearingCD > 30)
                             return OriginalHook(EnergySiphon);
@@ -832,7 +808,7 @@ internal partial class SMN : Caster
                 }
 
                 // Demi Nuke
-                if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_DemiSummons_Attacks) && DemiExists &&
+                if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_DemiSummons_Attacks) && DemiExists &&
                     (HasStatusEffect(Buffs.SearingLight, anyOwner: true) || dontWaitForSearing) &&
                     (GetCooldown(EnergyDrain).CooldownRemaining >= 3 || !ActionReady(OriginalHook(Painflare))))
                 {
@@ -844,9 +820,9 @@ internal partial class SMN : Caster
                         if (DemiNotPheonix)
                             return OriginalHook(AstralFlow);
 
-                        if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_DemiSummons_Rekindle) && DemiPheonix)
+                        if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_DemiSummons_Rekindle) && DemiPheonix)
                         {
-                            if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_DemiSummons_Rekindle_Retarget))
+                            if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_DemiSummons_Rekindle_Retarget))
                                 return OriginalHook(AstralFlow).Retarget([Outburst, Tridisaster],
                                     SimpleTarget.TargetsTarget.IfInParty() ??
                                     SimpleTarget.AnyTank.IfMissingHP() ??
@@ -858,9 +834,9 @@ internal partial class SMN : Caster
                 }
 
                 // Fester Logic
-                if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_ESPainflare) && ActionReady(OriginalHook(Fester)) && !HasStatusEffect(Buffs.TitansFavor))
+                if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_ESPainflare) && ActionReady(OriginalHook(Fester)) && !HasStatusEffect(Buffs.TitansFavor))
                 {
-                    if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_oGCDPooling) && LevelChecked(SearingLight))
+                    if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_oGCDPooling) && LevelChecked(SearingLight))
                     {
                         if (HasStatusEffect(Buffs.SearingLight, anyOwner: true))
                             return OriginalHook(Painflare);
@@ -871,30 +847,30 @@ internal partial class SMN : Caster
 
 
                 // Searing Flash
-                if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_SearingFlash) && HasStatusEffect(Buffs.RubysGlimmer))
+                if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_SearingFlash) && HasStatusEffect(Buffs.RubysGlimmer))
                     return SearingFlash;
 
                 // Lux Solaris
-                if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_DemiSummons_LuxSolaris) && ActionReady(LuxSolaris) &&
+                if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_DemiSummons_LuxSolaris) && ActionReady(LuxSolaris) &&
                     (PlayerHealthPercentageHp() < 100 || (GetStatusEffectRemainingTime(Buffs.RefulgentLux) is < 3 and > 0)))
                     return OriginalHook(LuxSolaris);
 
                 // Self Shield Overcap
-                if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_Radiant) &&
+                if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_Radiant) &&
                     !HasStatusEffect(Buffs.SearingLight) && !HasStatusEffect(Buffs.TitansFavor) &&
                     GetRemainingCharges(RadiantAegis) == 2 && ActionReady(RadiantAegis))
                     return RadiantAegis;
 
                 // Lucid Dreaming
-                if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_Lucid) && Role.CanLucidDream(lucidThreshold))
+                if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_Lucid) && Role.CanLucidDream(lucidThreshold))
                     return Role.LucidDreaming;
             }
             #endregion
 
             #region Demi Summon
             // Demi
-            if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_DemiSummons) && PartyInCombat() && ActionReady(OriginalHook(Aethercharge)))
-                return IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_SearingLight_Burst) && SearingBurstDriftCheck
+            if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_DemiSummons) && PartyInCombat() && ActionReady(OriginalHook(Aethercharge)))
+                return IsEnabled(Preset.SMN_AoE_Advanced_Combo_SearingLight_Burst) && SearingBurstDriftCheck
                     ? OriginalHook(Outburst)
                     : OriginalHook(Aethercharge);
             #endregion
@@ -905,7 +881,7 @@ internal partial class SMN : Caster
                 if (TitanAstralFlow && ActionReady(AstralFlow) && SummonerWeave)
                     return OriginalHook(AstralFlow);
 
-                if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_EgiSummons_Attacks) && GemshineReady)
+                if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_EgiSummons_Attacks) && GemshineReady)
                     return OriginalHook(PreciousBrilliance);
 
             }
@@ -916,17 +892,17 @@ internal partial class SMN : Caster
             {
                 if (GarudaAstralFlow && HasStatusEffect(Buffs.GarudasFavor))
                 {
-                    if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_DemiEgiMenu_SwiftcastEgi) && swiftcastPhase is 1 or 3 && Role.CanSwiftcast()) // Forced Swiftcast option
+                    if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_DemiEgiMenu_SwiftcastEgi) && swiftcastPhase is 1 or 3 && Role.CanSwiftcast()) // Forced Swiftcast option
                         return Role.Swiftcast;
                    
                     if (!IsMoving() || HasStatusEffect(Role.Buffs.Swiftcast))
                         return OriginalHook(AstralFlow);
                 }                
 
-                if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_EgiSummons_Attacks) && GemshineReady)
+                if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_EgiSummons_Attacks) && GemshineReady)
                     return OriginalHook(PreciousBrilliance);
 
-                if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_Ruin4) && HasStatusEffect(Buffs.FurtherRuin) && IsMoving())
+                if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_Ruin4) && HasStatusEffect(Buffs.FurtherRuin) && IsMoving())
                     return Ruin4;
             }
 
@@ -935,27 +911,27 @@ internal partial class SMN : Caster
             #region Ifrit Phase
             if (IsIfritAttuned || OriginalHook(AstralFlow) is CrimsonCyclone or CrimsonStrike)
             {
-                if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_DemiEgiMenu_SwiftcastEgi) && swiftcastPhase is 2 or 3 && (Role.CanSwiftcast()))
+                if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_DemiEgiMenu_SwiftcastEgi) && swiftcastPhase is 2 or 3 && (Role.CanSwiftcast()))
                     return Role.Swiftcast;
 
-                if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_EgiSummons_Attacks) && GemshineReady && 
+                if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_EgiSummons_Attacks) && GemshineReady && 
                     (!IsMoving() || HasStatusEffect(Role.Buffs.Swiftcast)))
                     return OriginalHook(PreciousBrilliance);
 
                 if (IfritAstralFlowCyclone && HasStatusEffect(Buffs.IfritsFavor) &&
-                   GetTargetDistance() <= Config.SMN_AoE_CrimsonCycloneMeleeDistance //Melee Check
+                   GetTargetDistance() <= SMN_AoE_CrimsonCycloneMeleeDistance //Melee Check
                    || IfritAstralFlowStrike && HasStatusEffect(Buffs.CrimsonStrike) && InMeleeRange()) //After Strike
                     return OriginalHook(AstralFlow);
 
-                if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_Ruin4) && HasStatusEffect(Buffs.FurtherRuin) && !HasStatusEffect(Role.Buffs.Swiftcast))
+                if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_Ruin4) && HasStatusEffect(Buffs.FurtherRuin) && !HasStatusEffect(Role.Buffs.Swiftcast))
                     return Ruin4;
             }
             #endregion
 
             #region Egi Priority
-            foreach (var prio in Config.SMN_AoE_Egi_Priority.Items.OrderBy(x => x))
+            foreach (var prio in SMN_AoE_Egi_Priority.Items.OrderBy(x => x))
             {
-                var index = Config.SMN_AoE_Egi_Priority.IndexOf(prio);
+                var index = SMN_AoE_Egi_Priority.IndexOf(prio);
                 var config = GetMatchingConfigAoE(index, OptionalTarget,
                     out var spell, out var enabled);
 
@@ -968,7 +944,7 @@ internal partial class SMN : Caster
 
             #region Ruin 4 Dump
             // Ruin 4 Dump
-            if (IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_Ruin4) && !IsAttunedAny && DemiNone && HasStatusEffect(Buffs.FurtherRuin))
+            if (IsEnabled(Preset.SMN_AoE_Advanced_Combo_Ruin4) && !IsAttunedAny && DemiNone && HasStatusEffect(Buffs.FurtherRuin))
                 return Ruin4;
             #endregion
 

--- a/WrathCombo/Combos/PvE/SMN/SMN_Config.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN_Config.cs
@@ -3,6 +3,7 @@ using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Extensions;
 using WrathCombo.Window.Functions;
 using static WrathCombo.Window.Functions.UserConfig;
+using Preset = WrathCombo.Combos.CustomComboPreset;
 
 namespace WrathCombo.Combos.PvE;
 
@@ -10,20 +11,17 @@ internal partial class SMN
 {
     internal static class Config
     {
+        #region Options
         public static UserInt
             SMN_ST_Advanced_Combo_AltMode = new("SMN_ST_Advanced_Combo_AltMode"),
             SMN_ST_Lucid = new("SMN_ST_Lucid", 8000),
-            SMN_ST_BurstPhase = new("SMN_ST_BurstPhase", 1),
             SMN_ST_SwiftcastPhase = new("SMN_SwiftcastPhase", 1),
-            SMN_ST_Burst_Delay = new("SMN_Burst_Delay", 0),
             SMN_ST_CrimsonCycloneMeleeDistance = new("SMN_ST_CrimsonCycloneMeleeDistance", 25),
             SMN_Opener_SkipSwiftcast = new("SMN_Opener_SkipSwiftcast", 1),
             
             SMN_AoE_Lucid = new("SMN_AoE_Lucid", 8000),
-            SMN_AoE_BurstPhase = new("SMN_AoE_BurstPhase", 1),
             SMN_AoE_CrimsonCycloneMeleeDistance = new("SMN_AoE_CrimsonCycloneMeleeDistance", 25),
             SMN_AoE_SwiftcastPhase = new("SMN_AoE_SwiftcastPhase", 1),
-            SMN_AoE_Burst_Delay = new("SMN_AoE_Burst_Delay", 0),
             
             SMN_VariantCure = new("SMN_VariantCure"),
             SMN_Balance_Content = new("SMN_Balance_Content", 1);
@@ -32,132 +30,115 @@ internal partial class SMN
             SMN_ST_Egi_AstralFlow = new("SMN_ST_Egi_AstralFlow"),
             SMN_AoE_Egi_AstralFlow = new("SMN_AoE_Egi_AstralFlow");
 
-        public static UserBool
-            SMN_ST_Searing_Any = new("SMN_ST_Searing_Any"),
-            SMN_AoE_Searing_Any = new("SMN_AoE_Searing_Any");
-
         internal static UserIntArray
             SMN_ST_Egi_Priority = new("SMN_ST_Egi_Priority"),
             SMN_AoE_Egi_Priority = new("SMN_AoE_Egi_Priority");
-
-        internal static void Draw(CustomComboPreset preset)
+        #endregion
+        internal static void Draw(Preset preset)
         {
             switch (preset)
             {
-                case CustomComboPreset.SMN_ST_Advanced_Combo:
+                #region Single Target
+                case Preset.SMN_ST_Advanced_Combo:
                     DrawRadioButton(SMN_ST_Advanced_Combo_AltMode, "On Ruin 1, 2, and 3", "", 0);
                     DrawRadioButton(SMN_ST_Advanced_Combo_AltMode, "On Ruin 1 and 2 Only", "Alternative DPS Mode. Leaves Ruin 3 alone for pure DPS.", 1);
                     break;
 
-                case CustomComboPreset.SMN_ST_Advanced_Combo_Balance_Opener:
-
+                case Preset.SMN_ST_Advanced_Combo_Balance_Opener:
                     DrawBossOnlyChoice(SMN_Balance_Content);
-
                     ImGui.NewLine();
-
                     DrawHorizontalRadioButton(SMN_Opener_SkipSwiftcast, "Use Swiftcast",
                         "Will use Swiftcast in opener to try and snapshot in pots for lower gcds", 1);
-
                     DrawHorizontalRadioButton(SMN_Opener_SkipSwiftcast, "Skip Swiftcast",
                         "Will not use swiftcast in opener for higher gcds", 2);
                     break;
 
-                case CustomComboPreset.SMN_ST_Advanced_Combo_Titan:
+                case Preset.SMN_ST_Advanced_Combo_Titan:
                     DrawPriorityInput(SMN_ST_Egi_Priority, 3, 0,
                         $"{SummonTopaz.ActionName()} Priority: ");
                     break;
 
-                case CustomComboPreset.SMN_ST_Advanced_Combo_Garuda:
+                case Preset.SMN_ST_Advanced_Combo_Garuda:
                     DrawPriorityInput(SMN_ST_Egi_Priority, 3, 1,
                         $"{SummonEmerald.ActionName()} Priority: ");
                     break;
 
-                case CustomComboPreset.SMN_ST_Advanced_Combo_Ifrit:
+                case Preset.SMN_ST_Advanced_Combo_Ifrit:
                     DrawPriorityInput(SMN_ST_Egi_Priority, 3, 2,
                         $"{SummonRuby.ActionName()} Priority: ");
                     break;
-
-                case CustomComboPreset.SMN_AoE_Advanced_Combo_Titan:
-                    DrawPriorityInput(SMN_AoE_Egi_Priority, 3, 0,
-                        $"{SummonTopaz.ActionName()} Priority: ");
-                    break;
-
-                case CustomComboPreset.SMN_AoE_Advanced_Combo_Garuda:
-                    DrawPriorityInput(SMN_AoE_Egi_Priority, 3, 1,
-                        $"{SummonEmerald.ActionName()} Priority: ");
-                    break;
-
-                case CustomComboPreset.SMN_AoE_Advanced_Combo_Ifrit:
-                    DrawPriorityInput(SMN_AoE_Egi_Priority, 3, 2,
-                        $"{SummonRuby.ActionName()} Priority: ");
-                    break;
-
-                case CustomComboPreset.SMN_ST_Advanced_Combo_DemiEgiMenu_SwiftcastEgi:
+                
+                case Preset.SMN_ST_Advanced_Combo_DemiEgiMenu_SwiftcastEgi:
                     DrawHorizontalRadioButton(SMN_ST_SwiftcastPhase, "Garuda", "Swiftcasts Slipstream", 1);
-
-                    DrawHorizontalRadioButton(SMN_ST_SwiftcastPhase, "Ifrit", "Swiftcasts Ruby Ruin/Ruby Rite",
-                        2);
-
+                    DrawHorizontalRadioButton(SMN_ST_SwiftcastPhase, "Ifrit", "Swiftcasts Ruby Ruin/Ruby Rite", 2);
                     DrawHorizontalRadioButton(SMN_ST_SwiftcastPhase, "Flexible (SpS) Option",
                         "Swiftcasts the first available Egi when Swiftcast is ready.", 3);
-
                     break;
-
-                case CustomComboPreset.SMN_AoE_Advanced_Combo_DemiEgiMenu_SwiftcastEgi:
-                    DrawHorizontalRadioButton(SMN_AoE_SwiftcastPhase, "Garuda", "Swiftcasts Slipstream", 1);
-
-                    DrawHorizontalRadioButton(SMN_AoE_SwiftcastPhase, "Ifrit", "Swiftcasts Ruby Ruin/Ruby Rite",
-                        2);
-
-                    DrawHorizontalRadioButton(SMN_AoE_SwiftcastPhase, "Flexible (SpS) Option",
-                        "Swiftcasts the first available Egi when Swiftcast is ready.", 3);
-
-                    break;
-
-                case CustomComboPreset.SMN_ST_Advanced_Combo_Lucid:
-                    DrawSliderInt(4000, 9500, SMN_ST_Lucid,
-                        "Set value for your MP to be at or under for this feature to take effect.", 150,
+                
+                case Preset.SMN_ST_Advanced_Combo_Lucid:
+                    DrawSliderInt(4000, 9500, SMN_ST_Lucid, "Set value for your MP to be at or under for this feature to take effect.", 150,
                         SliderIncrements.Hundreds);
-
                     break;
-
-                case CustomComboPreset.SMN_AoE_Advanced_Combo_Lucid:
-                    DrawSliderInt(4000, 9500, SMN_AoE_Lucid,
-                        "Set value for your MP to be at or under for this feature to take effect.", 150,
-                        SliderIncrements.Hundreds);
-
-                    break;
-
-                case CustomComboPreset.SMN_Variant_Cure:
-                    DrawSliderInt(1, 100, SMN_VariantCure, "HP% to be at or under", 200);
-
-                    break;
-
-                case CustomComboPreset.SMN_ST_Advanced_Combo_Egi_AstralFlow:
-                {
+                
+                case Preset.SMN_ST_Advanced_Combo_Egi_AstralFlow:
                     DrawHorizontalMultiChoice(SMN_ST_Egi_AstralFlow, "Add Mountain Buster", "", 4, 0);
                     DrawHorizontalMultiChoice(SMN_ST_Egi_AstralFlow, "Add Crimson Cyclone", "", 4, 1);
                     DrawHorizontalMultiChoice(SMN_ST_Egi_AstralFlow, "Add Crimson Strike", "", 4, 3);
                     DrawHorizontalMultiChoice(SMN_ST_Egi_AstralFlow, "Add Slipstream", "", 4, 2);
 
                     if (SMN_ST_Egi_AstralFlow[1])
+                    {
                         DrawSliderInt(0, 25, SMN_ST_CrimsonCycloneMeleeDistance, " Maximum range to use Crimson Cyclone.");
-
+                    }
                     break;
-                }
+                #endregion
+                
+                #region AoE
+                case Preset.SMN_AoE_Advanced_Combo_Titan:
+                    DrawPriorityInput(SMN_AoE_Egi_Priority, 3, 0,
+                        $"{SummonTopaz.ActionName()} Priority: ");
+                    break;
 
-                case CustomComboPreset.SMN_AoE_Advanced_Combo_Egi_AstralFlow:
-                {
+                case Preset.SMN_AoE_Advanced_Combo_Garuda:
+                    DrawPriorityInput(SMN_AoE_Egi_Priority, 3, 1,
+                        $"{SummonEmerald.ActionName()} Priority: ");
+                    break;
+
+                case Preset.SMN_AoE_Advanced_Combo_Ifrit:
+                    DrawPriorityInput(SMN_AoE_Egi_Priority, 3, 2,
+                        $"{SummonRuby.ActionName()} Priority: ");
+                    break;
+                
+                case Preset.SMN_AoE_Advanced_Combo_DemiEgiMenu_SwiftcastEgi:
+                    DrawHorizontalRadioButton(SMN_AoE_SwiftcastPhase, "Garuda", "Swiftcasts Slipstream", 1);
+                    DrawHorizontalRadioButton(SMN_AoE_SwiftcastPhase, "Ifrit", "Swiftcasts Ruby Ruin/Ruby Rite", 2);
+                    DrawHorizontalRadioButton(SMN_AoE_SwiftcastPhase, "Flexible (SpS) Option",
+                        "Swiftcasts the first available Egi when Swiftcast is ready.", 3);
+                    break;
+                
+                case Preset.SMN_AoE_Advanced_Combo_Lucid:
+                    DrawSliderInt(4000, 9500, SMN_AoE_Lucid, "Set value for your MP to be at or under for this feature to take effect.", 150,
+                        SliderIncrements.Hundreds);
+                    break;
+                
+                case Preset.SMN_AoE_Advanced_Combo_Egi_AstralFlow:
                     DrawHorizontalMultiChoice(SMN_AoE_Egi_AstralFlow, "Add Mountain Buster", "", 4, 0);
                     DrawHorizontalMultiChoice(SMN_AoE_Egi_AstralFlow, "Add Crimson Cyclone", "", 4, 1);
                     DrawHorizontalMultiChoice(SMN_AoE_Egi_AstralFlow, "Add Crimson Strike", "", 4, 3);
                     DrawHorizontalMultiChoice(SMN_AoE_Egi_AstralFlow, "Add Slipstream", "", 4, 2);
 
                     if (SMN_AoE_Egi_AstralFlow[1])
+                    {
                         DrawSliderInt(0, 25, SMN_AoE_CrimsonCycloneMeleeDistance, " Maximum range to use Crimson Cyclone.");
-
+                    }
                     break;
-                }
+                #endregion
+                
+                #region Standalones
+                case Preset.SMN_Variant_Cure:
+                    DrawSliderInt(1, 100, SMN_VariantCure, "HP% to be at or under", 200);
+                    break;
+                #endregion
             }
         }
     }

--- a/WrathCombo/Combos/PvE/SMN/SMN_Helper.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN_Helper.cs
@@ -7,8 +7,8 @@ using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 using Dalamud.Game.ClientState.Objects.Types;
-using WrathCombo.Data;
-using System.Diagnostics.Metrics;
+using Preset = WrathCombo.Combos.CustomComboPreset;
+using static WrathCombo.Combos.PvE.SMN.Config;
 
 namespace WrathCombo.Combos.PvE;
 
@@ -194,7 +194,6 @@ internal partial class SMN
     #endregion
 
     #region Demi Summon Detector
-
     internal static DemiSummon CurrentDemiSummon
     {
         get
@@ -221,7 +220,6 @@ internal partial class SMN
     #endregion
 
     #region Egi Priority
-
     public static int GetMatchingConfigST(
         int i,
         IGameObject? optionalTarget,
@@ -233,19 +231,19 @@ internal partial class SMN
             case 0:
                 action = OriginalHook(SummonTopaz);
 
-                enabled = IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_Titan) && Gauge.IsTitanReady;
+                enabled = IsEnabled(Preset.SMN_ST_Advanced_Combo_Titan) && Gauge.IsTitanReady;
                 return 0;
 
             case 1:
                 action = OriginalHook(SummonEmerald);
 
-                enabled = IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_Garuda) && Gauge.IsGarudaReady;
+                enabled = IsEnabled(Preset.SMN_ST_Advanced_Combo_Garuda) && Gauge.IsGarudaReady;
                 return 0;
 
             case 2:
                 action = OriginalHook(SummonRuby);
 
-                enabled = IsEnabled(CustomComboPreset.SMN_ST_Advanced_Combo_Ifrit) && Gauge.IsIfritReady;
+                enabled = IsEnabled(Preset.SMN_ST_Advanced_Combo_Ifrit) && Gauge.IsIfritReady;
                 return 0;
         }
 
@@ -266,17 +264,17 @@ internal partial class SMN
             case 0:
                 action = OriginalHook(SummonTopaz);
 
-                enabled = IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_Titan) && Gauge.IsTitanReady;
+                enabled = IsEnabled(Preset.SMN_AoE_Advanced_Combo_Titan) && Gauge.IsTitanReady;
                 return 0;
             case 1:
                 action = OriginalHook(SummonEmerald);
 
-                enabled = IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_Garuda) && Gauge.IsGarudaReady;
+                enabled = IsEnabled(Preset.SMN_AoE_Advanced_Combo_Garuda) && Gauge.IsGarudaReady;
                 return 0;
             case 2:
                 action = OriginalHook(SummonRuby);
 
-                enabled = IsEnabled(CustomComboPreset.SMN_AoE_Advanced_Combo_Ifrit) && Gauge.IsIfritReady;
+                enabled = IsEnabled(Preset.SMN_AoE_Advanced_Combo_Ifrit) && Gauge.IsIfritReady;
                 return 0;
         }
 
@@ -285,18 +283,13 @@ internal partial class SMN
 
         return 0;
     }
-
     #endregion   
 
     #region Opener
-
     internal static SMNOpenerMaxLevel1 Opener1 = new();
     internal static WrathOpener Opener()
     {
-        if (Opener1.LevelChecked)
-            return Opener1;
-
-        return WrathOpener.Dummy;
+        return Opener1.LevelChecked ? Opener1 : WrathOpener.Dummy;
     }
 
     internal class SMNOpenerMaxLevel1 : WrathOpener
@@ -338,10 +331,10 @@ internal partial class SMN
             4,
         ];
 
-        public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } = [([26], () => Config.SMN_Opener_SkipSwiftcast == 2)];
+        public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } = [([26], () => SMN_Opener_SkipSwiftcast == 2)];
         public override int MinOpenerLevel => 100;
         public override int MaxOpenerLevel => 109;
-        internal override UserData? ContentCheckConfig => Config.SMN_Balance_Content;
+        internal override UserData? ContentCheckConfig => SMN_Balance_Content;
 
         public override bool HasCooldowns()
         {


### PR DESCRIPTION
- !Upgraded Feature RDM OGCD Standalone Customization
- !Upgraded Feature RDM Riposte Melee Combo added OGCD weave options
- !Upgraded Feature RDM Moulinet Melee Combo added OGCD weave options
- !Adjusted Feature PCT Burst Mode adjusted to 7.3 Hammer changes to use standard burst per balance
- Cleaning (SMN, PCT, BRD, RDM)
  - Used Alias to turn CustomComboPreset into Preset 
  - Cleaned a buttload of emptylines for no reason
  - using static config. so I dont need to type Config.
