### PR TITLE
[Various] Kage's Class Cleanup

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -3720,10 +3720,12 @@ public enum CustomComboPreset
     #endregion
 
     [ReplaceSkill(MCH.Dismantle)]
+    [ConflictingCombos(MCH_DismantleTactician)]
     [CustomComboInfo("Double Dismantle Protection", "Prevents the use of Dismantle when target already has the effect by replacing it with Savage Blade.", MCH.JobID)]
     MCH_DismantleProtection = 8042,
 
     [ReplaceSkill(MCH.Dismantle)]
+    [ConflictingCombos(MCH_DismantleProtection)]
     [CustomComboInfo("Dismantle - Tactician", "Swap dismantle with tactician when dismantle is on cooldown.", MCH.JobID)]
     MCH_DismantleTactician = 8058,
 

--- a/WrathCombo/Combos/PvE/DRG/DRG.cs
+++ b/WrathCombo/Combos/PvE/DRG/DRG.cs
@@ -711,9 +711,14 @@ internal partial class DRG : Melee
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.DRG_BurstCDFeature;
 
-        protected override uint Invoke(uint actionID) =>
-            actionID is LanceCharge && IsOnCooldown(LanceCharge) && ActionReady(BattleLitany)
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not LanceCharge)
+                return actionID;
+
+            return IsOnCooldown(LanceCharge) && ActionReady(BattleLitany)
                 ? BattleLitany
                 : actionID;
+        }
     }
 }

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -741,17 +741,22 @@ internal partial class MCH : PhysicalRanged
             if (actionID is not (Drill or HotShot or AirAnchor or Chainsaw))
                 return actionID;
 
-            return LevelChecked(Excavator) && HasStatusEffect(Buffs.ExcavatorReady)
-                ? CalcBestAction(actionID, Excavator, Chainsaw, AirAnchor, Drill)
-                : LevelChecked(Chainsaw)
-                    ? CalcBestAction(actionID, Chainsaw, AirAnchor, Drill)
-                    : LevelChecked(AirAnchor)
-                        ? CalcBestAction(actionID, AirAnchor, Drill)
-                        : LevelChecked(Drill)
-                            ? CalcBestAction(actionID, Drill, HotShot)
-                            : !LevelChecked(Drill)
-                                ? HotShot
-                                : actionID;
+            if (LevelChecked(Excavator) && HasStatusEffect(Buffs.ExcavatorReady))
+                return CalcBestAction(actionID, Excavator, Chainsaw, AirAnchor, Drill);
+
+            if (LevelChecked(Chainsaw))
+                return CalcBestAction(actionID, Chainsaw, AirAnchor, Drill);
+            
+            if (LevelChecked(AirAnchor))
+                return CalcBestAction(actionID, AirAnchor, Drill);
+            
+            if (LevelChecked(Drill))
+                return CalcBestAction(actionID, Drill, HotShot);
+            
+            if (!LevelChecked(Drill))
+                return HotShot;
+            
+            return actionID;
         }
     }
 

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -721,51 +721,68 @@ internal partial class MCH : PhysicalRanged
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.MCH_Overdrive;
 
-        protected override uint Invoke(uint actionID) =>
-            actionID is RookAutoturret or AutomatonQueen && RobotActive
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not (AutomatonQueen or RookAutoturret))
+                return actionID;
+
+            return RobotActive
                 ? OriginalHook(QueenOverdrive)
                 : actionID;
+        }
     }
 
     internal class MCH_HotShotDrillChainsawExcavator : CustomCombo
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.MCH_HotShotDrillChainsawExcavator;
 
-        protected override uint Invoke(uint actionID) =>
-            actionID is not (Drill or HotShot or AirAnchor or Chainsaw)
-                ? actionID
-                : LevelChecked(Excavator) && HasStatusEffect(Buffs.ExcavatorReady)
-                    ? CalcBestAction(actionID, Excavator, Chainsaw, AirAnchor, Drill)
-                    : LevelChecked(Chainsaw)
-                        ? CalcBestAction(actionID, Chainsaw, AirAnchor, Drill)
-                        : LevelChecked(AirAnchor)
-                            ? CalcBestAction(actionID, AirAnchor, Drill)
-                            : LevelChecked(Drill)
-                                ? CalcBestAction(actionID, Drill, HotShot)
-                                : !LevelChecked(Drill)
-                                    ? HotShot
-                                    : actionID;
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not (Drill or HotShot or AirAnchor or Chainsaw))
+                return actionID;
+
+            return LevelChecked(Excavator) && HasStatusEffect(Buffs.ExcavatorReady)
+                ? CalcBestAction(actionID, Excavator, Chainsaw, AirAnchor, Drill)
+                : LevelChecked(Chainsaw)
+                    ? CalcBestAction(actionID, Chainsaw, AirAnchor, Drill)
+                    : LevelChecked(AirAnchor)
+                        ? CalcBestAction(actionID, AirAnchor, Drill)
+                        : LevelChecked(Drill)
+                            ? CalcBestAction(actionID, Drill, HotShot)
+                            : !LevelChecked(Drill)
+                                ? HotShot
+                                : actionID;
+        }
     }
 
     internal class MCH_DismantleTactician : CustomCombo
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.MCH_DismantleTactician;
 
-        protected override uint Invoke(uint actionID) =>
-            actionID is Dismantle &&
-            (IsOnCooldown(Dismantle) || !LevelChecked(Dismantle) || !HasBattleTarget()) &&
-            ActionReady(Tactician) && !HasStatusEffect(Buffs.Tactician)
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not Dismantle)
+                return actionID;
+
+            return (IsOnCooldown(Dismantle) || !LevelChecked(Dismantle) || !HasBattleTarget()) &&
+                   ActionReady(Tactician) && !HasStatusEffect(Buffs.Tactician)
                 ? Tactician
                 : actionID;
