### PR TITLE
[Core] Auto Rotation pausing for some Acceleration Bombs

### DIFF
--- a/WrathCombo/CustomCombo/Functions/Status.cs
+++ b/WrathCombo/CustomCombo/Functions/Status.cs
@@ -2,6 +2,7 @@
 using ECommons.DalamudServices;
 using ECommons.GameFunctions;
 using FFXIVClientStructs.FFXIV.Client.Game;
+using ImGuiNET;
 using System.Linq;
 using WrathCombo.Data;
 using WrathCombo.Services;
@@ -145,65 +146,21 @@ namespace WrathCombo.CustomComboNS.Functions
             var targetStatuses = tar.StatusList.Select(s => s.StatusId).ToHashSet();
             uint targetID = tar.DataId;
 
+            // Returning False in each case because there should be no other General Invinicibility Check needed
+            // for specified areas
             switch (Svc.ClientState.TerritoryType)
             {
-                case 174:   // Labyrinth of the Ancients
+                case 174: // Labyrinth of the Ancients
                     // Thanatos, Spooky Ghosts Only
                     if (targetID is 2350) return !HasStatusEffect(398);
-
                     // Allagan Bomb
                     if (targetID is 2407) return NumberOfObjectsInRange<SelfCircle>(30) > 1;
-
                     return false;
-                case 1248:  // Jeuno 1 Ark Angels
-                    // ArkAngel HM = 1804
-                    if (targetID is 18049 && HasStatusEffect(4410, tar, true)) return true;
 
-                    // ArkAngel MR = 18051 (A)
-                    // ArkAngel GK = 18053 (B)
-                    // ArkAngel TT = 18052 (C)
-                    if (targetID is 18051 or 18052 or 18053)
-                    {
-                        if (HasStatusEffect(4192)) return targetID != 18051; // Alliance A Red Epic
-                        if (HasStatusEffect(4194)) return targetID != 18053; // Alliance B Yellow Fated
-                        if (HasStatusEffect(4196)) return targetID != 18052; // Alliance C Blue Vaunted
-                    }
-                    return false;
-                case 917:   //Puppet's Bunker, Flight Mechs
-                    // 724P Alpha = 11792 (A)
-                    // 767P Beta  = 11793 (B)
-                    // 772P Chi   = 11794 (C)
-                    if (targetID is 11792 or 11793 or 11794)
-                    {
-                        if (HasStatusEffect(2288)) return targetID != 11792;
-                        if (HasStatusEffect(2289)) return targetID != 11793;
-                        if (HasStatusEffect(2290)) return targetID != 11794;
-                    }
-                    return false;
-                case 966: //The Tower at Paradigm's Breach, Hansel & Gretel
-                          // Hansel = 12709
-                          // Gretel = 12708
-                          // 680 Directional Parry
-                          // 2538 Strong of Shield
-                          // 2539 Stronger Together
-
-                    if (targetID is 12709 or 12708)
-                    {
-                        bool Tank = (LocalPlayer!).GetRole() is CombatRole.Tank;
-                        bool bossHasStatus = HasStatusEffect(680, tar);
-
-                        // Non Tanks should just ignore parrying boss(s)
-                        if (!Tank)
-                        {
-                            if (bossHasStatus) return true;
-                        }
-                        //Tanks should only ignore their target if it has the buff and they aren't in front.
-                        else
-                        {
-                            if (bossHasStatus && AngleToTarget(tar) != AttackAngle.Front)
-                                return true;
-                        }
-                    }
+                case 556: // The Weeping City of Mhach
+                    // Ozma - Acceleration Bomb
+                    // Technically not invincible, just need to stop attacking
+                    if (targetID is 5472 && (GetStatusEffectRemainingTime(1072, anyOwner: true) is > 0f and < 1.5f)) return true;
                     return false;
 
                 case 801 or 805 or 1122: //Interdimensional Rift (Omega 12 / Alphascape 4), Regular/Savage?/Ultimate?
@@ -227,15 +184,70 @@ namespace WrathCombo.CustomComboNS.Functions
                     if (StatusCache.CompareLists(StatusCache.InvincibleStatuses, targetStatuses)) return true;
 
                     return false;
-                case 952:  //ToZ final boss (technically not invincible)
-                    if (targetID is (13298 or 13299) && Svc.Objects.Any(y => y.DataId is 13297 && !y.IsDead))
-                        return true;
 
-                    return false;
                 case 821: //Dohn Mheg Final Boss Lyre
                     if (targetID is 3939 && !HasStatusEffect(386))
                         return true; //Unfooled means you can attack the Lyre
                     return false;
+
+                case 917: //Puppet's Bunker, Flight Mechs
+                    // 724P Alpha = 11792 (A)
+                    // 767P Beta  = 11793 (B)
+                    // 772P Chi   = 11794 (C)
+                    if (targetID is 11792 or 11793 or 11794)
+                    {
+                        if (HasStatusEffect(2288)) return targetID != 11792;
+                        if (HasStatusEffect(2289)) return targetID != 11793;
+                        if (HasStatusEffect(2290)) return targetID != 11794;
+                    }
+                    return false;
+
+                case 952: // Tower of Zot final bosses
+                          // Technically not invincible, just need to ignore
+                    if (targetID is (13298 or 13299) && Svc.Objects.Any(y => y.DataId is 13297 && !y.IsDead))
+                        return true;
+                    return false;
+
+                case 966: //The Tower at Paradigm's Breach, Hansel & Gretel
+                    // Hansel = 12709
+                    // Gretel = 12708
+                    // If boss has shield or too close, boss gains 680 Parry, so easier to check for that
+                    // 680 Directional Parry
+                    // 2538 Strong of Shield
+                    // 2539 Stronger Together
+
+                    if (targetID is 12709 or 12708)
+                    {
+                        bool isTank = (LocalPlayer!).GetRole() is CombatRole.Tank;
+                        bool bossHasParry = HasStatusEffect(680, tar);
+                        bool isFrontFacing = AngleToTarget(tar) is AttackAngle.Front;
+
+                        // Non Tanks should just ignore parrying boss(s)
+                        // Tanks should only ignore their target if it has the buff and they aren't in front.
+                        if (bossHasParry && (!isTank || !isFrontFacing)) return true;
+                    }
+                    return false;
+
+                case 1198: // Vanguard - Protector's Acceleration Bomb
+                           // Technically not invincible, just need to stop attacking
+                    if (targetID is 16951 && (GetStatusEffectRemainingTime(3802, anyOwner: true) is > 0f and < 1.5f)) return true;
+                    return false;
+
+                case 1248: // Jeuno 1 Ark Angels
+                    // ArkAngel HM = 1804
+                    // ArkAngel MR = 18051 (A)
+                    // ArkAngel GK = 18053 (B)
+                    // ArkAngel TT = 18052 (C)
+                    if (targetID is 18049 && HasStatusEffect(4410, tar, true)) return true;
+
+                    if (targetID is 18051 or 18052 or 18053)
+                    {
+                        if (HasStatusEffect(4192)) return targetID != 18051; // Alliance A Red Epic
+                        if (HasStatusEffect(4194)) return targetID != 18053; // Alliance B Yellow Fated
+                        if (HasStatusEffect(4196)) return targetID != 18052; // Alliance C Blue Vaunted
+                    }
+                    return false;
+
             }
 
             // General invincibility check

