### PR TITLE
[Core] Fix BossModReborn Conflicts

### DIFF
--- a/WrathCombo/Data/Conflicts/ConflictingPlugins.cs
+++ b/WrathCombo/Data/Conflicts/ConflictingPlugins.cs
@@ -340,6 +340,18 @@ public static class ConflictingPlugins
 
         #endregion
 
+        #region BossModReborn
+
+        if (ConflictingPluginsChecks.BossModReborn.SettingConflicted)
+        {
+            conflicts = conflicts.Append(new Conflict(
+                    "BossModReborn", ConflictType.Settings,
+                    "AI is enabled WITH targeting [check 'Manual targeting']"))
+                .ToArray();
+        }
+
+        #endregion
+
         #region Redirect
 
         if (ConflictingPluginsChecks.Redirect.Conflicted)

--- a/WrathCombo/Data/Conflicts/ConflictingPluginsChecks.cs
+++ b/WrathCombo/Data/Conflicts/ConflictingPluginsChecks.cs
@@ -176,7 +176,7 @@ public static class ConflictingPluginsChecks
         ///     <b>Key <c>1</c></b> is Beneficial Actions enabled meta action,<br />
         ///     <b>Key <c>3</c>+</b> are all overlapping action retargets.
         /// </remarks>
-        public uint[] ConflictingActions = [];
+        public uint[] ConflictingActions = [0, 0];
 
         protected override RedirectIPC IPC => (RedirectIPC)_ipc;
 
@@ -185,7 +185,7 @@ public static class ConflictingPluginsChecks
             if (!ThrottlePassed())
                 return;
 
-            ConflictingActions = [];
+            ConflictingActions = [0, 0];
 
             var conflictedThisCheck = false;
             var wrathRetargeted = PresetStorage.AllRetargetedActions.ToHashSet();
@@ -196,7 +196,7 @@ public static class ConflictingPluginsChecks
             {
                 PluginLog.Verbose(
                     $"[ConflictingPlugins] [{Name}] Ground Targeted Actions are Redirected");
-                ConflictingActions = [1];
+                ConflictingActions[0] = 1;
                 MarkConflict();
                 conflictedThisCheck = true;
             }
@@ -207,10 +207,7 @@ public static class ConflictingPluginsChecks
             {
                 PluginLog.Verbose(
                     $"[ConflictingPlugins] [{Name}] Beneficial Actions are Redirected");
-                if (ConflictingActions.Length == 0)
-                    ConflictingActions = [0, 1];
-                else
-                    ConflictingActions = [1, 1];
+                ConflictingActions[1] = 1;
                 MarkConflict();
                 conflictedThisCheck = true;
             }

--- a/WrathCombo/Data/Conflicts/ConflictingPluginsChecks.cs
+++ b/WrathCombo/Data/Conflicts/ConflictingPluginsChecks.cs
@@ -108,6 +108,7 @@ public static class ConflictingPluginsChecks
                     $"or config updated");
                 Conflicted = false;
                 _conflictsInARow = 0;
+                _conflictRegistered = null;
                 return;
             }
 

--- a/WrathCombo/Services/IPC_Subscriber/BossMod.cs
+++ b/WrathCombo/Services/IPC_Subscriber/BossMod.cs
@@ -60,7 +60,7 @@ internal sealed class BossModIPC(
             return false;
         }
 
-        var aiConfig = ai.GetFoP("Config");
+        var aiConfig = ai.GetFoP("Config") ?? ai.GetFoP("_config");
         if (aiConfig == null)
         {
             PluginLog.Debug(
@@ -68,14 +68,17 @@ internal sealed class BossModIPC(
             return false;
         }
 
-        var aiEnabled = aiConfig.GetFoP<bool>("Enabled");
+        var aiEnabled = (bool)(aiConfig.GetFoP("Enabled") ??
+                         (ai.GetFoP("Beh") is not null));
         var aiDisableTargeting = aiConfig.GetFoP<bool>("ForbidActions");
+        var aiManualTargeting = (bool)(aiConfig.GetFoP("ManualTarget") ?? false);
+        var targetingDisabled = aiDisableTargeting || aiManualTargeting;
 
         PluginLog.Verbose(
             $"[ConflictingPlugins] [{PluginName}] `AI.Enabled`: {aiEnabled}, " +
-            $"`AI.DisableTargeting`: {aiDisableTargeting}");
+            $"`AI.DisableTargeting`: {targetingDisabled}");
 
-        return aiEnabled && aiDisableTargeting != true;
+        return aiEnabled && !targetingDisabled;
     }
 
     public DateTime LastModified()
@@ -96,10 +99,10 @@ internal sealed class BossModIPC(
     }
 
 #pragma warning disable CS0649, CS8618 // Complaints of the method
-    [EzIPC("Rotation.ActionQueue.HasEntries")]
+    [EzIPC("BossMod.Rotation.ActionQueue.HasEntries", false)]
     private readonly Func<bool> _hasEntries = null!;
 
-    [EzIPC("Configuration.LastModified")]
+    [EzIPC("BossMod.Configuration.LastModified", false)]
     private readonly Func<DateTime> _lastModified = null!;
 #pragma warning restore CS8618, CS0649
 }


### PR DESCRIPTION
Currently if BossModReborn is installed Wrath will throw warnings every 10 or so seconds, which is annoying.\
This is due to it not working with BMR's IPC Name or AI Config. This PR fixes both, expected to release next Sunday or so.

- [X] Fixes BossModReborn's IPC Signature (unexpectedly uses "BossMod")
- [X] Fixes BossModReborn's AI Config variables (lacks the same naming as VBM, but has an addition, easier option, too)
- [X] Adds BossModReborn's missing Settings Conflict