+        }
     }
 
     internal class MCH_DismantleProtection : CustomCombo
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.MCH_DismantleProtection;
 
-        protected override uint Invoke(uint actionID) =>
-            actionID is Dismantle && HasStatusEffect(Debuffs.Dismantled, CurrentTarget, true) && IsOffCooldown(Dismantle)
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not Dismantle)
+                return actionID;
+
+            return HasStatusEffect(Debuffs.Dismantled, CurrentTarget, true) && IsOffCooldown(Dismantle)
                 ? All.SavageBlade
                 : actionID;
+        }
     }
 }

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -264,7 +264,7 @@ internal partial class MCH
         public override int MinOpenerLevel => 100;
 
         public override int MaxOpenerLevel => 109;
-        
+
         public override List<uint> OpenerActions { get; set; } =
         [
             Reassemble,
@@ -325,7 +325,7 @@ internal partial class MCH
         public override int MinOpenerLevel => 90;
 
         public override int MaxOpenerLevel => 99;
-        
+
         public override List<uint> OpenerActions { get; set; } =
         [
             Reassemble,

--- a/WrathCombo/Combos/PvE/RPR/RPR.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR.cs
@@ -636,137 +636,127 @@ internal partial class RPR : Melee
 
         protected override uint Invoke(uint actionID)
         {
-            switch (actionID)
+            if (actionID is not (GrimSwathe or BloodStalk))
+                return actionID;
+
+            if (IsEnabled(CustomComboPreset.RPR_GluttonyBloodSwathe_OGCD))
             {
-                case GrimSwathe:
+                if (Shroud >= 50 || HasStatusEffect(Buffs.IdealHost))
+                    return Enshroud;
+
+                if (HasStatusEffect(Buffs.Enshrouded))
                 {
-                    if (IsEnabled(CustomComboPreset.RPR_GluttonyBloodSwathe_OGCD))
-                    {
-                        if (Shroud >= 50 || HasStatusEffect(Buffs.IdealHost))
-                            return Enshroud;
-
-                        if (HasStatusEffect(Buffs.Enshrouded))
-                        {
-                            //Sacrificium
-                            if (Lemure is 2 && HasStatusEffect(Buffs.Oblatio))
-                                return OriginalHook(Gluttony);
-
-                            //Lemure's Slice
-                            if (Void >= 2 && LevelChecked(LemuresScythe))
-                                return OriginalHook(GrimSwathe);
-                        }
-                    }
-
-                    if (IsEnabled(CustomComboPreset.RPR_GluttonyBloodSwathe_Enshroud))
-                    {
-                        if (HasStatusEffect(Buffs.PerfectioParata))
-                            return OriginalHook(Communio);
-
-                        if (HasStatusEffect(Buffs.Enshrouded))
-                        {
-                            switch (Lemure)
-                            {
-                                case 1 when Void == 0 && LevelChecked(Communio):
-                                    return Communio;
-
-                                case 2 when Void is 1 && HasStatusEffect(Buffs.Oblatio):
-                                    return OriginalHook(Gluttony);
-                            }
-
-                            if (Void >= 2 && LevelChecked(LemuresScythe))
-                                return OriginalHook(GrimSwathe);
-
-                            if (Lemure > 1)
-                                return OriginalHook(Guillotine);
-                        }
-                    }
-
-                    if (ActionReady(Gluttony) && !HasStatusEffect(Buffs.Enshrouded) && !HasStatusEffect(Buffs.SoulReaver))
-                        return Gluttony;
-
-                    if (IsEnabled(CustomComboPreset.RPR_GluttonyBloodSwathe_Sacrificium) &&
-                        HasStatusEffect(Buffs.Enshrouded) && HasStatusEffect(Buffs.Oblatio))
+                    //Sacrificium
+                    if (Lemure is 2 && HasStatusEffect(Buffs.Oblatio))
                         return OriginalHook(Gluttony);
 
-                    if (IsEnabled(CustomComboPreset.RPR_GluttonyBloodSwathe_BloodSwatheCombo) &&
-                        (HasStatusEffect(Buffs.SoulReaver) || HasStatusEffect(Buffs.Executioner)) && LevelChecked(Guillotine))
-                        return Guillotine;
-
-                    break;
+                    //Lemure's Slice
+                    if (Void >= 2 && LevelChecked(LemuresScythe))
+                        return OriginalHook(GrimSwathe);
                 }
+            }
 
+            if (IsEnabled(CustomComboPreset.RPR_GluttonyBloodSwathe_Enshroud))
+            {
+                if (HasStatusEffect(Buffs.PerfectioParata))
+                    return OriginalHook(Communio);
 
-                case BloodStalk:
+                if (HasStatusEffect(Buffs.Enshrouded))
                 {
-                    if (IsEnabled(CustomComboPreset.RPR_TrueNorthGluttony) && Role.CanTrueNorth() &&
-                        (GetStatusEffectStacks(Buffs.SoulReaver) is 2 || HasStatusEffect(Buffs.Executioner)))
-                        return Role.TrueNorth;
-
-                    if (IsEnabled(CustomComboPreset.RPR_GluttonyBloodSwathe_OGCD))
+                    switch (Lemure)
                     {
-                        if (Shroud >= 50 || HasStatusEffect(Buffs.IdealHost))
-                            return Enshroud;
+                        case 1 when Void == 0 && LevelChecked(Communio):
+                            return Communio;
 
-                        if (HasStatusEffect(Buffs.Enshrouded))
-                        {
-                            //Sacrificium
-                            if (Lemure is 2 && HasStatusEffect(Buffs.Oblatio))
-                                return OriginalHook(Gluttony);
-
-                            //Lemure's Slice
-                            if (Void >= 2 && LevelChecked(LemuresSlice))
-                                return OriginalHook(BloodStalk);
-                        }
+                        case 2 when Void is 1 && HasStatusEffect(Buffs.Oblatio):
+                            return OriginalHook(Gluttony);
                     }
 
-                    if (IsEnabled(CustomComboPreset.RPR_GluttonyBloodSwathe_Enshroud))
-                    {
-                        if (HasStatusEffect(Buffs.PerfectioParata))
-                            return OriginalHook(Communio);
+                    if (Void >= 2 && LevelChecked(LemuresScythe))
+                        return OriginalHook(GrimSwathe);
 
-                        if (HasStatusEffect(Buffs.Enshrouded))
-                        {
-                            switch (Lemure)
-                            {
-                                case 1 when Void == 0 && LevelChecked(Communio):
-                                    return Communio;
+                    if (Lemure > 1)
+                        return OriginalHook(Guillotine);
+                }
+            }
 
-                                case 2 when Void is 1 && HasStatusEffect(Buffs.Oblatio):
-                                    return OriginalHook(Gluttony);
-                            }
+            if (ActionReady(Gluttony) && !HasStatusEffect(Buffs.Enshrouded) && !HasStatusEffect(Buffs.SoulReaver))
+                return Gluttony;
 
-                            if (Void >= 2 && LevelChecked(LemuresSlice))
-                                return OriginalHook(BloodStalk);
+            if (IsEnabled(CustomComboPreset.RPR_GluttonyBloodSwathe_Sacrificium) &&
+                HasStatusEffect(Buffs.Enshrouded) && HasStatusEffect(Buffs.Oblatio))
+                return OriginalHook(Gluttony);
 
-                            if (HasStatusEffect(Buffs.EnhancedVoidReaping))
-                                return OriginalHook(Gibbet);
+            if (IsEnabled(CustomComboPreset.RPR_GluttonyBloodSwathe_BloodSwatheCombo) &&
+                (HasStatusEffect(Buffs.SoulReaver) || HasStatusEffect(Buffs.Executioner)) && LevelChecked(Guillotine))
+                return Guillotine;
 
-                            if (HasStatusEffect(Buffs.EnhancedCrossReaping) ||
-                                !HasStatusEffect(Buffs.EnhancedCrossReaping) && !HasStatusEffect(Buffs.EnhancedVoidReaping))
-                                return OriginalHook(Gallows);
-                        }
-                    }
 
-                    if (ActionReady(Gluttony) && !HasStatusEffect(Buffs.Enshrouded) && !HasStatusEffect(Buffs.SoulReaver))
-                        return Gluttony;
+            if (IsEnabled(CustomComboPreset.RPR_TrueNorthGluttony) && Role.CanTrueNorth() &&
+                (GetStatusEffectStacks(Buffs.SoulReaver) is 2 || HasStatusEffect(Buffs.Executioner)))
+                return Role.TrueNorth;
 
-                    if (IsEnabled(CustomComboPreset.RPR_GluttonyBloodSwathe_Sacrificium) &&
-                        HasStatusEffect(Buffs.Enshrouded) && HasStatusEffect(Buffs.Oblatio))
+            if (IsEnabled(CustomComboPreset.RPR_GluttonyBloodSwathe_OGCD))
+            {
+                if (Shroud >= 50 || HasStatusEffect(Buffs.IdealHost))
+                    return Enshroud;
+
+                if (HasStatusEffect(Buffs.Enshrouded))
+                {
+                    //Sacrificium
+                    if (Lemure is 2 && HasStatusEffect(Buffs.Oblatio))
                         return OriginalHook(Gluttony);
 
-                    if (IsEnabled(CustomComboPreset.RPR_GluttonyBloodSwathe_BloodSwatheCombo) &&
-                        (HasStatusEffect(Buffs.SoulReaver) || HasStatusEffect(Buffs.Executioner)))
-                    {
-                        if (HasStatusEffect(Buffs.EnhancedGibbet))
-                            return OriginalHook(Gibbet);
+                    //Lemure's Slice
+                    if (Void >= 2 && LevelChecked(LemuresSlice))
+                        return OriginalHook(BloodStalk);
+                }
+            }
 
-                        if (HasStatusEffect(Buffs.EnhancedGallows) ||
-                            !HasStatusEffect(Buffs.EnhancedGibbet) && !HasStatusEffect(Buffs.EnhancedGallows))
-                            return OriginalHook(Gallows);
+            if (IsEnabled(CustomComboPreset.RPR_GluttonyBloodSwathe_Enshroud))
+            {
+                if (HasStatusEffect(Buffs.PerfectioParata))
+                    return OriginalHook(Communio);
+
+                if (HasStatusEffect(Buffs.Enshrouded))
+                {
+                    switch (Lemure)
+                    {
+                        case 1 when Void == 0 && LevelChecked(Communio):
+                            return Communio;
+
+                        case 2 when Void is 1 && HasStatusEffect(Buffs.Oblatio):
+                            return OriginalHook(Gluttony);
                     }
 
-                    break;
+                    if (Void >= 2 && LevelChecked(LemuresSlice))
+                        return OriginalHook(BloodStalk);
+
+                    if (HasStatusEffect(Buffs.EnhancedVoidReaping))
+                        return OriginalHook(Gibbet);
+
+                    if (HasStatusEffect(Buffs.EnhancedCrossReaping) ||
+                        !HasStatusEffect(Buffs.EnhancedCrossReaping) && !HasStatusEffect(Buffs.EnhancedVoidReaping))
+                        return OriginalHook(Gallows);
                 }
+            }
+
+            if (ActionReady(Gluttony) && !HasStatusEffect(Buffs.Enshrouded) && !HasStatusEffect(Buffs.SoulReaver))
+                return Gluttony;
+
+            if (IsEnabled(CustomComboPreset.RPR_GluttonyBloodSwathe_Sacrificium) &&
+                HasStatusEffect(Buffs.Enshrouded) && HasStatusEffect(Buffs.Oblatio))
+                return OriginalHook(Gluttony);
+
+            if (IsEnabled(CustomComboPreset.RPR_GluttonyBloodSwathe_BloodSwatheCombo) &&
+                (HasStatusEffect(Buffs.SoulReaver) || HasStatusEffect(Buffs.Executioner)))
+            {
+                if (HasStatusEffect(Buffs.EnhancedGibbet))
+                    return OriginalHook(Gibbet);
+
+                if (HasStatusEffect(Buffs.EnhancedGallows) ||
+                    !HasStatusEffect(Buffs.EnhancedGibbet) && !HasStatusEffect(Buffs.EnhancedGallows))
+                    return OriginalHook(Gallows);
             }
 
             return actionID;
@@ -777,23 +767,31 @@ internal partial class RPR : Melee
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.RPR_ArcaneCirclePlentifulHarvest;
 
-        protected override uint Invoke(uint actionID) =>
-            actionID is ArcaneCircle &&
-            HasStatusEffect(Buffs.ImmortalSacrifice) &&
-            LevelChecked(PlentifulHarvest)
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not ArcaneCircle)
+                return actionID;
+
+            return HasStatusEffect(Buffs.ImmortalSacrifice) &&
+                   LevelChecked(PlentifulHarvest)
                 ? PlentifulHarvest
                 : actionID;
+        }
     }
 
     internal class RPR_Regress : CustomCombo
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.RPR_Regress;
 
-        protected override uint Invoke(uint actionID) =>
-            actionID is HellsEgress or HellsIngress &&
-            GetStatusEffect(Buffs.Threshold)?.RemainingTime <= 9
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not (HellsEgress or HellsIngress))
+                return actionID;
+
+            return GetStatusEffect(Buffs.Threshold)?.RemainingTime <= 9
                 ? Regress
                 : actionID;
