### PR TITLE
[RDM] Aero and Thunder Standalone Update

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5487,6 +5487,14 @@ public enum Preset
     [ReplaceSkill(RDM.Verthunder, RDM.Verthunder3)]
     [CustomComboInfo("Spell Combo on Verthunder", "Replaces Verthunder with options.", RDM.JobID)]
     RDM_VerThunder = 13418,
+    
+    [ReplaceSkill(RDM.Veraero2)]
+    [CustomComboInfo("Spell Combo on Veraero 2", "Replaces Veraero 2 with options.", RDM.JobID)]
+    RDM_VerAero2 = 13432,
+    
+    [ReplaceSkill(RDM.Verthunder2)]
+    [CustomComboInfo("Spell Combo on Verthunder 2", "Replaces Verthunder 2 with options.", RDM.JobID)]
+    RDM_VerThunder2 = 13433,
 
     [ReplaceSkill(RDM.Riposte)]
     [CustomComboInfo("Riposte Melee Combo", "Replaces Riposte with the basic melee combo.", RDM.JobID)]
@@ -5494,7 +5502,7 @@ public enum Preset
     
     [ParentCombo(RDM_Riposte)]
     [CustomComboInfo("Riposte OGCD Weave Options", "Weave the following OGCDS in the melee combo", RDM.JobID)]
