### PR TITLE
[Various] General code cleanup/BLM - MNK - RPR Updates

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -3740,6 +3740,14 @@ public enum CustomComboPreset
     MNK_AOE_SimpleMode = 9003,
 
     #endregion
+    
+    #region Movement
+
+    [CustomComboInfo("Thunderclap Movement Option", "Retargets Thunderclap to UI/Field Mouseover", MNK.JobID)]
+    [Retargeted(MNK.Thunderclap)]
+    MNK_Retarget_Thunderclap = 9043,
+    
+    #endregion
 
     #region Monk Advanced ST
 
@@ -3807,7 +3815,7 @@ public enum CustomComboPreset
     MNK_ST_ComboHeals = 9018,
 
     #endregion
-
+    
     #region Monk Advanced AOE
 
     [AutoAction(true, false)]
@@ -3889,20 +3897,6 @@ public enum CustomComboPreset
     MNK_BC_COEURL = 9022,
 
     #endregion
-
-    #region Variant
-
-    [Variant]
-    [VariantParent(MNK_ST_SimpleMode, MNK_ST_AdvancedMode, MNK_AOE_SimpleMode, MNK_AOE_AdvancedMode)]
-    [CustomComboInfo("Rampart Option", "Use Variant Rampart on cooldown.", MNK.JobID)]
-    MNK_Variant_Rampart = 9025,
-
-    [Variant]
-    [VariantParent(MNK_ST_SimpleMode, MNK_ST_AdvancedMode, MNK_AOE_SimpleMode, MNK_AOE_AdvancedMode)]
-    [CustomComboInfo("Cure Option", "Use Variant Cure when HP is below set threshold.", MNK.JobID)]
-    MNK_Variant_Cure = 9026,
-
-    #endregion
     
     #region Misc
 
@@ -3926,6 +3920,20 @@ public enum CustomComboPreset
     
     #endregion
 
+    #region Variant
+
+    [Variant]
+    [VariantParent(MNK_ST_SimpleMode, MNK_ST_AdvancedMode, MNK_AOE_SimpleMode, MNK_AOE_AdvancedMode)]
+    [CustomComboInfo("Rampart Option", "Use Variant Rampart on cooldown.", MNK.JobID)]
+    MNK_Variant_Rampart = 9025,
+
+    [Variant]
+    [VariantParent(MNK_ST_SimpleMode, MNK_ST_AdvancedMode, MNK_AOE_SimpleMode, MNK_AOE_AdvancedMode)]
+    [CustomComboInfo("Cure Option", "Use Variant Cure when HP is below set threshold.", MNK.JobID)]
+    MNK_Variant_Cure = 9026,
+
+    #endregion
+
     #region Hidden Features
 
     [Hidden]
@@ -3939,7 +3947,7 @@ public enum CustomComboPreset
 
     #endregion
 
-    // Last value = 9042
+    // Last value = 9043
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -3905,14 +3905,10 @@ public enum CustomComboPreset
     [CustomComboInfo("Perfect Balance Feature", "Perfect Balance becomes Masterful Blitz while you have 3 Beast Chakra.", MNK.JobID)]
     MNK_PerfectBalance = 9023,
 
-    [ReplaceSkill(MNK.RiddleOfFire)]
-    [CustomComboInfo("Riddle of Fire/Brotherhood Feature", "Replaces Riddle of Fire with Brotherhood when Riddle of Fire is on cooldown.", MNK.JobID)]
-    MNK_Riddle_Brotherhood = 9024,
-
-    [ReplaceSkill(MNK.RiddleOfFire)]
-    [CustomComboInfo("Riddle of Fire/Brotherhood Feature", "Replaces Brotherhood with Riddle of Fire when Brotherhood is on cooldown.", MNK.JobID)]
-    MNK_Brotherhood_Riddle = 9041,
-
+    [ReplaceSkill(MNK.RiddleOfFire, MNK.Brotherhood)]
+    [CustomComboInfo("Riddle of Fire/Brotherhood Feature", "Replaces Riddle of Fire or Brotherhood when the other is on cooldown.", MNK.JobID)]
+    MNK_Brotherhood_Riddle = 9024,
+    
     [ReplaceSkill(MNK.PerfectBalance)]
     [ConflictingCombos(MNK_PerfectBalance)]
     [CustomComboInfo("Perfect Balance Protection", "Replaces Perfect Balance with Savage Blade when you already have Perfect Balance active.", MNK.JobID)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1116,8 +1116,8 @@ public enum CustomComboPreset
     [CustomComboInfo("Fire to Despair", "Replaces Fire  with Despair when in Astral Fire and below 2400 MP.", BLM.JobID)]
     BLM_Fire1Despair = 2065,
 
-    [ReplaceSkill(BLM.Blizzard4)]
-    [CustomComboInfo("Blizzard 4 to Despair", "Replaces Blizzard 4 with Despair when in Astral Fire.", BLM.JobID)]
+    [ReplaceSkill(BLM.Blizzard4, BLM.Blizzard3)]
+    [CustomComboInfo("Blizzard 3/4 to Despair", "Replaces Blizzard 3/4 with Despair when in Astral Fire.", BLM.JobID)]
     BLM_Blizzard4toDespair = 2060,
     
     [ReplaceSkill(BLM.Fire4, BLM.Flare)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -3751,11 +3751,11 @@ public enum CustomComboPreset
     MNK_ST_AdvancedMode = 9005,
 
     [ParentCombo(MNK_ST_AdvancedMode)]
-    [CustomComboInfo("Meditation Option", "Adds Meditation to the rotation", MNK.JobID)]
+    [CustomComboInfo("Steeled / Forbidden Meditation Option", "Adds Steeled / Forbidden Meditation to the rotation", MNK.JobID)]
     MNK_STUseMeditation = 9007,
 
     [ParentCombo(MNK_ST_AdvancedMode)]
-    [CustomComboInfo("The Forbidden Chakra Option", "Adds The Forbidden Chakra to the rotation", MNK.JobID)]
+    [CustomComboInfo("Steeled Peak / The Forbidden Chakra Option", "Adds Steeled Peak / The Forbidden Chakra to the rotation", MNK.JobID)]
     MNK_STUseTheForbiddenChakra = 9012,
 
     [ParentCombo(MNK_ST_AdvancedMode)]
@@ -3818,11 +3818,11 @@ public enum CustomComboPreset
     MNK_AOE_AdvancedMode = 9027,
 
     [ParentCombo(MNK_AOE_AdvancedMode)]
-    [CustomComboInfo("Meditation Option", "Adds Meditation to the rotation", MNK.JobID)]
+    [CustomComboInfo("Inspirited / Enlightened Meditation Option", "Adds Inspirited / Enlightened Meditation to the rotation", MNK.JobID)]
     MNK_AoEUseMeditation = 9028,
 
     [ParentCombo(MNK_AOE_AdvancedMode)]
-    [CustomComboInfo("Howling Fist Option", "Adds Howling Fist to the rotation", MNK.JobID)]
+    [CustomComboInfo("Howling Fist / Enlightenment Option", "Adds Howling Fist / Enlightenment to the rotation", MNK.JobID)]
     MNK_AoEUseHowlingFist = 9033,
 
     [ParentCombo(MNK_AOE_AdvancedMode)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1102,7 +1102,7 @@ public enum CustomComboPreset
     BLM_Fire1to3 = 2054,
 
     [ReplaceSkill(BLM.Blizzard, BLM.Blizzard3)]
-    [ConflictingCombos(BLM_FreezeBlizzard2)]
+    [ConflictingCombos(BLM_FreezeBlizzard2, BLM_Blizzard4toDespair)]
     [CustomComboInfo("Blizzard I/III Feature", "Replaces Blizzard I or Blizzard III.\nReplaces Freeze with Blizzard II when synced below Lv.40.", BLM.JobID)]
     BLM_Blizzard1to3 = 2052,
 
@@ -1117,6 +1117,7 @@ public enum CustomComboPreset
     BLM_Fire1Despair = 2065,
 
     [ReplaceSkill(BLM.Blizzard4, BLM.Blizzard3)]
+    [ConflictingCombos(BLM_Blizzard1to3, BLM_FreezeBlizzard2)]
     [CustomComboInfo("Blizzard 3/4 to Despair", "Replaces Blizzard 3/4 with Despair when in Astral Fire.", BLM.JobID)]
     BLM_Blizzard4toDespair = 2060,
     
@@ -1126,7 +1127,7 @@ public enum CustomComboPreset
     BLM_FireandIce = 2057,
 
     [ReplaceSkill(BLM.Blizzard, BLM.Blizzard3)]
-    [ConflictingCombos(BLM_FreezeParadox, BLM_Blizzard1to3)]
+    [ConflictingCombos(BLM_FreezeParadox, BLM_Blizzard1to3, BLM_Blizzard4toDespair)]
     [CustomComboInfo("Freeze to Blizzard II", "nReplaces Freeze with Blizzard II when synced below Lv.40.", BLM.JobID)]
     BLM_FreezeBlizzard2 = 2064,
 

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -591,6 +591,7 @@ internal partial class BLM : Caster
                         ActionReady(Transpose))
                         return Transpose;
                 }
+
                 if (LevelChecked(Freeze))
                     return IsEnabled(CustomComboPreset.BLM_AoE_Blizzard4Sub) &&
                            LevelChecked(Blizzard4) && HasBattleTarget() &&

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -84,7 +84,7 @@ internal partial class BLM : Caster
                 HasMaxPolyglotStacks)
                 return Xenoglossy;
 