+        }
     }
 
     internal class RPR_Soulsow : CustomCombo
@@ -810,12 +808,12 @@ internal partial class RPR : Melee
             bool soulsowReady = ActionReady(Soulsow) && !HasStatusEffect(Buffs.Soulsow);
 
             return soulSowOptions.Length > 0 &&
-                   (actionID is Harpe && soulSowOptions[0] ||
-                    actionID is Slice && soulSowOptions[1] ||
-                    actionID is SpinningScythe && soulSowOptions[2] ||
-                    actionID is ShadowOfDeath && soulSowOptions[3] ||
-                    actionID is BloodStalk && soulSowOptions[4]) && soulsowReady && !InCombat() ||
-                   IsEnabled(CustomComboPreset.RPR_Soulsow_Combat) && actionID is Harpe && !HasBattleTarget()
+                   (soulSowOptions[0] ||
+                    soulSowOptions[1] ||
+                    soulSowOptions[2] ||
+                    soulSowOptions[3] ||
+                    soulSowOptions[4]) && soulsowReady && !InCombat() ||
+                   IsEnabled(CustomComboPreset.RPR_Soulsow_Combat) && !HasBattleTarget()
                 ? Soulsow
                 : actionID;
         }
@@ -827,27 +825,22 @@ internal partial class RPR : Melee
 
         protected override uint Invoke(uint actionID)
         {
-            switch (actionID)
+            if (actionID is not Enshroud)
+                return actionID;
+
+            if (IsEnabled(CustomComboPreset.RPR_TrueNorthEnshroud) &&
+                (GetStatusEffectStacks(Buffs.SoulReaver) is 2 || HasStatusEffect(Buffs.Executioner)) &&
+                Role.CanTrueNorth())
+                return Role.TrueNorth;
+
+            if (HasStatusEffect(Buffs.SoulReaver) || HasStatusEffect(Buffs.Executioner))
             {
-                case Enshroud when IsEnabled(CustomComboPreset.RPR_TrueNorthEnshroud) &&
-                                   (GetStatusEffectStacks(Buffs.SoulReaver) is 2 || HasStatusEffect(Buffs.Executioner)) &&
-                                   Role.CanTrueNorth():
-                    return Role.TrueNorth;
+                if (HasStatusEffect(Buffs.EnhancedGibbet))
+                    return OriginalHook(Gibbet);
 
-                case Enshroud:
-                {
-                    if (HasStatusEffect(Buffs.SoulReaver) || HasStatusEffect(Buffs.Executioner))
-                    {
-                        if (HasStatusEffect(Buffs.EnhancedGibbet))
-                            return OriginalHook(Gibbet);
-
-                        if (HasStatusEffect(Buffs.EnhancedGallows) ||
-                            !HasStatusEffect(Buffs.EnhancedGibbet) && !HasStatusEffect(Buffs.EnhancedGallows))
-                            return OriginalHook(Gallows);
-                    }
-
-                    break;
-                }
+                if (HasStatusEffect(Buffs.EnhancedGallows) ||
+                    !HasStatusEffect(Buffs.EnhancedGibbet) && !HasStatusEffect(Buffs.EnhancedGallows))
+                    return OriginalHook(Gallows);
             }
 
             return actionID;
@@ -860,6 +853,9 @@ internal partial class RPR : Melee
 
         protected override uint Invoke(uint actionID)
         {
+            if (actionID is not (Gibbet or Gallows or Guillotine))
+                return actionID;
+
             switch (actionID)
             {
                 case Gibbet or Gallows when HasStatusEffect(Buffs.Enshrouded):
@@ -895,12 +891,18 @@ internal partial class RPR : Melee
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.RPR_EnshroudCommunio;
 
-        protected override uint Invoke(uint actionID) =>
-            actionID switch
-            {
-                Enshroud when HasStatusEffect(Buffs.PerfectioParata) => OriginalHook(Communio),
-                Enshroud when HasStatusEffect(Buffs.Enshrouded) => Communio,
-                var _ => actionID
-            };
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not Enshroud)
+                return actionID;
+
+            if (HasStatusEffect(Buffs.PerfectioParata))
+                return OriginalHook(Communio);
+
+            if (HasStatusEffect(Buffs.Enshrouded))
+                return Communio;
+
+            return actionID;
+        }
     }
 }