-    RDM_Riposte_Weaves = 134230,
+    RDM_Riposte_Weaves = 13434,
     
     [ParentCombo(RDM_Riposte)]
     [CustomComboInfo("Gap-Close with Corps-a-corps Option",
@@ -5594,7 +5602,7 @@ public enum Preset
     [CustomComboInfo("Cure on Vercure Option", "Replaces Vercure with Variant Cure.", RDM.JobID)]
     RDM_Variant_Cure2 = 13417,
     
-    //Last Used 13431
+    //Last Used 13434
     #endregion
 
     #endregion

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5481,20 +5481,12 @@ public enum Preset
     #region Stand Alone Features
 
     [ReplaceSkill(RDM.Veraero, RDM.Veraero3)]
-    [CustomComboInfo("Spell Combo on Veraero", "Replaces Veraero with Jolt.", RDM.JobID)]
+    [CustomComboInfo("Spell Combo on Veraero", "Replaces Veraero with options.", RDM.JobID)]
     RDM_VerAero = 13400,
-
-    [ParentCombo(RDM_VerAero)]
-    [CustomComboInfo("Add Verstone", "Replaces Veraero with Verstone.", RDM.JobID)]
-    RDM_VerAero_Stone = 13401,
     
     [ReplaceSkill(RDM.Verthunder, RDM.Verthunder3)]
-    [CustomComboInfo("Spell Combo on Verthunder", "Replaces Verthunder with Jolt.", RDM.JobID)]
+    [CustomComboInfo("Spell Combo on Verthunder", "Replaces Verthunder with options.", RDM.JobID)]
     RDM_VerThunder = 13418,
-
-    [ParentCombo(RDM_VerThunder)]
-    [CustomComboInfo("Add Verfire", "Replaces Verthunder With Verfire.", RDM.JobID)]
-    RDM_VerThunder_Fire = 13419,
 
     [ReplaceSkill(RDM.Riposte)]
     [CustomComboInfo("Riposte Melee Combo", "Replaces Riposte with the basic melee combo.", RDM.JobID)]

--- a/WrathCombo/Combos/PvE/RDM/RDM.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM.cs
@@ -500,16 +500,17 @@ internal partial class RDM : Caster
             if (actionID is not (Veraero or Veraero3))
                 return actionID;
 
-            if (ComboAction is Scorch or Verholy or Verflare)
+            if (RDM_VerAero_Options[2] && ComboAction is Scorch or Verholy or Verflare)
                 return OriginalHook(Jolt);
 
-            if (HasManaStacks)
+            if (RDM_VerAero_Options[0] && HasManaStacks)
                 return UseHolyFlare(actionID);
 
-            if (IsEnabled(Preset.RDM_VerAero_Stone) && CanVerStone)
+            if (RDM_VerAero_Options[1] && CanVerStone)
                 return Verstone;
 
-            if (!HasDualcast && !HasSwiftcast)
+            if (RDM_VerAero_Options[3] && !HasDualcast && !HasSwiftcast && !HasManaStacks &&
+                ComboAction is not (Scorch or Verholy or Verflare))
                 return OriginalHook(Jolt);
 
             return actionID;
@@ -525,16 +526,17 @@ internal partial class RDM : Caster
             if (actionID is not (Verthunder or Verthunder3))
                 return actionID;
 
-            if (ComboAction is Scorch or Verholy or Verflare) 
+            if (RDM_VerThunder_Options[2] && ComboAction is Scorch or Verholy or Verflare) 
                 return OriginalHook(Jolt);
 
-            if (HasManaStacks) 
+            if (RDM_VerThunder_Options[0] && HasManaStacks) 
                 return UseHolyFlare(actionID);
 
-            if (IsEnabled(Preset.RDM_VerThunder_Fire) && CanVerFire) 
+            if (RDM_VerThunder_Options[1] && CanVerFire) 
                 return Verfire;
         
-            if (!HasDualcast && !HasSwiftcast)
+            if (RDM_VerThunder_Options[3] && !HasDualcast && !HasSwiftcast && !HasManaStacks &&
+                ComboAction is not (Scorch or Verholy or Verflare))
                 return OriginalHook(Jolt);
         
             return actionID;

--- a/WrathCombo/Combos/PvE/RDM/RDM.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM.cs
@@ -506,7 +506,7 @@ internal partial class RDM : Caster
             if (RDM_VerAero_Options[0] && HasManaStacks)
                 return UseHolyFlare(actionID);
 
-            if (RDM_VerAero_Options[1] && CanVerStone)
+            if (RDM_VerAero_Options[1] && CanVerStone && !HasDualcast && !HasSwiftcast)
                 return Verstone;
 
             if (RDM_VerAero_Options[3] && !HasDualcast && !HasSwiftcast && !HasManaStacks &&
@@ -532,7 +532,7 @@ internal partial class RDM : Caster
             if (RDM_VerThunder_Options[0] && HasManaStacks) 
                 return UseHolyFlare(actionID);
 
-            if (RDM_VerThunder_Options[1] && CanVerFire) 
+            if (RDM_VerThunder_Options[1] && CanVerFire && !HasDualcast && !HasSwiftcast) 
                 return Verfire;
         
             if (RDM_VerThunder_Options[3] && !HasDualcast && !HasSwiftcast && !HasManaStacks &&

--- a/WrathCombo/Combos/PvE/RDM/RDM.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM.cs
@@ -543,6 +543,52 @@ internal partial class RDM : Caster
         }
     }
     
+    internal class RDM_VerAeroAoE : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.RDM_VerAero2;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not Veraero2)
+                return actionID;
+
+            if (RDM_VerAero2_Options[1] && ComboAction is Scorch or Verholy or Verflare)
+                return OriginalHook(Impact);
+
+            if (RDM_VerAero2_Options[0] && HasManaStacks)
+                return UseHolyFlare(actionID);
+
+            if (RDM_VerAero2_Options[2] && (HasDualcast || HasSwiftcast) && !HasManaStacks &&
+                ComboAction is not (Scorch or Verholy or Verflare))
+                return OriginalHook(Impact);
+
+            return actionID;
+        }
+    }
+
+    internal class RDM_VerThunderAoE : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.RDM_VerThunder2;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not Verthunder2)
+                return actionID;
+
+            if (RDM_VerThunder2_Options[1] && ComboAction is Scorch or Verholy or Verflare) 
+                return OriginalHook(Impact);
+
+            if (RDM_VerThunder2_Options[0] && HasManaStacks) 
+                return UseHolyFlare(actionID);
+        
+            if (RDM_VerThunder2_Options[2] && (HasDualcast || HasSwiftcast) && !HasManaStacks &&
+                ComboAction is not (Scorch or Verholy or Verflare))
+                return OriginalHook(Impact);
+        
+            return actionID;
+        }
+    }
+    
     internal class RDM_ST_Melee_Combo : CustomCombo
     {
         protected internal override Preset Preset => Preset.RDM_Riposte;

--- a/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
@@ -30,12 +30,13 @@ internal partial class RDM
             RDM_OGCDs_Options_CorpsCharges = new("RDM_OGCDs_Options_CorpsCharges", 0),
             RDM_OGCDs_Options_EngagementCharges = new("RDM_OGCDs_Options_EngagementCharges", 0),
             RDM_OGCDs_Options_Corpsacorps_Distance = new("RDM_OGCDs_Options_Corpsacorps_Distance", 25);
-        
+
         internal static UserBoolArray
             RDM_OGCDs_Options = new("RDM_OGCDs_Options"),
             RDM_Riposte_Weaves_Options = new("RDM_Riposte_Weaves_Options"),
-            RDM_Moulinet_Weaves_Options = new("RDM_Moulinet_Weaves_Options");
-        
+            RDM_Moulinet_Weaves_Options = new("RDM_Moulinet_Weaves_Options"),
+            RDM_VerAero_Options = new("RDM_VerAero_Options"),
+            RDM_VerThunder_Options = new("RDM_VerThunder_Options");
         #endregion
 
         internal static void Draw(Preset preset)
@@ -160,7 +161,21 @@ internal partial class RDM
                         DrawSliderInt(0, 25, RDM_OGCDs_Options_Corpsacorps_Distance, "Use Corps when distance is less than or equal to:");
                     }
                     break;