--- a/WrathCombo/CustomCombo/Functions/Status.cs
+++ b/WrathCombo/CustomCombo/Functions/Status.cs
@@ -1,6 +1,7 @@
 ﻿using Dalamud.Game.ClientState.Objects.Types;
 using ECommons.DalamudServices;
 using ECommons.GameFunctions;
+using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using System.Linq;
 using WrathCombo.Data;
@@ -137,30 +138,17 @@ namespace WrathCombo.CustomComboNS.Functions
         /// </summary>
         public static bool PlayerHasActionPenalty()
         {
-            static bool CheckStatus()
-            {
-                return Svc.ClientState.TerritoryType switch
-                {
-                    // Weeping City, Ozma's Bomb
-                    556 => GetStatusEffectRemainingTime(1072, anyOwner: true) is > 0f and < 1.5f,
-                    // Deltascape 4.0 Pyretic
-                    694 => HasStatusEffect(960, anyOwner: true),
-                    // Vanguard, Protector's Bomb
-                    1198 => GetStatusEffectRemainingTime(3802, anyOwner: true) is > 0f and < 1.5f,
+            bool hasActionPenalty = 
+                //Player.IsInDuty &&  <-?
+                Player.Status.Any(s =>
+                    // Acceleration Bomb within Timeframe
+                    (StatusCache.AccelerationBombs.Contains(s.StatusId) &&
+                        GetStatusEffectRemainingTime(s) is > 0f and < 1.5f) ||
 
-                    // Fallback: general lists
-                    _ => Svc.ClientState.LocalPlayer?.StatusList.Any(s =>
-                            // Acceleration Bomb within Timeframe
-                            (StatusCache.AccelerationBombs.Contains(s.StatusId) &&
-                             GetStatusEffectRemainingTime(s) is > 0f and < 1.5f) ||
+                    // Pyretic
+                    StatusCache.Pyretics.Contains(s.StatusId)
 
-                            // Pyretic
-                            StatusCache.Pyretics.Contains(s.StatusId)
-                        ) == true
-                };
-            }
-
-            bool hasActionPenalty = CheckStatus();
+                ) == true;
 
             if (hasActionPenalty)
                 Svc.Targets.Target = null;

--- a/WrathCombo/Data/StatusCache.cs
+++ b/WrathCombo/Data/StatusCache.cs
@@ -1,12 +1,10 @@
 ﻿using Dalamud.Game.ClientState.Objects.Types;
 using ECommons.DalamudServices;
-using ECommons.GameFunctions;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
-using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 using Status = Dalamud.Game.ClientState.Statuses.Status; // conflicts with structs if not defined
 
 namespace WrathCombo.Data
@@ -66,50 +64,55 @@ namespace WrathCombo.Data
             Svc.Data.GetExcelSheet<Lumina.Excel.Sheets.Status>(Dalamud.Game.ClientLanguage.English)
                 .ToFrozenDictionary(i => i.RowId);
 
-        private static readonly HashSet<uint> DamageDownStatuses =
+        private static readonly FrozenSet<uint> DamageDownStatuses =
             ENStatusSheet.TryGetValue(62, out var refRow)
-                ? [.. ENStatusSheet
-                .Where(x => x.Value.Name.ToString().Equals(refRow.Name.ToString(), StringComparison.CurrentCultureIgnoreCase))
-                .Select(x => x.Key)] : [];
+                ? ENStatusSheet
+                    .Where(x => x.Value.Name.ToString().Equals(refRow.Name.ToString(), StringComparison.CurrentCultureIgnoreCase))
+                    .Select(x => x.Key)
+                    .ToFrozenSet()
+                : [];
 
         public static bool HasDamageDown(IGameObject? target) => HasStatusInCacheList(DamageDownStatuses, target);
 
-        private static readonly HashSet<uint> DamageUpStatuses =
+        private static readonly FrozenSet<uint> DamageUpStatuses =
             ENStatusSheet.TryGetValue(61, out var refRow)
-                 ? [.. ENStatusSheet
-                .Where(x => x.Value.Name.ToString().Contains(refRow.Name.ToString(), StringComparison.CurrentCultureIgnoreCase))
-                .Select(x => x.Key)] : [];
+                ? ENStatusSheet
+                    .Where(x => x.Value.Name.ToString().Contains(refRow.Name.ToString(), StringComparison.CurrentCultureIgnoreCase))
+                    .Select(x => x.Key)
+                    .ToFrozenSet()
+                : [];
 
         public static bool HasDamageUp(IGameObject? target) => HasStatusInCacheList(DamageUpStatuses, target);
         
-        public static bool HasEvasionUp(IGameObject? target)
-        {
-            HashSet<uint> evasionUpStatuses =
-                ENStatusSheet.TryGetValue(61, out var refRow)
-                    ? [.. ENStatusSheet
-                        .Where(x => x.Value.Name.ToString().Contains(refRow.Name.ToString(), StringComparison.CurrentCultureIgnoreCase))
-                        .Select(x => x.Key)]
-                    : [];
-            return HasStatusInCacheList(evasionUpStatuses, target);
-        }
+        private static readonly FrozenSet<uint> evasionUpStatuses =
+            ENStatusSheet.TryGetValue(61, out var refRow)
+                ? ENStatusSheet
+                    .Where(x => x.Value.Name.ToString().Contains(refRow.Name.ToString(), StringComparison.CurrentCultureIgnoreCase))
+                    .Select(x => x.Key)
+                    .ToFrozenSet()
+                : [];
+
+        public static bool HasEvasionUp(IGameObject? target) => HasStatusInCacheList(evasionUpStatuses, target);
 
         /// <summary>
         /// A cached set of dispellable status IDs for quick lookup.
         /// </summary>
-        private static readonly HashSet<uint> DispellableStatuses = [..
+        private static readonly FrozenSet<uint> DispellableStatuses = 
             StatusSheet
                 .Where(kvp => kvp.Value.CanDispel)
-                .Select(kvp => kvp.Key)];
+                .Select(kvp => kvp.Key)
+                .ToFrozenSet();
 
         public static bool HasCleansableDebuff(IGameObject? target) => HasStatusInCacheList(DispellableStatuses, target);
 
         /// <summary>
         /// A cached set of beneficial status IDs for quick lookup.
         /// </summary>
-        private static readonly HashSet<uint> BeneficialStatuses = [..
+        private static readonly FrozenSet<uint> BeneficialStatuses =
             StatusSheet
                 .Where(kvp => kvp.Value.StatusCategory == 1)
-                .Select(kvp => kvp.Key)];
+                .Select(kvp => kvp.Key)
+                .ToFrozenSet();
 
         public static bool HasBeneficialStatus(IGameObject? targt) => HasStatusInCacheList(BeneficialStatuses, targt);
 
@@ -119,7 +122,7 @@ namespace WrathCombo.Data
         /// <remarks>
         /// Includes statuses like Hallowed Ground (151), Living Dead (325), etc.
         /// </remarks>
-        internal static readonly HashSet<uint> InvincibleStatuses = GenerateInv();
+        internal static readonly FrozenSet<uint> InvincibleStatuses = GenerateInv().ToFrozenSet();
 
         private static HashSet<uint> GenerateInv()
         {
@@ -132,8 +135,6 @@ namespace WrathCombo.Data
             invincibles.UnionWith([151, 198, 469, 592, 1240, 1302, 1303, 1567, 1936, 2413, 2654, 3012, 3039, 3052, 3054, 4175]);
             return invincibles;
         }
-
-        
 
         /// <summary>
         /// Looks up the name of a Status by ID in Lumina Sheets
@@ -164,7 +165,7 @@ namespace WrathCombo.Data
         /// <param name="statusList">Hashset of Status IDs to check</param>
         /// <param name="gameObject">GameObject to check</param>
         /// <returns></returns>
-        internal static bool HasStatusInCacheList(HashSet<uint> statusList, IGameObject? gameObject = null)
+        internal static bool HasStatusInCacheList(FrozenSet<uint> statusList, IGameObject? gameObject = null)
         {
             if (gameObject is not IBattleChara chara)
                 return false;
@@ -184,7 +185,7 @@ namespace WrathCombo.Data
         /// <param name="statusList"></param>
         /// <param name="charaStatusList"></param>
         /// <returns></returns>
-        internal static bool CompareLists(HashSet<uint> statusList, HashSet<uint> charaStatusList) => 
+        internal static bool CompareLists(FrozenSet<uint> statusList, HashSet<uint> charaStatusList) => 
             charaStatusList.Any(id => statusList.Contains(id));
     }
 }

