### PR TITLE
[IPC] Expose `DPSSettings.DPSAoETargets`

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationConfigIPCWrapper.cs
+++ b/WrathCombo/AutoRotation/AutoRotationConfigIPCWrapper.cs
@@ -119,9 +119,17 @@ public class DPSSettingsIPCWrapper(DPSSettings settings)
         }
     }
 
-    #region Direct Pass-Throughs (no IPC check)
+    public int? DPSAoETargets
+    {
+        get
+        {
+            var checkControlled =
+                P.UIHelper.AutoRotationConfigControlled("DPSAoETargets");
+            return checkControlled?.state ?? settings.DPSAoETargets;
+        }
+    }
 
-    public int? DPSAoETargets => settings.DPSAoETargets;
+    #region Direct Pass-Throughs (no IPC check)
 
     public bool PreferNonCombat => settings.PreferNonCombat;
 

--- a/WrathCombo/Services/IPC/Enums.cs
+++ b/WrathCombo/Services/IPC/Enums.cs
@@ -135,7 +135,8 @@ public enum CancellationReason
                  "https://github.com/PunishXIV/WrathCombo/commits/main/res/ipc_status.txt")]
     AllServicesSuspended = 4,
 
-    [Description("Player job has been changed and leases will have to be reapplied.")]
+    [Description(
+        "Player job has been changed and leases will have to be reapplied.")]
     JobChanged = 5,
 }
 
@@ -157,11 +158,9 @@ public enum SetResult
     [Description("IPC services are currently disabled.")]
     IPCDisabled = 10,
 
-    [Description("Invalid lease.")]
-    InvalidLease = 11,
+    [Description("Invalid lease.")] InvalidLease = 11,
 
-    [Description("Blacklisted lease.")]
-    BlacklistedLease = 12,
+    [Description("Blacklisted lease.")] BlacklistedLease = 12,
 
     [Description("Configuration you are trying to set is already set.")]
     Duplicate = 13,
@@ -222,14 +221,16 @@ public enum AutoRotationConfigOption
     /// <seealso cref="HealerSettings.AutoCleanse" />
     [ConfigValueType(typeof(bool))] AutoCleanse = 11,
 
-    /// <seealso cref="HealerSettings.IncludeNPCs"/>
+    /// <seealso cref="HealerSettings.IncludeNPCs" />
     [ConfigValueType(typeof(bool))] IncludeNPCs = 12,
 
     /// <seealso cref="DPSSettings.OnlyAttackInCombat" />
     [ConfigValueType(typeof(bool))] OnlyAttackInCombat = 13,
 
+    /// <seealso cref="AutoRotationConfig.OrbwalkerIntegration" />
     [ConfigValueType(typeof(bool))] OrbwalkerIntegration = 14,
 
+    /// <seealso cref="HealerSettings.AutoRezOutOfParty" />
     [ConfigValueType(typeof(bool))] AutoRezOutOfParty = 15,
 }
 

--- a/WrathCombo/Services/IPC/Enums.cs
+++ b/WrathCombo/Services/IPC/Enums.cs
@@ -232,6 +232,9 @@ public enum AutoRotationConfigOption
 
     /// <seealso cref="HealerSettings.AutoRezOutOfParty" />
     [ConfigValueType(typeof(bool))] AutoRezOutOfParty = 15,
+
+    /// <seealso cref="DPSSettings.DPSAoETargets" />
+    [ConfigValueType(typeof(int?))] DPSAoETargets = 16,
 }
 
 #region Type Attribute

--- a/WrathCombo/Services/IPC/Enums.cs
+++ b/WrathCombo/Services/IPC/Enums.cs
@@ -234,7 +234,7 @@ public enum AutoRotationConfigOption
     [ConfigValueType(typeof(bool))] AutoRezOutOfParty = 15,
 
     /// <seealso cref="DPSSettings.DPSAoETargets" />