-                #endregion
+                
+                case Preset.RDM_VerAero:
+                    DrawHorizontalMultiChoice(RDM_VerAero_Options,"Holy Flare Combo", "Adds smart Holy/Flare", 4, 0);
+                    DrawHorizontalMultiChoice(RDM_VerAero_Options,"VerStone", "Adds VerStone", 4, 1);
+                    DrawHorizontalMultiChoice(RDM_VerAero_Options,"Scorch Combo", "Adds Scorch/Resolution Finishers", 4, 2);
+                    DrawHorizontalMultiChoice(RDM_VerAero_Options,"Jolt", "Adds Jolt", 4, 3);
+                    break;
+                
+                case Preset.RDM_VerThunder:
+                    DrawHorizontalMultiChoice(RDM_VerThunder_Options,"Holy Flare Combo", "Adds smart Holy/Flare", 4, 0);
+                    DrawHorizontalMultiChoice(RDM_VerThunder_Options,"VerFire", "Adds VerFire", 4, 1);
+                    DrawHorizontalMultiChoice(RDM_VerThunder_Options,"Scorch Combo", "Adds Scorch/Resolution Finishers", 4, 2);
+                    DrawHorizontalMultiChoice(RDM_VerThunder_Options,"Jolt", "Adds Jolt", 4, 3);
+                    break;
+                    #endregion
             }
         }
     }

--- a/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
@@ -36,7 +36,10 @@ internal partial class RDM
             RDM_Riposte_Weaves_Options = new("RDM_Riposte_Weaves_Options"),
             RDM_Moulinet_Weaves_Options = new("RDM_Moulinet_Weaves_Options"),
             RDM_VerAero_Options = new("RDM_VerAero_Options"),
-            RDM_VerThunder_Options = new("RDM_VerThunder_Options");
+            RDM_VerThunder_Options = new("RDM_VerThunder_Options"),
+            RDM_VerAero2_Options = new("RDM_VerAero2_Options"),
+            RDM_VerThunder2_Options = new("RDM_VerThunder2_Options");
+                
         #endregion
 
         internal static void Draw(Preset preset)
@@ -174,6 +177,18 @@ internal partial class RDM
                     DrawHorizontalMultiChoice(RDM_VerThunder_Options,"VerFire", "Adds VerFire", 4, 1);
                     DrawHorizontalMultiChoice(RDM_VerThunder_Options,"Scorch Combo", "Adds Scorch/Resolution Finishers", 4, 2);
                     DrawHorizontalMultiChoice(RDM_VerThunder_Options,"Jolt", "Adds Jolt", 4, 3);
+                    break;
+                
+                case Preset.RDM_VerAero2:
+                    DrawHorizontalMultiChoice(RDM_VerAero2_Options,"Holy Flare Combo", "Adds smart Holy/Flare", 3, 0);
+                    DrawHorizontalMultiChoice(RDM_VerAero2_Options,"Scorch Combo", "Adds Scorch/Resolution Finishers", 3, 1);
+                    DrawHorizontalMultiChoice(RDM_VerAero2_Options,"Impact", "Adds Impact", 3, 2);
+                    break;
+                
+                case Preset.RDM_VerThunder2:
+                    DrawHorizontalMultiChoice(RDM_VerThunder2_Options,"Holy Flare Combo", "Adds smart Holy/Flare", 3, 0);
+                    DrawHorizontalMultiChoice(RDM_VerThunder2_Options,"Scorch Combo", "Adds Scorch/Resolution Finishers", 3, 1);
+                    DrawHorizontalMultiChoice(RDM_VerThunder2_Options,"Impact", "Adds Impact", 3, 2);
                     break;
                     #endregion
             }


### PR DESCRIPTION
Added options to the Aero and Thunder standalones to customize what buttons it replaces with.  Mirrored it adding an aoe version

<img width="684" height="227" alt="image" src="https://github.com/user-attachments/assets/ee0828ea-232c-4f19-b46a-204e17ff5a2a" />

<img width="702" height="234" alt="image" src="https://github.com/user-attachments/assets/3031e938-bfe9-43ab-a69f-f104ff81842d" />