--- a/WrathCombo/Combos/PvE/SAM/SAM.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM.cs
@@ -798,20 +798,20 @@ internal partial class SAM : Melee
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Shinten)
-            {
-                if (IsEnabled(CustomComboPreset.SAM_Shinten_Senei) &&
-                    ActionReady(Senei))
-                    return Senei;
+            if (actionID is not Shinten)
+                return actionID;
 
-                if (IsEnabled(CustomComboPreset.SAM_Shinten_Zanshin) &&
-                    HasStatusEffect(Buffs.ZanshinReady))
-                    return Zanshin;
+            if (IsEnabled(CustomComboPreset.SAM_Shinten_Senei) &&
+                ActionReady(Senei))
+                return Senei;
 
-                if (IsEnabled(CustomComboPreset.SAM_Shinten_Shoha) &&
-                    ActionReady(Shoha) && MeditationStacks is 3)
-                    return Shoha;
-            }
+            if (IsEnabled(CustomComboPreset.SAM_Shinten_Zanshin) &&
+                HasStatusEffect(Buffs.ZanshinReady))
+                return Zanshin;
+
+            if (IsEnabled(CustomComboPreset.SAM_Shinten_Shoha) &&
+                ActionReady(Shoha) && MeditationStacks is 3)
+                return Shoha;
 
             return actionID;
         }
