### PR TITLE
[NIN] Little fixes

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -4159,7 +4159,7 @@ public enum Preset
     
     [ParentCombo(NIN_AoE_AdvancedMode)]
     [CustomComboInfo("Leg Sweep Option", "Adds Leg Sweep when target non-boss is casting.", Job.NIN)]
-    NIN_AoE_AdvancedMode_StunInterupt =10043,
+    NIN_AoE_AdvancedMode_StunInterupt =10044,
     
     [ParentCombo(NIN_AoE_AdvancedMode)]
     [CustomComboInfo("Phantom Kamaitachi Option", "Adds Phantom Kamaitachi to Advanced Mode.", Job.NIN)]
@@ -4251,7 +4251,7 @@ public enum Preset
     NIN_Variant_Rampart = 10070,
     #endregion
 
-    // Last value = 10042
+    // Last value = 10044
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -4214,10 +4214,12 @@ public enum Preset
     NIN_HideMug = 10038,
 
     [ReplaceSkill(NIN.Ten, NIN.Chi, NIN.Jin)]
+    [ConflictingCombos(Preset.NIN_Simple_Mudras_Alt)]
     [CustomComboInfo("Simple Mudras Feature", "Simplify the mudra casting to avoid failing.", Job.NIN)]
     NIN_Simple_Mudras = 10039,
     
     [ReplaceSkill(NIN.Ten, NIN.Chi, NIN.Jin)]
+    [ConflictingCombos(Preset.NIN_Simple_Mudras)]
     [CustomComboInfo("Simpler Mudras Alternate Feature", "Puts mudras on to a single button following basic logic and finishes them with Ninjutsu." +
                                                         "\nTen = Hyosho Ranryu > Suiton if trick cd less than 20s > Raiton. \nChi = Goka Mekkyaku > Huton if trick cd less than 20s > Katon. \nJin = Doton ", Job.NIN)]
     NIN_Simple_Mudras_Alt = 10043,

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -4216,6 +4216,11 @@ public enum Preset
     [ReplaceSkill(NIN.Ten, NIN.Chi, NIN.Jin)]
     [CustomComboInfo("Simple Mudras Feature", "Simplify the mudra casting to avoid failing.", Job.NIN)]
     NIN_Simple_Mudras = 10039,
+    
+    [ReplaceSkill(NIN.Ten, NIN.Chi, NIN.Jin)]
+    [CustomComboInfo("Simpler Mudras Alternate Feature", "Puts mudras on to a single button following basic logic and finishes them with Ninjutsu." +
+                                                        "\nTen = Hyosho Ranryu > Suiton if trick cd less than 20s > Raiton. \nChi = Goka Mekkyaku > Huton if trick cd less than 20s > Katon. \nJin = Doton ", Job.NIN)]
+    NIN_Simple_Mudras_Alt = 10043,
 
     [ReplaceSkill(NIN.TenChiJin)]
     [ParentCombo(NIN_TCJMeisui)]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -4075,7 +4075,7 @@ public enum Preset
     
     [ParentCombo(NIN_ST_AdvancedMode)]
     [CustomComboInfo("Leg Sweep Option", "Adds Leg Sweep when target non-boss is casting.", Job.NIN)]
-    NIN_ST_AdvancedMode_StunInterupt =10043,
+    NIN_ST_AdvancedMode_StunInterupt =10045,
 
     [ParentCombo(NIN_ST_AdvancedMode)]
     [CustomComboInfo("Phantom Kamaitachi Option", "Adds Phantom Kamaitachi to Advanced Mode.", Job.NIN)]
@@ -4251,7 +4251,7 @@ public enum Preset
     NIN_Variant_Rampart = 10070,
     #endregion
 
-    // Last value = 10044
+    // Last value = 10045
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -4072,6 +4072,10 @@ public enum Preset
     [ParentCombo(NIN_ST_AdvancedMode)]
     [CustomComboInfo("Meisui Option", "Adds Meisui to Advanced Mode.", Job.NIN)]
     NIN_ST_AdvancedMode_Meisui = 10013,