-            if (IsMoving() && InCombat())
+            if (IsMoving() && InCombat() && HasBattleTarget())
             {
                 if (ActionReady(Triplecast) &&
                     !HasStatusEffect(Buffs.Triplecast) &&
@@ -304,7 +304,7 @@ internal partial class BLM : Caster
                 HasMaxPolyglotStacks)
                 return Xenoglossy;
 
-            if (IsMoving() && InCombat())
+            if (IsMoving() && InCombat() && HasBattleTarget())
             {
                 foreach(int priority in BLM_ST_Movement_Priority.Items.OrderBy(x => x))
                 {
@@ -646,8 +646,18 @@ internal partial class BLM : Caster
         protected override uint Invoke(uint actionID) =>
             actionID switch
             {
-                Fire when BLM_F1to3 == 0 && LevelChecked(Fire3) && (IcePhase || ((AstralFireStacks is 1 or 2) && HasStatusEffect(Buffs.Firestarter)) || !InCombat()) && !JustUsed(Fire3) => Fire3,
-                Fire3 when BLM_F1to3 == 1 && LevelChecked(Fire3) && FirePhase && (AstralFireStacks is 3 || ((AstralFireStacks is 1 or 2) && !HasStatusEffect(Buffs.Firestarter))) && !JustUsed(OriginalHook(Fire)) => OriginalHook(Fire),
+                Fire when BLM_F1to3 == 0 && LevelChecked(Fire3) &&
+                          (AstralFireStacks is 1 or 2 && HasStatusEffect(Buffs.Firestarter) ||
+                           LevelChecked(Paradox) && !ActiveParadox ||
+                           !InCombat() && LevelChecked(Fire4) ||
+                           IcePhase ||
+                           !LevelChecked(Fire4) && HasStatusEffect(Buffs.Firestarter)) &&
+                          !JustUsed(Fire3) => Fire3,
+
+                Fire3 when BLM_F1to3 == 1 && LevelChecked(Fire3) && FirePhase &&
+                           (LevelChecked(Paradox) && ActiveParadox && AstralFireStacks is 3 ||
+                            !LevelChecked(Fire4) && !HasStatusEffect(Buffs.Firestarter)) &&
+                           !JustUsed(OriginalHook(Fire)) => OriginalHook(Fire),
                 var _ => actionID
             };
     }

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -699,15 +699,12 @@ internal partial class BLM : Caster
     internal class BLM_Fire1Despair : CustomCombo
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_Fire1Despair;
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not Fire)
-                return actionID;
-            
-            return FirePhase && CurMp < 2400
-                ? Despair
-                : OriginalHook(Fire);
-        }
+        protected override uint Invoke(uint actionID) =>
+            actionID is not Fire
+                ? actionID
+                : FirePhase && CurMp < 2400
+                    ? Despair
+                    : OriginalHook(Fire);
     }
 
     internal class BLM_FreezeParadox : CustomCombo

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -650,7 +650,7 @@ internal partial class BLM : Caster
                           (AstralFireStacks is 1 or 2 && HasStatusEffect(Buffs.Firestarter) ||
                            LevelChecked(Paradox) && !ActiveParadox ||
                            !InCombat() && LevelChecked(Fire4) ||
-                           IcePhase ||
+                           IcePhase && !ActiveParadox ||
                            !LevelChecked(Fire4) && HasStatusEffect(Buffs.Firestarter)) &&
                           !JustUsed(Fire3) => Fire3,
 
@@ -701,9 +701,12 @@ internal partial class BLM : Caster
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_Blizzard4toDespair;
         protected override uint Invoke(uint actionID) =>
-            actionID is Blizzard4 && FirePhase && LevelChecked(Despair)
-                ? Despair
-                : actionID;
+            actionID switch
+            {
+                Blizzard4 when BLM_B4toDespair == 0 && FirePhase && LevelChecked(Despair) => Despair,
+                Blizzard3 when BLM_B4toDespair == 1 && FirePhase && LevelChecked(Despair) => Despair,
+                var _ => actionID
+            };
     }
 
     internal class BLM_Fire1Despair : CustomCombo

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -699,10 +699,15 @@ internal partial class BLM : Caster
     internal class BLM_Fire1Despair : CustomCombo
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.BLM_Fire1Despair;
-        protected override uint Invoke(uint actionID) =>
-            actionID is Fire && FirePhase && CurMp < 2400
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not Fire)
+                return actionID;
+            
+            return FirePhase && CurMp < 2400
                 ? Despair
                 : OriginalHook(Fire);
+        }
     }
 
     internal class BLM_FreezeParadox : CustomCombo

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -73,7 +73,7 @@ internal partial class BLM : Caster
 
             if (LevelChecked(Thunder) && HasStatusEffect(Buffs.Thunderhead) &&
                 CanApplyStatus(CurrentTarget, ThunderList[OriginalHook(Thunder)]) &&
-                ((ThunderDebuffST is null && ThunderDebuffAoE is null) ||
+                (ThunderDebuffST is null && ThunderDebuffAoE is null ||
                  ThunderDebuffST?.RemainingTime <= 3 ||
                  ThunderDebuffAoE?.RemainingTime <= 3) &&
                 GetTargetHPPercent() > 0)
@@ -113,7 +113,7 @@ internal partial class BLM : Caster
             if (FirePhase)
             {
                 // TODO: Revisit when Raid Buff checks are in place
-                if ((PolyglotStacks > 1))
+                if (PolyglotStacks > 1)
                     return LevelChecked(Xenoglossy)
                         ? Xenoglossy
                         : Foul;
@@ -233,7 +233,7 @@ internal partial class BLM : Caster
                         ActionReady(Triplecast) && IsOnCooldown(Role.Swiftcast) &&
                         !HasStatusEffect(Role.Buffs.Swiftcast) && !HasStatusEffect(Buffs.Triplecast) &&
                         (BLM_ST_Triplecast_SubOption == 0 || !HasStatusEffect(Buffs.LeyLines)) &&
-                        ((BLM_ST_MovementOption[0] && GetRemainingCharges(Triplecast) > BLM_ST_Triplecast_Movement) ||
+                        (BLM_ST_MovementOption[0] && GetRemainingCharges(Triplecast) > BLM_ST_Triplecast_Movement ||
                          !BLM_ST_MovementOption[0]) && JustUsed(Despair) && !ActionReady(Manafont))
                         return Triplecast;
 
@@ -261,7 +261,7 @@ internal partial class BLM : Caster
                             ActionReady(Triplecast) && IsOnCooldown(Role.Swiftcast) &&
                             !HasStatusEffect(Role.Buffs.Swiftcast) && !HasStatusEffect(Buffs.Triplecast) &&
                             (BLM_ST_Triplecast_SubOption == 0 || !HasStatusEffect(Buffs.LeyLines)) &&
-                            ((BLM_ST_MovementOption[0] && GetRemainingCharges(Triplecast) > BLM_ST_Triplecast_Movement) ||
+                            (BLM_ST_MovementOption[0] && GetRemainingCharges(Triplecast) > BLM_ST_Triplecast_Movement ||
                              !BLM_ST_MovementOption[0]) && JustUsed(Despair) && !ActionReady(Manafont))
                             return Triplecast;
                     }
@@ -290,7 +290,7 @@ internal partial class BLM : Caster
                 int hpThreshold = BLM_ST_Thunder_SubOption == 1 || !InBossEncounter() ? BLM_ST_ThunderOption : 0;
 
                 if (CanApplyStatus(CurrentTarget, ThunderList[OriginalHook(Thunder)]) &&
-                    ((ThunderDebuffST is null && ThunderDebuffAoE is null) ||
+                    (ThunderDebuffST is null && ThunderDebuffAoE is null ||
                      ThunderDebuffST?.RemainingTime <= refreshTimer ||
                      ThunderDebuffAoE?.RemainingTime <= refreshTimer) &&
                     GetTargetHPPercent() > hpThreshold)
@@ -318,11 +318,11 @@ internal partial class BLM : Caster
             {
                 // TODO: Revisit when Raid Buff checks are in place
                 if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot) &&
-                    ((BLM_ST_MovementOption[3] &&
-                      PolyglotStacks > BLM_ST_Polyglot_Movement &&
-                      PolyglotStacks > BLM_ST_Polyglot_Save) ||
-                     (!BLM_ST_MovementOption[3] &&
-                      PolyglotStacks > BLM_ST_Polyglot_Save)))
+                    (BLM_ST_MovementOption[3] &&
+                     PolyglotStacks > BLM_ST_Polyglot_Movement &&
+                     PolyglotStacks > BLM_ST_Polyglot_Save ||
+                     !BLM_ST_MovementOption[3] &&
+                     PolyglotStacks > BLM_ST_Polyglot_Save))
                     return LevelChecked(Xenoglossy)
                         ? Xenoglossy
                         : Foul;
@@ -442,7 +442,7 @@ internal partial class BLM : Caster
             if (HasStatusEffect(Buffs.Thunderhead) && LevelChecked(Thunder2) &&
                 GetTargetHPPercent() > 1 &&
                 CanApplyStatus(CurrentTarget, ThunderList[OriginalHook(Thunder2)]) &&
-                ((ThunderDebuffAoE is null && ThunderDebuffST is null) ||
+                (ThunderDebuffAoE is null && ThunderDebuffST is null ||
                  ThunderDebuffAoE?.RemainingTime <= 3 ||
                  ThunderDebuffST?.RemainingTime <= 3) &&
                 (EndOfFirePhase || EndOfIcePhase || EndOfIcePhaseAoEMaxLevel))
@@ -542,8 +542,8 @@ internal partial class BLM : Caster
             if (IsEnabled(CustomComboPreset.BLM_AoE_Thunder) &&
                 HasStatusEffect(Buffs.Thunderhead) && LevelChecked(Thunder2) &&
                 CanApplyStatus(CurrentTarget, ThunderList[OriginalHook(Thunder2)]) &&
-                (GetTargetHPPercent() > BLM_AoE_ThunderHP) &&
-                ((ThunderDebuffAoE is null && ThunderDebuffST is null) ||
+                GetTargetHPPercent() > BLM_AoE_ThunderHP &&
+                (ThunderDebuffAoE is null && ThunderDebuffST is null ||
                  ThunderDebuffAoE?.RemainingTime <= 3 ||
                  ThunderDebuffST?.RemainingTime <= 3) &&
                 (EndOfFirePhase || EndOfIcePhase || EndOfIcePhaseAoEMaxLevel))

--- a/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Config.cs
@@ -143,6 +143,14 @@ internal partial class BLM
                     DrawRadioButton(BLM_F1to3,
                         $"Replaces {Fire3.ActionName()}", $"Replaces {Fire3.ActionName()} with {Fire.ActionName()} when in Astral Fire III.", 1);
                     break;
+
+                case CustomComboPreset.BLM_Blizzard4toDespair:
+                    DrawRadioButton(BLM_B4toDespair,
+                        $"Replaces {Blizzard4.ActionName()}", $"Replaces {Blizzard4.ActionName()} with {Despair.ActionName()} when in Astral Fire.", 0);
+
+                    DrawRadioButton(BLM_B4toDespair,
+                        $"Replaces {Blizzard3.ActionName()}", $"Replaces {Blizzard3.ActionName()} with {Despair.ActionName()} when in Astral Fire.", 1);
+                    break;
             }
         }
 
@@ -165,6 +173,7 @@ internal partial class BLM
             BLM_AoE_ThunderHP = new("BLM_AoE_ThunderHP", 20),
             BLM_VariantCure = new("BLM_VariantCure", 50),
             BLM_B1to3 = new("BLM_B1to3", 0),
+            BLM_B4toDespair = new("BLM_B4toDespair", 0),
             BLM_F1to3 = new("BLM_F1to3", 0);
 
         public static UserBoolArray

--- a/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
@@ -52,7 +52,7 @@ internal partial class BLM
             : Blizzard;
 
     internal static bool HasMaxUmbralHeartStacks =>
-        !TraitLevelChecked(Traits.UmbralHeart) || UmbralHearts is 3; //Returns true before you can have Umbral Hearts out of design
+        UmbralHearts is 3;
 
     internal static bool HasPolyglotStacks() =>
         PolyglotStacks > 0;

--- a/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
@@ -165,13 +165,10 @@ internal partial class BLM
 
         internal override UserData ContentCheckConfig => Config.BLM_Balance_Content;
 
-        public override List<int> DelayedWeaveSteps { get; set; } =
-        [
-            6
-        ];
+        public override List<int> DelayedWeaveSteps { get; set; } = [6];
 
         public override bool HasCooldowns() =>
-            CurMp == MP.MaxMP &&
+            CurMp is MP.MaxMP &&
             IsOffCooldown(Manafont) &&
             GetRemainingCharges(Triplecast) >= 1 &&
             GetRemainingCharges(LeyLines) >= 1 &&