@@ -823,20 +823,21 @@ internal partial class SAM : Melee
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Kyuten)
-            {
-                if (IsEnabled(CustomComboPreset.SAM_Kyuten_Guren) &&
-                    ActionReady(Guren))
-                    return Guren;
+            if (actionID is not Kyuten)
+                return actionID;
 
-                if (IsEnabled(CustomComboPreset.SAM_Kyuten_Zanshin) &&
-                    HasStatusEffect(Buffs.ZanshinReady))
-                    return Zanshin;
+            if (IsEnabled(CustomComboPreset.SAM_Kyuten_Guren) &&
+                ActionReady(Guren))
+                return Guren;
 
-                if (IsEnabled(CustomComboPreset.SAM_Kyuten_Shoha) &&
-                    ActionReady(Shoha) && MeditationStacks is 3)
-                    return Shoha;
-            }
+            if (IsEnabled(CustomComboPreset.SAM_Kyuten_Zanshin) &&
+                HasStatusEffect(Buffs.ZanshinReady))
+                return Zanshin;
+
+            if (IsEnabled(CustomComboPreset.SAM_Kyuten_Shoha) &&
+                ActionReady(Shoha) && MeditationStacks is 3)
+                return Shoha;
+
             return actionID;
         }
     }
@@ -870,7 +871,10 @@ internal partial class SAM : Melee
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Gyoten && Kenki >= 10)
+            if (actionID is not Gyoten)
+                return actionID;
+
+            if (Kenki >= 10)
             {
                 if (InMeleeRange())
                     return Yaten;
@@ -887,21 +891,30 @@ internal partial class SAM : Melee
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.SAM_MeikyoShisuiProtection;
 
-        protected override uint Invoke(uint actionID) =>
-            actionID is MeikyoShisui &&
-            HasStatusEffect(Buffs.MeikyoShisui) &&
-            ActionReady(MeikyoShisui)
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not MeikyoShisui)
+                return actionID;
+
+            return HasStatusEffect(Buffs.MeikyoShisui) &&
+                   ActionReady(MeikyoShisui)
                 ? All.SavageBlade
                 : actionID;
+        }
     }
 
     internal class SAM_SeneiGuren : CustomCombo
     {
         protected internal override CustomComboPreset Preset => CustomComboPreset.SAM_SeneiGuren;
 
-        protected override uint Invoke(uint actionID) =>
-            actionID is Senei && !LevelChecked(Senei)
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not Senei)
+                return actionID;
+
+            return !LevelChecked(Senei)
                 ? Guren
                 : actionID;
+        }
     }
 }