+    
+    [ParentCombo(NIN_ST_AdvancedMode)]
+    [CustomComboInfo("Leg Sweep Option", "Adds Leg Sweep when target non-boss is casting.", Job.NIN)]
+    NIN_ST_AdvancedMode_StunInterupt =10043,
 
     [ParentCombo(NIN_ST_AdvancedMode)]
     [CustomComboInfo("Phantom Kamaitachi Option", "Adds Phantom Kamaitachi to Advanced Mode.", Job.NIN)]
@@ -4152,6 +4156,10 @@ public enum Preset
     [ParentCombo(NIN_AoE_AdvancedMode)]
     [CustomComboInfo("Meisui Option", "Adds Meisui to Advanced Mode.", Job.NIN)]
     NIN_AoE_AdvancedMode_Meisui = 10029,
+    
+    [ParentCombo(NIN_AoE_AdvancedMode)]
+    [CustomComboInfo("Leg Sweep Option", "Adds Leg Sweep when target non-boss is casting.", Job.NIN)]
+    NIN_AoE_AdvancedMode_StunInterupt =10043,
     
     [ParentCombo(NIN_AoE_AdvancedMode)]
     [CustomComboInfo("Phantom Kamaitachi Option", "Adds Phantom Kamaitachi to Advanced Mode.", Job.NIN)]