@@ -221,13 +218,10 @@ internal partial class BLM
 
         internal override UserData ContentCheckConfig => Config.BLM_Balance_Content;
 
-        public override List<int> DelayedWeaveSteps { get; set; } =
-        [
-            6
-        ];
+        public override List<int> DelayedWeaveSteps { get; set; } = [6];
 
         public override bool HasCooldowns() =>
-            CurMp == MP.MaxMP &&
+            CurMp is MP.MaxMP &&
             IsOffCooldown(Manafont) &&
             GetRemainingCharges(Triplecast) >= 1 &&
             GetRemainingCharges(LeyLines) >= 1 &&

--- a/WrathCombo/Combos/PvE/DRG/DRG.cs
+++ b/WrathCombo/Combos/PvE/DRG/DRG.cs
@@ -18,8 +18,8 @@ internal partial class DRG : Melee
             {
                 if (ComboAction is TrueThrust or RaidenThrust && LevelChecked(VorpalThrust))
                     return LevelChecked(Disembowel) &&
-                           ((LevelChecked(ChaosThrust) && ChaosDebuff is null &&
-                             CanApplyStatus(CurrentTarget, ChaoticList[OriginalHook(ChaosThrust)])) ||
+                           (LevelChecked(ChaosThrust) && ChaosDebuff is null &&
+                            CanApplyStatus(CurrentTarget, ChaoticList[OriginalHook(ChaosThrust)]) ||
                             GetStatusEffectRemainingTime(Buffs.PowerSurge) < 15)
                         ? OriginalHook(Disembowel)
                         : OriginalHook(VorpalThrust);
@@ -87,10 +87,10 @@ internal partial class DRG : Melee
                     //Mirage Feature
                     if (ActionReady(MirageDive) &&
                         HasStatusEffect(Buffs.DiveReady) &&
-                        (OriginalHook(Jump) is MirageDive) &&
+                        OriginalHook(Jump) is MirageDive &&
                         (LoTDActive ||
-                         (GetStatusEffectRemainingTime(Buffs.DiveReady) <= 1.2f &&
-                          GetCooldownRemainingTime(Geirskogul) > 3)))
+                         GetStatusEffectRemainingTime(Buffs.DiveReady) <= 1.2f &&
+                         GetCooldownRemainingTime(Geirskogul) > 3))
                         return MirageDive;
 
                     //Wyrmwind Thrust Feature
@@ -161,23 +161,19 @@ internal partial class DRG : Melee
             {
                 if (ComboAction is TrueThrust or RaidenThrust && LevelChecked(VorpalThrust))
                     return LevelChecked(Disembowel) &&
-                           ((LevelChecked(ChaosThrust) && ChaosDebuff is null &&
-                             CanApplyStatus(CurrentTarget, ChaoticList[OriginalHook(ChaosThrust)])) ||
+                           (LevelChecked(ChaosThrust) && ChaosDebuff is null &&
+                            CanApplyStatus(CurrentTarget, ChaoticList[OriginalHook(ChaosThrust)]) ||
                             GetStatusEffectRemainingTime(Buffs.PowerSurge) < 15)
                         ? OriginalHook(Disembowel)
                         : OriginalHook(VorpalThrust);
 
                 if (ComboAction == OriginalHook(Disembowel) && LevelChecked(ChaosThrust))
-                    return Role.CanTrueNorth() &&
-                           CanDRGWeave() &&
-                           !OnTargetsRear()
+                    return Role.CanTrueNorth() && CanDRGWeave() && !OnTargetsRear()
                         ? Role.TrueNorth
                         : OriginalHook(ChaosThrust);
 
                 if (ComboAction == OriginalHook(ChaosThrust) && LevelChecked(WheelingThrust))
-                    return Role.CanTrueNorth() &&
-                           CanDRGWeave() &&
-                           !OnTargetsRear()
+                    return Role.CanTrueNorth() && CanDRGWeave() && !OnTargetsRear()
                         ? Role.TrueNorth
                         : WheelingThrust;
 
@@ -185,9 +181,7 @@ internal partial class DRG : Melee
                     return OriginalHook(FullThrust);
 
                 if (ComboAction == OriginalHook(FullThrust) && LevelChecked(FangAndClaw))
-                    return Role.CanTrueNorth() &&
-                           CanDRGWeave() &&
-                           !OnTargetsFlank()
+                    return Role.CanTrueNorth() && CanDRGWeave() && !OnTargetsFlank()
                         ? Role.TrueNorth
                         : FangAndClaw;
 
@@ -260,10 +254,10 @@ internal partial class DRG : Melee
                             ActionReady(MirageDive) &&
                             HasStatusEffect(Buffs.DiveReady) &&
                             (OriginalHook(Jump) is MirageDive) &&
-                            ((DRG_ST_DoubleMirage &&
-                              (LoTDActive ||
-                               (GetStatusEffectRemainingTime(Buffs.DiveReady) <= 1.2f &&
-                                GetCooldownRemainingTime(Geirskogul) > 3))) ||
+                            (DRG_ST_DoubleMirage &&
+                             (LoTDActive ||
+                              GetStatusEffectRemainingTime(Buffs.DiveReady) <= 1.2f &&
+                              GetCooldownRemainingTime(Geirskogul) > 3) ||
                              !DRG_ST_DoubleMirage))
                             return MirageDive;
 
@@ -317,8 +311,8 @@ internal partial class DRG : Melee
                                 return Jump;
 
                             if (LevelChecked(HighJump) &&
-                                ((DRG_ST_DoubleMirage &&
-                                  (GetCooldownRemainingTime(Geirskogul) < 13 || LoTDActive)) ||
+                                (DRG_ST_DoubleMirage &&
+                                 (GetCooldownRemainingTime(Geirskogul) < 13 || LoTDActive) ||
                                  !DRG_ST_DoubleMirage))
                                 return (HighJump);
                         }
@@ -364,25 +358,21 @@ internal partial class DRG : Melee
             {
                 if (ComboAction is TrueThrust or RaidenThrust && LevelChecked(VorpalThrust))
                     return LevelChecked(Disembowel) &&
-                           ((LevelChecked(ChaosThrust) && ChaosDebuff is null &&
-                             CanApplyStatus(CurrentTarget, ChaoticList[OriginalHook(ChaosThrust)])) ||
+                           (LevelChecked(ChaosThrust) && ChaosDebuff is null &&
+                            CanApplyStatus(CurrentTarget, ChaoticList[OriginalHook(ChaosThrust)]) ||
                             GetStatusEffectRemainingTime(Buffs.PowerSurge) < 15)
                         ? OriginalHook(Disembowel)
                         : OriginalHook(VorpalThrust);
 
                 if (ComboAction == OriginalHook(Disembowel) && LevelChecked(ChaosThrust))
                     return IsEnabled(CustomComboPreset.DRG_TrueNorthDynamic) &&
-                           Role.CanTrueNorth() &&
-                           CanDRGWeave() &&
-                           !OnTargetsRear()
+                           Role.CanTrueNorth() && CanDRGWeave() && !OnTargetsRear()
                         ? Role.TrueNorth
                         : OriginalHook(ChaosThrust);
 
                 if (ComboAction == OriginalHook(ChaosThrust) && LevelChecked(WheelingThrust))
                     return IsEnabled(CustomComboPreset.DRG_TrueNorthDynamic) &&
-                           Role.CanTrueNorth() &&
-                           CanDRGWeave() &&
-                           !OnTargetsRear()
+                           Role.CanTrueNorth() && CanDRGWeave() && !OnTargetsRear()
                         ? Role.TrueNorth
                         : WheelingThrust;
 
@@ -391,9 +381,7 @@ internal partial class DRG : Melee
 
                 if (ComboAction == OriginalHook(FullThrust) && LevelChecked(FangAndClaw))
                     return IsEnabled(CustomComboPreset.DRG_TrueNorthDynamic) &&
-                           Role.CanTrueNorth() &&
-                           CanDRGWeave() &&
-                           !OnTargetsFlank()
+                           Role.CanTrueNorth() && CanDRGWeave() && !OnTargetsFlank()
                         ? Role.TrueNorth
                         : FangAndClaw;
 
@@ -472,10 +460,10 @@ internal partial class DRG : Melee
 
                     if (ActionReady(MirageDive) &&
                         HasStatusEffect(Buffs.DiveReady) &&
-                        (OriginalHook(Jump) is MirageDive) &&
+                        OriginalHook(Jump) is MirageDive &&
                         (LoTDActive ||
-                         (GetStatusEffectRemainingTime(Buffs.DiveReady) <= 1.2f &&
-                          GetCooldownRemainingTime(Geirskogul) > 3)))
+                         GetStatusEffectRemainingTime(Buffs.DiveReady) <= 1.2f &&
+                         GetCooldownRemainingTime(Geirskogul) > 3))
                         return MirageDive;
 
                     //Nastrond Feature
@@ -624,10 +612,10 @@ internal partial class DRG : Melee
                         if (IsEnabled(CustomComboPreset.DRG_AoE_Mirage) &&
                             ActionReady(MirageDive) &&
                             HasStatusEffect(Buffs.DiveReady) &&
-                            (OriginalHook(Jump) is MirageDive) &&
+                            OriginalHook(Jump) is MirageDive &&
                             (LoTDActive ||
-                             (GetStatusEffectRemainingTime(Buffs.DiveReady) <= 1.2f &&
-                              GetCooldownRemainingTime(Geirskogul) > 3)))
+                             GetStatusEffectRemainingTime(Buffs.DiveReady) <= 1.2f &&
+                             GetCooldownRemainingTime(Geirskogul) > 3))
                             return MirageDive;
 
                         //Nastrond Feature

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -171,7 +171,6 @@ internal partial class MCH
             LevelChecked(Excavator) && HasStatusEffect(Buffs.ExcavatorReady))
         {
             actionID = Excavator;
-
             return true;
         }
 
@@ -187,7 +186,6 @@ internal partial class MCH
              GetStatusEffectRemainingTime(Buffs.ExcavatorReady) <= 6))
         {
             actionID = Excavator;
-
             return true;
         }
 
@@ -197,7 +195,6 @@ internal partial class MCH
             GetCooldownRemainingTime(Chainsaw) <= GCD / 2)
         {
             actionID = Chainsaw;
-
             return true;
         }
 
@@ -207,7 +204,6 @@ internal partial class MCH
             GetCooldownRemainingTime(AirAnchor) <= GCD / 2)
         {
             actionID = AirAnchor;
-
             return true;
         }
 
@@ -217,7 +213,6 @@ internal partial class MCH
             ActionReady(Drill) && GetCooldownRemainingTime(Wildfire) is >= 20 or <= 10)
         {
             actionID = Drill;
-
             return true;
         }
 
@@ -227,7 +222,6 @@ internal partial class MCH
             GetCooldownRemainingTime(HotShot) <= GCD / 2)
         {
             actionID = HotShot;
-
             return true;
         }
 
@@ -270,6 +264,7 @@ internal partial class MCH
         public override int MinOpenerLevel => 100;
 
         public override int MaxOpenerLevel => 109;