--- a/WrathCombo/Data/StatusCache.cs
+++ b/WrathCombo/Data/StatusCache.cs
@@ -121,20 +121,39 @@ namespace WrathCombo.Data
         /// </summary>
         /// <remarks>
         /// Includes statuses like Hallowed Ground (151), Living Dead (325), etc.
+        /// Icon from StatusSheet.FirstOrDefault(row => row.Value.RowId == 325).Value.Icon; (General Invincibility)
         /// </remarks>
-        internal static readonly FrozenSet<uint> InvincibleStatuses = GenerateInv().ToFrozenSet();
+        internal static readonly FrozenSet<uint> InvincibleStatuses =
+            StatusSheet
+                .Where(row => row.Value.Icon == 215024)
+                .Select(row => row.Key)
+                .Concat(new uint[] {
+                    151, 198, 469, 592, 1240, 1302, 1303,
+                    1567, 1936, 2413, 2654, 3012, 3039,
+                    3052, 3054, 4175
+                })
+                .ToFrozenSet();
 
-        private static HashSet<uint> GenerateInv()
-        {
-            //Search by Invincibility Icon
-            uint targetIcon = 215024; //StatusSheet.FirstOrDefault(row => row.Value.RowId == 325).Value.Icon;
-            //Svc.Log.Debug($"Invincible Icon: {targetIcon}");
+        internal static readonly FrozenSet<uint> AccelerationBombs =
+            new HashSet<uint>(
+                StatusSheet
+                    .Where(row => row.Value.Icon == 215727) // Acceleration Bomb Icon
+                    .Select(row => row.Key)
+            )
+            {
+                4130 // Authority's Hold
+            }.ToFrozenSet();
 
-            var invincibles = StatusSheet.Where(row => row.Value.Icon == targetIcon).Select(row => row.Key).ToHashSet();
-            //Add Random Invulnerabilities not yet assigned to TerritoryType
-            invincibles.UnionWith([151, 198, 469, 592, 1240, 1302, 1303, 1567, 1936, 2413, 2654, 3012, 3039, 3052, 3054, 4175]);
-            return invincibles;
-        }
+        internal static readonly FrozenSet<uint> Pyretics =
+            new HashSet<uint>(
+                StatusSheet
+                    .Where(row => row.Value.Icon == 215647) // Pyretic Icon
+                    .Select(row => row.Key)
+            )
+            {
+                514 // Causality
+            }.ToFrozenSet();
+
 
         /// <summary>
         /// Looks up the name of a Status by ID in Lumina Sheets


### PR DESCRIPTION
Public Change:
Auto Rotation should now pause for Weeping City's Ozma & Vanguard's Protector Acceleration Bombs

Internal Changes
Sorted area list
Status Caches now Frozen Sets