--- a/WrathCombo/Combos/PvE/NIN/NIN.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN.cs
@@ -242,9 +242,9 @@ internal partial class NIN : Melee
             {
                 switch (ComboAction)
                 {
-                    case SpinningEdge when LevelChecked(GustSlash):
+                    case SpinningEdge when LevelChecked(GustSlash) && !LevelChecked(DeathBlossom):
                         return OriginalHook(GustSlash);
-                    case GustSlash when !LevelChecked(ArmorCrush) && LevelChecked(AeolianEdge):
+                    case GustSlash when !LevelChecked(ArmorCrush) && LevelChecked(AeolianEdge) && !LevelChecked(DeathBlossom):
                         return TNAeolianEdge ? Role.TrueNorth : AeolianEdge;
                     case DeathBlossom when LevelChecked(HakkeMujinsatsu):
                         return HakkeMujinsatsu;
@@ -552,9 +552,9 @@ internal partial class NIN : Melee
             {
                 switch (ComboAction)
                 {
-                    case SpinningEdge when LevelChecked(GustSlash):
+                    case SpinningEdge when LevelChecked(GustSlash) && !LevelChecked(DeathBlossom):
                         return OriginalHook(GustSlash);
-                    case GustSlash when !LevelChecked(ArmorCrush) && LevelChecked(AeolianEdge):
+                    case GustSlash when !LevelChecked(ArmorCrush) && LevelChecked(AeolianEdge) && !LevelChecked(DeathBlossom):
                         return TNAeolianEdge ? Role.TrueNorth : AeolianEdge;
                     case DeathBlossom when LevelChecked(HakkeMujinsatsu):
                         return HakkeMujinsatsu;

--- a/WrathCombo/Combos/PvE/NIN/NIN.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN.cs
@@ -360,8 +360,8 @@ internal partial class NIN : Melee
             #region Selfcare
             if ((!MudraPhase || HasKassatsu && TrickCD > 5) && CanWeave())
             {
-                if (IsEnabled(Preset.NIN_ST_AdvancedMode_Feint) && ActionReady(Role.Feint) && 
-                    !HasStatusEffect(RoleActions.Melee.Debuffs.Feint, CurrentTarget, true) &&
+                if (IsEnabled(Preset.NIN_ST_AdvancedMode_Feint) && 
+                    RoleActions.Melee.CanFeint() &&
                     CanApplyStatus(CurrentTarget, RoleActions.Melee.Debuffs.Feint) &&
                     RaidWideCasting())
                     return Role.Feint;

--- a/WrathCombo/Combos/PvE/NIN/NIN.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN.cs
@@ -24,13 +24,12 @@ internal partial class NIN : Melee
             if (OriginalHook(Ninjutsu) is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
                 return OriginalHook(Ninjutsu);
             
-            if (InMudra && MudraState.ContinueCurrentMudra(ref actionID))
-                return actionID;
-            
-            if (IsNotEnabled(Preset.NIN_AoE_AdvancedMode_Ninjitsus) || 
-                ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat() ||
+            if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat() ||
                 ActionWatching.LastAction == OriginalHook(Ninjutsu))
                 MudraState.CurrentMudra = MudraCasting.MudraState.None;
+            
+            if (InMudra && MudraState.ContinueCurrentMudra(ref actionID))
+                return actionID;
             
             if (HasStatusEffect(Buffs.TenChiJin))
                 return STTenChiJin(actionID);
@@ -149,13 +148,12 @@ internal partial class NIN : Melee
             if (OriginalHook(Ninjutsu) is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
                 return OriginalHook(Ninjutsu);
             
-            if (InMudra && MudraState.ContinueCurrentMudra(ref actionID))
-                return actionID;
-            
-            if (IsNotEnabled(Preset.NIN_AoE_AdvancedMode_Ninjitsus) || 
-                ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat() ||
+            if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat() ||
                 ActionWatching.LastAction == OriginalHook(Ninjutsu))
                 MudraState.CurrentMudra = MudraCasting.MudraState.None;
+            
+            if (InMudra && MudraState.ContinueCurrentMudra(ref actionID))
+                return actionID;
 
             if (HasStatusEffect(Buffs.TenChiJin))
                 return DotonRemaining < 3
@@ -279,13 +277,12 @@ internal partial class NIN : Melee
                 OriginalHook(Ninjutsu) is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
                 return OriginalHook(Ninjutsu);
             
-            if (OriginalHook(Ninjutsu) != Ninjutsu && InMudra && MudraState.ContinueCurrentMudra(ref actionID))
-                return actionID;
-            
-            if (IsNotEnabled(Preset.NIN_ST_AdvancedMode_Ninjitsus) || 
-                ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat() ||
+            if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat() ||
                 ActionWatching.LastAction == OriginalHook(Ninjutsu))
                 MudraState.CurrentMudra = MudraCasting.MudraState.None;
+            
+            if (IsEnabled(Preset.NIN_ST_AdvancedMode_Ninjitsus) && InMudra && MudraState.ContinueCurrentMudra(ref actionID))
+                return actionID;
             
             if (NIN_ST_AdvancedMode_TenChiJin_Options[0] &&
                 HasStatusEffect(Buffs.TenChiJin))
@@ -436,14 +433,13 @@ internal partial class NIN : Melee
                 OriginalHook(Ninjutsu) is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
                 return OriginalHook(Ninjutsu);
             
-            if (OriginalHook(Ninjutsu) != Ninjutsu && InMudra && MudraState.ContinueCurrentMudra(ref actionID))
-                return actionID;
-            
-            if (IsNotEnabled(Preset.NIN_AoE_AdvancedMode_Ninjitsus) || 
-                ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat() ||
+            if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat() ||
                 ActionWatching.LastAction == OriginalHook(Ninjutsu))
                 MudraState.CurrentMudra = MudraCasting.MudraState.None;
             
+            if (IsEnabled(Preset.NIN_AoE_AdvancedMode_Ninjitsus) && InMudra && MudraState.ContinueCurrentMudra(ref actionID))
+                return actionID;
+           
             if (NIN_AoE_AdvancedMode_TenChiJin_Options[0] &&
                 HasStatusEffect(Buffs.TenChiJin))
                 return NIN_AoE_AdvancedMode_Ninjitsus_Options[2] && DotonRemaining < 3

--- a/WrathCombo/Combos/PvE/NIN/NIN.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN.cs
@@ -339,6 +339,10 @@ internal partial class NIN : Melee
                 if (IsEnabled(Preset.NIN_ST_AdvancedMode_TrickAttack) && CanTrickST && CombatEngageDuration().TotalSeconds > 5 &&
                     GetTargetHPPercent() > STTrickThreshold)
                     return OriginalHook(TrickAttack);
+
+                if (IsEnabled(Preset.NIN_ST_AdvancedMode_StunInterupt) && CanWeave() && !MudraPhase &&
+                    RoleActions.Melee.CanLegSweep() && !TargetIsBoss() && TargetIsCasting())
+                    return Role.LegSweep;
             }
             #endregion
             
@@ -495,6 +499,10 @@ internal partial class NIN : Melee
                 if (IsEnabled(Preset.NIN_AoE_AdvancedMode_TrickAttack) && CanTrickAoE && CombatEngageDuration().TotalSeconds > 5 &&
                     GetTargetHPPercent() > AoETrickThreshold)
                     return OriginalHook(TrickAttack);
+                
+                if (IsEnabled(Preset.NIN_AoE_AdvancedMode_StunInterupt) && CanWeave() && !MudraPhase &&
+                    RoleActions.Melee.CanLegSweep() && !TargetIsBoss() && TargetIsCasting())
+                    return Role.LegSweep;
             }
             #endregion
             

--- a/WrathCombo/Combos/PvE/NIN/NIN.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN.cs
@@ -611,12 +611,13 @@ internal partial class NIN : Melee
             if (actionID is not Hide)
                 return actionID;
             
+            
             if (NIN_HideMug_Toggle && HasStatusEffect(Buffs.Hidden) &&
                 (LevelChecked(Suiton) || !NIN_HideMug_ToggleLevelCheck)) //Check level to get ShadowWalker buff. 
                 StatusManager.ExecuteStatusOff(Buffs.Hidden);
 
             if (NIN_HideMug_Trick && 
-                (!NIN_HideMug_Mug || !NIN_HideMug_TrickAfterMug || IsOnCooldown(OriginalHook(Mug))) && //Check mug if you want mug to have priority
+                (!NIN_HideMug_Mug || !NIN_HideMug_TrickAfterMug || IsOnCooldown(OriginalHook(Mug)) || !InCombat()) && //Check mug if you want mug to have priority
                 (HasStatusEffect(Buffs.Hidden) || HasStatusEffect(Buffs.ShadowWalker))) //Check for ability to use trick
                 return OriginalHook(TrickAttack);
 
@@ -798,6 +799,43 @@ internal partial class NIN : Melee
             }
 
             return actionID;
+        }
+    }
+    
+    internal class NIN_Simple_MudrasAlt : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.NIN_Simple_Mudras_Alt;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not (Ten or Chi or Jin) || !HasStatusEffect(Buffs.Mudra))
+                return actionID;
+            
+            switch (actionID)
+            {
+                case Ten when LevelChecked(HyoshoRanryu) && MudraReady && HasKassatsu:
+                    return UseHyoshoRanryu(actionID);
+                case Ten when LevelChecked(Suiton) && MudraReady && !HasStatusEffect(Buffs.ShadowWalker) && TrickCD <= 20:
+                    return UseSuiton(actionID);
+                case Ten when MudraReady:
+                    return LevelChecked(Raiton)
+                        ? UseRaiton(actionID)
+                        : UseFumaShuriken(actionID);
+                case Chi when LevelChecked(GokaMekkyaku) && MudraReady && HasKassatsu:
+                    return UseGokaMekkyaku(actionID);
+                case Chi when LevelChecked(Huton) && MudraReady && !HasStatusEffect(Buffs.ShadowWalker) && TrickCD <= 20:
+                    return UseHuton(actionID);
+                case Chi when MudraReady:
+                    return LevelChecked(Katon)
+                        ? UseKaton(actionID)
+                        : UseFumaShuriken(actionID);
+                case Jin:
+                    return LevelChecked(Doton)
+                        ? UseDoton(actionID)
+                        : UseFumaShuriken(actionID);
+                default:
+                    return actionID;
+            }
         }
     }
     