-    [ConfigValueType(typeof(int?))] DPSAoETargets = 16,
+    [ConfigValueType(typeof(int))] DPSAoETargets = 16,
 }
 
 #region Type Attribute

--- a/WrathCombo/Services/IPC/ProvideAutoRotConfig.cs
+++ b/WrathCombo/Services/IPC/ProvideAutoRotConfig.cs
@@ -69,6 +69,7 @@ public partial class Provider
                 arcOption.OnlyAttackInCombat => arcD.OnlyAttackInCombat,
                 arcOption.OrbwalkerIntegration => arc.OrbwalkerIntegration,
                 arcOption.AutoRezOutOfParty => arcH.AutoRezOutOfParty,
+                arcOption.DPSAoETargets => arcD.DPSAoETargets,
                 _ => throw new ArgumentOutOfRangeException(
                     nameof(passedOption), passedOption, null),
             };

--- a/WrathCombo/Services/IPC/ProvideAutoRotConfig.cs
+++ b/WrathCombo/Services/IPC/ProvideAutoRotConfig.cs
@@ -64,12 +64,13 @@ public partial class Provider
                 arcOption.ManageKardia => arcH.ManageKardia,
                 arcOption.AutoRez => arcH.AutoRez,
                 arcOption.AutoRezDPSJobs => arcH.AutoRezDPSJobs,
-                arcOption.AutoRezOutOfParty => arcH.AutoRezOutOfParty,
                 arcOption.AutoCleanse => arcH.AutoCleanse,
                 arcOption.IncludeNPCs => arcH.IncludeNPCs,
                 arcOption.OnlyAttackInCombat => arcD.OnlyAttackInCombat,
+                arcOption.OrbwalkerIntegration => arc.OrbwalkerIntegration,
+                arcOption.AutoRezOutOfParty => arcH.AutoRezOutOfParty,
                 _ => throw new ArgumentOutOfRangeException(
-                    nameof(passedOption), passedOption, null)
+                    nameof(passedOption), passedOption, null),
             };
         }
         catch (Exception)

--- a/WrathCombo/Services/IPC/UIHelper.cs
+++ b/WrathCombo/Services/IPC/UIHelper.cs
@@ -626,16 +626,14 @@ public class UIHelper(Leasing leasing)
 
         ImGui.BeginGroup();
         ImGui.PushStyleColor(ImGuiCol.FrameBg, _backgroundColor);
-        ImGui.PushStyleColor(ImGuiCol.Text, _textColor);
         ImGui.PushStyleColor(ImGuiCol.TextDisabled, _textColor);
-        ImGui.PushStyleColor(ImGuiCol.SliderGrab, _backgroundColor);
 
         var _ = controlled?.state;
         ImGui.BeginDisabled();
         ImGuiEx.InputInt(100f.Scale(), label, ref _);
         ImGui.EndDisabled();
 
-        ImGui.PopStyleColor(4);
+        ImGui.PopStyleColor(2);
         ImGui.EndGroup();
 
         if (ImGui.IsItemHovered())

--- a/WrathCombo/Services/IPC/UIHelper.cs
+++ b/WrathCombo/Services/IPC/UIHelper.cs
@@ -595,6 +595,12 @@ public class UIHelper(Leasing leasing)
         return false;
     }
 
+    private bool ShowIPCControlledNumberInput
+        (string label, ref int? backupVar)
+    {
+        
+    }
+
     /// <summary>
     ///     Button click method for Indicator to cancel plugin control.
     /// </summary>

--- a/WrathCombo/Window/Tabs/AutoRotationTab.cs
+++ b/WrathCombo/Window/Tabs/AutoRotationTab.cs
@@ -94,7 +94,8 @@ namespace WrathCombo.Window.Tabs
 
                 
                 P.UIHelper.ShowIPCControlledIndicatorIfNeeded("DPSAoETargets");