+        
         public override List<uint> OpenerActions { get; set; } =
         [
             Reassemble,
@@ -330,6 +325,7 @@ internal partial class MCH
         public override int MinOpenerLevel => 90;
 
         public override int MaxOpenerLevel => 99;
+        
         public override List<uint> OpenerActions { get; set; } =
         [
             Reassemble,

--- a/WrathCombo/Combos/PvE/MNK/MNK.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK.cs
@@ -513,8 +513,8 @@ internal partial class MNK : Melee
         protected internal override CustomComboPreset Preset => CustomComboPreset.MNK_Retarget_Thunderclap;
 
         protected override uint Invoke(uint actionID) =>
-            actionID is Thunderclap 
-                ? Thunderclap.Retarget(SimpleTarget.Stack.MouseOver ?? SimpleTarget.HardTarget, true) 
+            actionID is Thunderclap
+                ? Thunderclap.Retarget(SimpleTarget.Stack.MouseOver ?? SimpleTarget.HardTarget, true)
                 : actionID;
     }
 

--- a/WrathCombo/Combos/PvE/MNK/MNK.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK.cs
@@ -45,6 +45,9 @@ internal partial class MNK : Melee
             // OGCDs
             if (CanWeave())
             {
+                if (UsePerfectBalanceST())
+                    return PerfectBalance;
+
                 if (UseBrotherhood())
                     return Brotherhood;
 
@@ -53,9 +56,6 @@ internal partial class MNK : Melee
 
                 if (UseRoW())
                     return RiddleOfWind;
-
-                if (UsePerfectBalanceST())
-                    return PerfectBalance;
 
                 if (Role.CanSecondWind(25))
                     return Role.SecondWind;
@@ -81,30 +81,27 @@ internal partial class MNK : Melee
                 InMasterfulRange() && !IsOriginal(MasterfulBlitz))
                 return OriginalHook(MasterfulBlitz);
 
-            if (HasStatusEffect(Buffs.FiresRumination) &&
-                !HasStatusEffect(Buffs.FormlessFist) &&
-                !HasStatusEffect(Buffs.PerfectBalance) &&
-                !JustUsed(RiddleOfFire, 4) &&
-                (JustUsed(OriginalHook(Bootshine)) ||
-                 JustUsed(DragonKick) ||
-                 GetStatusEffectRemainingTime(Buffs.FiresRumination) < 4 ||
-                 !InMeleeRange()))
-                return FiresReply;
-
             if (HasStatusEffect(Buffs.WindsRumination) &&
-                !HasStatusEffect(Buffs.PerfectBalance) &&
-                (GetCooldownRemainingTime(RiddleOfFire) > 10 ||
+                (GetCooldownRemainingTime(RiddleOfFire) > 5 ||
                  HasStatusEffect(Buffs.RiddleOfFire) ||
                  GetStatusEffectRemainingTime(Buffs.WindsRumination) < GCD * 2 ||
                  !InMeleeRange()))
                 return WindsReply;
 
-            // Perfect Balance
-            if (DoPerfectBalanceComboST(ref actionID))
-                return actionID;
+            if (HasStatusEffect(Buffs.FiresRumination) &&
+                !HasStatusEffect(Buffs.FormlessFist) &&
+                !HasStatusEffect(Buffs.PerfectBalance) &&
+                IsOriginal(MasterfulBlitz) &&
+                (JustUsed(OriginalHook(Bootshine)) ||
+                 JustUsed(DragonKick) ||
+                 GetStatusEffectRemainingTime(Buffs.FiresRumination) < GCD * 2 ||
+                 !InMeleeRange()))
+                return FiresReply;
 
-            // Standard Beast Chakras
-            return DetermineCoreAbility(actionID, true);
+            // Perfect Balance or Standard Beast Chakras
+            return DoPerfectBalanceComboST(ref actionID)
+                ? actionID
+                : DetermineCoreAbility(actionID, true);
         }
     }
 
@@ -158,6 +155,10 @@ internal partial class MNK : Melee
             // OGCDs
             if (CanWeave() && M6SReady)
             {
+                if (IsEnabled(CustomComboPreset.MNK_STUsePerfectBalance) &&
+                    UsePerfectBalanceST())
+                    return PerfectBalance;
+
                 if (IsEnabled(CustomComboPreset.MNK_STUseBuffs))
                 {
                     if (IsEnabled(CustomComboPreset.MNK_STUseBrotherhood) &&
@@ -175,10 +176,6 @@ internal partial class MNK : Melee
                         (MNK_ST_RiddleOfWind_SubOption == 0 || InBossEncounter()))
                         return RiddleOfWind;
                 }
-
-                if (IsEnabled(CustomComboPreset.MNK_STUsePerfectBalance) &&
-                    UsePerfectBalanceST())
-                    return PerfectBalance;
 
                 if (IsEnabled(CustomComboPreset.MNK_ST_ComboHeals))
                 {
@@ -212,33 +209,30 @@ internal partial class MNK : Melee
 
             if (IsEnabled(CustomComboPreset.MNK_STUseBuffs))
             {
-                if (IsEnabled(CustomComboPreset.MNK_STUseFiresReply) &&
-                    HasStatusEffect(Buffs.FiresRumination) &&
-                    !HasStatusEffect(Buffs.FormlessFist) &&
-                    !HasStatusEffect(Buffs.PerfectBalance) &&
-                    !JustUsed(RiddleOfFire, 4) &&
-                    (JustUsed(OriginalHook(Bootshine)) ||
-                     JustUsed(DragonKick) ||
-                     (GetStatusEffectRemainingTime(Buffs.FiresRumination) < GCD * 2) ||
-                     !InMeleeRange()))
-                    return FiresReply;
-
                 if (IsEnabled(CustomComboPreset.MNK_STUseWindsReply) &&
                     HasStatusEffect(Buffs.WindsRumination) &&
-                    !HasStatusEffect(Buffs.PerfectBalance) &&
-                    (GetCooldownRemainingTime(RiddleOfFire) > 10 ||
+                    (GetCooldownRemainingTime(RiddleOfFire) > 5 ||
                      HasStatusEffect(Buffs.RiddleOfFire) ||
                      GetStatusEffectRemainingTime(Buffs.WindsRumination) < GCD * 2 ||
                      !InMeleeRange()))
                     return WindsReply;
+
+                if (IsEnabled(CustomComboPreset.MNK_STUseFiresReply) &&
+                    HasStatusEffect(Buffs.FiresRumination) &&
+                    !HasStatusEffect(Buffs.FormlessFist) &&
+                    !HasStatusEffect(Buffs.PerfectBalance) &&
+                    IsOriginal(MasterfulBlitz) &&
+                    (JustUsed(OriginalHook(Bootshine)) ||
+                     JustUsed(DragonKick) ||
+                     GetStatusEffectRemainingTime(Buffs.FiresRumination) < GCD * 2 ||
+                     !InMeleeRange()))
+                    return FiresReply;
             }
 
-            // Perfect Balance
-            if (DoPerfectBalanceComboST(ref actionID))
-                return actionID;
-
-            // Standard Beast Chakras
-            return DetermineCoreAbility(actionID, IsEnabled(CustomComboPreset.MNK_STUseTrueNorth));
+            // Perfect Balance or Standard Beast Chakras
+            return DoPerfectBalanceComboST(ref actionID)
+                ? actionID
+                : DetermineCoreAbility(actionID, IsEnabled(CustomComboPreset.MNK_STUseTrueNorth));
         }
     }
 
@@ -282,6 +276,9 @@ internal partial class MNK : Melee
             // OGCD's
             if (CanWeave())
             {
+                if (UsePerfectBalanceAoE())
+                    return PerfectBalance;
+
                 if (UseBrotherhood())
                     return Brotherhood;
 
@@ -290,9 +287,6 @@ internal partial class MNK : Melee
 
                 if (UseRoW())
                     return RiddleOfWind;
-
-                if (UsePerfectBalanceAoE())
-                    return PerfectBalance;
 
                 if (Role.CanSecondWind(25))
                     return Role.SecondWind;
@@ -393,6 +387,10 @@ internal partial class MNK : Melee
             // OGCD's 
             if (CanWeave() && M6SReady)
             {
+                if (IsEnabled(CustomComboPreset.MNK_AoEUsePerfectBalance) &&
+                    UsePerfectBalanceAoE())
+                    return PerfectBalance;
+
                 if (IsEnabled(CustomComboPreset.MNK_AoEUseBuffs))
                 {
                     if (IsEnabled(CustomComboPreset.MNK_AoEUseBrotherhood) &&
@@ -410,9 +408,6 @@ internal partial class MNK : Melee
                         GetTargetHPPercent() >= MNK_AoE_RiddleOfWind_HP)
                         return RiddleOfWind;
                 }
-                if (IsEnabled(CustomComboPreset.MNK_AoEUsePerfectBalance) &&
-                    UsePerfectBalanceAoE())
-                    return PerfectBalance;
 
                 if (IsEnabled(CustomComboPreset.MNK_AoE_ComboHeals))
                 {

--- a/WrathCombo/Combos/PvE/MNK/MNK.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK.cs
@@ -1,3 +1,4 @@
+using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 using static WrathCombo.Combos.PvE.MNK.Config;
 namespace WrathCombo.Combos.PvE;
@@ -505,6 +506,16 @@ internal partial class MNK : Melee
 
             return actionID;
         }
+    }
+
+    internal class MNK_Retarget_Thunderclap : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset => CustomComboPreset.MNK_Retarget_Thunderclap;
+
+        protected override uint Invoke(uint actionID) =>
+            actionID is Thunderclap 
+                ? Thunderclap.Retarget(SimpleTarget.Stack.MouseOver ?? SimpleTarget.HardTarget, true) 
+                : actionID;
     }
 
     internal class MNK_PerfectBalance : CustomCombo

--- a/WrathCombo/Combos/PvE/MNK/MNK.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK.cs
@@ -92,9 +92,9 @@ internal partial class MNK : Melee
 
             if (HasStatusEffect(Buffs.WindsRumination) &&
                 !HasStatusEffect(Buffs.PerfectBalance) &&
-                ((GetCooldownRemainingTime(RiddleOfFire) > 10) ||
+                (GetCooldownRemainingTime(RiddleOfFire) > 10 ||
                  HasStatusEffect(Buffs.RiddleOfFire) ||
-                 (GetStatusEffectRemainingTime(Buffs.WindsRumination) < GCD * 2) ||
+                 GetStatusEffectRemainingTime(Buffs.WindsRumination) < GCD * 2 ||
                  !InMeleeRange()))
                 return WindsReply;
 
@@ -174,6 +174,7 @@ internal partial class MNK : Melee
                         (MNK_ST_RiddleOfWind_SubOption == 0 || InBossEncounter()))
                         return RiddleOfWind;
                 }
+
                 if (IsEnabled(CustomComboPreset.MNK_STUsePerfectBalance) &&
                     UsePerfectBalanceST())
                     return PerfectBalance;