--- a/WrathCombo/Combos/PvE/NIN/NIN.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN.cs
@@ -360,7 +360,9 @@ internal partial class NIN : Melee
             #region Selfcare
             if ((!MudraPhase || HasKassatsu && TrickCD > 5) && CanWeave())
             {
-                if (IsEnabled(Preset.NIN_ST_AdvancedMode_Feint) && ActionReady(Role.Feint) &&
+                if (IsEnabled(Preset.NIN_ST_AdvancedMode_Feint) && ActionReady(Role.Feint) && 
+                    !HasStatusEffect(RoleActions.Melee.Debuffs.Feint, CurrentTarget, true) &&
+                    CanApplyStatus(CurrentTarget, RoleActions.Melee.Debuffs.Feint) &&
                     RaidWideCasting())
                     return Role.Feint;
 

--- a/WrathCombo/Combos/PvE/NIN/NIN.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN.cs
@@ -619,10 +619,11 @@ internal partial class NIN : Melee
                 (!NIN_HideMug_Mug || !NIN_HideMug_TrickAfterMug || IsOnCooldown(OriginalHook(Mug))) && //Check mug if you want mug to have priority
                 (HasStatusEffect(Buffs.Hidden) || HasStatusEffect(Buffs.ShadowWalker))) //Check for ability to use trick
                 return OriginalHook(TrickAttack);
+
+            if (InCombat() && NIN_HideMug_Mug)
+                return OriginalHook(Mug);
             
-            return InCombat() && NIN_HideMug_Mug
-                ? OriginalHook(Mug)
-                : actionID;
+            return InCombat() && NIN_HideMug_Trick ? OriginalHook(TrickAttack) : actionID;
         }
     }
 