--- a/WrathCombo/Combos/PvE/SGE/SGE.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE.cs
@@ -11,207 +11,6 @@ namespace WrathCombo.Combos.PvE;
 
 internal partial class SGE : Healer
 {
-    #region Simple Mode
-
-    internal class SGE_ST_Simple_DPS : CustomCombo
-    {
-        private static uint[] DosisActions => [.. DosisList.Keys];
-
-        protected internal override Preset Preset => Preset.SGE_ST_DPS;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (!DosisActions.Contains(actionID))
-                return actionID;
-
-            // Kardia Reminder
-            if (LevelChecked(Kardia) &&
-                !HasStatusEffect(Buffs.Kardia) &&
-                Target is not null)
-                return Kardia
-                    .Retarget(actionID, Target);
-
-            // Variant
-            if (Variant.CanRampart(Preset.SGE_DPS_Variant_Rampart))
-                return Variant.Rampart;
-
-            //Occult skills
-            if (OccultCrescent.ShouldUsePhantomActions())
-                return OccultCrescent.BestPhantomAction();
-
-            if (CanWeave() && !HasStatusEffect(Buffs.Eukrasia))
-            {
-                if (Variant.CanSpiritDart(Preset.SGE_DPS_Variant_SpiritDart))
-                    return Variant.SpiritDart;
-
-                // Lucid Dreaming
-                if (Role.CanLucidDream(7500))
-                    return Role.LucidDreaming;
-
-                // Addersgall Protection
-                if (ActionReady(Druochole) && Addersgall >= 3)
-                    return Druochole.RetargetIfEnabled(null, DosisActions);
-
-                // Psyche
-                if (ActionReady(Psyche) && InCombat())
-                    return Psyche;
-
-                // Rhizomata
-                if (ActionReady(Rhizomata) && Addersgall < 1)
-                    return Rhizomata;
-
-                //Soteria
-                if (ActionReady(Soteria) && HasStatusEffect(Buffs.Kardia))
-                    return Soteria;
-            }
-
-            if (HasBattleTarget() && !HasStatusEffect(Buffs.Eukrasia))
-            {
-                if (LevelChecked(Eukrasia) && InCombat() &&
-                    !JustUsedOn(DosisList[OriginalHook(Dosis)].Eukrasian, CurrentTarget) &&
-                    CanApplyStatus(CurrentTarget, DosisList[OriginalHook(Dosis)].Debuff))
-                {
-                    const float refreshTimer = 5;
-                    const int hpThreshold = 1;
-
-                    if (GetTargetHPPercent() > hpThreshold &&
-                        ((DosisDebuff is null && DyskrasiaDebuff is null) ||
-                         DosisDebuff?.RemainingTime <= refreshTimer ||
-                         DyskrasiaDebuff?.RemainingTime <= refreshTimer))
-                        return Eukrasia;
-                }
-
-                // Phlegma
-                if (InCombat() && InActionRange(OriginalHook(Phlegma)) &&
-                    ActionReady(Phlegma))
-                {
-                    //If not enabled or not high enough level, follow slider
-                    if ((!LevelChecked(Psyche)) &&
-                        GetRemainingCharges(OriginalHook(Phlegma)) > 1)
-                        return OriginalHook(Phlegma);
-
-                    //If enabled and high enough level, burst
-                    if (((GetCooldownRemainingTime(Psyche) > 40 && MaxPhlegma) ||
-                         IsOffCooldown(Psyche) ||
-                         JustUsed(Psyche, 5f)))
-                        return OriginalHook(Phlegma);
-                }
-
-                // Movement Options
-                if (InCombat() && IsMoving() && HasBattleTarget())
-                {
-                    //Toxikon
-                    if (ActionReady(Toxikon) && HasAddersting())
-                        return OriginalHook(Toxikon);
-
-                    // Dyskrasia
-                    if (ActionReady(Dyskrasia) && InActionRange(Dyskrasia))
-                        return OriginalHook(Dyskrasia);
-                    //Eukrasia
-                    if (ActionReady(Eukrasia) && !HasStatusEffect(Buffs.Eukrasia))
-                        return Eukrasia;
-                }
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class SGE_AoE_Simple_DPS : CustomCombo
-    {
-        protected internal override Preset Preset => Preset.SGE_AoE_Simple_DPS;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (!DyskrasiaList.Contains(actionID) ||
-                HasStatusEffect(Buffs.Eukrasia))
-                return actionID;
-
-            // Variant Rampart
-            if (Variant.CanRampart(Preset.SGE_DPS_Variant_Rampart))
-                return Variant.Rampart;
-
-            //Occult skills
-            if (OccultCrescent.ShouldUsePhantomActions())
-                return OccultCrescent.BestPhantomAction();
-         
-            if (ActionReady(Kerachole) && HasAddersgall() &&
-                CanWeave() && RaidWideCasting())
-                return Kerachole;
-
-            if (ActionReady(Holos) && CanWeave() && RaidWideCasting() &&
-                GetPartyAvgHPPercent() <= 70)
-                return Holos;
-
-            if (RaidwideEprognosis())
-                return HasStatusEffect(Buffs.Eukrasia)
-                    ? OriginalHook(Prognosis)
-                    : Eukrasia;
-            
-            if (CanWeave())
-            {
-                // Variant Spirit Dart
-                if (Variant.CanSpiritDart(Preset.SGE_DPS_Variant_SpiritDart))
-                    return Variant.SpiritDart;
-
-                // Lucid Dreaming
-                if (Role.CanLucidDream(7500))
-                    return Role.LucidDreaming;
-
-                // Addersgall Protection
-                if (ActionReady(Druochole) && Addersgall >= 3)
-                    return Druochole
-                        .RetargetIfEnabled(null, OriginalHook(Dyskrasia));
-
-                // Psyche
-                if (ActionReady(Psyche) && HasBattleTarget() &&
-                    InActionRange(Psyche))
-                    return Psyche;
-
-                // Rhizomata
-                if (ActionReady(Rhizomata) && Addersgall < 1)
-                    return Rhizomata;
-
-                //Soteria
-                if (ActionReady(Soteria) && HasStatusEffect(Buffs.Kardia))
-                    return Soteria;
-            }
-
-            //Eukrasia for DoT
-            if (IsOffCooldown(Eukrasia) &&
-                !JustUsedOn(EukrasianDyskrasia, CurrentTarget) && //AoE DoT can be slow to take affect, doesn't apply to target first before others
-                TraitLevelChecked(Traits.OffensiveMagicMasteryII) &&
-                HasBattleTarget() && InActionRange(Dyskrasia) &&
-                CanApplyStatus(CurrentTarget, Debuffs.EukrasianDyskrasia) &&
-                GetTargetHPPercent() > 25 &&
-                ((DyskrasiaDebuff is null && DosisDebuff is null) ||
-                 DyskrasiaDebuff?.RemainingTime <= 4 ||
-                 DosisDebuff?.RemainingTime <= 4))
-                return Eukrasia;
-
-            //Phlegma
-            if (ActionReady(Phlegma) &&
-                HasBattleTarget() &&
-                InActionRange(OriginalHook(Phlegma)))
-                return OriginalHook(Phlegma);
-
-            //Toxikon
-            if (ActionReady(Toxikon) &&
-                HasBattleTarget() && HasAddersting() &&
-                InActionRange(OriginalHook(Toxikon)))
-                return OriginalHook(Toxikon);
-
-            //Pneuma
-            if (ActionReady(Pneuma) && HasBattleTarget() &&
-                InActionRange(Pneuma))
-                return Pneuma;
-
-            return actionID;
-        }
-    }
-    
-    #endregion
-    
     #region Advanced ST
 
     internal class SGE_ST_DPS_AdvancedMode : CustomCombo
@@ -590,6 +389,206 @@ internal partial class SGE : Healer
     }
 
     #endregion
+    #region Simple Mode
+
+    internal class SGE_ST_Simple_DPS : CustomCombo
+    {
+        private static uint[] DosisActions => [.. DosisList.Keys];
+
+        protected internal override Preset Preset => Preset.SGE_ST_DPS;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (!DosisActions.Contains(actionID))
+                return actionID;
+
+            // Kardia Reminder
+            if (LevelChecked(Kardia) &&
+                !HasStatusEffect(Buffs.Kardia) &&
+                Target is not null)
+                return Kardia
+                    .Retarget(actionID, Target);
+
+            // Variant
+            if (Variant.CanRampart(Preset.SGE_DPS_Variant_Rampart))
+                return Variant.Rampart;
+
+            //Occult skills
+            if (OccultCrescent.ShouldUsePhantomActions())
+                return OccultCrescent.BestPhantomAction();
+
+            if (CanWeave() && !HasStatusEffect(Buffs.Eukrasia))
+            {
+                if (Variant.CanSpiritDart(Preset.SGE_DPS_Variant_SpiritDart))
+                    return Variant.SpiritDart;
+
+                // Lucid Dreaming
+                if (Role.CanLucidDream(7500))
+                    return Role.LucidDreaming;
+
+                // Addersgall Protection
+                if (ActionReady(Druochole) && Addersgall >= 3)
+                    return Druochole.RetargetIfEnabled(null, DosisActions);
+
+                // Psyche
+                if (ActionReady(Psyche) && InCombat())
+                    return Psyche;
+
+                // Rhizomata
+                if (ActionReady(Rhizomata) && Addersgall < 1)
+                    return Rhizomata;
+
+                //Soteria
+                if (ActionReady(Soteria) && HasStatusEffect(Buffs.Kardia))
+                    return Soteria;
+            }
+
+            if (HasBattleTarget() && !HasStatusEffect(Buffs.Eukrasia))
+            {
+                if (LevelChecked(Eukrasia) && InCombat() &&
+                    !JustUsedOn(DosisList[OriginalHook(Dosis)].Eukrasian, CurrentTarget) &&
+                    CanApplyStatus(CurrentTarget, DosisList[OriginalHook(Dosis)].Debuff))
+                {
+                    const float refreshTimer = 5;
+                    const int hpThreshold = 1;
+
+                    if (GetTargetHPPercent() > hpThreshold &&
+                        ((DosisDebuff is null && DyskrasiaDebuff is null) ||
+                         DosisDebuff?.RemainingTime <= refreshTimer ||
+                         DyskrasiaDebuff?.RemainingTime <= refreshTimer))
+                        return Eukrasia;
+                }
+
+                // Phlegma
+                if (InCombat() && InActionRange(OriginalHook(Phlegma)) &&
+                    ActionReady(Phlegma))
+                {
+                    //If not enabled or not high enough level, follow slider
+                    if ((!LevelChecked(Psyche)) &&
+                        GetRemainingCharges(OriginalHook(Phlegma)) > 1)
+                        return OriginalHook(Phlegma);
+
+                    //If enabled and high enough level, burst
+                    if (((GetCooldownRemainingTime(Psyche) > 40 && MaxPhlegma) ||
+                         IsOffCooldown(Psyche) ||
+                         JustUsed(Psyche, 5f)))
+                        return OriginalHook(Phlegma);
+                }
+
+                // Movement Options
+                if (InCombat() && IsMoving() && HasBattleTarget())
+                {
+                    //Toxikon
+                    if (ActionReady(Toxikon) && HasAddersting())
+                        return OriginalHook(Toxikon);
+
+                    // Dyskrasia
+                    if (ActionReady(Dyskrasia) && InActionRange(Dyskrasia))
+                        return OriginalHook(Dyskrasia);
+                    //Eukrasia
+                    if (ActionReady(Eukrasia) && !HasStatusEffect(Buffs.Eukrasia))
+                        return Eukrasia;
+                }
+            }
+
+            return actionID;
+        }
+    }
+
+    internal class SGE_AoE_Simple_DPS : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.SGE_AoE_Simple_DPS;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (!DyskrasiaList.Contains(actionID) ||
+                HasStatusEffect(Buffs.Eukrasia))
+                return actionID;
+
+            // Variant Rampart
+            if (Variant.CanRampart(Preset.SGE_DPS_Variant_Rampart))
+                return Variant.Rampart;
+
+            //Occult skills
+            if (OccultCrescent.ShouldUsePhantomActions())
+                return OccultCrescent.BestPhantomAction();
+
+            if (ActionReady(Kerachole) && HasAddersgall() &&
+                CanWeave() && RaidWideCasting())
+                return Kerachole;
+
+            if (ActionReady(Holos) && CanWeave() && RaidWideCasting() &&
+                GetPartyAvgHPPercent() <= 70)
+                return Holos;
+
+            if (RaidwideEprognosis())
+                return HasStatusEffect(Buffs.Eukrasia)
+                    ? OriginalHook(Prognosis)
+                    : Eukrasia;
+
+            if (CanWeave())
+            {
+                // Variant Spirit Dart
+                if (Variant.CanSpiritDart(Preset.SGE_DPS_Variant_SpiritDart))
+                    return Variant.SpiritDart;
+
+                // Lucid Dreaming
+                if (Role.CanLucidDream(7500))
+                    return Role.LucidDreaming;
+
+                // Addersgall Protection
+                if (ActionReady(Druochole) && Addersgall >= 3)
+                    return Druochole
+                        .RetargetIfEnabled(null, OriginalHook(Dyskrasia));
+
+                // Psyche
+                if (ActionReady(Psyche) && HasBattleTarget() &&
+                    InActionRange(Psyche))
+                    return Psyche;
+
+                // Rhizomata
+                if (ActionReady(Rhizomata) && Addersgall < 1)
+                    return Rhizomata;
+
+                //Soteria
+                if (ActionReady(Soteria) && HasStatusEffect(Buffs.Kardia))
+                    return Soteria;
+            }
+
+            //Eukrasia for DoT
+            if (IsOffCooldown(Eukrasia) &&
+                !JustUsedOn(EukrasianDyskrasia, CurrentTarget) && //AoE DoT can be slow to take affect, doesn't apply to target first before others
+                TraitLevelChecked(Traits.OffensiveMagicMasteryII) &&
+                HasBattleTarget() && InActionRange(Dyskrasia) &&
+                CanApplyStatus(CurrentTarget, Debuffs.EukrasianDyskrasia) &&
+                GetTargetHPPercent() > 25 &&
+                ((DyskrasiaDebuff is null && DosisDebuff is null) ||
+                 DyskrasiaDebuff?.RemainingTime <= 4 ||
+                 DosisDebuff?.RemainingTime <= 4))
+                return Eukrasia;
+
+            //Phlegma
+            if (ActionReady(Phlegma) &&
+                HasBattleTarget() &&
+                InActionRange(OriginalHook(Phlegma)))
+                return OriginalHook(Phlegma);
+
+            //Toxikon
+            if (ActionReady(Toxikon) &&
+                HasBattleTarget() && HasAddersting() &&
+                InActionRange(OriginalHook(Toxikon)))
+                return OriginalHook(Toxikon);
+
+            //Pneuma
+            if (ActionReady(Pneuma) && HasBattleTarget() &&
+                InActionRange(Pneuma))
+                return Pneuma;
+
+            return actionID;
+        }
+    }
+
+    #endregion
 
     #region Standalones
 