@@ -224,9 +225,9 @@ internal partial class MNK : Melee
                 if (IsEnabled(CustomComboPreset.MNK_STUseWindsReply) &&
                     HasStatusEffect(Buffs.WindsRumination) &&
                     !HasStatusEffect(Buffs.PerfectBalance) &&
-                    ((GetCooldownRemainingTime(RiddleOfFire) > 10) ||
+                    (GetCooldownRemainingTime(RiddleOfFire) > 10 ||
                      HasStatusEffect(Buffs.RiddleOfFire) ||
-                     (GetStatusEffectRemainingTime(Buffs.WindsRumination) < GCD * 2) ||
+                     GetStatusEffectRemainingTime(Buffs.WindsRumination) < GCD * 2 ||
                      !InMeleeRange()))
                     return WindsReply;
             }
@@ -321,7 +322,7 @@ internal partial class MNK : Melee
 
             if (HasStatusEffect(Buffs.WindsRumination) &&
                 !HasStatusEffect(Buffs.PerfectBalance) &&
-                ((GetCooldownRemainingTime(RiddleOfFire) > 10) ||
+                (GetCooldownRemainingTime(RiddleOfFire) > 10 ||
                  HasStatusEffect(Buffs.RiddleOfFire)))
                 return WindsReply;
 
@@ -449,7 +450,7 @@ internal partial class MNK : Melee
                 if (IsEnabled(CustomComboPreset.MNK_AoEUseWindsReply) &&
                     HasStatusEffect(Buffs.WindsRumination) &&
                     !HasStatusEffect(Buffs.PerfectBalance) &&
-                    ((GetCooldownRemainingTime(RiddleOfFire) > 10) ||
+                    (GetCooldownRemainingTime(RiddleOfFire) > 10 ||
                      HasStatusEffect(Buffs.RiddleOfFire)))
                     return WindsReply;
             }
@@ -473,6 +474,34 @@ internal partial class MNK : Melee
 
             if (HasStatusEffect(Buffs.CoeurlForm) && LevelChecked(Rockbreaker))
                 return Rockbreaker;
+
+            return actionID;
+        }
+    }
+
+    internal class MNK_BeastChakras : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset => CustomComboPreset.MNK_ST_BeastChakras;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (IsEnabled(CustomComboPreset.MNK_BC_OPOOPO) &&
+                actionID is Bootshine or LeapingOpo)
+                return OpoOpo is 0 && LevelChecked(DragonKick)
+                    ? DragonKick
+                    : OriginalHook(Bootshine);
+
+            if (IsEnabled(CustomComboPreset.MNK_BC_RAPTOR) &&
+                actionID is TrueStrike or RisingRaptor)
+                return Raptor is 0 && LevelChecked(TwinSnakes)
+                    ? TwinSnakes
+                    : OriginalHook(TrueStrike);
+
+            if (IsEnabled(CustomComboPreset.MNK_BC_COEURL) &&
+                actionID is SnapPunch or PouncingCoeurl)
+                return Coeurl is 0 && LevelChecked(Demolish)
+                    ? Demolish
+                    : OriginalHook(SnapPunch);
 
             return actionID;
         }
@@ -510,34 +539,6 @@ internal partial class MNK : Melee
             ActionReady(RiddleOfFire) && IsOnCooldown(Brotherhood)
                 ? RiddleOfFire
                 : actionID;
-    }
-
-    internal class MNK_BeastChakras : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.MNK_ST_BeastChakras;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (IsEnabled(CustomComboPreset.MNK_BC_OPOOPO) &&
-                actionID is Bootshine or LeapingOpo)
-                return OpoOpo is 0 && LevelChecked(DragonKick)
-                    ? DragonKick
-                    : OriginalHook(Bootshine);
-
-            if (IsEnabled(CustomComboPreset.MNK_BC_RAPTOR) &&
-                actionID is TrueStrike or RisingRaptor)
-                return Raptor is 0 && LevelChecked(TwinSnakes)
-                    ? TwinSnakes
-                    : OriginalHook(TrueStrike);
-
-            if (IsEnabled(CustomComboPreset.MNK_BC_COEURL) &&
-                actionID is SnapPunch or PouncingCoeurl)
-                return Coeurl is 0 && LevelChecked(Demolish)
-                    ? Demolish
-                    : OriginalHook(SnapPunch);
-
-            return actionID;
-        }
     }
 
     internal class MNK_PerfectBalanceProtection : CustomCombo

--- a/WrathCombo/Combos/PvE/MNK/MNK.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK.cs
@@ -530,26 +530,17 @@ internal partial class MNK : Melee
                 : actionID;
     }
 
-    internal class MNK_Riddle_Brotherhood : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.MNK_Riddle_Brotherhood;
-
-        protected override uint Invoke(uint actionID) =>
-            actionID is RiddleOfFire &&
-            ActionReady(Brotherhood) && IsOnCooldown(RiddleOfFire)
-                ? Brotherhood
-                : actionID;
-    }
-
     internal class MNK_Brotherhood_Riddle : CustomCombo
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.MNK_Brotherhood_Riddle;
 
         protected override uint Invoke(uint actionID) =>
-            actionID is Brotherhood &&
-            ActionReady(RiddleOfFire) && IsOnCooldown(Brotherhood)
-                ? RiddleOfFire
-                : actionID;
+            actionID switch
+            {
+                Brotherhood when MNK_BH_RoF == 0 && ActionReady(RiddleOfFire) && IsOnCooldown(Brotherhood) => RiddleOfFire,
+                RiddleOfFire when MNK_BH_RoF == 1 && ActionReady(Brotherhood) && IsOnCooldown(RiddleOfFire) => Brotherhood,
+                var _ => actionID
+            };
     }
 
     internal class MNK_PerfectBalanceProtection : CustomCombo

--- a/WrathCombo/Combos/PvE/MNK/MNK_Config.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK_Config.cs
@@ -23,27 +23,26 @@ internal partial class MNK
             MNK_AoE_RiddleOfFire_HP = new("MNK_AoE_RiddleOfFire_HP", 20),
             MNK_AoE_SecondWind_Threshold = new("MNK_AoE_SecondWindThreshold", 40),
             MNK_AoE_Bloodbath_Threshold = new("MNK_AoE_BloodbathThreshold", 30),
-            MNK_VariantCure = new("MNK_Variant_Cure", 50);
+            MNK_VariantCure = new("MNK_Variant_Cure", 50),
+            MNK_BH_RoF = new("MNK_BH_RoF", 0);
 
         #endregion
+        
         internal static void Draw(CustomComboPreset preset)
         {
             switch (preset)
             {
-                case CustomComboPreset.MNK_ST_ComboHeals:
-                    DrawSliderInt(0, 100, MNK_ST_SecondWind_Threshold,
-                        $"{Role.SecondWind.ActionName()} HP percentage threshold");
+                case CustomComboPreset.MNK_STUseOpener:
+                    DrawHorizontalRadioButton(MNK_SelectedOpener,
+                        "Double Lunar", "Uses Lunar/Lunar opener",
+                        0);
 
-                    DrawSliderInt(0, 100, MNK_ST_Bloodbath_Threshold,
-                        $"{Role.Bloodbath.ActionName()} HP percentage threshold");
-                    break;
+                    DrawHorizontalRadioButton(MNK_SelectedOpener,
+                        "Solar Lunar", "Uses Solar/Lunar opener",
+                        1);
 
-                case CustomComboPreset.MNK_AoE_ComboHeals:
-                    DrawSliderInt(0, 100, MNK_AoE_SecondWind_Threshold,
-                        $"{Role.SecondWind.ActionName()} HP percentage threshold");
-
-                    DrawSliderInt(0, 100, MNK_AoE_Bloodbath_Threshold,
-                        $"{Role.Bloodbath.ActionName()} HP percentage threshold");
+                    ImGui.NewLine();
+                    DrawBossOnlyChoice(MNK_Balance_Content);
                     break;
 
                 case CustomComboPreset.MNK_STUseBrotherhood:
@@ -70,6 +69,14 @@ internal partial class MNK
                         "Boss encounters Only", $"Only uses {RiddleOfWind.ActionName()} when in Boss encounters.", 1);
                     break;
 
+                case CustomComboPreset.MNK_ST_ComboHeals:
+                    DrawSliderInt(0, 100, MNK_ST_SecondWind_Threshold,
+                        $"{Role.SecondWind.ActionName()} HP percentage threshold");
+
+                    DrawSliderInt(0, 100, MNK_ST_Bloodbath_Threshold,
+                        $"{Role.Bloodbath.ActionName()} HP percentage threshold");
+                    break;
+
                 case CustomComboPreset.MNK_AoEUseBrotherhood:
                     DrawSliderInt(0, 100, MNK_AoE_Brotherhood_HP,
                         $"Stop Using {Brotherhood.ActionName()} When Target HP% is at or Below (Set to 0 to Disable This Check)");
@@ -85,22 +92,25 @@ internal partial class MNK
                         $"Stop Using {RiddleOfWind.ActionName()} When Target HP% is at or Below (Set to 0 to Disable This Check)");
                     break;
 
-                case CustomComboPreset.MNK_STUseOpener:
-                    DrawHorizontalRadioButton(MNK_SelectedOpener,
-                        "Double Lunar", "Uses Lunar/Lunar opener",
-                        0);
+                case CustomComboPreset.MNK_AoE_ComboHeals:
+                    DrawSliderInt(0, 100, MNK_AoE_SecondWind_Threshold,
+                        $"{Role.SecondWind.ActionName()} HP percentage threshold");
 
-                    DrawHorizontalRadioButton(MNK_SelectedOpener,
-                        "Solar Lunar", "Uses Solar/Lunar opener",
-                        1);
-
-                    ImGui.NewLine();
-                    DrawBossOnlyChoice(MNK_Balance_Content);
+                    DrawSliderInt(0, 100, MNK_AoE_Bloodbath_Threshold,
+                        $"{Role.Bloodbath.ActionName()} HP percentage threshold");
                     break;
 
                 case CustomComboPreset.MNK_Variant_Cure:
                     DrawSliderInt(1, 100, MNK_VariantCure,
                         "HP% to be at or under", 200);
+                    break;
+
+                case CustomComboPreset.MNK_Brotherhood_Riddle:
+                    DrawRadioButton(MNK_BH_RoF,
+                        $"Replaces {Brotherhood.ActionName()}", $"Replaces {Brotherhood.ActionName()} with {RiddleOfFire.ActionName()} when {Brotherhood.ActionName()} is on cooldown.", 0);
+
+                    DrawRadioButton(MNK_BH_RoF,
+                        $"Replaces {RiddleOfFire.ActionName()}", $"Replaces {RiddleOfFire.ActionName()} with {Brotherhood.ActionName()}when {RiddleOfFire.ActionName()} is on cooldown.", 1);
                     break;
             }
         }

--- a/WrathCombo/Combos/PvE/MNK/MNK_Config.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK_Config.cs
@@ -27,7 +27,7 @@ internal partial class MNK
             MNK_BH_RoF = new("MNK_BH_RoF", 0);
 
         #endregion