--- a/WrathCombo/Combos/PvE/NIN/NIN_Config.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN_Config.cs
@@ -53,6 +53,9 @@ internal partial class NIN
             NIN_AoE_AdvancedMode_Ninjitsus_Options = new("NIN_AoE_AdvancedMode_Ninjitsus_Options"),
             NIN_AoE_AdvancedMode_Katon_Options = new("NIN_AoE_AdvancedMode_Katon_Options"),
             NIN_AoE_AdvancedMode_TenChiJin_Options = new("NIN_AoE_AdvancedMode_TenChiJin_Options");
+        
+        internal static UserFloat
+            NIN_AoE_AdvancedMode_Doton_TimeStill = new("NIN_AoE_AdvancedMode_Doton_TimeStill");
         #endregion
         
         internal static void Draw(Preset preset)
@@ -180,6 +183,9 @@ internal partial class NIN
                     {
                         DrawSliderInt(0, 100, NIN_AoE_AdvancedMode_Doton_Threshold,
                             "Sets the max remaining HP percentage of the current target to cast Doton.");
+                        ImGui.Indent(); DrawSliderFloat(0, 3, NIN_AoE_AdvancedMode_Doton_TimeStill,"How Long Standing still before using Doton (in seconds):", decimals: 1);
+                        
+                        ImGui.Unindent();
                     }
                     break;
                 

--- a/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
@@ -479,6 +479,74 @@ internal partial class NIN
     }
     #endregion
     