@@ -624,34 +623,49 @@ internal partial class SGE : Healer
     {
         protected internal override Preset Preset => Preset.SGE_Raise;
 
-        protected override uint Invoke(uint actionID) =>
-            actionID == Role.Swiftcast && IsOnCooldown(Role.Swiftcast)
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID != Role.Swiftcast)
+                return actionID;
+
+            return IsOnCooldown(Role.Swiftcast)
                 ? IsEnabled(Preset.SGE_Raise_Retarget)
                     ? Egeiro.Retarget(Role.Swiftcast,
                         SimpleTarget.Stack.AllyToRaise)
                     : Egeiro
                 : actionID;
+        }
     }
 
     internal class SGE_ZoePneuma : CustomCombo
     {
         protected internal override Preset Preset => Preset.SGE_ZoePneuma;
 
-        protected override uint Invoke(uint actionID) =>
-            actionID is Pneuma && ActionReady(Pneuma) && IsOffCooldown(Zoe)
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not Pneuma)
+                return actionID;
+
+            return ActionReady(Pneuma) && IsOffCooldown(Zoe)
                 ? Zoe
                 : actionID;
+        }
     }
 
     internal class SGE_Rhizo : CustomCombo
     {
         protected internal override Preset Preset => Preset.SGE_Rhizo;
 
-        protected override uint Invoke(uint actionID) =>
-            AddersgallList.Contains(actionID) &&
-            ActionReady(Rhizomata) && !HasAddersgall() && IsOffCooldown(actionID)
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not (Kerachole or Taurochole or Druochole or Ixochole))
+                return actionID;
+
+            return AddersgallList.Contains(actionID) &&
+                   ActionReady(Rhizomata) && !HasAddersgall() && IsOffCooldown(actionID)
                 ? Rhizomata
                 : actionID;
+        }
     }
 
     internal class SGE_Eukrasia : CustomCombo

--- a/WrathCombo/Combos/PvE/SGE/SGE.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE.cs
@@ -17,7 +17,7 @@ internal partial class SGE : Healer
     {
         private static uint[] DosisActions => [.. DosisList.Keys];
 
-        protected internal override Preset Preset => Preset.SGE_ST_DPS;
+        protected internal override Preset Preset => Preset.SGE_ST_Simple_DPS;
 
         protected override uint Invoke(uint actionID)
         {

--- a/WrathCombo/Combos/PvE/SGE/SGE_Config.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE_Config.cs
@@ -1,5 +1,5 @@
-﻿using Dalamud.Interface.Colors;
-using Dalamud.Bindings.ImGui;
+﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Colors;
 using WrathCombo.CustomComboNS.Functions;
 using static WrathCombo.Extensions.UIntExtensions;
 using static WrathCombo.Window.Functions.SliderIncrements;


### PR DESCRIPTION
- Add in `ActionID is not` to standalone combo's where it was forgotten or removed

Will probably need a second pair of eyes to make sure they all behave as before.
It is late, i will also doublecheck tomorrow when im fully awake