-        
+
         internal static void Draw(CustomComboPreset preset)
         {
             switch (preset)

--- a/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
@@ -1,5 +1,6 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using WrathCombo.CustomComboNS;
@@ -58,7 +59,7 @@ internal partial class MNK
 
     internal static bool InMasterfulRange()
     {
-        if (NumberOfEnemiesInRange(ElixirField, null) >= 1 &&
+        if (NumberOfEnemiesInRange(ElixirField) >= 1 &&
             (OriginalHook(MasterfulBlitz) == ElixirField ||
              OriginalHook(MasterfulBlitz) == FlintStrike ||
              OriginalHook(MasterfulBlitz) == ElixirBurst ||
@@ -307,6 +308,8 @@ internal partial class MNK
 
         public override List<uint> OpenerActions { get; set; } =
         [
+            ForbiddenMeditation,
+            FormShift,
             DragonKick,
             PerfectBalance,
             LeapingOpo,
@@ -329,6 +332,12 @@ internal partial class MNK
             LeapingOpo
         ];
 
+        public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
+        [
+            ([1], () => Chakra >= 5),
+            ([2], () => HasStatusEffect(Buffs.FormlessFist))
+        ];
+
         internal override UserData ContentCheckConfig => MNK_Balance_Content;
 
         public override bool HasCooldowns() =>
@@ -349,6 +358,8 @@ internal partial class MNK
 
         public override List<uint> OpenerActions { get; set; } =
         [
+            ForbiddenMeditation,
+            FormShift,
             DragonKick,
             PerfectBalance,
             TwinSnakes,
@@ -369,6 +380,12 @@ internal partial class MNK
             DragonKick,
             ElixirBurst,
             LeapingOpo
+        ];
+
+        public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
+        [
+            ([1], () => Chakra >= 5),
+            ([2], () => HasStatusEffect(Buffs.FormlessFist))
         ];
 
         internal override UserData ContentCheckConfig => MNK_Balance_Content;

--- a/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
@@ -84,7 +84,7 @@ internal partial class MNK
         ActionReady(RiddleOfFire) &&
         !HasStatusEffect(Buffs.FiresRumination) &&
         (JustUsed(Brotherhood, GCD) ||
-         (GetCooldownRemainingTime(Brotherhood) is > 50 and < 65) ||
+         GetCooldownRemainingTime(Brotherhood) is > 50 and < 65 ||
          !LevelChecked(Brotherhood) ||
          HasStatusEffect(Buffs.Brotherhood));
 

--- a/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
@@ -104,22 +104,26 @@ internal partial class MNK
 
     internal static bool UsePerfectBalanceST()
     {
-        if (ActionReady(PerfectBalance) && !HasStatusEffect(Buffs.PerfectBalance) && !HasStatusEffect(Buffs.FormlessFist))
+        if (ActionReady(PerfectBalance) && !HasStatusEffect(Buffs.PerfectBalance) &&
+            !HasStatusEffect(Buffs.FormlessFist) && IsOriginal(MasterfulBlitz))
         {
             // Odd window
-            if ((JustUsed(OriginalHook(Bootshine)) || JustUsed(DragonKick)) &&
-                !JustUsed(PerfectBalance, 20) &&
-                HasStatusEffect(Buffs.RiddleOfFire) && !HasStatusEffect(Buffs.Brotherhood))
+            if ((JustUsed(OriginalHook(Bootshine), GCD) || JustUsed(DragonKick, GCD)) &&
+                !JustUsed(PerfectBalance, 20) && HasStatusEffect(Buffs.RiddleOfFire) && !HasStatusEffect(Buffs.Brotherhood))
                 return true;
 
-            // Even window
-            if ((JustUsed(OriginalHook(Bootshine)) || JustUsed(DragonKick)) &&
-                (GetCooldownRemainingTime(Brotherhood) <= GCD * 2 || HasStatusEffect(Buffs.Brotherhood)) &&
-                (GetCooldownRemainingTime(RiddleOfFire) <= GCD * 2 || HasStatusEffect(Buffs.RiddleOfFire)))
+            // Even window first use
+            if ((JustUsed(OriginalHook(Bootshine), GCD) || JustUsed(DragonKick, GCD)) &&
+                GetCooldownRemainingTime(Brotherhood) <= GCD * 2 && GetCooldownRemainingTime(RiddleOfFire) <= GCD * 2)
+                return true;
+
+            // Even window second use
+            if ((JustUsed(OriginalHook(Bootshine), GCD) || JustUsed(DragonKick, GCD)) &&
+                HasStatusEffect(Buffs.Brotherhood) && HasStatusEffect(Buffs.RiddleOfFire) && !HasStatusEffect(Buffs.FiresRumination))
                 return true;
 
             // Low level
-            if ((JustUsed(OriginalHook(Bootshine)) || JustUsed(DragonKick)) &&
+            if ((JustUsed(OriginalHook(Bootshine), GCD) || JustUsed(DragonKick, GCD)) &&
                 (HasStatusEffect(Buffs.RiddleOfFire) && !LevelChecked(Brotherhood) ||
                  !LevelChecked(RiddleOfFire)))
                 return true;

--- a/WrathCombo/Combos/PvE/RPR/RPR.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR.cs
@@ -335,8 +335,8 @@ internal partial class RPR : Melee
                      !HasStatusEffect(Buffs.EnhancedGallows)))
                 {
                     return IsEnabled(CustomComboPreset.RPR_ST_TrueNorthDynamic) &&
-                           ((RPR_ST_TrueNorthDynamic_HoldCharge &&
-                             GetRemainingCharges(Role.TrueNorth) < 2) ||
+                           (RPR_ST_TrueNorthDynamic_HoldCharge &&
+                            GetRemainingCharges(Role.TrueNorth) < 2 ||
                             !RPR_ST_TrueNorthDynamic_HoldCharge) &&
                            Role.CanTrueNorth() && !OnTargetsFlank()
                         ? Role.TrueNorth
@@ -349,8 +349,8 @@ internal partial class RPR : Melee
                      !HasStatusEffect(Buffs.EnhancedGallows)))
                 {
                     return IsEnabled(CustomComboPreset.RPR_ST_TrueNorthDynamic) &&
-                           ((RPR_ST_TrueNorthDynamic_HoldCharge &&
-                             GetRemainingCharges(Role.TrueNorth) < 2) ||
+                           (RPR_ST_TrueNorthDynamic_HoldCharge &&
+                            GetRemainingCharges(Role.TrueNorth) < 2 ||
                             !RPR_ST_TrueNorthDynamic_HoldCharge) &&
                            Role.CanTrueNorth() && !OnTargetsRear()
                         ? Role.TrueNorth
@@ -895,19 +895,12 @@ internal partial class RPR : Melee
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.RPR_EnshroudCommunio;
 
-        protected override uint Invoke(uint actionID)
-        {
-            switch (actionID)
+        protected override uint Invoke(uint actionID) =>
+            actionID switch
             {
-                case Enshroud when HasStatusEffect(Buffs.PerfectioParata):
-                    return OriginalHook(Communio);
-
-                case Enshroud when HasStatusEffect(Buffs.Enshrouded):
-                    return Communio;
-
-                default:
-                    return actionID;
-            }
-        }
+                Enshroud when HasStatusEffect(Buffs.PerfectioParata) => OriginalHook(Communio),
+                Enshroud when HasStatusEffect(Buffs.Enshrouded) => Communio,
+                var _ => actionID
+            };
     }
 }

--- a/WrathCombo/Combos/PvE/RPR/RPR.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR.cs
@@ -127,7 +127,7 @@ internal partial class RPR : Melee
                 return ShadowOfDeath;
 
             //Perfectio
-            if (HasStatusEffect(Buffs.PerfectioParata) && !IsComboExpiring(1))
+            if (HasStatusEffect(Buffs.PerfectioParata))
                 return OriginalHook(Communio);
 
             //Gibbet/Gallows
@@ -321,7 +321,7 @@ internal partial class RPR : Melee
 
             //Perfectio
             if (IsEnabled(CustomComboPreset.RPR_ST_Perfectio) &&
-                HasStatusEffect(Buffs.PerfectioParata) && !IsComboExpiring(1))
+                HasStatusEffect(Buffs.PerfectioParata))
                 return OriginalHook(Communio);
 
             //Gibbet/Gallows

--- a/WrathCombo/Combos/PvE/RPR/RPR_Config.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR_Config.cs
@@ -1,4 +1,3 @@
-using ImGuiNET;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Extensions;
 using static WrathCombo.Window.Functions.UserConfig;

--- a/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
@@ -70,11 +70,6 @@ internal partial class RPR
 
                 if (InBossEncounter())
                 {
-                    //1st part double enshroud
-                    //   if (LevelChecked(PlentifulHarvest) && HasStatusEffect(Buffs.Enshrouded) &&
-                    //     GetCooldownRemainingTime(ArcaneCircle) <= GCD * 2 + 1.5 && JustUsed(Enshroud))
-                    //   return true;
-
                     //Double enshroud
                     if (LevelChecked(PlentifulHarvest) && HasStatusEffect(Buffs.Enshrouded) &&
                         (GetCooldownRemainingTime(ArcaneCircle) <= GCD || IsOffCooldown(ArcaneCircle)) &&
@@ -104,11 +99,6 @@ internal partial class RPR
                 if (RPR_ST_ArcaneCircle_SubOption == 0 || InBossEncounter() ||
                     IsNotEnabled(CustomComboPreset.RPR_ST_ArcaneCircle))
                 {
-                    //1st part double enshroud
-                    // if (LevelChecked(PlentifulHarvest) && HasStatusEffect(Buffs.Enshrouded) &&
-                    //    GetCooldownRemainingTime(ArcaneCircle) <= GCD * 2 + 1.5 && JustUsed(Enshroud))
-                    //   return true;
-
                     //Double enshroud
                     if (LevelChecked(PlentifulHarvest) && HasStatusEffect(Buffs.Enshrouded) &&
                         (GetCooldownRemainingTime(ArcaneCircle) <= GCD || IsOffCooldown(ArcaneCircle)) &&

--- a/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
@@ -71,11 +71,11 @@ internal partial class RPR
                 if (InBossEncounter())
                 {
                     //1st part double enshroud
-                    if (LevelChecked(PlentifulHarvest) && HasStatusEffect(Buffs.Enshrouded) &&
-                        GetCooldownRemainingTime(ArcaneCircle) <= GCD * 2 + 1.5 && JustUsed(Enshroud))
-                        return true;
+                    //   if (LevelChecked(PlentifulHarvest) && HasStatusEffect(Buffs.Enshrouded) &&
+                    //     GetCooldownRemainingTime(ArcaneCircle) <= GCD * 2 + 1.5 && JustUsed(Enshroud))
+                    //   return true;
 
-                    //2nd part double enshroud
+                    //Double enshroud
                     if (LevelChecked(PlentifulHarvest) && HasStatusEffect(Buffs.Enshrouded) &&
                         (GetCooldownRemainingTime(ArcaneCircle) <= GCD || IsOffCooldown(ArcaneCircle)) &&
                         (JustUsed(VoidReaping) || JustUsed(CrossReaping)))
@@ -105,11 +105,11 @@ internal partial class RPR
                     IsNotEnabled(CustomComboPreset.RPR_ST_ArcaneCircle))
                 {
                     //1st part double enshroud
-                    if (LevelChecked(PlentifulHarvest) && HasStatusEffect(Buffs.Enshrouded) &&
-                        GetCooldownRemainingTime(ArcaneCircle) <= GCD * 2 + 1.5 && JustUsed(Enshroud))
-                        return true;
+                    // if (LevelChecked(PlentifulHarvest) && HasStatusEffect(Buffs.Enshrouded) &&
+                    //    GetCooldownRemainingTime(ArcaneCircle) <= GCD * 2 + 1.5 && JustUsed(Enshroud))
+                    //   return true;
 
-                    //2nd part double enshroud
+                    //Double enshroud
                     if (LevelChecked(PlentifulHarvest) && HasStatusEffect(Buffs.Enshrouded) &&
                         (GetCooldownRemainingTime(ArcaneCircle) <= GCD || IsOffCooldown(ArcaneCircle)) &&
                         (JustUsed(VoidReaping) || JustUsed(CrossReaping)))

--- a/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
@@ -28,7 +28,7 @@ internal partial class RPR
 
             // Prep for double Enshroud
             if (LevelChecked(PlentifulHarvest) &&
-                GetCooldownRemainingTime(ArcaneCircle) <= GCD * 2 + 1.5)
+                GetCooldownRemainingTime(ArcaneCircle) <= GCD + 1.5f)
                 return true;
 
             //2nd part of Double Enshroud
@@ -73,7 +73,7 @@ internal partial class RPR
                     //Double enshroud
                     if (LevelChecked(PlentifulHarvest) && HasStatusEffect(Buffs.Enshrouded) &&
                         (GetCooldownRemainingTime(ArcaneCircle) <= GCD || IsOffCooldown(ArcaneCircle)) &&
-                        (JustUsed(VoidReaping) || JustUsed(CrossReaping)))
+                        (JustUsed(VoidReaping, 2f) || JustUsed(CrossReaping, 2f)))
                         return true;
 
                     //lvl 88+ general use
@@ -102,7 +102,7 @@ internal partial class RPR
                     //Double enshroud
                     if (LevelChecked(PlentifulHarvest) && HasStatusEffect(Buffs.Enshrouded) &&
                         (GetCooldownRemainingTime(ArcaneCircle) <= GCD || IsOffCooldown(ArcaneCircle)) &&
-                        (JustUsed(VoidReaping) || JustUsed(CrossReaping)))
+                        (JustUsed(VoidReaping, 2f) || JustUsed(CrossReaping, 2f)))
                         return true;
 
                     //lvl 88+ general use

--- a/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
@@ -96,12 +96,10 @@ internal partial class RPR
 
             if (IsEnabled(CustomComboPreset.RPR_ST_AdvancedMode))
             {
-                if (RPR_ST_ArcaneCircle_SubOption == 1 && !InBossEncounter())
-                {
-                    if (!HasStatusEffect(Buffs.Enshrouded) &&
-                        GetStatusEffectRemainingTime(Debuffs.DeathsDesign, CurrentTarget) <= RPR_SoDRefreshRange)
-                        return true;
-                }
+                if (RPR_ST_ArcaneCircle_SubOption == 1 && !InBossEncounter() &&
+                    !HasStatusEffect(Buffs.Enshrouded) &&
+                    GetStatusEffectRemainingTime(Debuffs.DeathsDesign, CurrentTarget) <= RPR_SoDRefreshRange)
+                    return true;
 
                 if (RPR_ST_ArcaneCircle_SubOption == 0 || InBossEncounter() ||
                     IsNotEnabled(CustomComboPreset.RPR_ST_ArcaneCircle))

--- a/WrathCombo/Combos/PvE/SAM/SAM.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM.cs
@@ -119,15 +119,13 @@ internal partial class SAM : Melee
                 if (ActionReady(Ikishoten) &&
                     !HasStatusEffect(Buffs.ZanshinReady))
                 {
-                    switch (Kenki)
+                    return Kenki switch
                     {
                         //Dumps Kenki in preparation for Ikishoten
-                        case >= 50:
-                            return Shinten;
+                        >= 50 => Shinten,
 
-                        case < 50:
-                            return Ikishoten;
-                    }
+                        < 50 => Ikishoten
+                    };
                 }
 
                 switch (Kenki)
@@ -244,6 +242,7 @@ internal partial class SAM : Melee
                 if (ComboAction is Shifu && LevelChecked(Kasha))
                     return Kasha;
             }
+
             return actionID;
         }
     }
@@ -296,15 +295,13 @@ internal partial class SAM : Melee
                     if (IsEnabled(CustomComboPreset.SAM_ST_CDs_Ikishoten) &&
                         ActionReady(Ikishoten) && !HasStatusEffect(Buffs.ZanshinReady))
                     {
-                        switch (Kenki)
+                        return Kenki switch
                         {
                             //Dumps Kenki in preparation for Ikishoten
-                            case >= 50:
-                                return Shinten;
+                            >= 50 => Shinten,
 
-                            case < 50:
-                                return Ikishoten;
-                        }
+                            < 50 => Ikishoten
+                        };
                     }
                 }
 
@@ -524,15 +521,13 @@ internal partial class SAM : Melee
 
                 if (ActionReady(Ikishoten) && !HasStatusEffect(Buffs.ZanshinReady))
                 {
-                    switch (Kenki)
+                    return Kenki switch
                     {
                         //Dumps Kenki in preparation for Ikishoten
-                        case >= 50:
-                            return Kyuten;
+                        >= 50 => Kyuten,
 
-                        case < 50:
-                            return Ikishoten;
-                    }
+                        < 50 => Ikishoten
+                    };
                 }
 
                 if (ActionReady(MeikyoShisui) && !HasStatusEffect(Buffs.MeikyoShisui))