+     // Single Target
+    internal static uint UseFumaShuriken(uint actionId)
+    {
+        return OriginalHook(Ninjutsu) == FumaShuriken ? OriginalHook(Ninjutsu) : Ten;
+    }
+    internal static uint UseRaiton(uint actionId) // Ten Chi
+    {
+        if (OriginalHook(Ninjutsu) == Ninjutsu) 
+            return HasKassatsu ? TenCombo : Ten;
+        return OriginalHook(Ninjutsu) == FumaShuriken &&
+               ActionWatching.LastAction is TenCombo or Ten or JinCombo or Jin 
+            ? ChiCombo 
+            : OriginalHook(Ninjutsu);
+    }
+    internal static uint UseHyoshoRanryu(uint actionId) // Ten Jin
+    {
+        if (OriginalHook(Ninjutsu) == Ninjutsu)
+            return TenCombo;
+        return OriginalHook(Ninjutsu) == FumaShuriken &&
+               ActionWatching.LastAction is TenCombo 
+            ? JinCombo 
+            : OriginalHook(Ninjutsu);
+    }
+    internal static uint UseSuiton(uint actionId) // Ten Chi Jin
+    {
+        if (OriginalHook(Ninjutsu) == Ninjutsu)
+            return Ten;
+        if (ActionWatching.LastAction is Ten)
+            return ChiCombo;
+        return ActionWatching.LastAction is ChiCombo ? JinCombo : OriginalHook(Ninjutsu);
+    }
+    //Multi Target
+    internal static uint UseGokaMekkyaku(uint actionId) // Chi Ten
+    {
+        if (OriginalHook(Ninjutsu) == Ninjutsu)
+            return HasKassatsu ? ChiCombo : Chi;
+        return OriginalHook(Ninjutsu) == FumaShuriken && 
+               ActionWatching.LastAction is Chi or ChiCombo 
+            ? TenCombo 
+            : OriginalHook(Ninjutsu);
+    }
+    internal static uint UseKaton(uint actionId) // Chi Ten
+    {
+        if (OriginalHook(Ninjutsu) == Ninjutsu)
+            return HasKassatsu ? ChiCombo : Chi;
+        return OriginalHook(Ninjutsu) == FumaShuriken && 
+               ActionWatching.LastAction is Jin or JinCombo or ChiCombo or Chi
+            ? TenCombo 
+            : OriginalHook(Ninjutsu);
+    }
+    internal static uint UseDoton(uint actionId)  //Jin Ten Chi
+    {
+        if (OriginalHook(Ninjutsu) == Ninjutsu)
+            return HasKassatsu ? JinCombo : Jin;
+        if (ActionWatching.LastAction is Jin or JinCombo)
+            return TenCombo;
+        return ActionWatching.LastAction is TenCombo ? ChiCombo : OriginalHook(Ninjutsu);
+    }
+
+    internal static uint UseHuton(uint actionId) // Jin Chi Ten
+    {
+        if (OriginalHook(Ninjutsu) == Ninjutsu)
+            return Chi;
+        if (ActionWatching.LastAction is Chi or ChiCombo)
+            return JinCombo;
+        return ActionWatching.LastAction is JinCombo ? TenCombo : Huton;
+    }
+
     #region Opener
     internal static NINOpenerMaxLevel4thGCDKunai Opener1 = new();
     internal static NINOpenerMaxLevel3rdGCDDokumori Opener2 = new();

--- a/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Frozen;
+﻿using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using Dalamud.Game.ClientState.JobGauge.Types;
 using WrathCombo.CustomComboNS;
@@ -29,6 +30,8 @@ internal partial class NIN
     #region Ninjutsu Logic
     internal static bool HasDoton => HasStatusEffect(Buffs.Doton);
     internal static float DotonRemaining => GetStatusEffectRemainingTime(Buffs.Doton);
+    internal static bool StoppedMoving => TimeStoodStill >= TimeSpan.FromSeconds(DotonTimeStill);
+    internal static float DotonTimeStill => AoESimpleMode ? 1.5f : NIN_AoE_AdvancedMode_Doton_TimeStill;
     
     internal static bool CanUseFumaShuriken => LevelChecked(FumaShuriken) && MudraReady;
      
@@ -49,7 +52,7 @@ internal partial class NIN
                                           NIN_AoE_AdvancedMode_Katon_Options[1] && !InMeleeRange() && 
                                           GetCooldownChargeRemainingTime(Ten) <= TrickCD - 10); //Uptime option
     