-                var input = ImGuiEx.InputInt(100f.Scale(), "Targets Required for AoE Damage Features", ref cfg.DPSSettings.DPSAoETargets);
+                var input = P.UIHelper.ShowIPCControlledNumberInputIfNeeded(
+                    "Targets Required for AoE Damage Features", ref cfg.DPSSettings.DPSAoETargets, "DPSAoETargets");
                 if (input)
                 {
                     changed |= input;

--- a/WrathCombo/Window/Tabs/AutoRotationTab.cs
+++ b/WrathCombo/Window/Tabs/AutoRotationTab.cs
@@ -221,7 +221,9 @@ namespace WrathCombo.Window.Tabs
                 if (autoRez)
                 {
                     ImGuiExtensions.Prefix(false);
-                    changed |= ImGui.Checkbox("Apply to Out of Party Members", ref cfg.HealerSettings.AutoRezOutOfParty);
+                    P.UIHelper.ShowIPCControlledIndicatorIfNeeded("AutoRezOutOfParty");
+                    changed |= P.UIHelper.ShowIPCControlledCheckboxIfNeeded(
+                        "Apply to Out of Party Members", ref cfg.HealerSettings.AutoRezOutOfParty, "AutoRezOutOfParty");
 
                     ImGuiExtensions.Prefix(false);
                     changed |= ImGui.Checkbox("Require Swiftcast/Dualcast", ref
@@ -266,9 +268,12 @@ namespace WrathCombo.Window.Tabs
             changed |= ImGui.InputInt("Throttle Delay (ms)", ref cfg.Throttler);
             ImGuiComponents.HelpMarker("Auto-Rotation has a built in throttler to only run every so many milliseconds for performance reasons. If you experience issues with frame rate, try increasing this value. Do note this may have a side-effect of introducing clipping if set too high, so experiment with the value.");
 
-            using (ImRaii.Disabled(!OrbwalkerIPC.IsEnabled))
+            var orbwalker = (bool)P.IPC.GetAutoRotationConfigState(AutoRotationConfigOption.OrbwalkerIntegration)!;
+            using (ImRaii.Disabled(!orbwalker))
             {
-                changed |= ImGui.Checkbox($"Enable Orbwalker Integration", ref cfg.OrbwalkerIntegration);
+                P.UIHelper.ShowIPCControlledIndicatorIfNeeded("OrbwalkerIntegration");
+                changed |= P.UIHelper.ShowIPCControlledCheckboxIfNeeded(
+                    "Enable Orbwalker Integration", ref cfg.OrbwalkerIntegration, "OrbwalkerIntegration");
 
                 ImGuiComponents.HelpMarker($"This will make Auto-Rotation use actions with cast times even whilst moving, as Orbwalker will lock movement during the cast.");
             }

--- a/WrathCombo/Window/Tabs/AutoRotationTab.cs
+++ b/WrathCombo/Window/Tabs/AutoRotationTab.cs
@@ -92,6 +92,8 @@ namespace WrathCombo.Window.Tabs
                     ImGuiComponents.HelpMarker("For all other targeting modes, AoE will target based on highest number of targets hit. In manual mode, it will only do this if you tick this box.");
                 }
 
+                
+                P.UIHelper.ShowIPCControlledIndicatorIfNeeded("DPSAoETargets");
                 var input = ImGuiEx.InputInt(100f.Scale(), "Targets Required for AoE Damage Features", ref cfg.DPSSettings.DPSAoETargets);
                 if (input)
                 {


### PR DESCRIPTION
- [X] Updates the `AutoRotationConfig` Wrapper to get the IPC-set value
- [X] Includes the new setting in the IPC's `AutoRotationConfigOption` Enum
- [X] Updates `GetAutoRotationConfigState` to support the new option (and others that had been forgotten)
- [X] Updates `AutoRotationTab` to show if the new option is IPC-Controlled (and others that had been forgotten)
- [X] Updates the IPC's `UIHelper` to support the UI used for the new option
- [X] Test `SetAutoRotationConfigState`'s handling of null values