@@ -643,15 +638,13 @@ internal partial class SAM : Melee
                     if (IsEnabled(CustomComboPreset.SAM_AOE_CDs_Ikishoten) &&
                         ActionReady(Ikishoten) && !HasStatusEffect(Buffs.ZanshinReady))
                     {
-                        switch (Kenki)
+                        return Kenki switch
                         {
                             //Dumps Kenki in preparation for Ikishoten
-                            case >= 50:
-                                return Kyuten;
+                            >= 50 => Kyuten,
 
-                            case < 50:
-                                return Ikishoten;
-                        }
+                            < 50 => Ikishoten
+                        };
                     }
                 }
 

--- a/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
@@ -1,12 +1,12 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
-using FFXIVClientStructs.FFXIV.Client.Game;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
+using static FFXIVClientStructs.FFXIV.Client.Game.ActionManager;
 using static WrathCombo.Combos.PvE.SAM.Config;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 using static WrathCombo.Data.ActionWatching;
@@ -30,7 +30,7 @@ internal partial class SAM
     internal static bool UseTsubame =>
         LevelChecked(TsubameGaeshi) &&
         (HasStatusEffect(Buffs.TendoKaeshiSetsugekkaReady) ||
-         (HasStatusEffect(Buffs.TsubameReady) && (SenCount is 3 || GetCooldownRemainingTime(Senei) > 33)));
+         HasStatusEffect(Buffs.TsubameReady) && (SenCount is 3 || GetCooldownRemainingTime(Senei) > 33));
 
     internal static bool M6SReady =>
         !HiddenFeaturesData.IsEnabledWith(CustomComboPreset.SAM_Hid_M6SHoldSquirrelBurst, () =>
@@ -40,7 +40,7 @@ internal partial class SAM
 
     internal static bool UseMeikyo()
     {
-        float gcd = ActionManager.GetAdjustedRecastTime(ActionType.Action, Hakaze) / 100f;
+        float gcd = GetAdjustedRecastTime(ActionType.Action, Hakaze) / 100f;
         int meikyoUsed = CombatActions.Count(x => x == MeikyoShisui);
 
         if (ActionReady(MeikyoShisui) && !HasStatusEffect(Buffs.Tendo) && !HasStatusEffect(Buffs.MeikyoShisui) &&
@@ -104,37 +104,37 @@ internal partial class SAM
             if (IsEnabled(CustomComboPreset.SAM_ST_AdvancedMode) &&
 
                 //Higanbana
-                ((SAM_ST_CDs_IaijutsuOption[0] &&
-                  SenCount is 1 && GetTargetHPPercent() > higanbanaHPThreshold &&
-                  (SAM_ST_Higanbana_Suboption == 0 || TargetIsBoss()) &&
-                  CanApplyStatus(CurrentTarget, Debuffs.Higanbana) &&
-                  ((JustUsed(MeikyoShisui, 15f) && GetStatusEffectRemainingTime(Debuffs.Higanbana, CurrentTarget) <= higanbanaRefresh) ||
-                   !HasStatusEffect(Debuffs.Higanbana, CurrentTarget))) ||
+                (SAM_ST_CDs_IaijutsuOption[0] &&
+                 SenCount is 1 && GetTargetHPPercent() > higanbanaHPThreshold &&
+                 (SAM_ST_Higanbana_Suboption == 0 || TargetIsBoss()) &&
+                 CanApplyStatus(CurrentTarget, Debuffs.Higanbana) &&
+                 (JustUsed(MeikyoShisui, 15f) && GetStatusEffectRemainingTime(Debuffs.Higanbana, CurrentTarget) <= higanbanaRefresh ||
+                  !HasStatusEffect(Debuffs.Higanbana, CurrentTarget)) ||
 
                  //Tenka Goken
-                 (SAM_ST_CDs_IaijutsuOption[1] && SenCount is 2 &&
-                  !LevelChecked(MidareSetsugekka)) ||
+                 SAM_ST_CDs_IaijutsuOption[1] && SenCount is 2 &&
+                 !LevelChecked(MidareSetsugekka) ||
 
                  //Midare Setsugekka
-                 (SAM_ST_CDs_IaijutsuOption[2] && SenCount is 3 &&
-                  LevelChecked(MidareSetsugekka) && !HasStatusEffect(Buffs.TsubameReady))))
+                 SAM_ST_CDs_IaijutsuOption[2] && SenCount is 3 &&
+                 LevelChecked(MidareSetsugekka) && !HasStatusEffect(Buffs.TsubameReady)))
                 return true;
 
             if (IsEnabled(CustomComboPreset.SAM_ST_SimpleMode) &&
 
                 //Higanbana
-                ((SenCount is 1 && GetTargetHPPercent() > 1 && TargetIsBoss() &&
-                  CanApplyStatus(CurrentTarget, Debuffs.Higanbana) &&
-                  ((JustUsed(MeikyoShisui, 15f) && GetStatusEffectRemainingTime(Debuffs.Higanbana, CurrentTarget) <= 15) ||
-                   !HasStatusEffect(Debuffs.Higanbana, CurrentTarget))) ||
+                (SenCount is 1 && GetTargetHPPercent() > 1 && TargetIsBoss() &&
+                 CanApplyStatus(CurrentTarget, Debuffs.Higanbana) &&
+                 (JustUsed(MeikyoShisui, 15f) && GetStatusEffectRemainingTime(Debuffs.Higanbana, CurrentTarget) <= 15 ||
+                  !HasStatusEffect(Debuffs.Higanbana, CurrentTarget)) ||
 
                  //Tenka Goken
-                 (SenCount is 2 &&
-                  !LevelChecked(MidareSetsugekka)) ||
+                 SenCount is 2 &&
+                 !LevelChecked(MidareSetsugekka) ||
 
                  //Midare Setsugekka
-                 (SenCount is 3 &&
-                  LevelChecked(MidareSetsugekka) && !HasStatusEffect(Buffs.TsubameReady))))
+                 SenCount is 3 &&
+                 LevelChecked(MidareSetsugekka) && !HasStatusEffect(Buffs.TsubameReady)))
                 return true;
         }
 