-    internal static bool CanUseDoton => LevelChecked(Doton) && MudraReady && 
+    internal static bool CanUseDoton => LevelChecked(Doton) && MudraReady && StoppedMoving &&
                                         (!HasDoton || DotonRemaining <= 2) &&
                                         (TrickDebuff || //Buff Window
                                          GetCooldownChargeRemainingTime(Ten) < 3); // Use if you have Kassatsu before you get Hosho Ranryu

--- a/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
@@ -94,15 +94,15 @@ internal partial class NIN
     internal static float TrickCD => GetCooldownRemainingTime(OriginalHook(TrickAttack));
     internal static float MugCD => GetCooldownRemainingTime(OriginalHook(Mug));
     
-    internal static bool CanTrickST => ActionReady(OriginalHook(TrickAttack)) && NinjaWeave && HasStatusEffect(Buffs.ShadowWalker) && !MudraPhase &&
+    internal static bool CanTrickST => ActionReady(OriginalHook(TrickAttack)) && NinjaWeave && CanApplyStatus(CurrentTarget, [Debuffs.TrickAttack, Debuffs.KunaisBane]) && HasStatusEffect(Buffs.ShadowWalker) && !MudraPhase &&
                                      (MugDebuff || MugCD >= 45 || MugDisabledST);
-    internal static bool CanTrickAoE => ActionReady(OriginalHook(TrickAttack)) && NinjaWeave && HasStatusEffect(Buffs.ShadowWalker) && !MudraPhase &&
+    internal static bool CanTrickAoE => ActionReady(OriginalHook(TrickAttack)) && NinjaWeave && CanApplyStatus(CurrentTarget, [Debuffs.TrickAttack, Debuffs.KunaisBane])&& HasStatusEffect(Buffs.ShadowWalker) && !MudraPhase &&
                                      (MugDebuff || MugCD >= 45 || MugDisabledAoE);
     
-    internal static bool CanMugST => ActionReady(OriginalHook(Mug)) && CanDelayedWeave(1.25f, .6f, 10) && !MudraPhase &&
+    internal static bool CanMugST => ActionReady(OriginalHook(Mug)) && CanApplyStatus(CurrentTarget, [Debuffs.Mug, Debuffs.Dokumori])&& CanDelayedWeave(1.25f, .6f, 10) && !MudraPhase &&
                                    (TrickCD <= 6 || TrickDisabledST) && 
                                    (LevelChecked(Dokumori) && GetTargetDistance() <= 8 ||InMeleeRange());
-    internal static bool CanMugAoE => ActionReady(OriginalHook(Mug)) && CanDelayedWeave(1.25f, .6f, 10) && !MudraPhase &&
+    internal static bool CanMugAoE => ActionReady(OriginalHook(Mug)) && CanApplyStatus(CurrentTarget, [Debuffs.Mug, Debuffs.Dokumori])&& CanDelayedWeave(1.25f, .6f, 10) && !MudraPhase &&
                                    (TrickCD <= 6 || TrickDisabledAoE) && 
                                    (LevelChecked(Dokumori) && GetTargetDistance() <= 8 ||InMeleeRange());
     

--- a/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
@@ -479,6 +479,7 @@ internal partial class NIN
     }
     #endregion
     
+    #region Mudra Standalone Logic
      // Single Target
     internal static uint UseFumaShuriken(uint actionId)
     {
@@ -546,6 +547,7 @@ internal partial class NIN
             return JinCombo;
         return ActionWatching.LastAction is JinCombo ? TenCombo : Huton;
     }
+    #endregion
 
     #region Opener
     internal static NINOpenerMaxLevel4thGCDKunai Opener1 = new();


### PR DESCRIPTION
- Doton time stood still timer
- Feint check for any owner
- Canapplystatus check for feint, trick, and mug
- Fix for missing level check. Aoe 1-2 combo
- Added line to hide feature so it shows trick attack if mug is not selected and in combat. Not just only when you have suiton. 
- !New Feature Simpler Mudras Alternate Feature
  - Ten = ST Mudras, Chi = Aoe Mudras without Doton, Jin = Doton