--- a/WrathCombo/Combos/PvE/VPR/VPR.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR.cs
@@ -45,7 +45,7 @@ internal partial class VPR : Melee
             //LowLevels
             if (LevelChecked(ReavingFangs) &&
                 (HasStatusEffect(Buffs.HonedReavers) ||
-                 (!HasStatusEffect(Buffs.HonedReavers) && !HasStatusEffect(Buffs.HonedSteel))))
+                 !HasStatusEffect(Buffs.HonedReavers) && !HasStatusEffect(Buffs.HonedSteel)))
                 return OriginalHook(ReavingFangs);
             return actionID;
         }
@@ -134,8 +134,8 @@ internal partial class VPR : Melee
 
             //Overcap protection
             if (CappedOnCoils() &&
-                ((HasCharges(Vicewinder) && !HasStatusEffect(Buffs.SwiftskinsVenom) &&
-                  !HasStatusEffect(Buffs.HuntersVenom) && !HasStatusEffect(Buffs.Reawakened)) || //spend if Vicewinder is up, after Reawaken
+                (HasCharges(Vicewinder) && !HasStatusEffect(Buffs.SwiftskinsVenom) &&
+                 !HasStatusEffect(Buffs.HuntersVenom) && !HasStatusEffect(Buffs.Reawakened) || //spend if Vicewinder is up, after Reawaken
                  IreCD <= GCD * 5)) //spend in case under Reawaken right as Ire comes up
                 return UncoiledFury;
 
@@ -143,7 +143,7 @@ internal partial class VPR : Melee
             if (HasStatusEffect(Buffs.Swiftscaled) && !IsComboExpiring(3) &&
                 ActionReady(Vicewinder) && !HasStatusEffect(Buffs.Reawakened) &&
                 InMeleeRange() &&
-                ((IreCD >= GCD * 5) || !LevelChecked(SerpentsIre)) &&
+                (IreCD >= GCD * 5 || !LevelChecked(SerpentsIre)) &&
                 !IsVenomExpiring(3) && !IsHoningExpiring(3))
                 return Role.CanTrueNorth()
                     ? Role.TrueNorth
@@ -794,20 +794,13 @@ internal partial class VPR : Melee
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.VPR_UncoiledTwins;
 
-        protected override uint Invoke(uint actionID)
-        {
-            switch (actionID)
+        protected override uint Invoke(uint actionID) =>
+            actionID switch
             {
-                case UncoiledFury when HasStatusEffect(Buffs.PoisedForTwinfang):
-                    return OriginalHook(Twinfang);
-
-                case UncoiledFury when HasStatusEffect(Buffs.PoisedForTwinblood):
-                    return OriginalHook(Twinblood);
-
-                default:
-                    return actionID;
-            }
-        }
+                UncoiledFury when HasStatusEffect(Buffs.PoisedForTwinfang) => OriginalHook(Twinfang),
+                UncoiledFury when HasStatusEffect(Buffs.PoisedForTwinblood) => OriginalHook(Twinblood),
+                var _ => actionID
+            };
     }
 
     internal class VPR_ReawakenLegacy : CustomCombo
@@ -844,29 +837,15 @@ internal partial class VPR : Melee
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.VPR_TwinTails;
 
-        protected override uint Invoke(uint actionID)
-        {
-            switch (actionID)
+        protected override uint Invoke(uint actionID) =>
+            actionID switch
             {
                 // Death Rattle / Legacy Weaves
-                case SerpentsTail when LevelChecked(SerpentsTail) &&
-                                       OriginalHook(SerpentsTail) is not SerpentsTail:
-                    return OriginalHook(SerpentsTail);
-
-                case SerpentsTail when HasStatusEffect(Buffs.PoisedForTwinfang) ||
-                                       HasStatusEffect(Buffs.HuntersVenom) ||
-                                       HasStatusEffect(Buffs.FellhuntersVenom):
-                    return OriginalHook(Twinfang);
-
-                case SerpentsTail when HasStatusEffect(Buffs.PoisedForTwinblood) ||
-                                       HasStatusEffect(Buffs.SwiftskinsVenom) ||
-                                       HasStatusEffect(Buffs.FellskinsVenom):
-                    return OriginalHook(Twinblood);
-
-                default:
-                    return actionID;
-            }
-        }
+                SerpentsTail when LevelChecked(SerpentsTail) && OriginalHook(SerpentsTail) is not SerpentsTail => OriginalHook(SerpentsTail),
+                SerpentsTail when HasStatusEffect(Buffs.PoisedForTwinfang) || HasStatusEffect(Buffs.HuntersVenom) || HasStatusEffect(Buffs.FellhuntersVenom) => OriginalHook(Twinfang),
+                SerpentsTail when HasStatusEffect(Buffs.PoisedForTwinblood) || HasStatusEffect(Buffs.SwiftskinsVenom) || HasStatusEffect(Buffs.FellskinsVenom) => OriginalHook(Twinblood),
+                var _ => actionID
+            };
     }
 
     internal class VPR_Legacies : CustomCombo
@@ -879,16 +858,14 @@ internal partial class VPR : Melee
                 return actionID;
 
             //Reawaken combo
-            switch (actionID)
+            return actionID switch
             {
-                case SteelFangs when JustUsed(OriginalHook(SteelFangs)) && AnguineTribute is 4:
-                case ReavingFangs when JustUsed(OriginalHook(ReavingFangs)) && AnguineTribute is 3:
-                case HuntersCoil when JustUsed(OriginalHook(HuntersCoil)) && AnguineTribute is 2:
-                case SwiftskinsCoil when JustUsed(OriginalHook(SwiftskinsCoil)) && AnguineTribute is 1:
-                    return OriginalHook(SerpentsTail);
-            }
-
-            return actionID;
+                SteelFangs when JustUsed(OriginalHook(SteelFangs)) && AnguineTribute is 4 => OriginalHook(SerpentsTail),
+                ReavingFangs when JustUsed(OriginalHook(ReavingFangs)) && AnguineTribute is 3 => OriginalHook(SerpentsTail),
+                HuntersCoil when JustUsed(OriginalHook(HuntersCoil)) && AnguineTribute is 2 => OriginalHook(SerpentsTail),
+                SwiftskinsCoil when JustUsed(OriginalHook(SwiftskinsCoil)) && AnguineTribute is 1 => OriginalHook(SerpentsTail),
+                var _ => actionID
+            };
         }
     }
 
@@ -896,23 +873,12 @@ internal partial class VPR : Melee
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.VPR_SerpentsTail;
 
-        protected override uint Invoke(uint actionID)
-        {
-            switch (actionID)
+        protected override uint Invoke(uint actionID) =>
+            actionID switch
             {
-                case SteelFangs or ReavingFangs when
-                    OriginalHook(SerpentsTail) is DeathRattle &&
-                    (JustUsed(FlankstingStrike) || JustUsed(FlanksbaneFang) ||
-                     JustUsed(HindstingStrike) || JustUsed(HindsbaneFang)):
-
-                case SteelMaw or ReavingMaw when
-                    OriginalHook(SerpentsTail) is LastLash &&
-                    (JustUsed(JaggedMaw) || JustUsed(BloodiedMaw)):
-                    return OriginalHook(SerpentsTail);
-
-                default:
-                    return actionID;
-            }
-        }
+                SteelFangs or ReavingFangs when OriginalHook(SerpentsTail) is DeathRattle && (JustUsed(FlankstingStrike) || JustUsed(FlanksbaneFang) || JustUsed(HindstingStrike) || JustUsed(HindsbaneFang)) => OriginalHook(SerpentsTail),
+                SteelMaw or ReavingMaw when OriginalHook(SerpentsTail) is LastLash && (JustUsed(JaggedMaw) || JustUsed(BloodiedMaw)) => OriginalHook(SerpentsTail),
+                var _ => actionID
+            };
     }
 }

--- a/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
@@ -1,10 +1,10 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
-using FFXIVClientStructs.FFXIV.Client.Game;
 using System;
 using System.Collections.Generic;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
+using static FFXIVClientStructs.FFXIV.Client.Game.ActionManager;
 using static WrathCombo.Combos.PvE.VPR.Config;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 namespace WrathCombo.Combos.PvE;
@@ -55,8 +55,8 @@ internal partial class VPR
         {
             //Use whenever
             if (SerpentOffering >= 50 && TargetIsBoss() &&
-                ((IsEnabled(CustomComboPreset.VPR_ST_SimpleMode) && GetTargetHPPercent() < 5) ||
-                 (IsEnabled(CustomComboPreset.VPR_ST_AdvancedMode) && GetTargetHPPercent() < VPR_ST_ReAwaken_Threshold)))
+                (IsEnabled(CustomComboPreset.VPR_ST_SimpleMode) && GetTargetHPPercent() < 5 ||
+                 IsEnabled(CustomComboPreset.VPR_ST_AdvancedMode) && GetTargetHPPercent() < VPR_ST_ReAwaken_Threshold))
                 return true;
 
             //2min burst
@@ -74,8 +74,8 @@ internal partial class VPR
                 return true;
 
             //non boss encounters
-            if (((IsEnabled(CustomComboPreset.VPR_ST_SimpleMode) && !InBossEncounter()) ||
-                 (IsEnabled(CustomComboPreset.VPR_ST_AdvancedMode) && VPR_ST_SerpentsIre_SubOption == 1 && !InBossEncounter())) &&
+            if ((IsEnabled(CustomComboPreset.VPR_ST_SimpleMode) && !InBossEncounter() ||
+                 IsEnabled(CustomComboPreset.VPR_ST_AdvancedMode) && VPR_ST_SerpentsIre_SubOption == 1 && !InBossEncounter()) &&
                 SerpentOffering >= 50)
                 return true;
 
@@ -242,7 +242,7 @@ internal partial class VPR
     {
         float gcd = GCD * times;
 
-        return ActionManager.Instance()->Combo.Timer != 0 && ActionManager.Instance()->Combo.Timer < gcd;
+        return Instance()->Combo.Timer != 0 && Instance()->Combo.Timer < gcd;
     }
 
     #endregion


### PR DESCRIPTION
BLM

- Update Standalone options
  - Update Fire I / Fire III
  - Update Blizzard 4 to Despair
    - Add option to choose B4 or B3
  - Fix Fire 1 to Despair
- Add needing a battle target for movement options
- Closes #726 

MNK
- Add in opener prepull.
- Add Thunderclap retargetting
- Condense `ROF- BH` and `BH - ROF` into 1 option where u can choose the button.
- Update Perfect Balance usage 
- Made sure Fire's reply is always inside buff windows
- update Wind's reply usage to be used in buffs when possible

RPR
- Update to follow new graph
<img width="13486" height="2328" alt="image" src="https://github.com/user-attachments/assets/428f2da1-c657-46ad-b8c6-e5fdce8daf5f" />

Various
- cleanups of unneeded Parenthese
- Transformed most to switch or switch expressions
