### PR TITLE
[PVP] 7.3 Update

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -8376,7 +8376,7 @@ public enum Preset
 
     [PvPCustomCombo]
     [ReplaceSkill(ASTPvP.AspectedBenefic)]
-    [CustomComboInfo("Double Cast Heal Feature", "Adds Double Cast to Aspected Benefic.", Job.AST)]
+    [CustomComboInfo("Aspected Benefic Heal Feature", "Adds options to Aspected Benefic", Job.AST)]
     ASTPvP_Heal = 111004,
 
     [PvPCustomCombo]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -9247,7 +9247,7 @@ public enum Preset
 
     [PvPCustomCombo]
     [ParentCombo(SGEPvP_BurstMode)]
-    [CustomComboInfo("Kardia Reminder Option", "Adds Kardia to Burst Mode.", Job.SGE)]
+    [CustomComboInfo("Kardia Reminder Option", "Adds Kardia Reminder to Burst Mode if buff is missing", Job.SGE)]
     SGEPvP_BurstMode_KardiaReminder = 124007,
 
     [PvPCustomCombo]
@@ -9256,8 +9256,14 @@ public enum Preset
        "Adds Role Action Diabrosis to Burst Mode below selected health",
        Job.SGE)]
     SGEPvP_Diabrosis = 124008,
+    
+    [PvPCustomCombo]
+    [ReplaceSkill(SGEPvP.Kardia)]
+    [CustomComboInfo("Kardia Retarget", "Retargets Kardia to the heal stack (In Wrath Settings) outside of the Burst Feature", Job.SGE)]
+    [Retargeted]
+    SGEPvP_RetargetKardia = 124009,
 
-    // Last value = 124008
+    // Last value = 124009
 
     #endregion
 
@@ -9356,7 +9362,7 @@ public enum Preset
     SCHPvP_Adlo = 126006,
     
     [PvPCustomCombo]
-    [ReplaceSkill(SCHPvP.Broil)]
+    [ReplaceSkill(SCHPvP.Adloquilum)]
     [CustomComboInfo("Adlo Retarget", "Retargets Adlo to the heal stack (In Wrath Settings) outside of the Burst Feature", Job.SCH)]
     [Retargeted]
     SCHPvP_RetargetAdlo = 126007,

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -9567,12 +9567,14 @@ public enum Preset
 
     [PvPCustomCombo]
     [ParentCombo(WHMPvP_Burst)]
-    [CustomComboInfo("Cure 3 Waste Prevention", "Adds Cure 3 to Burst combo when the Cure 3 Ready buff is under 6 seconds", Job.WHM)]
-    WHMPvP_NoWasteCure = 129010,
+    [CustomComboInfo("Heals in the Burst Mode", "Adds Cure 2/3 and Aquaveil to Burst combo below all damage options.", Job.WHM)]
+    [Retargeted]
+    WHMPvP_Burst_Heals = 129010,
 
     [PvPCustomCombo]
     [ReplaceSkill(WHMPvP.Cure2)]
     [CustomComboInfo("Heal Feature", "Adds the below options onto Cure II.", Job.WHM)]
+    [Retargeted]
     WHMPvP_Heals = 129004,
 
     [PvPCustomCombo]

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -8375,11 +8375,6 @@ public enum Preset
     ASTPvP_Burst_PlayCard = 111003,
 
     [PvPCustomCombo]
-    [ReplaceSkill(ASTPvP.AspectedBenefic)]
-    [CustomComboInfo("Aspected Benefic Heal Feature", "Adds options to Aspected Benefic", Job.AST)]
-    ASTPvP_Heal = 111004,
-
-    [PvPCustomCombo]
     [ParentCombo(ASTPvP_Burst)]
     [CustomComboInfo("Double Malefic Cast Option", "Adds Double Malefic Cast to Burst Mode.", Job.AST)]
     ASTPvP_Burst_DoubleMalefic = 111005,
@@ -8407,11 +8402,23 @@ public enum Preset
         "Adds Role Action Diabrosis to Burst Mode below selected health",
         Job.AST)]
     ASTPvP_Diabrosis = 111010,
+    
+    [PvPCustomCombo]
+    [ParentCombo(ASTPvP_Burst)]
+    [CustomComboInfo("Aspected Benefic Option", "Adds Aspected Benefic when target is below set health", Job.AST)]
+    [PossiblyRetargeted]
+    ASTPvP_Burst_Heal = 111011,
 
     [PvPCustomCombo]
     [ReplaceSkill(ASTPvP.Epicycle)]
     [CustomComboInfo("Epicycle Burst Feature", "Turns Epicycle into burst combo.", Job.AST)]
     ASTPvP_Epicycle = 111008,
+    
+    [PvPCustomCombo]
+    [ReplaceSkill(ASTPvP.AspectedBenefic)]
+    [CustomComboInfo("Aspected Benefic Heal Feature", "Adds options to Aspected Benefic", Job.AST)]
+    [PossiblyRetargeted]
+    ASTPvP_Heal = 111004,
 
     // Last value = 111010
 
@@ -9344,10 +9351,15 @@ public enum Preset
 
     [PvPCustomCombo]
     [ParentCombo(SCHPvP_Burst)]
-    [CustomComboInfo("Self Adlo Option",
-       "Adds Adloquium to self when at or beneath selected heath threshold. \n Will Not Overwrite Catalyze",
-       Job.SCH)]
-    SCHPvP_Selfcare = 126006,
+    [CustomComboInfo("Adlo Option", "Adds Adloquium when target is below set health", Job.SCH)]
+    [PossiblyRetargeted]
+    SCHPvP_Adlo = 126006,
+    
+    [PvPCustomCombo]
+    [ReplaceSkill(SCHPvP.Broil)]
+    [CustomComboInfo("Adlo Retarget", "Retargets Adlo to the heal stack (In Wrath Settings) outside of the Burst Feature", Job.SCH)]
+    [Retargeted]
+    SCHPvP_RetargetAdlo = 126007,
 
     // Last value = 126006
 

--- a/WrathCombo/Combos/PvP/ALL/ALL.cs
+++ b/WrathCombo/Combos/PvP/ALL/ALL.cs
@@ -86,7 +86,7 @@ internal static class PvPCommon
                     break;
 
                 case Preset.PvP_QuickPurify:
-                    DrawSliderInt(0, 10000, PurifyMPThreshold, "Do not use Purify below set MP", sliderIncrement:100);
+                    DrawSliderInt(2500, 10000, PurifyMPThreshold, "Do not use Purify below set MP", sliderIncrement:100);
                     DrawPvPStatusMultiChoice(QuickPurifyStatuses);
                     break;
             }

--- a/WrathCombo/Combos/PvP/ALL/ALL.cs
+++ b/WrathCombo/Combos/PvP/ALL/ALL.cs
@@ -54,7 +54,8 @@ internal static class PvPCommon
     {
         public static UserInt
             EmergencyHealThreshold = new("EmergencyHealThreshold"),
-            EmergencyGuardThreshold = new("EmergencyGuardThreshold");
+            EmergencyGuardThreshold = new("EmergencyGuardThreshold"),
+            PurifyMPThreshold = new("PurifyMPThreshold");
 
         public static UserBoolArray
             QuickPurifyStatuses = new("QuickPurifyStatuses");
@@ -85,6 +86,7 @@ internal static class PvPCommon
                     break;
 
                 case Preset.PvP_QuickPurify:
+                    DrawSliderInt(0, 10000, PurifyMPThreshold, "Do not use Purify below set MP", sliderIncrement:100);
                     DrawPvPStatusMultiChoice(QuickPurifyStatuses);
                     break;
             }
@@ -248,8 +250,9 @@ internal static class PvPCommon
                 return All.SavageBlade;
             }
 
-            if (Execute() && InPvP() &&
-                !CommonActions.Contains(actionID))
+            if (Execute() && InPvP() && IsOffCooldown(Purify) &&
+                !CommonActions.Contains(actionID) && 
+                LocalPlayer.CurrentMp >= Config.PurifyMPThreshold)
                 return OriginalHook(Purify);
 
             return actionID;

--- a/WrathCombo/Combos/PvP/ASTPVP.cs
+++ b/WrathCombo/Combos/PvP/ASTPVP.cs
@@ -138,7 +138,7 @@ internal static class ASTPvP
                 {
                     IGameObject? healTarget = ASTPvP_BurstHealRetarget ? SimpleTarget.Stack.AllyToHealPVP : SimpleTarget.Stack.Allies;
                 
-                    if (!HasStatusEffect(Buffs.DiurnalBenefic, healTarget) && GetTargetHPPercent(healTarget) <= ASTPvP_Burst_HealThreshold)
+                    if (!HasStatusEffect(Buffs.DiurnalBenefic, healTarget) && GetTargetHPPercent(healTarget) <= ASTPvP_Burst_HealThreshold && ActionReady(AspectedBenefic))
                         return ASTPvP_BurstHealRetarget
                             ? AspectedBenefic.Retarget(Malefic, healTarget, true)
                             : AspectedBenefic;

--- a/WrathCombo/Combos/PvP/ASTPVP.cs
+++ b/WrathCombo/Combos/PvP/ASTPVP.cs
@@ -1,8 +1,6 @@
-﻿using WrathCombo.Combos.PvE;
-using WrathCombo.Core;
+﻿using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
-using WrathCombo.Window.Functions;
 using static WrathCombo.Window.Functions.UserConfig;
 using static WrathCombo.Combos.PvP.ASTPvP.Config;
 

--- a/WrathCombo/Combos/PvP/ASTPVP.cs
+++ b/WrathCombo/Combos/PvP/ASTPVP.cs
@@ -1,13 +1,16 @@
-﻿using WrathCombo.CustomComboNS;
+﻿using WrathCombo.Combos.PvE;
+using WrathCombo.Core;
+using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Window.Functions;
+using static WrathCombo.Window.Functions.UserConfig;
 using static WrathCombo.Combos.PvP.ASTPvP.Config;
 
 namespace WrathCombo.Combos.PvP;
 
 internal static class ASTPvP
 {
-        #region IDS
+    #region IDS
     internal class Role : PvPHealer;
 
     internal const uint
@@ -32,13 +35,15 @@ internal static class ASTPvP
             LordOfCrowns = 4329,
             RetrogradeReady = 4331;
     }
+    #endregion
 
-        #endregion
-
-        #region Config
+    #region Config
     public static class Config
     {
-        public static UserInt
+        internal static UserBool
+            ASTPvP_Heal_DoubleCast = new("ASTPvP_Heal_DoubleCast"),
+            ASTPvP_Heal_Retarget = new("ASTPvP_Heal_Retarget");
+        internal static UserInt
             ASTPvP_Burst_PlayCardOption = new("ASTPvP_Burst_PlayCardOption"),
             ASTPvP_DiabrosisThreshold = new("ASTPvP_DiabrosisThreshold");
 
@@ -47,27 +52,27 @@ internal static class ASTPvP
             switch (preset)
             {
                 case Preset.ASTPvP_Burst_PlayCard:
-                    UserConfig.DrawHorizontalRadioButton(ASTPvP_Burst_PlayCardOption, "Lord and Lady card play",
+                    DrawHorizontalRadioButton(ASTPvP_Burst_PlayCardOption, "Lord and Lady card play",
                         "Uses Lord and Lady of Crowns when available.", 1);
 
-                    UserConfig.DrawHorizontalRadioButton(ASTPvP_Burst_PlayCardOption, "Lord of Crowns card play",
+                    DrawHorizontalRadioButton(ASTPvP_Burst_PlayCardOption, "Lord of Crowns card play",
                         "Only uses Lord of Crowns when available.", 2);
 
-                    UserConfig.DrawHorizontalRadioButton(ASTPvP_Burst_PlayCardOption, "Lady of Crowns card play",
-                        "Only uses Lady of Crowns when available.", 3);
-
-                    break;
+                    DrawHorizontalRadioButton(ASTPvP_Burst_PlayCardOption, "Lady of Crowns card play",
+                        "Only uses Lady of Crowns when available.", 3); break;
 
                 case Preset.ASTPvP_Diabrosis:
-                    UserConfig.DrawSliderInt(0, 100, ASTPvP_DiabrosisThreshold,
-                        "Target HP% to use Diabrosis");
-
+                    DrawSliderInt(0, 100, ASTPvP_DiabrosisThreshold, "Target HP% to use Diabrosis");
+                    break;
+                
+                case Preset.ASTPvP_Heal:
+                    DrawAdditionalBoolChoice(ASTPvP_Heal_DoubleCast, "Double Cast", "Adds Doublecast to Aspected Benefic");
+                    DrawAdditionalBoolChoice(ASTPvP_Heal_Retarget, "Retarget", "Retargets Aspected Benefic to the Heal Stack(In Wrath Settings)");
                     break;
             }
         }
     }
-
-        #endregion
+    #endregion
 
     internal class ASTPvP_Burst : CustomCombo
     {
@@ -75,99 +80,95 @@ internal static class ASTPvP
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Malefic)
+            if (actionID is not Malefic)
+                return actionID;
+
+            // Card Draw
+            if (IsEnabled(Preset.ASTPvP_Burst_DrawCard) && IsOffCooldown(MinorArcana) &&
+                (!HasStatusEffect(Buffs.LadyOfCrowns) && !HasStatusEffect(Buffs.LordOfCrowns)))
+                return MinorArcana;
+
+            if (IsEnabled(Preset.ASTPvP_Burst_PlayCard))
             {
-                // Card Draw
-                if (IsEnabled(Preset.ASTPvP_Burst_DrawCard) && IsOffCooldown(MinorArcana) && (!HasStatusEffect(Buffs.LadyOfCrowns) && !HasStatusEffect(Buffs.LordOfCrowns)))
-                    return MinorArcana;                                      
-                   
                 int cardPlayOption = ASTPvP_Burst_PlayCardOption;
+                bool hasLadyOfCrowns = HasStatusEffect(Buffs.LadyOfCrowns);
+                bool hasLordOfCrowns = HasStatusEffect(Buffs.LordOfCrowns);
 
-                if (IsEnabled(Preset.ASTPvP_Burst_PlayCard))
-                {
-                    bool hasLadyOfCrowns = HasStatusEffect(Buffs.LadyOfCrowns);
-                    bool hasLordOfCrowns = HasStatusEffect(Buffs.LordOfCrowns);
+                // Card Playing Split so Lady can still be used if target is immune
+                if ((cardPlayOption == 1 && hasLordOfCrowns && !PvPCommon.TargetImmuneToDamage()) ||
+                    (cardPlayOption == 1 && hasLadyOfCrowns) ||
+                    (cardPlayOption == 2 && hasLordOfCrowns && !PvPCommon.TargetImmuneToDamage()) ||
+                    (cardPlayOption == 3 && hasLadyOfCrowns))
+                    return OriginalHook(MinorArcana);
+            }
 
-                    // Card Playing Split so Lady can still be used if target is immune
-                    if ((cardPlayOption == 1 && hasLordOfCrowns && !PvPCommon.TargetImmuneToDamage()) ||
-                        (cardPlayOption == 1 && hasLadyOfCrowns) ||
-                        (cardPlayOption == 2 && hasLordOfCrowns && !PvPCommon.TargetImmuneToDamage()) ||
-                        (cardPlayOption == 3 && hasLadyOfCrowns))
+            if (!PvPCommon.TargetImmuneToDamage())
+            {
+                if (IsEnabled(Preset.ASTPvP_Diabrosis) && PvPHealer.CanDiabrosis() && HasTarget() &&
+                    GetTargetHPPercent() <= ASTPvP_DiabrosisThreshold)
+                    return PvPHealer.Diabrosis;
 
-                        return OriginalHook(MinorArcana);
-                }    
-                        
-                if (!PvPCommon.TargetImmuneToDamage())
-                { 
-                    if (IsEnabled(Preset.ASTPvP_Diabrosis) && PvPHealer.CanDiabrosis() && HasTarget() &&
-                        GetTargetHPPercent() <= ASTPvP_DiabrosisThreshold)
-                        return PvPHealer.Diabrosis;
+                // Macrocosmos only with double gravity or on cooldown when double gravity is disabled
+                if (IsEnabled(Preset.ASTPvP_Burst_Macrocosmos) && IsOffCooldown(Macrocosmos) &&
+                    (ComboAction == DoubleGravity || !IsEnabled(Preset.ASTPvP_Burst_DoubleGravity)))
+                    return Macrocosmos;
 
-                    // Macrocosmos only with double gravity or on coodlown when double gravity is disabled
-                    if (IsEnabled(Preset.ASTPvP_Burst_Macrocosmos) && IsOffCooldown(Macrocosmos) &&
-                        (ComboAction == DoubleGravity || !IsEnabled(Preset.ASTPvP_Burst_DoubleGravity)))
-                        return Macrocosmos;
+                // Double Gravity
+                if (IsEnabled(Preset.ASTPvP_Burst_DoubleGravity) && ComboAction == Gravity && HasCharges(DoubleCast))
+                    return DoubleGravity;
 
-                    // Double Gravity
-                    if (IsEnabled(Preset.ASTPvP_Burst_DoubleGravity) && ComboAction == Gravity && HasCharges(DoubleCast))
-                        return DoubleGravity;
+                // Gravity on cd
+                if (IsEnabled(Preset.ASTPvP_Burst_Gravity) && IsOffCooldown(Gravity))
+                    return Gravity;
 
-                    // Gravity on cd
-                    if (IsEnabled(Preset.ASTPvP_Burst_Gravity) && IsOffCooldown(Gravity))
-                        return Gravity;
-
-                    // Double Malefic logic to not leave gravity without a charge
-                    if (IsEnabled(Preset.ASTPvP_Burst_DoubleMalefic))
-                    {
-                        if (ComboAction == Malefic && (GetRemainingCharges(DoubleCast) > 1 ||
-                                                       GetCooldownRemainingTime(Gravity) > 7.5f) && CanWeave())
-                            return DoubleMalefic;
-                    }
-
-                }
-
+                // Double Malefic logic to not leave gravity without a charge
+                if (IsEnabled(Preset.ASTPvP_Burst_DoubleMalefic) && ComboAction == Malefic &&
+                    (GetRemainingCharges(DoubleCast) > 1 || GetCooldownRemainingTime(Gravity) > 7.5f) && CanWeave())
+                    return DoubleMalefic;
             }
 
             return actionID;
         }
+    }
 
-        internal class ASTPvP_Epicycle : CustomCombo
+    internal class ASTPvP_Epicycle : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.ASTPvP_Epicycle;
+
+        protected override uint Invoke(uint actionID)
         {
-            protected internal override Preset Preset => Preset.ASTPvP_Epicycle;
-
-            protected override uint Invoke(uint actionID)
-            {
-                if(actionID is Epicycle)
-                {
-                    if (IsOffCooldown(MinorArcana))
-                        return MinorArcana;
-
-                    if (HasStatusEffect(Buffs.RetrogradeReady))
-                    {
-                        if (HasStatusEffect(Buffs.LordOfCrowns))
-                            return OriginalHook(MinorArcana);
-                        if (IsOffCooldown(Macrocosmos))
-                            return Macrocosmos;
-                    }
-                }
-
+            if (actionID is not Epicycle) 
                 return actionID;
+            
+            if (IsOffCooldown(MinorArcana))
+                return MinorArcana;
+
+            if (HasStatusEffect(Buffs.RetrogradeReady))
+            {
+                if (HasStatusEffect(Buffs.LordOfCrowns))
+                    return OriginalHook(MinorArcana);
+                if (IsOffCooldown(Macrocosmos))
+                    return Macrocosmos;
             }
+            return actionID;
         }
+    }
 
-        internal class ASTPvP_Heal : CustomCombo
+    internal class ASTPvP_Heal : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.ASTPvP_Heal;
+
+        protected override uint Invoke(uint actionID)
         {
-            protected internal override Preset Preset => Preset.ASTPvP_Heal;
-
-            protected override uint Invoke(uint actionID)
-            {
-                if (actionID is AspectedBenefic && CanWeave() &&
-                    ComboAction == AspectedBenefic &&
-                    HasCharges(DoubleCast))
-                    return OriginalHook(DoubleCast);
-
+            if (actionID is not AspectedBenefic) 
                 return actionID;
-            }
+            
+            if (ASTPvP_Heal_DoubleCast && CanWeave() && ComboAction == AspectedBenefic && HasCharges(DoubleCast))
+                return OriginalHook(DoubleCast);
+            
+            return ASTPvP_Heal_Retarget
+                ? actionID.Retarget(SimpleTarget.Stack.AllyToHeal)
+                : actionID;
         }
     }
 }

--- a/WrathCombo/Combos/PvP/ASTPVP.cs
+++ b/WrathCombo/Combos/PvP/ASTPVP.cs
@@ -136,7 +136,7 @@ internal static class ASTPvP
                 
                 if (IsEnabled(Preset.ASTPvP_Burst_Heal))
                 {
-                    IGameObject? healTarget = ASTPvP_BurstHealRetarget ? SimpleTarget.Stack.AllyToHeal : SimpleTarget.Stack.Allies;
+                    IGameObject? healTarget = ASTPvP_BurstHealRetarget ? SimpleTarget.Stack.AllyToHealPVP : SimpleTarget.Stack.Allies;
                 
                     if (!HasStatusEffect(Buffs.DiurnalBenefic, healTarget) && GetTargetHPPercent(healTarget) <= ASTPvP_Burst_HealThreshold)
                         return ASTPvP_BurstHealRetarget
@@ -184,7 +184,7 @@ internal static class ASTPvP
                 return OriginalHook(DoubleCast);
             
             return ASTPvP_Heal_Retarget
-                ? actionID.Retarget(SimpleTarget.Stack.AllyToHeal)
+                ? actionID.Retarget(SimpleTarget.Stack.AllyToHealPVP)
                 : actionID;
         }
     }

--- a/WrathCombo/Combos/PvP/BLMPVP.cs
+++ b/WrathCombo/Combos/PvP/BLMPVP.cs
@@ -1,7 +1,6 @@
 ﻿using Dalamud.Game.ClientState.Objects.Types;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
-using WrathCombo.Window.Functions;
 using static WrathCombo.Window.Functions.UserConfig;
 using static WrathCombo.Combos.PvP.BLMPvP.Config;
 

--- a/WrathCombo/Combos/PvP/BLMPVP.cs
+++ b/WrathCombo/Combos/PvP/BLMPVP.cs
@@ -2,16 +2,15 @@
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Window.Functions;
+using static WrathCombo.Window.Functions.UserConfig;
 using static WrathCombo.Combos.PvP.BLMPvP.Config;
 
 namespace WrathCombo.Combos.PvP;
 
 internal static class BLMPvP
 {
-        #region IDs
-
+    #region IDs
     internal class Role : PvPCaster;
-
     public const uint
         Fire = 29649,
         Blizzard = 29653,
@@ -49,7 +48,6 @@ internal static class BLMPvP
             WreathOfIce = 4316,
             Paradox = 3223;
     }
-
     public static class Debuffs
     {
         public const ushort
@@ -57,19 +55,18 @@ internal static class BLMPvP
             DeepFreeze = 3219,
             Lethargy = 4333;
     }
-        #endregion
+    #endregion
 
-        #region Config
+    #region Config
     public static class Config
     {
         public static UserInt
             BLMPvP_ElementalWeave_PlayerHP = new("BLMPvP_ElementalWeave_PlayerHP", 50),
             BLMPvP_Lethargy_TargetHP = new("BLMPvP_Lethargy_TargetHP", 50),
-            BLMPvP_BurstMode_WreathOfIce = new("BLMPvP_BurstMode_WreathOfIce", 0),
-            BLMPvP_BurstMode_WreathOfFireExecute = new("BLMPvP_BurstMode_WreathOfFireExecute", 0),
             BLMPVP_BurstButtonOption = new("BLMPVP_BurstButtonOption"),
             BLMPvP_Xenoglossy_TargetHP = new("BLMPvP_Xenoglossy_TargetHP", 50),
-            BLMPvP_PhantomDartThreshold = new("BLMPvP_PhantomDartThreshold", 50);
+            BLMPvP_PhantomDartThreshold = new("BLMPvP_PhantomDartThreshold", 50),
+            BLMPvP_Manipulation_Feature_PurifyMPThreshold = new("BLMPvP_Manipulation_Feature_PurifyMPThreshold", 5000);
 
         public static UserBool
             BLMPvP_Burst_SubOption = new("BLMPvP_Burst_SubOption"),
@@ -86,13 +83,13 @@ internal static class BLMPvP
             {
                 // Movement Threshold
                 case Preset.BLMPvP_BurstMode:
-                    UserConfig.DrawHorizontalRadioButton(BLMPVP_BurstButtonOption, "One Button Mode", "Combines Fire & Blizzard onto one button", 0);
-                    UserConfig.DrawHorizontalRadioButton(BLMPVP_BurstButtonOption, "Dual Button Mode", "Puts the combo onto separate Fire & Blizzard buttons, which will only use that element.", 1);
+                    DrawHorizontalRadioButton(BLMPVP_BurstButtonOption, "One Button Mode", "Combines Fire & Blizzard onto one button", 0);
+                    DrawHorizontalRadioButton(BLMPVP_BurstButtonOption, "Dual Button Mode", "Puts the combo onto separate Fire & Blizzard buttons, which will only use that element.", 1);
 
                     if (BLMPVP_BurstButtonOption == 0)
                     {
                         ImGui.Indent();
-                        UserConfig.DrawRoundedSliderFloat(0.1f, 3, BLMPvP_Movement_Threshold, "Movement Threshold", 137);
+                        DrawRoundedSliderFloat(0.1f, 3, BLMPvP_Movement_Threshold, "Movement Threshold", 137);
                         ImGui.Unindent();
                         if (ImGui.IsItemHovered())
                         {
@@ -105,48 +102,47 @@ internal static class BLMPvP
 
                 // Burst
                 case Preset.BLMPvP_Burst:
-                    UserConfig.DrawAdditionalBoolChoice(BLMPvP_Burst_SubOption, "Defensive Burst",
+                    DrawAdditionalBoolChoice(BLMPvP_Burst_SubOption, "Defensive Burst",
                         "Also uses Burst when under 50% HP.\n- Will not use outside combat.");
-
                     break;
 
                 // Elemental Weave
                 case Preset.BLMPvP_ElementalWeave:
-                    UserConfig.DrawSliderInt(10, 100, BLMPvP_ElementalWeave_PlayerHP, "Player HP%", 180);
+                    DrawSliderInt(10, 100, BLMPvP_ElementalWeave_PlayerHP, "Player HP%", 180);
                     ImGui.Spacing();
-                    UserConfig.DrawAdditionalBoolChoice(BLMPvP_ElementalWeave_SubOption, "Defensive Elemental Weave",
+                    DrawAdditionalBoolChoice(BLMPvP_ElementalWeave_SubOption, "Defensive Elemental Weave",
                         "When under, uses Wreath of Ice instead.\n- Will not use outside combat.");
-
                     break;
 
                 // Lethargy
                 case Preset.BLMPvP_Lethargy:
-                    UserConfig.DrawSliderInt(10, 100, BLMPvP_Lethargy_TargetHP, "Target HP%", 180);
+                    DrawSliderInt(10, 100, BLMPvP_Lethargy_TargetHP, "Target HP%", 180);
                     ImGui.Spacing();
-                    UserConfig.DrawAdditionalBoolChoice(BLMPvP_Lethargy_SubOption, "Defensive Lethargy",
+                    DrawAdditionalBoolChoice(BLMPvP_Lethargy_SubOption, "Defensive Lethargy",
                         "Also uses Lethargy when under 50% HP.\n- Uses only when targeted by enemy.");
-
                     break;
 
                 // Xenoglossy
                 case Preset.BLMPvP_Xenoglossy:
-                    UserConfig.DrawSliderInt(10, 100, BLMPvP_Xenoglossy_TargetHP, "Target HP%", 180);
+                    DrawSliderInt(10, 100, BLMPvP_Xenoglossy_TargetHP, "Target HP%", 180);
                     ImGui.Spacing();
-                    UserConfig.DrawAdditionalBoolChoice(BLMPvP_Xenoglossy_SubOption, "Defensive Xenoglossy",
+                    DrawAdditionalBoolChoice(BLMPvP_Xenoglossy_SubOption, "Defensive Xenoglossy",
                         "Also uses Xenoglossy when under 50% HP.");
-
                     break;
 
                 // Phantom Dart
                 case Preset.BLMPvP_PhantomDart:
-                    UserConfig.DrawSliderInt(1, 100, BLMPvP_PhantomDartThreshold,
-                        "Target HP% to use Phantom Dart at or below");
-
+                    DrawSliderInt(1, 100, BLMPvP_PhantomDartThreshold, "Target HP% to use Phantom Dart at or below");
                     break;
+                
+                case Preset.BLMPvP_Manipulation_Feature:
+                    DrawSliderInt(2500, 10000, BLMPvP_Manipulation_Feature_PurifyMPThreshold, "Do not use Purify below set MP.");
+                    break;
+                    
             }
         }
     }
-        #endregion
+    #endregion
 
     internal class BLMPvP_BurstMode : CustomCombo
     {
@@ -157,123 +153,116 @@ internal static class BLMPvP
             bool actionIsFire = actionID is Fire or Fire3 or Fire4 or HighFire2 or Flare;
             bool actionIsIce = actionID is Blizzard or Blizzard3 or Blizzard4 or HighBlizzard2 or Freeze;
 
-            if (actionIsFire || (actionIsIce && BLMPVP_BurstButtonOption == 1))
+            if (!actionIsFire && (!actionIsIce || BLMPVP_BurstButtonOption != 1)) 
+                return actionID;
+
+            #region Variables
+            float targetDistance = GetTargetDistance();
+            float targetCurrentPercentHp = GetTargetHPPercent();
+            float playerCurrentPercentHp = PlayerHealthPercentageHp();
+            uint chargesXenoglossy = HasCharges(Xenoglossy) ? GetCooldown(Xenoglossy).RemainingCharges : 0;
+            bool isMoving = IsMoving();
+            bool inCombat = InCombat();
+            bool hasTarget = HasTarget();
+            bool isTargetNPC = CurrentTarget is IBattleNpc && CurrentTarget.DataId != 8016;
+            bool hasParadox = HasStatusEffect(Buffs.Paradox);
+            bool hasResonance = HasStatusEffect(Buffs.SoulResonance);
+            bool hasWreathOfFire = HasStatusEffect(Buffs.WreathOfFire);
+            bool hasFlareStar = OriginalHook(SoulResonance) is FlareStar;
+            bool hasFrostStar = OriginalHook(SoulResonance) is FrostStar;
+            bool targetHasGuard = HasStatusEffect(PvPCommon.Buffs.Guard, CurrentTarget, true);
+            bool targetHasHeavy = HasStatusEffect(PvPCommon.Debuffs.Heavy, CurrentTarget, true);
+            bool isPlayerTargeted = CurrentTarget?.TargetObjectId == LocalPlayer.GameObjectId;
+            bool isParadoxPrimed = HasStatusEffect(Buffs.UmbralIce1) || HasStatusEffect(Buffs.AstralFire1);
+            bool isMovingAdjusted = TimeMoving.TotalMilliseconds / 1000f >= BLMPvP_Movement_Threshold;
+            bool isResonanceExpiring = HasStatusEffect(Buffs.SoulResonance) && GetStatusEffectRemainingTime(Buffs.SoulResonance) <= 10;
+            bool hasUmbralIce = HasStatusEffect(Buffs.UmbralIce1) || HasStatusEffect(Buffs.UmbralIce2) || HasStatusEffect(Buffs.UmbralIce3);
+            bool isElementalStarDelayed = HasStatusEffect(Buffs.ElementalStar) && GetStatusEffectRemainingTime(Buffs.ElementalStar) <= 20;
+            bool hasAstralFire = HasStatusEffect(Buffs.AstralFire1) || HasStatusEffect(Buffs.AstralFire2) || HasStatusEffect(Buffs.AstralFire3);
+            bool targetHasImmunity = HasStatusEffect(PLDPvP.Buffs.HallowedGround, CurrentTarget, true) || HasStatusEffect(DRKPvP.Buffs.UndeadRedemption, CurrentTarget, true);
+            #endregion
+
+            if (inCombat)
             {
-                    #region Variables
-                float targetDistance = GetTargetDistance();
-                float targetCurrentPercentHp = GetTargetHPPercent();
-                float playerCurrentPercentHp = PlayerHealthPercentageHp();
-                uint chargesXenoglossy = HasCharges(Xenoglossy) ? GetCooldown(Xenoglossy).RemainingCharges : 0;
-                bool isMoving = IsMoving();
-                bool inCombat = InCombat();
-                bool hasTarget = HasTarget();
-                bool isTargetNPC = CurrentTarget is IBattleNpc && CurrentTarget.DataId != 8016;
-                bool hasParadox = HasStatusEffect(Buffs.Paradox);
-                bool hasResonance = HasStatusEffect(Buffs.SoulResonance);
-                bool hasWreathOfFire = HasStatusEffect(Buffs.WreathOfFire);
-                bool hasFlareStar = OriginalHook(SoulResonance) is FlareStar;
-                bool hasFrostStar = OriginalHook(SoulResonance) is FrostStar;
-                bool targetHasGuard = HasStatusEffect(PvPCommon.Buffs.Guard, CurrentTarget, true);
-                bool targetHasHeavy = HasStatusEffect(PvPCommon.Debuffs.Heavy, CurrentTarget, true);
-                bool isPlayerTargeted = CurrentTarget?.TargetObjectId == LocalPlayer.GameObjectId;
-                bool isParadoxPrimed = HasStatusEffect(Buffs.UmbralIce1) || HasStatusEffect(Buffs.AstralFire1);
-                bool isMovingAdjusted = TimeMoving.TotalMilliseconds / 1000f >= BLMPvP_Movement_Threshold;
-                bool isResonanceExpiring = HasStatusEffect(Buffs.SoulResonance) && GetStatusEffectRemainingTime(Buffs.SoulResonance) <= 10;
-                bool hasUmbralIce = HasStatusEffect(Buffs.UmbralIce1) || HasStatusEffect(Buffs.UmbralIce2) || HasStatusEffect(Buffs.UmbralIce3);
-                bool isElementalStarDelayed = HasStatusEffect(Buffs.ElementalStar) && GetStatusEffectRemainingTime(Buffs.ElementalStar) <= 20;
-                bool hasAstralFire = HasStatusEffect(Buffs.AstralFire1) || HasStatusEffect(Buffs.AstralFire2) || HasStatusEffect(Buffs.AstralFire3);
-                bool targetHasImmunity = HasStatusEffect(PLDPvP.Buffs.HallowedGround, CurrentTarget, true) || HasStatusEffect(DRKPvP.Buffs.UndeadRedemption, CurrentTarget, true);
-                    #endregion
+                // Burst (Defensive)
+                if (IsEnabled(Preset.BLMPvP_Burst) && BLMPvP_Burst_SubOption && IsOffCooldown(Burst) && playerCurrentPercentHp < 50)
+                    return OriginalHook(Burst);
 
-                if (inCombat)
-                {
-                    // Burst (Defensive)
-                    if (IsEnabled(Preset.BLMPvP_Burst) && BLMPvP_Burst_SubOption && IsOffCooldown(Burst) && playerCurrentPercentHp < 50)
-                        return OriginalHook(Burst);
-
-                    // Elemental Weave (Defensive)
-                    if (IsEnabled(Preset.BLMPvP_ElementalWeave) && BLMPvP_ElementalWeave_SubOption &&
-                        IsOffCooldown(ElementalWeave) && hasUmbralIce && playerCurrentPercentHp < BLMPvP_ElementalWeave_PlayerHP)
-                        return OriginalHook(ElementalWeave);
-                }
-
-                if (hasTarget && !targetHasImmunity)
-                {
-                    // Elemental Weave (Offensive)
-                    if (IsEnabled(Preset.BLMPvP_ElementalWeave) && IsOffCooldown(ElementalWeave) && hasAstralFire &&
-                        targetDistance <= 25 && playerCurrentPercentHp >= BLMPvP_ElementalWeave_PlayerHP)
-                        return OriginalHook(ElementalWeave);
-
-                    if (!targetHasGuard)
-                    {
-                        // Lethargy
-                        if (IsEnabled(Preset.BLMPvP_Lethargy) && IsOffCooldown(Lethargy) && !isTargetNPC)
-                        {
-                            // Offensive
-                            if (targetCurrentPercentHp < BLMPvP_Lethargy_TargetHP && !targetHasHeavy)
-                                return OriginalHook(Lethargy);
-
-                            // Defensive
-                            if (BLMPvP_Lethargy_SubOption && playerCurrentPercentHp < 50 && isPlayerTargeted)
-                                return OriginalHook(Lethargy);
-                        }
-
-                        if (IsEnabled(Preset.BLMPvP_PhantomDart) && Role.CanPhantomDart() && CanWeave() && GetTargetHPPercent() <= BLMPvP_PhantomDartThreshold)
-                            return Role.PhantomDart;
-
-                        // Burst (Offensive)
-                        if (IsEnabled(Preset.BLMPvP_Burst) && IsOffCooldown(Burst) && targetDistance <= 4)
-                            return OriginalHook(Burst);
-
-                        // Flare Star / Frost Star
-                        if (IsEnabled(Preset.BLMPvP_ElementalStar) && ((hasFlareStar && !isMoving) || (hasFrostStar && isElementalStarDelayed)))
-                            return OriginalHook(SoulResonance);
-
-                        // Xenoglossy
-                        if (IsEnabled(Preset.BLMPvP_Xenoglossy) && chargesXenoglossy > 0)
-                        {
-                            // Defensive
-                            if (BLMPvP_Xenoglossy_SubOption && playerCurrentPercentHp < 50)
-                                return OriginalHook(Xenoglossy);
-
-                            // Offensive
-                            if (!isResonanceExpiring && (isTargetNPC ? chargesXenoglossy > 1 && hasWreathOfFire : targetCurrentPercentHp < BLMPvP_Xenoglossy_TargetHP))
-                                return OriginalHook(Xenoglossy);
-                        }
-                    }
-                }
-
-                // Paradox
-                if (hasParadox && ((isParadoxPrimed && !hasResonance) || (hasAstralFire && isMoving)))
-                    return OriginalHook(Paradox);
-
-
-                // Basic Spells
-                return isMovingAdjusted && BLMPVP_BurstButtonOption == 0
-                    ? OriginalHook(Blizzard)
-                    : OriginalHook(actionID);
-
-
+                // Elemental Weave (Defensive)
+                if (IsEnabled(Preset.BLMPvP_ElementalWeave) && BLMPvP_ElementalWeave_SubOption &&
+                    IsOffCooldown(ElementalWeave) && hasUmbralIce && playerCurrentPercentHp < BLMPvP_ElementalWeave_PlayerHP)
+                    return OriginalHook(ElementalWeave);
             }
 
-            return actionID;
+            if (hasTarget && !targetHasImmunity)
+            {
+                // Elemental Weave (Offensive)
+                if (IsEnabled(Preset.BLMPvP_ElementalWeave) && IsOffCooldown(ElementalWeave) && hasAstralFire &&
+                    targetDistance <= 25 && playerCurrentPercentHp >= BLMPvP_ElementalWeave_PlayerHP)
+                    return OriginalHook(ElementalWeave);
+
+                if (!targetHasGuard)
+                {
+                    // Lethargy
+                    if (IsEnabled(Preset.BLMPvP_Lethargy) && IsOffCooldown(Lethargy) && !isTargetNPC)
+                    {
+                        // Offensive
+                        if (targetCurrentPercentHp < BLMPvP_Lethargy_TargetHP && !targetHasHeavy)
+                            return OriginalHook(Lethargy);
+
+                        // Defensive
+                        if (BLMPvP_Lethargy_SubOption && playerCurrentPercentHp < 50 && isPlayerTargeted)
+                            return OriginalHook(Lethargy);
+                    }
+
+                    if (IsEnabled(Preset.BLMPvP_PhantomDart) && Role.CanPhantomDart() && CanWeave() && GetTargetHPPercent() <= BLMPvP_PhantomDartThreshold)
+                        return Role.PhantomDart;
+
+                    // Burst (Offensive)
+                    if (IsEnabled(Preset.BLMPvP_Burst) && IsOffCooldown(Burst) && targetDistance <= 4)
+                        return OriginalHook(Burst);
+
+                    // Flare Star / Frost Star
+                    if (IsEnabled(Preset.BLMPvP_ElementalStar) && ((hasFlareStar && !isMoving) || (hasFrostStar && isElementalStarDelayed)))
+                        return OriginalHook(SoulResonance);
+
+                    // Xenoglossy
+                    if (IsEnabled(Preset.BLMPvP_Xenoglossy) && chargesXenoglossy > 0)
+                    {
+                        // Defensive
+                        if (BLMPvP_Xenoglossy_SubOption && playerCurrentPercentHp < 50)
+                            return OriginalHook(Xenoglossy);
+
+                        // Offensive
+                        if (!isResonanceExpiring && (isTargetNPC ? chargesXenoglossy > 1 && hasWreathOfFire : targetCurrentPercentHp < BLMPvP_Xenoglossy_TargetHP))
+                            return OriginalHook(Xenoglossy);
+                    }
+                }
+            }
+            // Paradox
+            if (hasParadox && ((isParadoxPrimed && !hasResonance) || (hasAstralFire && isMoving)))
+                return OriginalHook(Paradox);
+
+            // Basic Spells
+            return isMovingAdjusted && BLMPVP_BurstButtonOption == 0
+                ? OriginalHook(Blizzard)
+                : OriginalHook(actionID);
         }
     }
-
     internal class BLMPvP_Manipulation_Feature : CustomCombo
     {
         protected internal override Preset Preset => Preset.BLMPvP_Manipulation_Feature;
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is AetherialManipulation)
-            {
-                bool hasCrowdControl = HasStatusEffect(PvPCommon.Debuffs.Stun, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.DeepFreeze, anyOwner: true) ||
-                                       HasStatusEffect(PvPCommon.Debuffs.Bind, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.Silence, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.MiracleOfNature, anyOwner: true);
+            if (actionID is not AetherialManipulation) 
+                return actionID;
+            
+            bool hasCrowdControl = HasStatusEffect(PvPCommon.Debuffs.Stun, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.DeepFreeze, anyOwner: true) ||
+                                   HasStatusEffect(PvPCommon.Debuffs.Bind, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.Silence, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.MiracleOfNature, anyOwner: true);
 
-                if (IsOffCooldown(AetherialManipulation) && IsOffCooldown(PvPCommon.Purify) && hasCrowdControl)
-                    return OriginalHook(PvPCommon.Purify);
-            }
+            if (IsOffCooldown(AetherialManipulation) && IsOffCooldown(PvPCommon.Purify) && hasCrowdControl && LocalPlayer.CurrentMp >= BLMPvP_Manipulation_Feature_PurifyMPThreshold)
+                return OriginalHook(PvPCommon.Purify);
 
             return actionID;
         }

--- a/WrathCombo/Combos/PvP/BRDPVP.cs
+++ b/WrathCombo/Combos/PvP/BRDPVP.cs
@@ -1,14 +1,13 @@
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
-using WrathCombo.Window.Functions;
+using static WrathCombo.Window.Functions.UserConfig;
 using static WrathCombo.Combos.PvP.BRDPvP.Config;
 
 namespace WrathCombo.Combos.PvP;
 
 internal static class BRDPvP
 {
-        #region IDs
-
+    #region IDs
     internal class Role : PvPPhysRanged;
 
     public const uint
@@ -32,9 +31,9 @@ internal static class BRDPvP
             EncoreofLightReady = 4312,
             FrontlineMarch = 3139;
     }
-        #endregion
+    #endregion
 
-        #region Config
+    #region Config
     public static class Config
     {
         public static UserInt
@@ -45,76 +44,65 @@ internal static class BRDPvP
         {
             switch (preset)
             {
-
                 case Preset.BRDPvP_HarmonicArrow:
-                    UserConfig.DrawSliderInt(1, 4, BRDPvP_HarmonicArrowCharges, "How many Charges to use it at \n 1 charge 8000 damage \n 2 charge 12000 damage \n 3 charge 15000 damage \n 4 charge 17000 damage");
-
+                    DrawSliderInt(1, 4, BRDPvP_HarmonicArrowCharges, "How many Charges to use it at \n 1 charge 8000 damage \n 2 charge 12000 damage \n 3 charge 15000 damage \n 4 charge 17000 damage");
                     break;
 
                 case Preset.BRDPvP_Eagle:
-                    UserConfig.DrawSliderInt(0, 100, BRDPvP_EagleThreshold,
-                        "Target HP percent threshold to use Eagle Eye Shot Below.");
-
+                    DrawSliderInt(0, 100, BRDPvP_EagleThreshold, "Target HP percent threshold to use Eagle Eye Shot Below.");
                     break;
             }
         }
-
     }
-        #endregion
+    #endregion
 
     internal class BRDPvP_BurstMode : CustomCombo
     {
         protected internal override Preset Preset => Preset.BRDPvP_BurstMode;
-
         protected override uint Invoke(uint actionID)
-
         {
+            if (actionID is not PowerfulShot) 
+                return actionID;
+            
+            var canWeave = CanWeave(0.5f);
+            uint harmonicCharges = GetRemainingCharges(HarmonicArrow);
 
-            if (actionID == PowerfulShot)
+            if (IsEnabled(Preset.BRDPvP_Eagle) && PvPPhysRanged.CanEagleEyeShot() && (PvPCommon.TargetImmuneToDamage() || GetTargetHPPercent() <= BRDPvP_EagleThreshold))
+                return PvPPhysRanged.EagleEyeShot;
+
+            if (!PvPCommon.TargetImmuneToDamage())
             {
-                var canWeave = CanWeave(0.5f);
-                uint harmonicCharges = GetRemainingCharges(HarmonicArrow);
+                if (IsEnabled(Preset.BRDPvP_Wardens) && InPvP() &&  //Autowardens set up only for soft ccs, it cant be used while cced like purify
+                    (HasStatusEffect(PvPCommon.Debuffs.Bind, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.Heavy, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.HalfAsleep, anyOwner: true)))
+                    return OriginalHook(WardensPaean);
 
-                if (IsEnabled(Preset.BRDPvP_Eagle) && PvPPhysRanged.CanEagleEyeShot() && (PvPCommon.TargetImmuneToDamage() || GetTargetHPPercent() <= BRDPvP_EagleThreshold))
-                    return PvPPhysRanged.EagleEyeShot;
-
-                if (!PvPCommon.TargetImmuneToDamage())
+                if (canWeave)
                 {
-                    if (IsEnabled(Preset.BRDPvP_Wardens) && InPvP() &&  //Autowardens set up only for soft ccs, it cant be used while cced like purify
-                        (HasStatusEffect(PvPCommon.Debuffs.Bind, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.Heavy, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.HalfAsleep, anyOwner: true)))
-                        return OriginalHook(WardensPaean);
+                    // Silence shot that gives PP, set up to not happen right after apex to tighten burst and silence after the bigger damage. Apex > Harmonic> Silent > Burst > PP or Apex > Burst > Silent >  PP
+                    if (IsEnabled(Preset.BRDPvP_SilentNocturne) && !GetCooldown(SilentNocturne).IsCooldown && !WasLastAction(ApexArrow) && !HasStatusEffect(Buffs.Repertoire)) 
+                        return OriginalHook(SilentNocturne);
 
-                    if (canWeave)
-                    {
-                        // Silence shot that gives PP, set up to not happen right after apex to tighten burst and silence after the bigger damage. Apex > Harmonic> Silent > Burst > PP or Apex > Burst > Silent >  PP
-                        if (IsEnabled(Preset.BRDPvP_SilentNocturne) && !GetCooldown(SilentNocturne).IsCooldown && !WasLastAction(ApexArrow) && !HasStatusEffect(Buffs.Repertoire)) 
-                            return OriginalHook(SilentNocturne);
-
-                        if (IsEnabled(Preset.BRDPvP_EncoreOfLight) && HasStatusEffect(Buffs.EncoreofLightReady)) // LB finisher shot
-                            return OriginalHook(FinalFantasia);
-                    }
-
-                    if (IsEnabled(Preset.BRDPvP_ApexArrow) && ActionReady(ApexArrow)) // Use on cd to keep up buff
-                        return OriginalHook(ApexArrow);
-
-                    if (HasStatusEffect(Buffs.FrontlineMarch))
-                    {
-                        if (IsEnabled(Preset.BRDPvP_HarmonicArrow) &&    //Harmonic Logic. Slider plus execute ranges
-                            (harmonicCharges >= BRDPvP_HarmonicArrowCharges ||
-                             harmonicCharges == 1 && GetTargetCurrentHP() <= 8000 ||
-                             harmonicCharges == 2 && GetTargetCurrentHP() <= 12000 ||
-                             harmonicCharges == 3 && GetTargetCurrentHP() <= 15000))
-                            return OriginalHook(HarmonicArrow);
-
-                        if (IsEnabled(Preset.BRDPvP_BlastArrow) && HasStatusEffect(Buffs.BlastArrowReady)) // Blast arrow when ready
-                            return OriginalHook(BlastArrow);
-                    }
-
-                    return OriginalHook(PowerfulShot); // Main shot but also Pitch Perfect
+                    if (IsEnabled(Preset.BRDPvP_EncoreOfLight) && HasStatusEffect(Buffs.EncoreofLightReady)) // LB finisher shot
+                        return OriginalHook(FinalFantasia);
                 }
 
-            }
+                if (IsEnabled(Preset.BRDPvP_ApexArrow) && ActionReady(ApexArrow)) // Use on cd to keep up buff
+                    return OriginalHook(ApexArrow);
 
+                if (HasStatusEffect(Buffs.FrontlineMarch))
+                {
+                    if (IsEnabled(Preset.BRDPvP_HarmonicArrow) &&    //Harmonic Logic. Slider plus execute ranges
+                        (harmonicCharges >= BRDPvP_HarmonicArrowCharges ||
+                         harmonicCharges == 1 && GetTargetCurrentHP() <= 8000 ||
+                         harmonicCharges == 2 && GetTargetCurrentHP() <= 12000 ||
+                         harmonicCharges == 3 && GetTargetCurrentHP() <= 15000))
+                        return OriginalHook(HarmonicArrow);
+
+                    if (IsEnabled(Preset.BRDPvP_BlastArrow) && HasStatusEffect(Buffs.BlastArrowReady)) // Blast arrow when ready
+                        return OriginalHook(BlastArrow);
+                }
+                return OriginalHook(PowerfulShot); // Main shot but also Pitch Perfect
+            }
             return actionID;
         }                       
     }

--- a/WrathCombo/Combos/PvP/DRKPVP.cs
+++ b/WrathCombo/Combos/PvP/DRKPVP.cs
@@ -1,16 +1,15 @@
 ﻿using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Window.Functions;
+using static WrathCombo.Window.Functions.UserConfig;
 using static WrathCombo.Combos.PvP.DRKPvP.Config;
 
 namespace WrathCombo.Combos.PvP;
 
 internal class DRKPvP
 {
-        #region IDS
-
+    #region IDS
     internal class Role : PvPTank;
-
     public const uint
         HardSlash = 29085,
         SyphonStrike = 29086,
@@ -35,100 +34,89 @@ internal class DRKPvP
             UndeadRedemption = 3039,
             Scorn = 4290;
     }
-        #endregion
+    #endregion
 
-        #region Config
+    #region Config
     public static class Config
     {
         public static UserInt
             ShadowbringerThreshold = new("ShadowbringerThreshold"),
             DRKPvP_RampartThreshold = new("DRKPvP_RampartThreshold");
 
-
         internal static void Draw(Preset preset)
         {
             switch (preset)
             {
                 case Preset.DRKPvP_Shadowbringer:
-                    UserConfig.DrawSliderInt(20, 100,
-                        ShadowbringerThreshold,
-                        "HP% to be at or Above to use ",
+                    DrawSliderInt(20, 100, ShadowbringerThreshold, "HP% to be at or Above to use ", 
                         itemWidth: 150f, sliderIncrement: SliderIncrements.Fives);
-
                     break;
 
-                case Preset.DRKPvP_Rampart:
-                    UserConfig.DrawSliderInt(1, 100, DRKPvP_RampartThreshold,
-                        "Use Rampart below set threshold for self");
+                case Preset.DRKPvP_Rampart: 
+                    DrawSliderInt(1, 100, DRKPvP_RampartThreshold, "Use Rampart below set threshold for self");
                     break;
-
             }
         }
     }
-        #endregion
-      
+    #endregion
 
     internal class DRKPvP_BurstMode : CustomCombo
     {
         protected internal override Preset Preset => Preset.DRKPvP_Burst;
-
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is HardSlash or SyphonStrike or Souleater)
+            if (actionID is not (HardSlash or SyphonStrike or Souleater)) 
+                return actionID;
+            
+            bool canWeave = CanWeave();
+            int shadowBringerThreshold = ShadowbringerThreshold;
+
+            if (IsEnabled(Preset.DRKPvP_Rampart) && PvPTank.CanRampart(DRKPvP_RampartThreshold))
+                return PvPTank.Rampart;
+
+            if (!PvPCommon.TargetImmuneToDamage())
             {
-                bool canWeave = CanWeave();
-                int shadowBringerThreshold = ShadowbringerThreshold;
-
-                if (IsEnabled(Preset.DRKPvP_Rampart) && PvPTank.CanRampart(DRKPvP_RampartThreshold))
-                    return PvPTank.Rampart;
-
-                if (!PvPCommon.TargetImmuneToDamage())
+                if (IsEnabled(Preset.DRKPvP_Plunge) && ActionReady(Plunge))
                 {
-                    if (IsEnabled(Preset.DRKPvP_Plunge) && ActionReady(Plunge))
+                    if (HasTarget() && (!InMeleeRange()) || (InMeleeRange() && IsEnabled(Preset.DRKPvP_PlungeMelee)))
+                        return OriginalHook(Plunge);
+                }
+
+                if (IsEnabled(Preset.DRKPvP_Scorn) && HasStatusEffect(Buffs.Scorn))
+                    return OriginalHook(Eventide);
+
+                if (canWeave)
+                {
+                    if (IsEnabled(Preset.DRKPvP_BlackestNight) && ActionReady(BlackestNight) && !HasStatusEffect(Buffs.BlackestNight) && !WasLastAbility(BlackestNight))
+                        return OriginalHook(BlackestNight);
+
+                    if (IsEnabled(Preset.DRKPvP_SaltedEarth) && ActionReady(SaltedEarth) && IsEnabled(Preset.DRKPvP_SaltedEarth))
+                        return OriginalHook(SaltedEarth);
+
+                    if (IsEnabled(Preset.DRKPvP_SaltAndDarkness) && HasStatusEffect(Buffs.SaltedEarthDMG) && ActionReady(SaltAndDarkness))
+                        return OriginalHook(SaltAndDarkness);
+
+                    if (IsEnabled(Preset.DRKPvP_Shadowbringer) && !HasStatusEffect(Buffs.Blackblood) && (HasStatusEffect(Buffs.DarkArts) || PlayerHealthPercentageHp() >= shadowBringerThreshold))
+                        return OriginalHook(Shadowbringer);
+                }
+
+                if (InMeleeRange())
+                {
+                    if (IsEnabled(Preset.DRKPvP_Impalement) && ActionReady(Impalement))
+                        return OriginalHook(Impalement);
+
+                    if (ComboTimer > 1f)
                     {
-                        if (HasTarget() && (!InMeleeRange()) || (InMeleeRange() && IsEnabled(Preset.DRKPvP_PlungeMelee)))
-                            return OriginalHook(Plunge);
+                        if (ComboAction == HardSlash)
+                            return OriginalHook(SyphonStrike);
+
+                        if (ComboAction == SyphonStrike)
+                            return OriginalHook(Souleater);
                     }
-
-                    if (IsEnabled(Preset.DRKPvP_Scorn) && HasStatusEffect(Buffs.Scorn))
-                        return OriginalHook(Eventide);
-
-                    if (canWeave)
-                    {
-                        if (IsEnabled(Preset.DRKPvP_BlackestNight) && ActionReady(BlackestNight) && !HasStatusEffect(Buffs.BlackestNight) && !WasLastAbility(BlackestNight))
-                            return OriginalHook(BlackestNight);
-
-                        if (IsEnabled(Preset.DRKPvP_SaltedEarth) && ActionReady(SaltedEarth) && IsEnabled(Preset.DRKPvP_SaltedEarth))
-                            return OriginalHook(SaltedEarth);
-
-                        if (IsEnabled(Preset.DRKPvP_SaltAndDarkness) && HasStatusEffect(Buffs.SaltedEarthDMG) && ActionReady(SaltAndDarkness))
-                            return OriginalHook(SaltAndDarkness);
-
-                        if (IsEnabled(Preset.DRKPvP_Shadowbringer) && !HasStatusEffect(Buffs.Blackblood) && (HasStatusEffect(Buffs.DarkArts) || PlayerHealthPercentageHp() >= shadowBringerThreshold))
-                            return OriginalHook(Shadowbringer);
-                    }
-
-                    if (InMeleeRange())
-                    {
-                        if (IsEnabled(Preset.DRKPvP_Impalement) && ActionReady(Impalement))
-                            return OriginalHook(Impalement);
-
-                        if (ComboTimer > 1f)
-                        {
-                            if (ComboAction == HardSlash)
-                                return OriginalHook(SyphonStrike);
-
-                            if (ComboAction == SyphonStrike)
-                                return OriginalHook(Souleater);
-                        }
-
-                        return OriginalHook(HardSlash);
-                    }
+                    return OriginalHook(HardSlash);
                 }
             }
-
             return actionID;
         }
     }
-
 }

--- a/WrathCombo/Combos/PvP/PCTPVP.cs
+++ b/WrathCombo/Combos/PvP/PCTPVP.cs
@@ -1,17 +1,14 @@
 ﻿using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
-using WrathCombo.Window.Functions;
+using static WrathCombo.Window.Functions.UserConfig;
 using static WrathCombo.Combos.PvP.PCTPvP.Config;
 
 namespace WrathCombo.Combos.PvP;
 
 internal static class PCTPvP
 {
-
-        #region IDs
-
+    #region IDs
     internal class Role : PvPCaster;
-
     internal const uint
         FireInRed = 39191,
         AeroInGreen = 39192,
@@ -38,10 +35,9 @@ internal static class PCTPvP
             MadeenPortrait = 4104,
             SubtractivePalette = 4102;
     }
-        #endregion
+    #endregion
 
-        #region Config
-
+    #region Config
     public static class Config
     {
         public static UserInt
@@ -54,25 +50,19 @@ internal static class PCTPvP
             switch (preset)
             {
                 // Phantom Dart
-                case Preset.PCTPvP_PhantomDart:
-                    UserConfig.DrawSliderInt(1, 100, PCTPvP_PhantomDartThreshold,
+                case Preset.PCTPvP_PhantomDart: DrawSliderInt(1, 100, PCTPvP_PhantomDartThreshold,
                         "Target HP% to use Phantom Dart at or below");
-
                     break;
 
-                case Preset.PCTPvP_BurstControl:
-                    UserConfig.DrawSliderInt(1, 100, PCTPvP_BurstHP, "Target HP%", 200);
-
+                case Preset.PCTPvP_BurstControl: DrawSliderInt(1, 100, PCTPvP_BurstHP, "Target HP%", 200);
                     break;
 
-                case Preset.PCTPvP_TemperaCoat:
-                    UserConfig.DrawSliderInt(1, 100, PCTPvP_TemperaHP, "Player HP%", 200);
-
+                case Preset.PCTPvP_TemperaCoat: DrawSliderInt(1, 100, PCTPvP_TemperaHP, "Player HP%", 200);
                     break;
             }
         }            
     }
-        #endregion
+    #endregion
 
     internal class PCTPvP_Burst : CustomCombo
     {
@@ -80,7 +70,10 @@ internal static class PCTPvP
 
         protected override uint Invoke(uint actionID)
         {
-                #region Variables
+            if (actionID is not (FireInRed or AeroInGreen or WaterInBlue)) 
+                return actionID;
+            
+            #region Variables
             bool isMoving = IsMoving();
             bool hasTarget = HasTarget();
             bool hasStarPrism = HasStatusEffect(Buffs.Starstruck);
@@ -90,56 +83,49 @@ internal static class PCTPvP
             bool isTemperaCoatExpiring = HasStatusEffect(Buffs.TemperaCoat) && GetStatusEffectRemainingTime(Buffs.TemperaCoat) <= 3;
             bool hasMotifDrawn = HasStatusEffect(Buffs.PomMotif) || HasStatusEffect(Buffs.WingMotif) || HasStatusEffect(Buffs.ClawMotif) || HasStatusEffect(Buffs.MawMotif);
             bool isBurstControlled = IsNotEnabled(Preset.PCTPvP_BurstControl) || (IsEnabled(Preset.PCTPvP_BurstControl) && GetTargetHPPercent() < PCTPvP_BurstHP);
-                #endregion
-
-            if (actionID is FireInRed or AeroInGreen or WaterInBlue)
+            #endregion
+            
+            // Tempera Coat / Tempera Grassa
+            if (IsEnabled(Preset.PCTPvP_TemperaCoat))
             {
-                // Tempera Coat / Tempera Grassa
-                if (IsEnabled(Preset.PCTPvP_TemperaCoat))
-                {
-                    if ((IsOffCooldown(TemperaCoat) &&
-                         InCombat() && PlayerHealthPercentageHp() < PCTPvP_TemperaHP) || isTemperaCoatExpiring)
-                        return OriginalHook(TemperaCoat);
-                }
-
-                if (hasTarget && !PvPCommon.TargetImmuneToDamage())
-                {
-                    // Star Prism
-                    if (IsEnabled(Preset.PCTPvP_StarPrism))
-                    {
-                        if (hasStarPrism && (isBurstControlled || isStarPrismExpiring))
-                            return StarPrism;
-                    }
-
-                    if (IsEnabled(Preset.PCTPvP_PhantomDart) && Role.CanPhantomDart() && CanWeave() && GetTargetHPPercent() <= (PCTPvP_PhantomDartThreshold))
-                        return Role.PhantomDart;
-
-                    // Moogle / Madeen Portrait
-                    if (IsEnabled(Preset.PCTPvP_MogOfTheAges) && hasPortrait && isBurstControlled)
-                        return OriginalHook(MogOfTheAges);
-
-                    // Living Muse
-                    if (IsEnabled(Preset.PCTPvP_LivingMuse) && hasMotifDrawn && HasCharges(OriginalHook(LivingMuse)) && isBurstControlled)
-                        return OriginalHook(LivingMuse);
-
-                    // Holy in White / Comet in Black
-                    if (IsEnabled(Preset.PCTPvP_HolyInWhite) && HasCharges(OriginalHook(HolyInWhite)) && isBurstControlled)
-                        return OriginalHook(HolyInWhite);
-                }
-
-                // Creature Motif
-                if (IsEnabled(Preset.PCTPvP_CreatureMotif) && !hasMotifDrawn && !isMoving)
-                    return OriginalHook(CreatureMotif);
-
-                // Subtractive Palette
-                if (IsEnabled(Preset.PCTPvP_SubtractivePalette))
-                {
-                    if (IsOffCooldown(OriginalHook(SubtractivePalette)) &&
-                        hasTarget && ((isMoving && hasSubtractivePalette) || (!isMoving && !hasSubtractivePalette)))
-                        return OriginalHook(SubtractivePalette);
-                }
+                if ((IsOffCooldown(TemperaCoat) &&
+                     InCombat() && PlayerHealthPercentageHp() < PCTPvP_TemperaHP) || isTemperaCoatExpiring)
+                    return OriginalHook(TemperaCoat);
             }
+            if (hasTarget && !PvPCommon.TargetImmuneToDamage())
+            {
+                // Star Prism
+                if (IsEnabled(Preset.PCTPvP_StarPrism))
+                {
+                    if (hasStarPrism && (isBurstControlled || isStarPrismExpiring))
+                        return StarPrism;
+                }
+                if (IsEnabled(Preset.PCTPvP_PhantomDart) && Role.CanPhantomDart() && CanWeave() && GetTargetHPPercent() <= (PCTPvP_PhantomDartThreshold))
+                    return Role.PhantomDart;
 
+                // Moogle / Madeen Portrait
+                if (IsEnabled(Preset.PCTPvP_MogOfTheAges) && hasPortrait && isBurstControlled)
+                    return OriginalHook(MogOfTheAges);
+
+                // Living Muse
+                if (IsEnabled(Preset.PCTPvP_LivingMuse) && hasMotifDrawn && HasCharges(OriginalHook(LivingMuse)) && isBurstControlled)
+                    return OriginalHook(LivingMuse);
+
+                // Holy in White / Comet in Black
+                if (IsEnabled(Preset.PCTPvP_HolyInWhite) && HasCharges(OriginalHook(HolyInWhite)) && isBurstControlled)
+                    return OriginalHook(HolyInWhite);
+            }
+            // Creature Motif
+            if (IsEnabled(Preset.PCTPvP_CreatureMotif) && !hasMotifDrawn && !isMoving)
+                return OriginalHook(CreatureMotif);
+
+            // Subtractive Palette
+            if (IsEnabled(Preset.PCTPvP_SubtractivePalette))
+            {
+                if (IsOffCooldown(OriginalHook(SubtractivePalette)) &&
+                    hasTarget && ((isMoving && hasSubtractivePalette) || (!isMoving && !hasSubtractivePalette)))
+                    return OriginalHook(SubtractivePalette);
+            }
             return actionID;
         }
     }

--- a/WrathCombo/Combos/PvP/RDMPVP.cs
+++ b/WrathCombo/Combos/PvP/RDMPVP.cs
@@ -2,18 +2,16 @@
 using WrathCombo.Combos.PvE;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
-using WrathCombo.Window.Functions;
-using static WrathCombo.Combos.PvP.RDMPvP.Config;
 using static WrathCombo.Window.Functions.UserConfig;
+using static WrathCombo.Combos.PvP.RDMPvP.Config;
+
 
 namespace WrathCombo.Combos.PvP;
 
 internal static class RDMPvP
 {
-        #region IDs
-
+    #region IDs
     internal class Role : PvPCaster;
-
     public const uint
         EnchantedRiposte = 41488,
         Resolution = 41492,
@@ -44,16 +42,14 @@ internal static class RDMPvP
             PrefulgenceReady = 4322,
             ThornedFlourish = 4321;
     }
-
     public static class Debuffs
     {
         public const ushort
             Monomachy = 3242;
     }
+    #endregion
 
-        #endregion
-
-        #region Config
+    #region Config
     public static class Config
     {
         internal static UserInt
@@ -62,7 +58,8 @@ internal static class RDMPvP
             RDMPvP_Displacement_Charges = new("RDMPvP_Displacement_Charges", 1),
             RDMPvP_Forte_PlayerHP = new("RDMPvP_Forte_PlayerHP", 50),
             RDMPvP_Resolution_TargetHP = new("RDMPvP_Resolution_TargetHP", 50),
-            RDMPvP_PhantomDartThreshold = new("RDMPvP_PhantomDartThreshold", 50);
+            RDMPvP_PhantomDartThreshold = new("RDMPvP_PhantomDartThreshold", 50),
+            RDMPvP_Dash_Feature_PurifyMPThreshold = new("RDMPvP_Dash_Feature_PurifyMPThreshold", 5000);
 
         public static UserBool
             RDMPvP_Forte_SubOption = new("RDMPvP_Forte_SubOption"),
@@ -76,51 +73,47 @@ internal static class RDMPvP
                 // Resolution
                 case Preset.RDMPvP_Resolution:
                     DrawSliderInt(10, 100, RDMPvP_Resolution_TargetHP, "Target HP%", 210);
-
                     break;
 
                 // Embolden / Prefulgence
                 case Preset.RDMPvP_Embolden:
                     DrawAdditionalBoolChoice(RDMPvP_Embolden_SubOption, "Prefulgence Option",
                         "Uses Prefulgence when available.");
-
                     break;
 
                 // Corps-a-Corps
                 case Preset.RDMPvP_Corps:
-                    DrawSliderInt(0, 1, RDMPvP_Corps_Charges, "Charges to Keep", 178);
-                    DrawSliderInt(5, 10, RDMPvP_Corps_Range, "Maximum Range", 173);
-
+                    DrawSliderInt(0, 1, RDMPvP_Corps_Charges, "Charges to Keep", 1);
+                    DrawSliderInt(5, 10, RDMPvP_Corps_Range, "Maximum Range", 5);
                     break;
 
                 // Displacement
                 case Preset.RDMPvP_Displacement:
-                    DrawSliderInt(0, 1, RDMPvP_Displacement_Charges, "Charges to Keep", 178);
+                    DrawSliderInt(0, 1, RDMPvP_Displacement_Charges, "Charges to Keep", 1);
                     ImGui.Spacing();
-                    DrawAdditionalBoolChoice(RDMPvP_Displacement_SubOption, "No Movement Option",
-                        "Uses Displacement only when not moving.");
+                    DrawAdditionalBoolChoice(RDMPvP_Displacement_SubOption, "No Movement Option", "Uses Displacement only when not moving.");
 
                     break;
 
                 // Forte / Vice of Thorns
                 case Preset.RDMPvP_Forte:
-                    DrawSliderInt(10, 100, RDMPvP_Forte_PlayerHP, "Player HP%", 210);
+                    DrawSliderInt(10, 100, RDMPvP_Forte_PlayerHP, "Player HP%", 10);
                     ImGui.Spacing();
-                    DrawAdditionalBoolChoice(RDMPvP_Forte_SubOption, "Vice of Thorns Option",
-                        "Uses Vice of Thorns when available.");
-
+                    DrawAdditionalBoolChoice(RDMPvP_Forte_SubOption, "Vice of Thorns Option", "Uses Vice of Thorns when available.");
                     break;
 
                 // Phantom Dart
                 case Preset.RDMPvP_PhantomDart:
-                    UserConfig.DrawSliderInt(1, 100, RDMPvP_PhantomDartThreshold,
-                        "Target HP% to use Phantom Dart at or below");
-
+                    DrawSliderInt(1, 100, RDMPvP_PhantomDartThreshold, "Target HP% to use Phantom Dart at or below");
+                    break;
+                
+                case Preset.RDMPvP_Dash_Feature:
+                    DrawSliderInt(2500, 10000, RDMPvP_Dash_Feature_PurifyMPThreshold, "Do not use Purify below set MP.");
                     break;
             }
         }
     }
-        #endregion
+    #endregion
 
     internal class RDMPvP_BurstMode : CustomCombo
     {
@@ -128,145 +121,132 @@ internal static class RDMPvP
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Jolt3)
+            if (actionID is not Jolt3) return actionID;
+
+            #region Variables
+            float targetDistance = GetTargetDistance();
+            float targetCurrentPercentHp = GetTargetHPPercent();
+            float playerCurrentPercentHp = PlayerHealthPercentageHp();
+            uint chargesCorps = HasCharges(CorpsACorps) ? GetCooldown(CorpsACorps).RemainingCharges : 0;
+            uint chargesDisplacement = HasCharges(Displacement) ? GetCooldown(Displacement).RemainingCharges : 0;
+            bool isMoving = IsMoving();
+            bool inCombat = InCombat();
+            bool hasTarget = HasTarget();
+            bool isTargetNPC = CurrentTarget is IBattleNpc && CurrentTarget.DataId != 8016;
+            bool inMeleeRange = targetDistance <= 5;
+            bool hasBind = HasStatusEffect(PvPCommon.Debuffs.Bind, anyOwner: true);
+            bool isCorpsAvailable = chargesCorps > 0 && !hasBind;
+            bool hasScorch = OriginalHook(EnchantedRiposte) is Scorch;
+            bool hasViceOfThorns = OriginalHook(Forte) is ViceOfThorns;
+            bool hasPrefulgence = OriginalHook(Embolden) is Prefulgence;
+            bool hasGrandImpact = OriginalHook(actionID) is GrandImpact;
+            bool targetHasGuard = HasStatusEffect(PvPCommon.Buffs.Guard, CurrentTarget, true);
+            bool hasForte = IsOffCooldown(Forte) && OriginalHook(Forte) is Forte;
+            bool hasEmbolden = IsOffCooldown(Embolden) && OriginalHook(Embolden) is Embolden;
+            bool isEmboldenDelayDependant = !JustUsed(Embolden, 5f) || IsOnCooldown(EnchantedRiposte);
+            bool hasMeleeCombo = OriginalHook(EnchantedRiposte) is EnchantedZwerchhau or EnchantedRedoublement;
+            bool isEnabledViceOfThorns = IsEnabled(Preset.RDMPvP_Forte) && RDMPvP_Forte_SubOption;
+            bool isEnabledPrefulgence = IsEnabled(Preset.RDMPvP_Embolden) && RDMPvP_Embolden_SubOption;
+            bool hasEnchantedRiposte = IsOffCooldown(EnchantedRiposte) && OriginalHook(EnchantedRiposte) is EnchantedRiposte;
+            bool isViceOfThornsExpiring = HasStatusEffect(Buffs.ThornedFlourish) && GetStatusEffectRemainingTime(Buffs.ThornedFlourish) <= 3;
+            bool isPrefulgenceExpiring = HasStatusEffect(Buffs.PrefulgenceReady) && GetStatusEffectRemainingTime(Buffs.PrefulgenceReady) <= 3;
+            bool isMovementDependant = !RDMPvP_Displacement_SubOption || (RDMPvP_Displacement_SubOption && !isMoving);
+            bool targetHasImmunity = HasStatusEffect(PLDPvP.Buffs.HallowedGround, CurrentTarget, true) || HasStatusEffect(DRKPvP.Buffs.UndeadRedemption, CurrentTarget, true);
+            bool isDisplacementPrimed = !hasBind && !JustUsed(Displacement, 8f) && !HasStatusEffect(Buffs.Displacement) && hasScorch && inMeleeRange;
+            bool isCorpsPrimed = !hasBind && !JustUsed(CorpsACorps, 8f) && chargesCorps > RDMPvP_Corps_Charges && targetDistance <= RDMPvP_Corps_Range;
+            #endregion
+
+            // Forte
+            if (IsEnabled(Preset.RDMPvP_Forte) && hasForte && inCombat &&
+                playerCurrentPercentHp < RDMPvP_Forte_PlayerHP)
+                return OriginalHook(Forte);
+
+            if (hasTarget && !targetHasImmunity)
             {
-                    #region Variables
-                float targetDistance = GetTargetDistance();
-                float targetCurrentPercentHp = GetTargetHPPercent();
-                float playerCurrentPercentHp = PlayerHealthPercentageHp();
-                uint chargesCorps = HasCharges(CorpsACorps) ? GetCooldown(CorpsACorps).RemainingCharges : 0;
-                uint chargesDisplacement = HasCharges(Displacement) ? GetCooldown(Displacement).RemainingCharges : 0;
-                bool isMoving = IsMoving();
-                bool inCombat = InCombat();
-                bool hasTarget = HasTarget();
-                bool isTargetNPC = CurrentTarget is IBattleNpc && CurrentTarget.DataId != 8016;
-                bool inMeleeRange = targetDistance <= 5;
-                bool hasBind = HasStatusEffect(PvPCommon.Debuffs.Bind, anyOwner: true);
-                bool isCorpsAvailable = chargesCorps > 0 && !hasBind;
-                bool hasScorch = OriginalHook(EnchantedRiposte) is Scorch;
-                bool hasViceOfThorns = OriginalHook(Forte) is ViceOfThorns;
-                bool hasPrefulgence = OriginalHook(Embolden) is Prefulgence;
-                bool hasGrandImpact = OriginalHook(actionID) is GrandImpact;
-                bool targetHasGuard = HasStatusEffect(PvPCommon.Buffs.Guard, CurrentTarget, true);
-                bool hasForte = IsOffCooldown(Forte) && OriginalHook(Forte) is Forte;
-                bool hasEmbolden = IsOffCooldown(Embolden) && OriginalHook(Embolden) is Embolden;
-                bool isEmboldenDelayDependant = !JustUsed(Embolden, 5f) || IsOnCooldown(EnchantedRiposte);
-                bool hasMeleeCombo = OriginalHook(EnchantedRiposte) is EnchantedZwerchhau or EnchantedRedoublement;
-                bool isEnabledViceOfThorns = IsEnabled(Preset.RDMPvP_Forte) && RDMPvP_Forte_SubOption;
-                bool isEnabledPrefulgence = IsEnabled(Preset.RDMPvP_Embolden) && RDMPvP_Embolden_SubOption;
-                bool hasEnchantedRiposte = IsOffCooldown(EnchantedRiposte) && OriginalHook(EnchantedRiposte) is EnchantedRiposte;
-                bool isViceOfThornsExpiring = HasStatusEffect(Buffs.ThornedFlourish) && GetStatusEffectRemainingTime(Buffs.ThornedFlourish) <= 3;
-                bool isPrefulgenceExpiring = HasStatusEffect(Buffs.PrefulgenceReady) && GetStatusEffectRemainingTime(Buffs.PrefulgenceReady) <= 3;
-                bool isMovementDependant = !RDMPvP_Displacement_SubOption || (RDMPvP_Displacement_SubOption && !isMoving);
-                bool targetHasImmunity = HasStatusEffect(PLDPvP.Buffs.HallowedGround, CurrentTarget, true) || HasStatusEffect(DRKPvP.Buffs.UndeadRedemption, CurrentTarget, true);
-                bool isDisplacementPrimed = !hasBind && !JustUsed(Displacement, 8f) && !HasStatusEffect(Buffs.Displacement) && hasScorch && inMeleeRange;
-                bool isCorpsPrimed = !hasBind && !JustUsed(CorpsACorps, 8f) && chargesCorps > RDMPvP_Corps_Charges && targetDistance <= RDMPvP_Corps_Range;
-                    #endregion
-
-                // Forte
-                if (IsEnabled(Preset.RDMPvP_Forte) && hasForte && inCombat &&
-                    playerCurrentPercentHp < RDMPvP_Forte_PlayerHP)
-                    return OriginalHook(Forte);
-
-                if (hasTarget && !targetHasImmunity)
+                if (!targetHasGuard)
                 {
-                    if (!targetHasGuard)
-                    {
-                        if (IsEnabled(Preset.RDMPvP_PhantomDart) && Role.CanPhantomDart() && CanWeave() && GetTargetHPPercent() <= (RDMPvP_PhantomDartThreshold))
-                            return Role.PhantomDart;
+                    if (IsEnabled(Preset.RDMPvP_PhantomDart) && Role.CanPhantomDart() && CanWeave() && GetTargetHPPercent() <= (RDMPvP_PhantomDartThreshold))
+                        return Role.PhantomDart;
 
-                        // Vice of Thorns
-                        if (isEnabledViceOfThorns && hasViceOfThorns && (!isTargetNPC || isViceOfThornsExpiring))
-                            return OriginalHook(Forte);
+                    // Vice of Thorns
+                    if (isEnabledViceOfThorns && hasViceOfThorns && (!isTargetNPC || isViceOfThornsExpiring))
+                        return OriginalHook(Forte);
 
-                        // Displacement
-                        if (IsEnabled(Preset.RDMPvP_Displacement) && isDisplacementPrimed &&
-                            isMovementDependant && chargesDisplacement > RDMPvP_Displacement_Charges)
-                            return OriginalHook(Displacement);
-                    }
-
-                    if (hasEnchantedRiposte)
-                    {
-                        // Embolden
-                        if (IsEnabled(Preset.RDMPvP_Embolden) && hasEmbolden)
-                        {
-                            // Combo Setting
-                            if (IsEnabled(Preset.RDMPvP_Corps) && (isCorpsPrimed || (!isCorpsPrimed && inMeleeRange)))
-                                return OriginalHook(Embolden);
-
-                            // Solo Setting
-                            if (IsNotEnabled(Preset.RDMPvP_Corps) && (inMeleeRange || (inCombat && isCorpsAvailable)))
-                                return OriginalHook(Embolden);
-                        }
-
-                        // Corps-a-Corps
-                        if (IsEnabled(Preset.RDMPvP_Corps) && isCorpsPrimed)
-                            return OriginalHook(CorpsACorps);
-                    }
-
-                    // Riposte Combo
-                    if (IsEnabled(Preset.RDMPvP_Riposte) && inMeleeRange && (hasEnchantedRiposte || hasMeleeCombo))
-                        return OriginalHook(EnchantedRiposte);
-
-                    // Prefulgence
-                    if (isEnabledPrefulgence && hasPrefulgence && isEmboldenDelayDependant)
-                    {
-                        // Conditional
-                        if (isPrefulgenceExpiring || playerCurrentPercentHp < 50)
-                            return OriginalHook(Embolden);
-
-                        // Offensive
-                        if (!targetHasGuard && !hasScorch)
-                            return OriginalHook(Embolden);
-                    }
-
-                    if (!targetHasGuard)
-                    {
-                        // Scorch
-                        if (IsEnabled(Preset.RDMPvP_Riposte) && hasScorch)
-                            return OriginalHook(EnchantedRiposte);
-
-                        // Resolution
-                        if (IsEnabled(Preset.RDMPvP_Resolution) && IsOffCooldown(Resolution) &&
-                            !isTargetNPC && targetCurrentPercentHp < RDMPvP_Resolution_TargetHP)
-                            return OriginalHook(Resolution);
-                    }
+                    // Displacement
+                    if (IsEnabled(Preset.RDMPvP_Displacement) && isDisplacementPrimed &&
+                        isMovementDependant && chargesDisplacement > RDMPvP_Displacement_Charges)
+                        return OriginalHook(Displacement);
                 }
 
-                // Grand Impact / Jolt III
-                return hasGrandImpact || !isMoving ? OriginalHook(actionID) : All.SavageBlade;
+                if (hasEnchantedRiposte)
+                {
+                    // Embolden
+                    if (IsEnabled(Preset.RDMPvP_Embolden) && hasEmbolden)
+                    {
+                        // Combo Setting
+                        if (IsEnabled(Preset.RDMPvP_Corps) && (isCorpsPrimed || (!isCorpsPrimed && inMeleeRange)))
+                            return OriginalHook(Embolden);
+
+                        // Solo Setting
+                        if (IsNotEnabled(Preset.RDMPvP_Corps) && (inMeleeRange || (inCombat && isCorpsAvailable)))
+                            return OriginalHook(Embolden);
+                    }
+
+                    // Corps-a-Corps
+                    if (IsEnabled(Preset.RDMPvP_Corps) && isCorpsPrimed)
+                        return OriginalHook(CorpsACorps);
+                }
+
+                // Riposte Combo
+                if (IsEnabled(Preset.RDMPvP_Riposte) && inMeleeRange && (hasEnchantedRiposte || hasMeleeCombo))
+                    return OriginalHook(EnchantedRiposte);
+
+                // Prefulgence
+                if (isEnabledPrefulgence && hasPrefulgence && isEmboldenDelayDependant)
+                {
+                    // Conditional
+                    if (isPrefulgenceExpiring || playerCurrentPercentHp < 50)
+                        return OriginalHook(Embolden);
+
+                    // Offensive
+                    if (!targetHasGuard && !hasScorch)
+                        return OriginalHook(Embolden);
+                }
+
+                if (!targetHasGuard)
+                {
+                    // Scorch
+                    if (IsEnabled(Preset.RDMPvP_Riposte) && hasScorch)
+                        return OriginalHook(EnchantedRiposte);
+
+                    // Resolution
+                    if (IsEnabled(Preset.RDMPvP_Resolution) && IsOffCooldown(Resolution) &&
+                        !isTargetNPC && targetCurrentPercentHp < RDMPvP_Resolution_TargetHP)
+                        return OriginalHook(Resolution);
+                }
             }
 
-            return actionID;
+            // Grand Impact / Jolt III
+            return hasGrandImpact || !isMoving ? OriginalHook(actionID) : All.SavageBlade;
+
         }
     }
-
     internal class RDMPvP_Dash_Feature : CustomCombo
     {
         protected internal override Preset Preset => Preset.RDMPvP_Dash_Feature;
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is CorpsACorps)
-            {
-                bool hasCrowdControl = HasStatusEffect(PvPCommon.Debuffs.Stun, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.DeepFreeze, anyOwner: true) ||
-                                       HasStatusEffect(PvPCommon.Debuffs.Bind, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.Silence, anyOwner: true) ||
-                                       HasStatusEffect(PvPCommon.Debuffs.MiracleOfNature, anyOwner: true);
-
-                if (HasCharges(CorpsACorps) && IsOffCooldown(PvPCommon.Purify) && hasCrowdControl)
-                    return OriginalHook(PvPCommon.Purify);
-            }
-
-            if (actionID is Displacement)
-            {
-                bool hasCrowdControl = HasStatusEffect(PvPCommon.Debuffs.Stun, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.DeepFreeze, anyOwner: true) ||
-                                       HasStatusEffect(PvPCommon.Debuffs.Bind, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.Silence, anyOwner: true) ||
-                                       HasStatusEffect(PvPCommon.Debuffs.MiracleOfNature, anyOwner: true);
-
-                if (HasCharges(Displacement) && IsOffCooldown(PvPCommon.Purify) && hasCrowdControl)
-                    return OriginalHook(PvPCommon.Purify);
-            }
-
+            if (actionID is not (CorpsACorps or Displacement)) 
+                return actionID;
+            
+            bool hasCrowdControl = HasStatusEffect(PvPCommon.Debuffs.Stun, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.DeepFreeze, anyOwner: true) ||
+                                   HasStatusEffect(PvPCommon.Debuffs.Bind, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.Silence, anyOwner: true) ||
+                                   HasStatusEffect(PvPCommon.Debuffs.MiracleOfNature, anyOwner: true);
+            
+            if (HasCharges(CorpsACorps) && IsOffCooldown(PvPCommon.Purify) && !hasCrowdControl && LocalPlayer.CurrentMp >= RDMPvP_Dash_Feature_PurifyMPThreshold)
+                return OriginalHook(PvPCommon.Purify);
+           
             return actionID;
         }
     }

--- a/WrathCombo/Combos/PvP/RDMPVP.cs
+++ b/WrathCombo/Combos/PvP/RDMPVP.cs
@@ -72,7 +72,7 @@ internal static class RDMPvP
             {
                 // Resolution
                 case Preset.RDMPvP_Resolution:
-                    DrawSliderInt(10, 100, RDMPvP_Resolution_TargetHP, "Target HP%", 210);
+                    DrawSliderInt(10, 100, RDMPvP_Resolution_TargetHP, "Target HP%");
                     break;
 
                 // Embolden / Prefulgence
@@ -83,22 +83,19 @@ internal static class RDMPvP
 
                 // Corps-a-Corps
                 case Preset.RDMPvP_Corps:
-                    DrawSliderInt(0, 1, RDMPvP_Corps_Charges, "Charges to Keep", 1);
-                    DrawSliderInt(5, 10, RDMPvP_Corps_Range, "Maximum Range", 5);
+                    DrawSliderInt(0, 1, RDMPvP_Corps_Charges, "Charges to Keep");
+                    DrawSliderInt(5, 10, RDMPvP_Corps_Range, "Maximum Range");
                     break;
 
                 // Displacement
                 case Preset.RDMPvP_Displacement:
-                    DrawSliderInt(0, 1, RDMPvP_Displacement_Charges, "Charges to Keep", 1);
-                    ImGui.Spacing();
+                    DrawSliderInt(0, 1, RDMPvP_Displacement_Charges, "Charges to Keep");
                     DrawAdditionalBoolChoice(RDMPvP_Displacement_SubOption, "No Movement Option", "Uses Displacement only when not moving.");
-
                     break;
 
                 // Forte / Vice of Thorns
                 case Preset.RDMPvP_Forte:
-                    DrawSliderInt(10, 100, RDMPvP_Forte_PlayerHP, "Player HP%", 10);
-                    ImGui.Spacing();
+                    DrawSliderInt(10, 100, RDMPvP_Forte_PlayerHP, "Player HP%");
                     DrawAdditionalBoolChoice(RDMPvP_Forte_SubOption, "Vice of Thorns Option", "Uses Vice of Thorns when available.");
                     break;
 

--- a/WrathCombo/Combos/PvP/RDMPVP.cs
+++ b/WrathCombo/Combos/PvP/RDMPVP.cs
@@ -241,7 +241,7 @@ internal static class RDMPvP
                                    HasStatusEffect(PvPCommon.Debuffs.Bind, anyOwner: true) || HasStatusEffect(PvPCommon.Debuffs.Silence, anyOwner: true) ||
                                    HasStatusEffect(PvPCommon.Debuffs.MiracleOfNature, anyOwner: true);
             
-            if (HasCharges(CorpsACorps) && IsOffCooldown(PvPCommon.Purify) && !hasCrowdControl && LocalPlayer.CurrentMp >= RDMPvP_Dash_Feature_PurifyMPThreshold)
+            if (HasCharges(CorpsACorps) && IsOffCooldown(PvPCommon.Purify) && hasCrowdControl && LocalPlayer.CurrentMp >= RDMPvP_Dash_Feature_PurifyMPThreshold)
                 return OriginalHook(PvPCommon.Purify);
            
             return actionID;

--- a/WrathCombo/Combos/PvP/SAMPVP.cs
+++ b/WrathCombo/Combos/PvP/SAMPVP.cs
@@ -1,15 +1,14 @@
 ﻿using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
-using WrathCombo.Window.Functions;
+using static WrathCombo.Window.Functions.UserConfig;
 using static WrathCombo.Combos.PvP.SAMPvP.Config;
 
 namespace WrathCombo.Combos.PvP;
 
 internal static class SAMPvP
 {
-        #region IDS
+    #region IDS
     internal class Role : PvPMelee;
-
     public const uint
         KashaCombo = 58,
         Yukikaze = 29523,
@@ -45,9 +44,9 @@ internal static class SAMPvP
         public const ushort
             Kuzushi = 3202;
     }
-        #endregion
+    #endregion
 
-        #region Config
+    #region Config
     public static class Config
     {
         public static UserInt
@@ -67,40 +66,31 @@ internal static class SAMPvP
             {
                 // Chiten
                 case Preset.SAMPvP_Chiten:
-                    UserConfig.DrawSliderInt(10, 100, SAMPvP_Chiten_PlayerHP, "Player HP%", 210);
-
+                    DrawSliderInt(10, 100, SAMPvP_Chiten_PlayerHP, "Player HP%", 10);
                     break;
 
                 // Mineuchi
                 case Preset.SAMPvP_Mineuchi:
-                    UserConfig.DrawSliderInt(10, 100, SAMPvP_Mineuchi_TargetHP, "Target HP%", 210);
-
-                    UserConfig.DrawAdditionalBoolChoice(SAMPvP_Mineuchi_SubOption, "Burst Preparation",
-                        "Also uses Mineuchi before Tendo Setsugekka.");
-
+                    DrawSliderInt(10, 100, SAMPvP_Mineuchi_TargetHP, "Target HP%", 10);
+                    DrawAdditionalBoolChoice(SAMPvP_Mineuchi_SubOption, "Burst Preparation", "Also uses Mineuchi before Tendo Setsugekka.");
                     break;
 
                 // Soten
                 case Preset.SAMPvP_Soten:
-                    UserConfig.DrawSliderInt(0, 2, SAMPvP_Soten_Charges, "Charges to Keep", 178);
-                    UserConfig.DrawSliderInt(1, 10, SAMPvP_Soten_Range, "Maximum Range", 173);
-
-                    UserConfig.DrawAdditionalBoolChoice(SAMPvP_Soten_SubOption, "Yukikaze Only",
-                        "Also requires next weaponskill to be Yukikaze.");
-
+                    DrawSliderInt(0, 2, SAMPvP_Soten_Charges, "Charges to Keep", 1);
+                    DrawSliderInt(1, 10, SAMPvP_Soten_Range, "Maximum Range", 10);
+                    DrawAdditionalBoolChoice(SAMPvP_Soten_SubOption, "Yukikaze Only", "Also requires next weaponskill to be Yukikaze.");
                     break;
 
                 // Smite
                 case Preset.SAMPvP_Smite:
-                    UserConfig.DrawSliderInt(0, 100, SAMPvP_SmiteThreshold,
+                    DrawSliderInt(0, 100, SAMPvP_SmiteThreshold,
                         "Target HP% to smite, Max damage below 25%");
-
                     break;
-
             }
         }
     }
-        #endregion
+    #endregion
        
     internal class SAMPvP_BurstMode : CustomCombo
     {
@@ -108,95 +98,93 @@ internal static class SAMPvP
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Yukikaze or Gekko or Kasha)
+            if (actionID is not (Yukikaze or Gekko or Kasha)) return actionID;
+
+            #region Variables
+            float targetDistance = GetTargetDistance();
+            float targetCurrentPercentHp = GetTargetHPPercent();
+            float playerCurrentPercentHp = PlayerHealthPercentageHp();
+            uint chargesSoten = HasCharges(Soten) ? GetCooldown(Soten).RemainingCharges : 0;
+            bool isMoving = IsMoving();
+            bool inCombat = InCombat();
+            bool hasTarget = HasTarget();
+            bool inMeleeRange = targetDistance <= 5;
+            bool hasKaiten = HasStatusEffect(Buffs.Kaiten);
+            bool hasZanshin = OriginalHook(Chiten) is Zanshin;
+            bool hasBind = HasStatusEffect(PvPCommon.Debuffs.Bind, anyOwner: true);
+            bool targetHasImmunity = PvPCommon.TargetImmuneToDamage();
+            bool isTargetPrimed = hasTarget && !targetHasImmunity;
+            bool targetHasKuzushi = HasStatusEffect(Debuffs.Kuzushi, CurrentTarget);
+            bool hasKaeshiNamikiri = OriginalHook(OgiNamikiri) is Kaeshi;
+            bool hasTendo = OriginalHook(MeikyoShisui) is TendoSetsugekka;
+            bool isYukikazePrimed = ComboTimer == 0 || ComboAction is Kasha;
+            bool hasTendoKaeshi = OriginalHook(MeikyoShisui) is TendoKaeshiSetsugekka;
+            bool hasPrioWeaponskill = hasTendo || hasTendoKaeshi || hasKaeshiNamikiri;
+            bool isMeikyoPrimed = IsOnCooldown(OgiNamikiri) && !hasKaeshiNamikiri && !hasKaiten && !isMoving;
+            bool isZantetsukenPrimed = IsLB1Ready && !hasBind && hasTarget && targetHasKuzushi && targetDistance <= 20;
+            bool isSotenPrimed = chargesSoten > SAMPvP_Soten_Charges && !hasKaiten && !hasBind && !hasPrioWeaponskill;
+            bool isTargetInvincible = HasStatusEffect(PLDPvP.Buffs.HallowedGround, CurrentTarget, true) || HasStatusEffect(DRKPvP.Buffs.UndeadRedemption, CurrentTarget, true);
+            #endregion
+
+            // Zantetsuken
+            if (IsEnabled(Preset.SAMPvP_Zantetsuken) && isZantetsukenPrimed && !isTargetInvincible)
+                return OriginalHook(Zantetsuken);
+
+            //Smite
+            if (IsEnabled(Preset.SAMPvP_Smite) && PvPMelee.CanSmite() && !PvPCommon.TargetImmuneToDamage() && GetTargetDistance() <= 10 && HasTarget() &&
+                GetTargetHPPercent() <= SAMPvP_SmiteThreshold)
+                return PvPMelee.Smite;
+
+            // Chiten
+            if (IsEnabled(Preset.SAMPvP_Chiten) && IsOffCooldown(Chiten) && inCombat && playerCurrentPercentHp < SAMPvP_Chiten_PlayerHP)
+                return OriginalHook(Chiten);
+
+            if (isTargetPrimed)
             {
-                    #region Variables
-                float targetDistance = GetTargetDistance();
-                float targetCurrentPercentHp = GetTargetHPPercent();
-                float playerCurrentPercentHp = PlayerHealthPercentageHp();
-                uint chargesSoten = HasCharges(Soten) ? GetCooldown(Soten).RemainingCharges : 0;
-                bool isMoving = IsMoving();
-                bool inCombat = InCombat();
-                bool hasTarget = HasTarget();
-                bool inMeleeRange = targetDistance <= 5;
-                bool hasKaiten = HasStatusEffect(Buffs.Kaiten);
-                bool hasZanshin = OriginalHook(Chiten) is Zanshin;
-                bool hasBind = HasStatusEffect(PvPCommon.Debuffs.Bind, anyOwner: true);
-                bool targetHasImmunity = PvPCommon.TargetImmuneToDamage();
-                bool isTargetPrimed = hasTarget && !targetHasImmunity;
-                bool targetHasKuzushi = HasStatusEffect(Debuffs.Kuzushi, CurrentTarget);
-                bool hasKaeshiNamikiri = OriginalHook(OgiNamikiri) is Kaeshi;
-                bool hasTendo = OriginalHook(MeikyoShisui) is TendoSetsugekka;
-                bool isYukikazePrimed = ComboTimer == 0 || ComboAction is Kasha;
-                bool hasTendoKaeshi = OriginalHook(MeikyoShisui) is TendoKaeshiSetsugekka;
-                bool hasPrioWeaponskill = hasTendo || hasTendoKaeshi || hasKaeshiNamikiri;
-                bool isMeikyoPrimed = IsOnCooldown(OgiNamikiri) && !hasKaeshiNamikiri && !hasKaiten && !isMoving;
-                bool isZantetsukenPrimed = IsLB1Ready && !hasBind && hasTarget && targetHasKuzushi && targetDistance <= 20;
-                bool isSotenPrimed = chargesSoten > SAMPvP_Soten_Charges && !hasKaiten && !hasBind && !hasPrioWeaponskill;
-                bool isTargetInvincible = HasStatusEffect(PLDPvP.Buffs.HallowedGround, CurrentTarget, true) || HasStatusEffect(DRKPvP.Buffs.UndeadRedemption, CurrentTarget, true);
-                    #endregion
-
-                // Zantetsuken
-                if (IsEnabled(Preset.SAMPvP_Zantetsuken) && isZantetsukenPrimed && !isTargetInvincible)
-                    return OriginalHook(Zantetsuken);
-
-                //Smite
-                if (IsEnabled(Preset.SAMPvP_Smite) && PvPMelee.CanSmite() && !PvPCommon.TargetImmuneToDamage() && GetTargetDistance() <= 10 && HasTarget() &&
-                    GetTargetHPPercent() <= SAMPvP_SmiteThreshold)
-                    return PvPMelee.Smite;
-
-                // Chiten
-                if (IsEnabled(Preset.SAMPvP_Chiten) && IsOffCooldown(Chiten) && inCombat && playerCurrentPercentHp < SAMPvP_Chiten_PlayerHP)
+                // Zanshin
+                if (hasZanshin && targetDistance <= 8)
                     return OriginalHook(Chiten);
 
-                if (isTargetPrimed)
+                // Soten
+                if (IsEnabled(Preset.SAMPvP_Soten) && isSotenPrimed && targetDistance <= SAMPvP_Soten_Range &&
+                    (!SAMPvP_Soten_SubOption || (SAMPvP_Soten_SubOption && isYukikazePrimed)))
+                    return OriginalHook(Soten);
+
+                if (inMeleeRange)
                 {
-                    // Zanshin
-                    if (hasZanshin && targetDistance <= 8)
-                        return OriginalHook(Chiten);
-
-                    // Soten
-                    if (IsEnabled(Preset.SAMPvP_Soten) && isSotenPrimed && targetDistance <= SAMPvP_Soten_Range &&
-                        (!SAMPvP_Soten_SubOption || (SAMPvP_Soten_SubOption && isYukikazePrimed)))
-                        return OriginalHook(Soten);
-
-                    if (inMeleeRange)
-                    {
-                        // Meikyo Shisui
-                        if (IsEnabled(Preset.SAMPvP_Meikyo) && IsOffCooldown(MeikyoShisui) && isMeikyoPrimed)
-                            return OriginalHook(MeikyoShisui);
-
-                        // Mineuchi
-                        if (IsEnabled(Preset.SAMPvP_Mineuchi) && IsOffCooldown(Mineuchi) && !HasBattleTarget() &&
-                            (targetCurrentPercentHp < SAMPvP_Mineuchi_TargetHP || (SAMPvP_Mineuchi_SubOption && hasTendo && !hasKaiten)))
-                            return OriginalHook(Mineuchi);
-                    }
-                }
-
-                // Tendo Kaeshi Setsugekka
-                if (hasTendoKaeshi)
-                    return OriginalHook(MeikyoShisui);
-
-                // Kaeshi Namikiri
-                if (hasKaeshiNamikiri)
-                    return OriginalHook(OgiNamikiri);
-
-                // Kaiten
-                if (hasKaiten)
-                    return OriginalHook(actionID);
-
-                if (!isMoving && isTargetPrimed)
-                {
-                    // Tendo Setsugekka
-                    if (hasTendo)
+                    // Meikyo Shisui
+                    if (IsEnabled(Preset.SAMPvP_Meikyo) && IsOffCooldown(MeikyoShisui) && isMeikyoPrimed)
                         return OriginalHook(MeikyoShisui);
 
-                    // Ogi Namikiri
-                    if (IsOffCooldown(OgiNamikiri))
-                        return OriginalHook(OgiNamikiri);
+                    // Mineuchi
+                    if (IsEnabled(Preset.SAMPvP_Mineuchi) && IsOffCooldown(Mineuchi) && !HasBattleTarget() &&
+                        (targetCurrentPercentHp < SAMPvP_Mineuchi_TargetHP || (SAMPvP_Mineuchi_SubOption && hasTendo && !hasKaiten)))
+                        return OriginalHook(Mineuchi);
                 }
             }
 
+            // Tendo Kaeshi Setsugekka
+            if (hasTendoKaeshi)
+                return OriginalHook(MeikyoShisui);
+
+            // Kaeshi Namikiri
+            if (hasKaeshiNamikiri)
+                return OriginalHook(OgiNamikiri);
+
+            // Kaiten
+            if (hasKaiten)
+                return OriginalHook(actionID);
+
+            if (!isMoving && isTargetPrimed)
+            {
+                // Tendo Setsugekka
+                if (hasTendo)
+                    return OriginalHook(MeikyoShisui);
+
+                // Ogi Namikiri
+                if (IsOffCooldown(OgiNamikiri))
+                    return OriginalHook(OgiNamikiri);
+            }
             return actionID;
         }
     }

--- a/WrathCombo/Combos/PvP/SAMPVP.cs
+++ b/WrathCombo/Combos/PvP/SAMPVP.cs
@@ -66,19 +66,19 @@ internal static class SAMPvP
             {
                 // Chiten
                 case Preset.SAMPvP_Chiten:
-                    DrawSliderInt(10, 100, SAMPvP_Chiten_PlayerHP, "Player HP%", 10);
+                    DrawSliderInt(10, 100, SAMPvP_Chiten_PlayerHP, "Player HP%");
                     break;
 
                 // Mineuchi
                 case Preset.SAMPvP_Mineuchi:
-                    DrawSliderInt(10, 100, SAMPvP_Mineuchi_TargetHP, "Target HP%", 10);
+                    DrawSliderInt(10, 100, SAMPvP_Mineuchi_TargetHP, "Target HP%");
                     DrawAdditionalBoolChoice(SAMPvP_Mineuchi_SubOption, "Burst Preparation", "Also uses Mineuchi before Tendo Setsugekka.");
                     break;
 
                 // Soten
                 case Preset.SAMPvP_Soten:
-                    DrawSliderInt(0, 2, SAMPvP_Soten_Charges, "Charges to Keep", 1);
-                    DrawSliderInt(1, 10, SAMPvP_Soten_Range, "Maximum Range", 10);
+                    DrawSliderInt(0, 2, SAMPvP_Soten_Charges, "Charges to Keep");
+                    DrawSliderInt(1, 10, SAMPvP_Soten_Range, "Maximum Range");
                     DrawAdditionalBoolChoice(SAMPvP_Soten_SubOption, "Yukikaze Only", "Also requires next weaponskill to be Yukikaze.");
                     break;
 

--- a/WrathCombo/Combos/PvP/SCHPVP.cs
+++ b/WrathCombo/Combos/PvP/SCHPVP.cs
@@ -1,16 +1,16 @@
-﻿using WrathCombo.CustomComboNS;
+﻿using Dalamud.Game.ClientState.Objects.Types;
+using WrathCombo.Core;
+using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
-using WrathCombo.Window.Functions;
+using static WrathCombo.Window.Functions.UserConfig;
 using static WrathCombo.Combos.PvP.SCHPvP.Config;
 
 namespace WrathCombo.Combos.PvP;
 
 internal static class SCHPvP
 {
-        #region IDS
-
+    #region IDS
     internal class Role : PvPHealer;
-
     public const uint
         Broil = 29231,
         Adloquilum = 29232,
@@ -32,11 +32,13 @@ internal static class SCHPvP
             Biolysis = 3089,
             Biolytic = 3090;
     }
-        #endregion
+    #endregion
 
-        #region Config
+    #region Config
     public static class Config
     {
+        public static UserBool
+            SCHPvP_Adlo_Retarget = new("SCHPvP_Adlo_Retarget");
         public static UserInt
             SCHPvP_DiabrosisThreshold = new("SCHPvP_DiabrosisThreshold"),
             SCHPvP_AdloThreshold = new("SCHPvP_AdloThreshold");
@@ -46,21 +48,18 @@ internal static class SCHPvP
             switch (preset)
             {
                 case Preset.SCHPvP_Diabrosis:
-                    UserConfig.DrawSliderInt(0, 100, SCHPvP_DiabrosisThreshold,
-                        "Target HP% to use Diabrosis");
-
+                    DrawSliderInt(0, 100, SCHPvP_DiabrosisThreshold, "Target HP% to use Diabrosis");
                     break;
 
-                case Preset.SCHPvP_Selfcare:
-                    UserConfig.DrawSliderInt(1, 100, SCHPvP_AdloThreshold,
-                        "Player HP% to use Adlo on self");
-
+                case Preset.SCHPvP_Adlo:
+                    DrawAdditionalBoolChoice(SCHPvP_Adlo_Retarget, "Retarget Adlo","Will use Heal stack.(In Wrath Settings)");
+                    DrawSliderInt(1, 100, SCHPvP_AdloThreshold, "HP% to use Adlo");
                     break;
+                
             }
         }
     }
-
-        #endregion
+    #endregion
           
     internal class SCHPvP_Burst : CustomCombo
     {
@@ -68,42 +67,55 @@ internal static class SCHPvP
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Broil && InCombat())
+            if (actionID is not Broil || !InCombat()) 
+                return actionID;
+            
+            // Uses Chain Stratagem when available
+            if (IsEnabled(Preset.SCHPvP_ChainStratagem) && IsOffCooldown(ChainStratagem))
+                return ChainStratagem;                    
+
+            // Uses Expedient when available and target isn't affected with Biolysis
+            if (IsEnabled(Preset.SCHPvP_Expedient) && IsOffCooldown(Expedient) && GetCooldownRemainingTime(Biolysis) < 3)
+                return Expedient;
+
+            // Uses Biolysis on cooldown or with Recitation when Expedient is enabled with safety for too long of an expedient cooldown. 
+            if (IsEnabled(Preset.SCHPvP_Biolysis) && IsOffCooldown(Biolysis))
             {
-                // Uses Chain Stratagem when available
-                if (IsEnabled(Preset.SCHPvP_ChainStratagem) && IsOffCooldown(ChainStratagem))
-                    return ChainStratagem;                    
-
-                // Uses Expedient when available and target isn't affected with Biolysis
-                if (IsEnabled(Preset.SCHPvP_Expedient) && IsOffCooldown(Expedient) && GetCooldownRemainingTime(Biolysis) < 3)
-                    return Expedient;
-
-                // Uses Biolysis on cooldown or with Recitation when Expedient is enabled with safety for too long of an expedient cooldown. 
-                if (IsEnabled(Preset.SCHPvP_Biolysis) && IsOffCooldown(Biolysis))
-                {
-                    if (IsEnabled(Preset.SCHPvP_Expedient))
-                    {
-                        if (HasStatusEffect(Buffs.Recitation) || GetCooldownRemainingTime(Expedient) > 5)
-                            return Biolysis;
-                    } 
+                if (IsNotEnabled(Preset.SCHPvP_Expedient) ||(HasStatusEffect(Buffs.Recitation) || GetCooldownRemainingTime(Expedient) > 5))
                     return Biolysis;
-                }
-
-                //Uses Diabrosis when below set health
-                if (IsEnabled(Preset.SCHPvP_Diabrosis) && PvPHealer.CanDiabrosis() && HasTarget() && 
-                    GetTargetHPPercent() <= SCHPvP_DiabrosisThreshold)
-                    return PvPHealer.Diabrosis;
-
-                // Uses Deployment Tactics when available
-                if (IsEnabled(Preset.SCHPvP_DeploymentTactics) && GetRemainingCharges(DeploymentTactics) > 1 && HasStatusEffect(Debuffs.Biolysis, CurrentTarget))
-                    return DeploymentTactics;
-
-                // Adds Adloquium when at or below threshold, will not Overwrite the 10% damage reduction buff to prevent waste
-                if (IsEnabled(Preset.SCHPvP_Selfcare) && !HasStatusEffect(Buffs.Catalyze) && PlayerHealthPercentageHp() <= SCHPvP_AdloThreshold)
-                    return Adloquilum;
             }
+            //Uses Diabrosis when below set health
+            if (IsEnabled(Preset.SCHPvP_Diabrosis) && PvPHealer.CanDiabrosis() && HasTarget() && 
+                GetTargetHPPercent() <= SCHPvP_DiabrosisThreshold)
+                return PvPHealer.Diabrosis;
 
+            // Uses Deployment Tactics when available
+            if (IsEnabled(Preset.SCHPvP_DeploymentTactics) && GetRemainingCharges(DeploymentTactics) > 1 && HasStatusEffect(Debuffs.Biolysis, CurrentTarget))
+                return DeploymentTactics;
+
+            // Adds Adloquium when at or below threshold, will not Overwrite the 10% damage reduction buff to prevent waste
+            if (IsEnabled(Preset.SCHPvP_Adlo))
+            {
+                IGameObject? healTarget = SCHPvP_Adlo_Retarget ? SimpleTarget.Stack.AllyToHeal : SimpleTarget.Stack.Allies;
+                
+                if (!HasStatusEffect(Buffs.Catalyze, healTarget) && GetTargetHPPercent(healTarget) <= SCHPvP_AdloThreshold)
+                    return SCHPvP_Adlo_Retarget
+                        ? Adloquilum.Retarget(Broil, healTarget, true)
+                        : Adloquilum;
+            }
             return actionID;
+        }
+    }
+    
+    internal class SCHPvP_RetargetAdlo : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.SCHPvP_RetargetAdlo;
+
+        protected override uint Invoke(uint actionID)
+        {
+            return actionID is not Adloquilum 
+                ? actionID 
+                : Adloquilum.Retarget(SimpleTarget.Stack.AllyToHeal);
         }
     }
 }

--- a/WrathCombo/Combos/PvP/SCHPVP.cs
+++ b/WrathCombo/Combos/PvP/SCHPVP.cs
@@ -96,7 +96,7 @@ internal static class SCHPvP
             // Adds Adloquium when at or below threshold, will not Overwrite the 10% damage reduction buff to prevent waste
             if (IsEnabled(Preset.SCHPvP_Adlo))
             {
-                IGameObject? healTarget = SCHPvP_Adlo_Retarget ? SimpleTarget.Stack.AllyToHeal : SimpleTarget.Stack.Allies;
+                IGameObject? healTarget = SCHPvP_Adlo_Retarget ? SimpleTarget.Stack.AllyToHealPVP : SimpleTarget.Stack.Allies;
                 
                 if (!HasStatusEffect(Buffs.Catalyze, healTarget) && GetTargetHPPercent(healTarget) <= SCHPvP_AdloThreshold)
                     return SCHPvP_Adlo_Retarget
@@ -115,7 +115,7 @@ internal static class SCHPvP
         {
             return actionID is not Adloquilum 
                 ? actionID 
-                : Adloquilum.Retarget(SimpleTarget.Stack.AllyToHeal);
+                : Adloquilum.Retarget(SimpleTarget.Stack.AllyToHealPVP);
         }
     }
 }

--- a/WrathCombo/Combos/PvP/SCHPVP.cs
+++ b/WrathCombo/Combos/PvP/SCHPVP.cs
@@ -98,7 +98,7 @@ internal static class SCHPvP
             {
                 IGameObject? healTarget = SCHPvP_Adlo_Retarget ? SimpleTarget.Stack.AllyToHealPVP : SimpleTarget.Stack.Allies;
                 
-                if (!HasStatusEffect(Buffs.Catalyze, healTarget) && GetTargetHPPercent(healTarget) <= SCHPvP_AdloThreshold)
+                if (!HasStatusEffect(Buffs.Catalyze, healTarget) && GetTargetHPPercent(healTarget) <= SCHPvP_AdloThreshold && ActionReady(Adloquilum))
                     return SCHPvP_Adlo_Retarget
                         ? Adloquilum.Retarget(Broil, healTarget, true)
                         : Adloquilum;

--- a/WrathCombo/Combos/PvP/SGEPVP.cs
+++ b/WrathCombo/Combos/PvP/SGEPVP.cs
@@ -1,16 +1,16 @@
-﻿using WrathCombo.CustomComboNS;
+﻿using Dalamud.Game.ClientState.Objects.Types;
+using WrathCombo.Core;
+using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
-using WrathCombo.Window.Functions;
+using static WrathCombo.Window.Functions.UserConfig;
 using static WrathCombo.Combos.PvP.SGEPvP.Config;
 
 namespace WrathCombo.Combos.PvP;
 
 internal static class SGEPvP
 {
-        #region IDS
-
+    #region IDS
     internal class Role : PvPHealer;
-
     internal const uint
         Dosis = 29256,
         Phlegma = 29259,
@@ -42,13 +42,15 @@ internal static class SGEPvP
             Haimatinon = 3111,
             Mesotes = 3119;
     }
+    #endregion
 
-        #endregion
-
-        #region Config
+    #region Config
     public static class Config
     {
+        public static UserBool
+            SGEPvP_BurstMode_KardiaReminder_Retarget = new("SGEPvP_BurstMode_KardiaReminder_Retarget");
         public static UserInt
+            SGEPvP_KardiaThreshold = new("SGEPvP_KardiaThreshold"),
             SGEPvP_DiabrosisThreshold = new("SGEPvP_DiabrosisThreshold");
 
         internal static void Draw(Preset preset)
@@ -56,15 +58,20 @@ internal static class SGEPvP
             switch (preset)
             {
                 case Preset.SGEPvP_Diabrosis:
-                    UserConfig.DrawSliderInt(0, 100, SGEPvP_DiabrosisThreshold,
-                        "Target HP% to use Diabrosis");
-
+                    DrawSliderInt(0, 100, SGEPvP_DiabrosisThreshold, "Target HP% to use Diabrosis");
+                    break;
+                
+                case Preset.SGEPvP_BurstMode_KardiaReminder:
+                    DrawAdditionalBoolChoice(SGEPvP_BurstMode_KardiaReminder_Retarget, "Mobile Kardia Option", "Retarget Kardia according to your heal stack. \nThis will move Kardia around via weaves. Will use Heal stack.(In Wrath Settings)");
+                    if (SGEPvP_BurstMode_KardiaReminder_Retarget)
+                    {
+                        DrawSliderInt(0, 100, SGEPvP_KardiaThreshold, "Minimum HP% to move Kardia. Set to 100% to disable this check. ");
+                    }
                     break;
             }
         }
     }
-
-        #endregion       
+    #endregion       
 
     internal class SGEPvP_BurstMode : CustomCombo
     {
@@ -72,42 +79,57 @@ internal static class SGEPvP
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID == Dosis)
+            if (actionID is not Dosis) return actionID;
+            if (IsEnabled(Preset.SGEPvP_BurstMode_KardiaReminder) && !HasStatusEffect(Buffs.Kardia, anyOwner: true))
+                return Kardia;
+
+            if (!PvPCommon.TargetImmuneToDamage())
             {
-                if (IsEnabled(Preset.SGEPvP_BurstMode_KardiaReminder) && !HasStatusEffect(Buffs.Kardia, anyOwner: true))
-                    return Kardia;
+                if (IsEnabled(Preset.SGEPvP_Diabrosis) && PvPHealer.CanDiabrosis() && HasTarget() &&
+                    GetTargetHPPercent() <= SGEPvP_DiabrosisThreshold)
+                    return PvPHealer.Diabrosis;
 
-                if (!PvPCommon.TargetImmuneToDamage())
-                {
-                    if (IsEnabled(Preset.SGEPvP_Diabrosis) && PvPHealer.CanDiabrosis() && HasTarget() &&
-                        GetTargetHPPercent() <= SGEPvP_DiabrosisThreshold)
-                        return PvPHealer.Diabrosis;
+                // Psyche after Phlegma
+                if (IsEnabled(Preset.SGEPvP_BurstMode_Psyche) && WasLastSpell(Phlegma))
+                    return Psyche;
 
-                    // Psyche after Phlegma
-                    if (IsEnabled(Preset.SGEPvP_BurstMode_Psyche) && WasLastSpell(Phlegma))
-                        return Psyche;
+                if (IsEnabled(Preset.SGEPvP_BurstMode_Pneuma) && !GetCooldown(Pneuma).IsCooldown)
+                    return Pneuma;
 
-                    if (IsEnabled(Preset.SGEPvP_BurstMode_Pneuma) && !GetCooldown(Pneuma).IsCooldown)
-                        return Pneuma;
+                if (IsEnabled(Preset.SGEPvP_BurstMode_Phlegma) && InMeleeRange() && !HasStatusEffect(Buffs.Eukrasia) && GetCooldown(Phlegma).RemainingCharges > 0)
+                    return Phlegma;
 
-                    if (IsEnabled(Preset.SGEPvP_BurstMode_Phlegma) && InMeleeRange() && !HasStatusEffect(Buffs.Eukrasia) && GetCooldown(Phlegma).RemainingCharges > 0)
-                        return Phlegma;
+                if (IsEnabled(Preset.SGEPvP_BurstMode_Toxikon2) && HasStatusEffect(Buffs.Addersting) && !HasStatusEffect(Buffs.Eukrasia))
+                    return Toxicon2;
 
-                    if (IsEnabled(Preset.SGEPvP_BurstMode_Toxikon2) && HasStatusEffect(Buffs.Addersting) && !HasStatusEffect(Buffs.Eukrasia))
-                        return Toxicon2;
+                if (IsEnabled(Preset.SGEPvP_BurstMode_Eukrasia) && !HasStatusEffect(Debuffs.EukrasianDosis, CurrentTarget, true) && GetCooldown(Eukrasia).RemainingCharges > 0 && !HasStatusEffect(Buffs.Eukrasia))
+                    return Eukrasia;
 
-                    if (IsEnabled(Preset.SGEPvP_BurstMode_Eukrasia) && !HasStatusEffect(Debuffs.EukrasianDosis, CurrentTarget, true) && GetCooldown(Eukrasia).RemainingCharges > 0 && !HasStatusEffect(Buffs.Eukrasia))
-                        return Eukrasia;
+                if (HasStatusEffect(Buffs.Eukrasia))
+                    return OriginalHook(Dosis);
 
-                    if (HasStatusEffect(Buffs.Eukrasia))
-                        return OriginalHook(Dosis);
-
-                    if (IsEnabled(Preset.SGEPvP_BurstMode_Toxikon) && !HasStatusEffect(Debuffs.Toxicon, CurrentTarget) && GetCooldown(Toxikon).RemainingCharges > 0)
-                        return OriginalHook(Toxikon);
-                }
-
+                if (IsEnabled(Preset.SGEPvP_BurstMode_Toxikon) && !HasStatusEffect(Debuffs.Toxicon, CurrentTarget) && GetCooldown(Toxikon).RemainingCharges > 0)
+                    return OriginalHook(Toxikon);
+            }
+            if (IsEnabled(Preset.SGEPvP_BurstMode_KardiaReminder))
+            {
+                IGameObject? healTarget = SimpleTarget.Stack.AllyToHeal;
+                
+                if (SGEPvP_BurstMode_KardiaReminder_Retarget && CanWeave() && GetTargetHPPercent(healTarget) <= SGEPvP_KardiaThreshold)
+                    return Kardia.Retarget(Dosis, healTarget, true);
             }
             return actionID;
+        }
+    }
+    internal class SGEPvP_RetargetKardia : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.SGEPvP_RetargetKardia;
+
+        protected override uint Invoke(uint actionID)
+        {
+            return actionID is not Kardia 
+                ? actionID 
+                : Kardia.Retarget(SimpleTarget.Stack.AllyToHeal);
         }
     }
 }

--- a/WrathCombo/Combos/PvP/SGEPVP.cs
+++ b/WrathCombo/Combos/PvP/SGEPVP.cs
@@ -113,7 +113,7 @@ internal static class SGEPvP
             }
             if (IsEnabled(Preset.SGEPvP_BurstMode_KardiaReminder))
             {
-                IGameObject? healTarget = SimpleTarget.Stack.AllyToHeal;
+                IGameObject? healTarget = SimpleTarget.Stack.AllyToHealPVP;
                 
                 if (SGEPvP_BurstMode_KardiaReminder_Retarget && CanWeave() && GetTargetHPPercent(healTarget) <= SGEPvP_KardiaThreshold)
                     return Kardia.Retarget(Dosis, healTarget, true);
@@ -129,7 +129,7 @@ internal static class SGEPvP
         {
             return actionID is not Kardia 
                 ? actionID 
-                : Kardia.Retarget(SimpleTarget.Stack.AllyToHeal);
+                : Kardia.Retarget(SimpleTarget.Stack.AllyToHealPVP);
         }
     }
 }

--- a/WrathCombo/Combos/PvP/SMNPvP.cs
+++ b/WrathCombo/Combos/PvP/SMNPvP.cs
@@ -2,14 +2,14 @@ using WrathCombo.Combos.PvE;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
-using WrathCombo.Window.Functions;
+using static WrathCombo.Window.Functions.UserConfig;
 using static WrathCombo.Combos.PvP.SMNPvP.Config;
 
 namespace WrathCombo.Combos.PvP;
 
 internal static class SMNPvP
 {
-        #region IDs
+    #region IDs
 
     internal class Role : PvPCaster;
 
@@ -39,9 +39,9 @@ internal static class SMNPvP
             FurtherRuin = 4399;
 
     }
-        #endregion
+    #endregion
 
-        #region Config
+    #region Config
     public static class Config
     {
         public static UserInt
@@ -54,18 +54,16 @@ internal static class SMNPvP
             {
                 // Phantom Dart
                 case Preset.SMNPvP_PhantomDart:
-                    UserConfig.DrawSliderInt(1, 100, SMNPvP_PhantomDartThreshold,
-                        "Target HP% to use Phantom Dart at or below");
+                    DrawSliderInt(1, 100, SMNPvP_PhantomDartThreshold, "Target HP% to use Phantom Dart at or below");
                     break;
 
                 case Preset.SMNPvP_BurstMode_RadiantAegis:
-                    UserConfig.DrawSliderInt(0, 90, SMNPvP_RadiantAegisThreshold,
-                        "Caps at 90 to prevent waste.");
+                    DrawSliderInt(0, 90, SMNPvP_RadiantAegisThreshold, "Caps at 90 to prevent waste.");
                     break;
             }
         }
     }
-        #endregion
+    #endregion
 
     internal class SMNPvP_BurstMode : CustomCombo
     {
@@ -73,61 +71,59 @@ internal static class SMNPvP
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Ruin3)
-            {
-                    #region Types
-                bool canWeave = CanWeave();
-                bool bahamutBurst = OriginalHook(Ruin3) is AstralImpulse;
-                bool phoenixBurst = OriginalHook(Ruin3) is FountainOfFire;
-                double playerHP = PlayerHealthPercentageHp();
-                int radiantThreshold = PluginConfiguration.GetCustomIntValue(SMNPvP_RadiantAegisThreshold);
-                    #endregion
+            if (actionID is not Ruin3) return actionID;
 
-                if (PvPCommon.TargetImmuneToDamage() && HasStatusEffect(Buffs.FurtherRuin)) // Block for ruin 4 because it is on action ID
-                    return All.SavageBlade;
+            #region Variables
+            bool canWeave = CanWeave();
+            bool bahamutBurst = OriginalHook(Ruin3) is AstralImpulse;
+            bool phoenixBurst = OriginalHook(Ruin3) is FountainOfFire;
+            double playerHP = PlayerHealthPercentageHp();
+            int radiantThreshold = PluginConfiguration.GetCustomIntValue(SMNPvP_RadiantAegisThreshold);
+            #endregion
+
+            if (PvPCommon.TargetImmuneToDamage() && HasStatusEffect(Buffs.FurtherRuin)) // Block for ruin 4 because it is on action ID
+                return All.SavageBlade;
                     
-                if (!PvPCommon.TargetImmuneToDamage())
+            if (!PvPCommon.TargetImmuneToDamage())
+            {
+                if (canWeave)
                 {
-                    if (canWeave)
-                    {
-                        // Radiant Aegis
-                        if (IsEnabled(Preset.SMNPvP_BurstMode_RadiantAegis) &&
-                            IsOffCooldown(RadiantAegis) && playerHP <= radiantThreshold)
-                            return RadiantAegis;
+                    // Radiant Aegis
+                    if (IsEnabled(Preset.SMNPvP_BurstMode_RadiantAegis) &&
+                        IsOffCooldown(RadiantAegis) && playerHP <= radiantThreshold)
+                        return RadiantAegis;
 
-                        if (IsEnabled(Preset.SMNPvP_PhantomDart) && Role.CanPhantomDart() && GetTargetHPPercent() <= SMNPvP_PhantomDartThreshold)
-                            return Role.PhantomDart;
-                    }
-                    // Phoenix & Bahamut bursts
-                    if (IsEnabled(Preset.SMNPvP_BurstMode_BrandofPurgatory) && phoenixBurst && IsOffCooldown(BrandofPurgatory))
-                        return BrandofPurgatory;
-
-                    if (IsEnabled(Preset.SMNPvP_BurstMode_DeathFlare) && bahamutBurst && IsOffCooldown(DeathFlare))
-                        return DeathFlare;
-
-                    if (HasStatusEffect(Buffs.FurtherRuin))
-                        return actionID;
-
-                    if (IsEnabled(Preset.SMNPvP_BurstMode_Necrotize) && GetRemainingCharges(Necrotize) > 0 && !HasStatusEffect(Buffs.FurtherRuin))
-                        return Necrotize;
-                        
-                    // Ifrit (check CrimsonCyclone conditions)
-                    if (IsEnabled(Preset.SMNPvP_BurstMode_CrimsonStrike) && OriginalHook(CrimsonCyclone) is CrimsonStrike)
-                        return CrimsonStrike;
-
-                    if (IsEnabled(Preset.SMNPvP_BurstMode_CrimsonCyclone) && IsOffCooldown(CrimsonCyclone))
-                        return CrimsonCyclone;
-
-                    // Titan
-                    if (IsEnabled(Preset.SMNPvP_BurstMode_MountainBuster) && IsOffCooldown(MountainBuster) && InActionRange(MountainBuster))
-                        return MountainBuster;
-
-                    // Garuda (check Slipstream cooldown)
-                    if (IsEnabled(Preset.SMNPvP_BurstMode_Slipstream) && IsOffCooldown(Slipstream) && !IsMoving())
-                        return Slipstream;
+                    if (IsEnabled(Preset.SMNPvP_PhantomDart) && PvPCaster.CanPhantomDart() && GetTargetHPPercent() <= SMNPvP_PhantomDartThreshold)
+                        return PvPCaster.PhantomDart;
                 }
-            }
+                // Phoenix & Bahamut bursts
+                if (IsEnabled(Preset.SMNPvP_BurstMode_BrandofPurgatory) && phoenixBurst && IsOffCooldown(BrandofPurgatory))
+                    return BrandofPurgatory;
 
+                if (IsEnabled(Preset.SMNPvP_BurstMode_DeathFlare) && bahamutBurst && IsOffCooldown(DeathFlare))
+                    return DeathFlare;
+
+                if (HasStatusEffect(Buffs.FurtherRuin))
+                    return actionID;
+
+                if (IsEnabled(Preset.SMNPvP_BurstMode_Necrotize) && GetRemainingCharges(Necrotize) > 0 && !HasStatusEffect(Buffs.FurtherRuin))
+                    return Necrotize;
+                        
+                // Ifrit (check CrimsonCyclone conditions)
+                if (IsEnabled(Preset.SMNPvP_BurstMode_CrimsonStrike) && OriginalHook(CrimsonCyclone) is CrimsonStrike)
+                    return CrimsonStrike;
+
+                if (IsEnabled(Preset.SMNPvP_BurstMode_CrimsonCyclone) && IsOffCooldown(CrimsonCyclone))
+                    return CrimsonCyclone;
+
+                // Titan
+                if (IsEnabled(Preset.SMNPvP_BurstMode_MountainBuster) && IsOffCooldown(MountainBuster) && InActionRange(MountainBuster))
+                    return MountainBuster;
+
+                // Garuda (check Slipstream cooldown)
+                if (IsEnabled(Preset.SMNPvP_BurstMode_Slipstream) && IsOffCooldown(Slipstream) && !IsMoving())
+                    return Slipstream;
+            }
             return actionID;
         }
     }

--- a/WrathCombo/Combos/PvP/VPRPVP.cs
+++ b/WrathCombo/Combos/PvP/VPRPVP.cs
@@ -72,13 +72,13 @@ internal static class VPRPvP
             {
                 // Bloodcoil
                 case Preset.VPRPvP_Bloodcoil:
-                    DrawSliderInt(10, 100, VPRPvP_Bloodcoil_TargetHP, "Target HP%", 10);
-                    DrawSliderInt(10, 100, VPRPvP_Bloodcoil_PlayerHP, "Player HP%", 10);
+                    DrawSliderInt(10, 100, VPRPvP_Bloodcoil_TargetHP, "Target HP%");
+                    DrawSliderInt(10, 100, VPRPvP_Bloodcoil_PlayerHP, "Player HP%");
                     break;
 
                 // Uncoiled Fury
                 case Preset.VPRPvP_UncoiledFury:
-                    DrawSliderInt(10, 100, VPRPvP_UncoiledFury_TargetHP, "Target HP%", 10);
+                    DrawSliderInt(10, 100, VPRPvP_UncoiledFury_TargetHP, "Target HP%");
                     break;
 
                 // Backlash
@@ -97,8 +97,8 @@ internal static class VPRPvP
 
                 // Slither
                 case Preset.VPRPvP_Slither:
-                    DrawSliderInt(0, 1, VPRPvP_Slither_Charges, "Charges to Keep", 1);
-                    DrawSliderInt(6, 10, VPRPvP_Slither_Range, "Maximum Range", 6);
+                    DrawSliderInt(0, 1, VPRPvP_Slither_Charges, "Charges to Keep");
+                    DrawSliderInt(6, 10, VPRPvP_Slither_Range, "Maximum Range");
                     break;
 
                 // Smite

--- a/WrathCombo/Combos/PvP/VPRPVP.cs
+++ b/WrathCombo/Combos/PvP/VPRPVP.cs
@@ -1,14 +1,14 @@
 ﻿using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
-using WrathCombo.Window.Functions;
+using static WrathCombo.Window.Functions.UserConfig;
 using static WrathCombo.Combos.PvP.VPRPvP.Config;
 
 namespace WrathCombo.Combos.PvP;
 
 internal static class VPRPvP
 {
-        #region IDS
-   internal class Role : PvPMelee;
+    #region IDS
+    internal class Role : PvPMelee;
 
     internal const uint
         SteelFangs = 39157,
@@ -47,10 +47,9 @@ internal static class VPRPvP
             HardenedScales = 4096,
             SnakesBane = 4098;
     }
+    #endregion
 
-        #endregion
-
-        #region Config
+    #region Config
     public static class Config
     {
         public static UserInt
@@ -73,46 +72,39 @@ internal static class VPRPvP
             {
                 // Bloodcoil
                 case Preset.VPRPvP_Bloodcoil:
-                    UserConfig.DrawSliderInt(10, 100, VPRPvP_Bloodcoil_TargetHP, "Target HP%", 210);
-                    UserConfig.DrawSliderInt(10, 100, VPRPvP_Bloodcoil_PlayerHP, "Player HP%", 210);
-
+                    DrawSliderInt(10, 100, VPRPvP_Bloodcoil_TargetHP, "Target HP%", 10);
+                    DrawSliderInt(10, 100, VPRPvP_Bloodcoil_PlayerHP, "Player HP%", 10);
                     break;
 
                 // Uncoiled Fury
                 case Preset.VPRPvP_UncoiledFury:
-                    UserConfig.DrawSliderInt(10, 100, VPRPvP_UncoiledFury_TargetHP, "Target HP%", 210);
-
+                    DrawSliderInt(10, 100, VPRPvP_UncoiledFury_TargetHP, "Target HP%", 10);
                     break;
 
                 // Backlash
                 case Preset.VPRPvP_Backlash:
-                    UserConfig.DrawAdditionalBoolChoice(VPRPvP_Backlash_SubOption, "Empowered Only",
+                    DrawAdditionalBoolChoice(VPRPvP_Backlash_SubOption, "Empowered Only", 
                         "Also requires Snake's Bane to be present.");
-
                     break;
 
                 // Rattling Coil
                 case Preset.VPRPvP_RattlingCoil:
-                    UserConfig.DrawHorizontalMultiChoice(VPRPvP_RattlingCoil_SubOptions, "No Uncoiled Fury",
+                    DrawHorizontalMultiChoice(VPRPvP_RattlingCoil_SubOptions, "No Uncoiled Fury",
                         "Must not have charges of Uncoiled Fury.", 2, 0);
-
-                    UserConfig.DrawHorizontalMultiChoice(VPRPvP_RattlingCoil_SubOptions, "No Snake Scales",
+                    DrawHorizontalMultiChoice(VPRPvP_RattlingCoil_SubOptions, "No Snake Scales",
                         "Snake Scales must be on cooldown.", 2, 1);
-
                     break;
 
                 // Slither
                 case Preset.VPRPvP_Slither:
-                    UserConfig.DrawSliderInt(0, 1, VPRPvP_Slither_Charges, "Charges to Keep", 178);
-                    UserConfig.DrawSliderInt(6, 10, VPRPvP_Slither_Range, "Maximum Range", 173);
-
+                    DrawSliderInt(0, 1, VPRPvP_Slither_Charges, "Charges to Keep", 1);
+                    DrawSliderInt(6, 10, VPRPvP_Slither_Range, "Maximum Range", 6);
                     break;
 
                 // Smite
                 case Preset.VPRPvP_Smite:
-                    UserConfig.DrawSliderInt(0, 100, VPRPvP_SmiteThreshold,
+                    DrawSliderInt(0, 100, VPRPvP_SmiteThreshold,
                         "Target HP% to smite, Max damage below 25%");
-
                     break;
             }
         }
@@ -125,76 +117,77 @@ internal static class VPRPvP
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is SteelFangs or HuntersSting or BarbarousSlice or PiercingFangs or SwiftskinsSting or RavenousBite)
+            if (actionID is not (SteelFangs or HuntersSting or BarbarousSlice or PiercingFangs or SwiftskinsSting or RavenousBite)) 
+                return actionID;
+
+            #region Variables
+            float targetDistance = GetTargetDistance();
+            float targetCurrentPercentHp = GetTargetHPPercent();
+            float playerCurrentPercentHp = PlayerHealthPercentageHp();
+            uint chargesSlither = HasCharges(Slither) ? GetCooldown(Slither).RemainingCharges : 0;
+            uint chargesUncoiledFury = HasCharges(UncoiledFury) ? GetCooldown(UncoiledFury).RemainingCharges : 0;
+            bool[] optionsRattlingCoil = VPRPvP_RattlingCoil_SubOptions;
+            bool hasTarget = HasTarget();
+            bool inMeleeRange = targetDistance <= 5;
+            bool hasSlither = HasStatusEffect(Buffs.Slither);
+            bool hasBind = HasStatusEffect(PvPCommon.Debuffs.Bind, anyOwner: true);
+            bool targetHasImmunity = PvPCommon.TargetImmuneToDamage();
+            bool hasBacklash = OriginalHook(SnakeScales) is Backlash;
+            bool hasOuroboros = OriginalHook(Bloodcoil) is Ouroboros;
+            bool hasSnakesBane = hasBacklash && HasStatusEffect(Buffs.SnakesBane);
+            bool hasSanguineFeast = OriginalHook(Bloodcoil) is SanguineFeast;
+            bool isMeleeDependant = !hasTarget || (hasTarget && inMeleeRange);
+            bool isSnakeScalesDown = IsOnCooldown(SnakeScales) && !hasBacklash;
+            bool isUncoiledFuryEnabled = IsEnabled(Preset.VPRPvP_UncoiledFury);
+            bool hasRangedWeave = OriginalHook(SerpentsTail) is UncoiledTwinfang or UncoiledTwinblood;
+            bool hasCommonWeave = OriginalHook(SerpentsTail) is DeathRattle or TwinfangBite or TwinbloodBite;
+            bool hasLegacyWeave = OriginalHook(SerpentsTail) is FirstLegacy or SecondLegacy or ThirdLegacy or FourthLegacy;
+            bool isBloodcoilPrimed = IsOffCooldown(Bloodcoil) && hasTarget && !targetHasImmunity && !hasOuroboros && !hasSanguineFeast;
+            bool inGenerationsCombo = OriginalHook(actionID) is FirstGeneration or SecondGeneration or ThirdGeneration or FourthGeneration;
+            bool isUncoiledFuryPrimed = chargesUncoiledFury > 0 && hasTarget && !targetHasImmunity && targetCurrentPercentHp < VPRPvP_UncoiledFury_TargetHP;
+            bool isUncoiledFuryDependant = !isUncoiledFuryEnabled || !(isUncoiledFuryEnabled && isUncoiledFuryPrimed);
+            bool isSlitherPrimed = hasTarget && !inMeleeRange && isUncoiledFuryDependant && !hasSlither && !hasBind;
+            #endregion
+            
+            // Smite
+            if (IsEnabled(Preset.VPRPvP_Smite) && PvPMelee.CanSmite() && !PvPCommon.TargetImmuneToDamage() && GetTargetDistance() <= 10 && HasTarget() &&
+                GetTargetHPPercent() <= VPRPvP_SmiteThreshold)
+                return PvPMelee.Smite;
+
+            // Backlash
+            if (IsEnabled(Preset.VPRPvP_Backlash) && ((!VPRPvP_Backlash_SubOption && hasBacklash) ||
+                                                      (VPRPvP_Backlash_SubOption && hasSnakesBane)))
+                return OriginalHook(SnakeScales);
+
+            // Rattling Coil
+            if (IsEnabled(Preset.VPRPvP_RattlingCoil) && IsOffCooldown(RattlingCoil) &&
+                ((optionsRattlingCoil[0] && chargesUncoiledFury == 0) || (optionsRattlingCoil[1] && isSnakeScalesDown)))
+                return OriginalHook(RattlingCoil);
+
+            // Slither
+            if (IsEnabled(Preset.VPRPvP_Slither) && chargesSlither > VPRPvP_Slither_Charges &&
+                isSlitherPrimed && targetDistance <= VPRPvP_Slither_Range)
+                return OriginalHook(Slither);
+
+            // Serpent's Tail
+            if (hasRangedWeave || ((isMeleeDependant || isUncoiledFuryDependant) && (hasLegacyWeave || (hasCommonWeave && !inGenerationsCombo))))
+                return OriginalHook(SerpentsTail);
+
+            if (isMeleeDependant || isUncoiledFuryDependant)
             {
-                    #region Variables
-                float targetDistance = GetTargetDistance();
-                float targetCurrentPercentHp = GetTargetHPPercent();
-                float playerCurrentPercentHp = PlayerHealthPercentageHp();
-                uint chargesSlither = HasCharges(Slither) ? GetCooldown(Slither).RemainingCharges : 0;
-                uint chargesUncoiledFury = HasCharges(UncoiledFury) ? GetCooldown(UncoiledFury).RemainingCharges : 0;
-                bool[] optionsRattlingCoil = VPRPvP_RattlingCoil_SubOptions;
-                bool hasTarget = HasTarget();
-                bool inMeleeRange = targetDistance <= 5;
-                bool hasSlither = HasStatusEffect(Buffs.Slither);
-                bool hasBind = HasStatusEffect(PvPCommon.Debuffs.Bind, anyOwner: true);
-                bool targetHasImmunity = PvPCommon.TargetImmuneToDamage();
-                bool hasBacklash = OriginalHook(SnakeScales) is Backlash;
-                bool hasOuroboros = OriginalHook(Bloodcoil) is Ouroboros;
-                bool hasSnakesBane = hasBacklash && HasStatusEffect(Buffs.SnakesBane);
-                bool hasSanguineFeast = OriginalHook(Bloodcoil) is SanguineFeast;
-                bool isMeleeDependant = !hasTarget || (hasTarget && inMeleeRange);
-                bool isSnakeScalesDown = IsOnCooldown(SnakeScales) && !hasBacklash;
-                bool isUncoiledFuryEnabled = IsEnabled(Preset.VPRPvP_UncoiledFury);
-                bool hasRangedWeave = OriginalHook(SerpentsTail) is UncoiledTwinfang or UncoiledTwinblood;
-                bool hasCommonWeave = OriginalHook(SerpentsTail) is DeathRattle or TwinfangBite or TwinbloodBite;
-                bool hasLegacyWeave = OriginalHook(SerpentsTail) is FirstLegacy or SecondLegacy or ThirdLegacy or FourthLegacy;
-                bool isBloodcoilPrimed = IsOffCooldown(Bloodcoil) && hasTarget && !targetHasImmunity && !hasOuroboros && !hasSanguineFeast;
-                bool inGenerationsCombo = OriginalHook(actionID) is FirstGeneration or SecondGeneration or ThirdGeneration or FourthGeneration;
-                bool isUncoiledFuryPrimed = chargesUncoiledFury > 0 && hasTarget && !targetHasImmunity && targetCurrentPercentHp < VPRPvP_UncoiledFury_TargetHP;
-                bool isUncoiledFuryDependant = !isUncoiledFuryEnabled || !(isUncoiledFuryEnabled && isUncoiledFuryPrimed);
-                bool isSlitherPrimed = hasTarget && !inMeleeRange && isUncoiledFuryDependant && !hasSlither && !hasBind;
-                    #endregion
-                // Smite
-                if (IsEnabled(Preset.VPRPvP_Smite) && PvPMelee.CanSmite() && !PvPCommon.TargetImmuneToDamage() && GetTargetDistance() <= 10 && HasTarget() &&
-                    GetTargetHPPercent() <= VPRPvP_SmiteThreshold)
-                    return PvPMelee.Smite;
+                // Reawakened
+                if (inGenerationsCombo)
+                    return OriginalHook(actionID);
 
-                // Backlash
-                if (IsEnabled(Preset.VPRPvP_Backlash) && ((!VPRPvP_Backlash_SubOption && hasBacklash) ||
-                                                          (VPRPvP_Backlash_SubOption && hasSnakesBane)))
-                    return OriginalHook(SnakeScales);
-
-                // Rattling Coil
-                if (IsEnabled(Preset.VPRPvP_RattlingCoil) && IsOffCooldown(RattlingCoil) &&
-                    ((optionsRattlingCoil[0] && chargesUncoiledFury == 0) || (optionsRattlingCoil[1] && isSnakeScalesDown)))
-                    return OriginalHook(RattlingCoil);
-
-                // Slither
-                if (IsEnabled(Preset.VPRPvP_Slither) && chargesSlither > VPRPvP_Slither_Charges &&
-                    isSlitherPrimed && targetDistance <= VPRPvP_Slither_Range)
-                    return OriginalHook(Slither);
-
-                // Serpent's Tail
-                if (hasRangedWeave || ((isMeleeDependant || isUncoiledFuryDependant) && (hasLegacyWeave || (hasCommonWeave && !inGenerationsCombo))))
-                    return OriginalHook(SerpentsTail);
-
-                if (isMeleeDependant || isUncoiledFuryDependant)
-                {
-                    // Reawakened
-                    if (inGenerationsCombo)
-                        return OriginalHook(actionID);
-
-                    // Ouroboros / Sanguine Feast / Bloodcoil
-                    if (hasOuroboros || hasSanguineFeast || (IsEnabled(Preset.VPRPvP_Bloodcoil) && isBloodcoilPrimed &&
-                                                             (targetCurrentPercentHp < VPRPvP_Bloodcoil_TargetHP || playerCurrentPercentHp < VPRPvP_Bloodcoil_PlayerHP)))
-                        return OriginalHook(Bloodcoil);
-                }
-
-                // Uncoiled Fury
-                if (isUncoiledFuryEnabled && isUncoiledFuryPrimed)
-                    return OriginalHook(UncoiledFury);
+                // Ouroboros / Sanguine Feast / Bloodcoil
+                if (hasOuroboros || hasSanguineFeast || (IsEnabled(Preset.VPRPvP_Bloodcoil) && isBloodcoilPrimed &&
+                                                         (targetCurrentPercentHp < VPRPvP_Bloodcoil_TargetHP || playerCurrentPercentHp < VPRPvP_Bloodcoil_PlayerHP)))
+                    return OriginalHook(Bloodcoil);
             }
+
+            // Uncoiled Fury
+            if (isUncoiledFuryEnabled && isUncoiledFuryPrimed)
+                return OriginalHook(UncoiledFury);
 
             return actionID;
         }
@@ -206,11 +199,11 @@ internal static class VPRPvP
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is SnakeScales)
-            {
-                if (IsOffCooldown(RattlingCoil) && IsOnCooldown(SnakeScales) && OriginalHook(SnakeScales) is not Backlash)
-                    return OriginalHook(RattlingCoil);
-            }
+            if (actionID is not SnakeScales) 
+                return actionID;
+            
+            if (IsOffCooldown(RattlingCoil) && IsOnCooldown(SnakeScales) && OriginalHook(SnakeScales) is not Backlash)
+                return OriginalHook(RattlingCoil);
 
             return actionID;
         }

--- a/WrathCombo/Combos/PvP/WARPVP.cs
+++ b/WrathCombo/Combos/PvP/WARPVP.cs
@@ -1,17 +1,15 @@
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Extensions;
-using WrathCombo.Window.Functions;
+using static WrathCombo.Window.Functions.UserConfig;
 using static WrathCombo.Combos.PvP.WARPvP.Config;
 
 namespace WrathCombo.Combos.PvP;
 
 internal static class WARPvP
 {
-        #region IDS
-
+    #region IDS
     internal class Role : PvPTank;
-
     internal const uint
         HeavySwing = 29074,
         Maim = 29075,
@@ -34,34 +32,32 @@ internal static class WARPvP
             PrimalRuinationReady = 4285,
             Wrathfull = 4286;
     }
-        #endregion
+    #endregion
 
-        #region Config
+    #region Config
     public static class Config
     {
         public static UserInt
             WARPVP_BlotaTiming = new("WARPVP_BlotaTiming"),
             WARPvP_RampartThreshold = new("WARPvP_RampartThreshold");
 
-
         internal static void Draw(Preset preset)
         {
             switch (preset)
             {
                 case Preset.WARPvP_Rampart:
-                    UserConfig.DrawSliderInt(1, 100, WARPvP_RampartThreshold,
+                    DrawSliderInt(1, 100, WARPvP_RampartThreshold,
                         "Use Rampart below set threshold for self");
                     break;
 
                 case Preset.WARPvP_BurstMode_Blota:
-                    UserConfig.DrawHorizontalRadioButton(WARPVP_BlotaTiming, $"Before {PrimalRend.ActionName()}", "", 0);
-                    UserConfig.DrawHorizontalRadioButton(WARPVP_BlotaTiming, $"After {PrimalRend.ActionName()}", "", 1);
-
+                    DrawHorizontalRadioButton(WARPVP_BlotaTiming, $"Before {PrimalRend.ActionName()}", "", 0);
+                    DrawHorizontalRadioButton(WARPVP_BlotaTiming, $"After {PrimalRend.ActionName()}", "", 1);
                     break;
             }
         }
     }
-        #endregion
+    #endregion
        
     internal class WARPvP_BurstMode : CustomCombo
     {
@@ -69,80 +65,78 @@ internal static class WARPvP
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is HeavySwing or Maim or StormsPath)
+            if (actionID is not (HeavySwing or Maim or StormsPath)) 
+                return actionID;
+            
+            if (IsEnabled(Preset.WARPvP_Rampart) && PvPTank.CanRampart(WARPvP_RampartThreshold))
+                return PvPTank.Rampart;
+
+            if (!PvPCommon.TargetImmuneToDamage())
             {
-                if (IsEnabled(Preset.WARPvP_Rampart) && PvPTank.CanRampart(WARPvP_RampartThreshold))
-                    return PvPTank.Rampart;
+                var canWeave = CanWeave();
 
-                if (!PvPCommon.TargetImmuneToDamage())
+                // Bloodwhetting condition (both WARPvP BurstMode and CanWeave)
+                if (IsEnabled(Preset.WARPvP_BurstMode_Bloodwhetting))
                 {
-                    var canWeave = CanWeave();
+                    if (!GetCooldown(Bloodwhetting).IsCooldown || canWeave && IsOffCooldown(Bloodwhetting))
+                        return OriginalHook(Bloodwhetting);
+                }
 
-                    // Bloodwhetting condition (both WARPvP BurstMode and CanWeave)
-                    if (IsEnabled(Preset.WARPvP_BurstMode_Bloodwhetting))
+                // Primal Wrath if in melee range and Wrathfull effect is active
+                if (IsEnabled(Preset.WARPvP_BurstMode_PrimalScream) && InMeleeRange() && canWeave && HasStatusEffect(Buffs.Wrathfull))
+                    return OriginalHook(PrimalScream);
+
+                // Blota and PrimalRend conditions based on range and cooldowns
+                if (!InMeleeRange())
+                {
+                    // Blota with specific conditions and burst mode enabled
+                    if (IsOffCooldown(Blota) && !HasStatusEffect(PvPCommon.Debuffs.Stun, CurrentTarget, true) && IsEnabled(Preset.WARPvP_BurstMode_Blota))
                     {
-                        if (!GetCooldown(Bloodwhetting).IsCooldown || canWeave && IsOffCooldown(Bloodwhetting))
-                            return OriginalHook(Bloodwhetting);
-                    }
-
-                    // Primal Wrath if in melee range and Wrathfull effect is active
-                    if (IsEnabled(Preset.WARPvP_BurstMode_PrimalScream) && InMeleeRange() && canWeave && HasStatusEffect(Buffs.Wrathfull))
-                        return OriginalHook(PrimalScream);
-
-                    // Blota and PrimalRend conditions based on range and cooldowns
-                    if (!InMeleeRange())
-                    {
-                        // Blota with specific conditions and burst mode enabled
-                        if (IsOffCooldown(Blota) && !HasStatusEffect(PvPCommon.Debuffs.Stun, CurrentTarget, true) && IsEnabled(Preset.WARPvP_BurstMode_Blota))
-                        {
-                            if (WARPVP_BlotaTiming == 0 && IsOffCooldown(PrimalRend))
-                                return OriginalHook(Blota);
-                            if (WARPVP_BlotaTiming == 1 && IsOnCooldown(PrimalRend))
-                                return OriginalHook(Blota);
-                        }
-
-                        // PrimalRend if ready or BurstMode enabled
-                        if (IsEnabled(Preset.WARPvP_BurstMode_PrimalRend))
-                        {
-                            if ((IsOffCooldown(PrimalRend) || HasStatusEffect(Buffs.PrimalRuinationReady)))
-                                return OriginalHook(PrimalRend);
-                        }
-
-                    }
-
-                    // In melee range logic
-                    if (InMeleeRange())
-                    {
-                        // Inner Chaos effect logic
-                        if (IsEnabled(Preset.WARPvP_BurstMode_InnerChaos) && HasStatusEffect(Buffs.InnerChaosReady))
+                        if (WARPVP_BlotaTiming == 0 && IsOffCooldown(PrimalRend))
                             return OriginalHook(Blota);
+                        if (WARPVP_BlotaTiming == 1 && IsOnCooldown(PrimalRend))
+                            return OriginalHook(Blota);
+                    }
 
-                        // Onslaught and Orogeny conditions for melee
-                        if (IsEnabled(Preset.WARPvP_BurstMode_Onslaught) && !GetCooldown(Onslaught).IsCooldown && canWeave)
-                            return OriginalHook(Onslaught);
+                    // PrimalRend if ready or BurstMode enabled
+                    if (IsEnabled(Preset.WARPvP_BurstMode_PrimalRend))
+                    {
+                        if ((IsOffCooldown(PrimalRend) || HasStatusEffect(Buffs.PrimalRuinationReady)))
+                            return OriginalHook(PrimalRend);
+                    }
 
-                        // Nascent Chaos and Orogeny conditions
-                        if (IsEnabled(Preset.WARPvP_BurstMode_Bloodwhetting) && HasStatusEffect(Buffs.NascentChaos))
-                            return OriginalHook(Bloodwhetting);
+                }
 
-                        if (IsEnabled(Preset.WARPvP_BurstMode_Orogeny) && !GetCooldown(Orogeny).IsCooldown && canWeave)
-                            return OriginalHook(Orogeny);
+                // In melee range logic
+                if (InMeleeRange())
+                {
+                    // Inner Chaos effect logic
+                    if (IsEnabled(Preset.WARPvP_BurstMode_InnerChaos) && HasStatusEffect(Buffs.InnerChaosReady))
+                        return OriginalHook(Blota);
 
-                        // PrimalRend if ready or BurstMode enabled
-                        if (IsEnabled(Preset.WARPvP_BurstMode_PrimalRend))
-                        {
-                            if (IsOffCooldown(PrimalRend) || HasStatusEffect(Buffs.PrimalRuinationReady))
-                                return OriginalHook(PrimalRend);
-                        }
+                    // Onslaught and Orogeny conditions for melee
+                    if (IsEnabled(Preset.WARPvP_BurstMode_Onslaught) && !GetCooldown(Onslaught).IsCooldown && canWeave)
+                        return OriginalHook(Onslaught);
 
-                        // Blota with specific conditions and burst mode enabled in meleerange
-                        if (IsOffCooldown(Blota) && !HasStatusEffect(PvPCommon.Debuffs.Stun, CurrentTarget, true) && IsEnabled(Preset.WARPvP_BurstMode_Blota))
-                        {
-                            if (WARPVP_BlotaTiming == 0 && IsOffCooldown(PrimalRend))
-                                return OriginalHook(Blota);
-                            if (WARPVP_BlotaTiming == 1 && IsOnCooldown(PrimalRend))
-                                return OriginalHook(Blota);
-                        }
+                    // Nascent Chaos and Orogeny conditions
+                    if (IsEnabled(Preset.WARPvP_BurstMode_Bloodwhetting) && HasStatusEffect(Buffs.NascentChaos))
+                        return OriginalHook(Bloodwhetting);
+
+                    if (IsEnabled(Preset.WARPvP_BurstMode_Orogeny) && !GetCooldown(Orogeny).IsCooldown && canWeave)
+                        return OriginalHook(Orogeny);
+
+                    // PrimalRend if ready or BurstMode enabled
+                    if (IsEnabled(Preset.WARPvP_BurstMode_PrimalRend))
+                    {
+                        if (IsOffCooldown(PrimalRend) || HasStatusEffect(Buffs.PrimalRuinationReady))
+                            return OriginalHook(PrimalRend);
+                    }
+
+                    // Blota with specific conditions and burst mode enabled in meleerange
+                    if (IsOffCooldown(Blota) && !HasStatusEffect(PvPCommon.Debuffs.Stun, CurrentTarget, true) && IsEnabled(Preset.WARPvP_BurstMode_Blota))
+                    {
+                        if (WARPVP_BlotaTiming == 0 && IsOffCooldown(PrimalRend) || WARPVP_BlotaTiming == 1 && IsOnCooldown(PrimalRend))
+                            return OriginalHook(Blota);
                     }
                 }
             }

--- a/WrathCombo/Combos/PvP/WHMPVP.cs
+++ b/WrathCombo/Combos/PvP/WHMPVP.cs
@@ -111,7 +111,7 @@ internal static class WHMPvP
             }
             if (IsEnabled(Preset.WHMPvP_Burst_Heals) && !HasStatusEffect(Buffs.SacredSight))
             {
-                IGameObject? healTarget = WHMPvP_Burst_HealsRetarget ? SimpleTarget.Stack.AllyToHeal : SimpleTarget.Stack.Allies;
+                IGameObject? healTarget = WHMPvP_Burst_HealsRetarget ? SimpleTarget.Stack.AllyToHealPVP : SimpleTarget.Stack.Allies;
                 
                 if (WHMPvP_Burst_Heals_Options[1] && HasStatusEffect(Buffs.Cure3Ready) && GetTargetHPPercent(healTarget) <= WHMPvP_Burst_HealsThreshold)
                     return WHMPvP_Burst_HealsRetarget
@@ -143,16 +143,16 @@ internal static class WHMPvP
             
             if (IsEnabled(Preset.WHMPvP_Cure3) && HasStatusEffect(Buffs.Cure3Ready))
                 return WHMPvP_Heals_Options[1]
-                    ? Cure3.Retarget(Cure2, SimpleTarget.Stack.AllyToHeal, true)
+                    ? Cure3.Retarget(Cure2, SimpleTarget.Stack.AllyToHealPVP, true)
                     : Cure3;
 
             if (IsEnabled(Preset.WHMPvP_Aquaveil) && IsOffCooldown(Aquaveil))
                 return WHMPvP_Heals_Options[2]
-                    ? Aquaveil.Retarget(Cure2, SimpleTarget.Stack.AllyToHeal, true)
+                    ? Aquaveil.Retarget(Cure2, SimpleTarget.Stack.AllyToHealPVP, true)
                     : Aquaveil;
 
             return WHMPvP_Heals_Options[2]
-                ? actionID.Retarget(Cure2, SimpleTarget.Stack.AllyToHeal, true)
+                ? actionID.Retarget(Cure2, SimpleTarget.Stack.AllyToHealPVP, true)
                 : actionID;
         }
     }

--- a/WrathCombo/Combos/PvP/WHMPVP.cs
+++ b/WrathCombo/Combos/PvP/WHMPVP.cs
@@ -1,16 +1,16 @@
-﻿using WrathCombo.CustomComboNS;
+﻿using Dalamud.Game.ClientState.Objects.Types;
+using WrathCombo.Core;
+using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
-using WrathCombo.Window.Functions;
+using static WrathCombo.Window.Functions.UserConfig;
 using static WrathCombo.Combos.PvP.WHMPvP.Config;
 
 namespace WrathCombo.Combos.PvP;
 
 internal static class WHMPvP
 {
-        #region IDS
-
+    #region IDS
     internal class Role : PvPHealer;
-
     public const uint
         Glare = 29223,
         Cure2 = 29224,
@@ -27,36 +27,51 @@ internal static class WHMPvP
             Cure3Ready = 3083,
             SacredSight = 4326;
     }
+    #endregion
 
-        #endregion
-
-        #region Config
+    #region Config
     public static class Config
     {
+        public static UserBool
+            WHMPvP_Burst_HealsRetarget = new("WHMPvP_Burst_HealsRetarget");
         public static UserInt
             WHMPvP_PurgationThreshold = new("WHMPvP_PurgationThreshold"),
+            WHMPvP_Burst_HealsThreshold = new("WHMPvP_Burst_HealsThreshold"),
             WHMPvP_DiabrosisThreshold = new("WHMPvP_DiabrosisThreshold");
+        
+        public static UserBoolArray
+            WHMPvP_Burst_Heals_Options = new("WHMPvP_Burst_Heals_Options"),
+            WHMPvP_Heals_Options = new("WHMPvP_Heals_Options");
 
         internal static void Draw(Preset preset)
         {
             switch (preset)
             {                    
                 case Preset.WHMPvP_Diabrosis:
-                    UserConfig.DrawSliderInt(1, 100, WHMPvP_DiabrosisThreshold,
-                        "Target HP% to use Diabrosis");
-
+                    DrawSliderInt(1, 100, WHMPvP_DiabrosisThreshold, "Target HP% to use Diabrosis");
                     break;
 
                 case Preset.WHMPvP_AfflatusPurgation:
-                    UserConfig.DrawSliderInt(1, 100, WHMPvP_PurgationThreshold,
-                        "Target HP% to use Line Aoe Limit Break");
-
+                    DrawSliderInt(1, 100, WHMPvP_PurgationThreshold, "Target HP% to use Line Aoe Limit Break");
+                    break;
+                
+                case Preset.WHMPvP_Heals:
+                    DrawHorizontalMultiChoice(WHMPvP_Heals_Options, "Retarget Cure 2","To the Heal Stack (In Wrath Settings)", 3, 0);
+                    DrawHorizontalMultiChoice(WHMPvP_Heals_Options, "Retarget Cure 3","To the Heal Stack (In Wrath Settings)", 3, 1);
+                    DrawHorizontalMultiChoice(WHMPvP_Heals_Options, "Retarget Aquaveil","To the Heal Stack (In Wrath Settings)", 3, 2);
+                    break;
+                
+                case Preset.WHMPvP_Burst_Heals:
+                    DrawAdditionalBoolChoice(WHMPvP_Burst_HealsRetarget, "Retarget", "Retargets  to the Heal Stack(In Wrath Settings)");
+                    DrawSliderInt(1, 100, WHMPvP_Burst_HealsThreshold, "HP% to use Heals");
+                    DrawHorizontalMultiChoice(WHMPvP_Burst_Heals_Options, "Cure 2","Adds Cure 2", 3, 0);
+                    DrawHorizontalMultiChoice(WHMPvP_Burst_Heals_Options, "Cure 3","Adds Cure 3", 3, 1);
+                    DrawHorizontalMultiChoice(WHMPvP_Burst_Heals_Options, "Aquaveil","Adds Aquaveil", 3, 2);
                     break;
             }
         }
     }
-
-        #endregion       
+    #endregion       
 
     internal class WHMPvP_Burst : CustomCombo
     {
@@ -64,40 +79,55 @@ internal static class WHMPvP
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Glare)
+            if (actionID is not Glare) 
+                return actionID;
+            
+            if (!PvPCommon.TargetImmuneToDamage())
             {
-                if (!PvPCommon.TargetImmuneToDamage())
+                //Limit break, with health slider
+                if (IsEnabled(Preset.WHMPvP_AfflatusPurgation) && IsLB1Ready && GetTargetHPPercent() <= WHMPvP_PurgationThreshold)
+                    return AfflatusPurgation;
+
+                // Seraph Strike if enabled and off cooldown
+                if (IsEnabled(Preset.WHMPvP_Seraph_Strike) && IsOffCooldown(SeraphStrike))
+                    return SeraphStrike;
+
+                // Weave conditions
+                if (CanWeave())
                 {
-                    //Limit break, with health slider
-                    if (IsEnabled(Preset.WHMPvP_AfflatusPurgation) && IsLB1Ready && GetTargetHPPercent() <= WHMPvP_PurgationThreshold)
-                        return AfflatusPurgation;
+                    //Role Action Diabrosis Role action
+                    if (IsEnabled(Preset.WHMPvP_Diabrosis) && PvPHealer.CanDiabrosis() && HasTarget() &&
+                        GetTargetHPPercent() <= WHMPvP_DiabrosisThreshold)
+                        return PvPHealer.Diabrosis;
 
-                    // Seraph Strike if enabled and off cooldown
-                    if (IsEnabled(Preset.WHMPvP_Seraph_Strike) && IsOffCooldown(SeraphStrike))
-                        return SeraphStrike;
-
-                    // Weave conditions
-                    if (CanWeave())
-                    {
-                        //Role Action Diabrosis Role action
-                        if (IsEnabled(Preset.WHMPvP_Diabrosis) && PvPHealer.CanDiabrosis() && HasTarget() &&
-                            GetTargetHPPercent() <= WHMPvP_DiabrosisThreshold)
-                            return PvPHealer.Diabrosis;
-
-                        // Miracle of Nature if enabled and off cooldown and inrange 
-                        if (IsEnabled(Preset.WHMPvP_Mirace_of_Nature) && IsOffCooldown(MiracleOfNature) && InActionRange(MiracleOfNature))
-                            return MiracleOfNature;
-                    }
-
-                    // Afflatus Misery if enabled and off cooldown
-                    if (IsEnabled(Preset.WHMPvP_Afflatus_Misery) && IsOffCooldown(AfflatusMisery))
-                        return AfflatusMisery;
+                    // Miracle of Nature if enabled and off cooldown and inrange 
+                    if (IsEnabled(Preset.WHMPvP_Mirace_of_Nature) && IsOffCooldown(MiracleOfNature) && InActionRange(MiracleOfNature))
+                        return MiracleOfNature;
                 }
-                // Prevent waste cure 3 option
-                if (IsEnabled(Preset.WHMPvP_NoWasteCure) && HasStatusEffect(Buffs.Cure3Ready) && GetStatusEffectRemainingTime(Buffs.Cure3Ready) < 6)
-                    return Cure3;
-            }
 
+                // Afflatus Misery if enabled and off cooldown
+                if (IsEnabled(Preset.WHMPvP_Afflatus_Misery) && IsOffCooldown(AfflatusMisery))
+                    return AfflatusMisery;
+            }
+            if (IsEnabled(Preset.WHMPvP_Burst_Heals) && !HasStatusEffect(Buffs.SacredSight))
+            {
+                IGameObject? healTarget = WHMPvP_Burst_HealsRetarget ? SimpleTarget.Stack.AllyToHeal : SimpleTarget.Stack.Allies;
+                
+                if (WHMPvP_Burst_Heals_Options[1] && HasStatusEffect(Buffs.Cure3Ready) && GetTargetHPPercent(healTarget) <= WHMPvP_Burst_HealsThreshold)
+                    return WHMPvP_Burst_HealsRetarget
+                        ? Cure3.Retarget(Glare, healTarget, true)
+                        : Cure3;
+                
+                if (WHMPvP_Burst_Heals_Options[2] && ActionReady(Aquaveil) && CanWeave() && GetTargetHPPercent(healTarget) <= WHMPvP_Burst_HealsThreshold)
+                    return WHMPvP_Burst_HealsRetarget
+                        ? Aquaveil.Retarget(Glare, healTarget, true)
+                        : Aquaveil;
+                
+                if (WHMPvP_Burst_Heals_Options[0] && ActionReady(Cure2) && GetTargetHPPercent(healTarget) <= WHMPvP_Burst_HealsThreshold)
+                    return WHMPvP_Burst_HealsRetarget
+                        ? Cure2.Retarget(Glare, healTarget, true)
+                        : Cure2;
+            }
             return actionID;
         }
     }
@@ -108,16 +138,22 @@ internal static class WHMPvP
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is Cure2)
-            { 
-                if (IsEnabled(Preset.WHMPvP_Cure3) && HasStatusEffect(Buffs.Cure3Ready))
-                    return Cure3;
+            if (actionID is not Cure2) 
+                return actionID;
+            
+            if (IsEnabled(Preset.WHMPvP_Cure3) && HasStatusEffect(Buffs.Cure3Ready))
+                return WHMPvP_Heals_Options[1]
+                    ? Cure3.Retarget(Cure2, SimpleTarget.Stack.AllyToHeal, true)
+                    : Cure3;
 
-                if (IsEnabled(Preset.WHMPvP_Aquaveil) && IsOffCooldown(Aquaveil))
-                    return Aquaveil;      
-            }
+            if (IsEnabled(Preset.WHMPvP_Aquaveil) && IsOffCooldown(Aquaveil))
+                return WHMPvP_Heals_Options[2]
+                    ? Aquaveil.Retarget(Cure2, SimpleTarget.Stack.AllyToHeal, true)
+                    : Aquaveil;
 
-            return actionID;
+            return WHMPvP_Heals_Options[2]
+                ? actionID.Retarget(Cure2, SimpleTarget.Stack.AllyToHeal, true)
+                : actionID;
         }
     }
 }

--- a/WrathCombo/CustomCombo/SimpleTarget.cs
+++ b/WrathCombo/CustomCombo/SimpleTarget.cs
@@ -113,6 +113,14 @@ internal static class SimpleTarget
         /// </summary>
         public static IGameObject? AllyToRaise =>
             GetStack(StackOption.RaiseStack);
+        
+        /// <summary>
+        ///     The <see cref="AllyToHeal">Heal Stack</see>, but filtered to
+        ///     those in Line of Sight.
+        /// </summary>
+        public static IGameObject? AllyToHealPVP =>
+            GetStack(logicForEachEntryInStack:
+                target => target.IfWithinLineOfSight());
 
         #region Custom Stack Resolving
 

--- a/WrathCombo/Extensions/GameObjectExtensions.cs
+++ b/WrathCombo/Extensions/GameObjectExtensions.cs
@@ -9,6 +9,7 @@ using System;
 using System.Linq;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
+using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 namespace WrathCombo.Extensions;
 
 public static class GameObjectExtensions
@@ -32,7 +33,7 @@ public static class GameObjectExtensions
     ///     See <see cref="SimpleTarget.Stack.AllyToHeal"/> for a use case.
     /// </remarks>
     public static IGameObject? IfFriendly (this IGameObject? obj) =>
-        obj != null && CustomComboFunctions.TargetIsFriendly(obj) ? obj : null;
+        obj != null && TargetIsFriendly(obj) ? obj : null;
 
     /// <summary>
     ///     Can be chained onto a <see cref="IGameObject" /> to make it return
@@ -40,7 +41,7 @@ public static class GameObjectExtensions
     /// </summary>
     public static IGameObject? IfInParty (this IGameObject? obj) =>
         obj != null &&
-        CustomComboFunctions.GetPartyMembers()
+        GetPartyMembers()
             .Any(x => x.GameObjectId == obj.GameObjectId) ? obj : null;
 
     /// <summary>
@@ -55,7 +56,7 @@ public static class GameObjectExtensions
     ///     <see langword="null" /> if the target is not a boss.
     /// </summary>
     public static IGameObject? IfBoss (this IGameObject? obj) =>
-        obj != null && CustomComboFunctions.TargetIsBoss(obj) ? obj : null;
+        obj != null && TargetIsBoss(obj) ? obj : null;
 
     /// <summary>
     ///     Can be chained onto a <see cref="IGameObject" /> to make it return
@@ -69,7 +70,7 @@ public static class GameObjectExtensions
     ///     <see langword="null" /> if the target does not need positionals.
     /// </summary>
     public static IGameObject? IfNeedsPositionals (this IGameObject? obj) =>
-        obj != null && CustomComboFunctions.TargetNeedsPositionals(obj) ? obj : null;
+        obj != null && TargetNeedsPositionals(obj) ? obj : null;
 
     /// <summary>
     ///     Can be chained onto a <see cref="IGameObject" /> to make it return
@@ -86,7 +87,16 @@ public static class GameObjectExtensions
     /// <param name="range">The range to check against. Defaults to 25 yalms.</param>
     public static IGameObject? IfWithinRange
         (this IGameObject? obj, float range = 25) =>
-        obj != null && CustomComboFunctions.IsInRange(obj, range) ? obj : null;
+        obj != null && IsInRange(obj, range) ? obj : null;
+    
+    /// <summary>
+    ///     Can be chained onto a <see cref="IGameObject" /> to make it return
+    ///     <see langword="null" /> if the target is not within line of sight.
+    /// </summary>
+    /// <param name="obj"></param>
+    public static IGameObject? IfWithinLineOfSight
+        (this IGameObject? obj) =>
+        obj != null && IsInLineOfSight(obj) ? obj : null;
 
     /// <summary>
     ///     Can be chained onto a <see cref="IGameObject" /> to make it return
@@ -103,7 +113,7 @@ public static class GameObjectExtensions
     ///     <see langword="null" /> if the target is not invulnerable/invincible.
     /// </summary>
     public static IGameObject? IfNotInvincible (this IGameObject? obj) =>
-        obj != null && !CustomComboFunctions.TargetIsInvincible(obj) ? obj : null;
+        obj != null && !TargetIsInvincible(obj) ? obj : null;
 
     /// <summary>
     ///     Can be chained onto a <see cref="IGameObject" /> to make it return
@@ -111,7 +121,7 @@ public static class GameObjectExtensions
     ///     debuff.
     /// </summary>
     public static IGameObject? IfHasCleansable (this IGameObject? obj) =>
-        obj != null && CustomComboFunctions.HasCleansableDebuff(obj) ? obj : null;
+        obj != null && HasCleansableDebuff(obj) ? obj : null;
 
     /// <summary>
     ///     Can be chained onto a <see cref="IGameObject" /> to make it return
@@ -176,7 +186,7 @@ public static class GameObjectExtensions
     ///     boolean check for if the target is friendly.
     /// </summary>
     public static bool IsFriendly(this IGameObject? obj) =>
-        obj != null && CustomComboFunctions.TargetIsFriendly(obj);
+        obj != null && TargetIsFriendly(obj);
 
     /// <summary>
     ///     Can be chained onto a <see cref="IGameObject" /> to make it a quick
@@ -184,7 +194,7 @@ public static class GameObjectExtensions
     /// </summary>
     public static bool IsInParty(this IGameObject? obj) =>
         obj != null &&
-        CustomComboFunctions.GetPartyMembers()
+        GetPartyMembers()
             .Any(x => x.GameObjectId == obj.GameObjectId);
 
     // `IsHostile` already exists, and works the exact same as we would write here
@@ -194,7 +204,7 @@ public static class GameObjectExtensions
     ///     boolean check for if the target is a boss.
     /// </summary>
     public static bool IsBoss(this IGameObject? obj) =>
-        obj != null && CustomComboFunctions.TargetIsBoss(obj);
+        obj != null && TargetIsBoss(obj);
 
     /// <summary>
     ///     Can be chained onto a <see cref="IGameObject" /> to make it a quick
@@ -208,7 +218,7 @@ public static class GameObjectExtensions
     ///     boolean check for if the target needs positionals.
     /// </summary>
     public static bool NeedsPositionals(this IGameObject? obj) =>
-        obj != null && CustomComboFunctions.TargetNeedsPositionals(obj);
+        obj != null && TargetNeedsPositionals(obj);
 
     /// <summary>
     ///     Can be chained onto a <see cref="IGameObject" /> to make it a quick
@@ -222,7 +232,7 @@ public static class GameObjectExtensions
     ///     boolean check for if the target is within range.
     /// </summary>
     public static bool IsWithinRange(this IGameObject? obj, float range = 25) =>
-        obj != null && CustomComboFunctions.IsInRange(obj, range);
+        obj != null && IsInRange(obj, range);
 
     /// <summary>
     ///     Can be chained onto a <see cref="IGameObject" /> to make it a quick
@@ -236,14 +246,14 @@ public static class GameObjectExtensions
     ///     boolean check for if the object is not invulnerable/invincible.
     /// </summary>
     public static bool IsNotInvincible(this IGameObject? obj) =>
-        obj != null && !CustomComboFunctions.TargetIsInvincible(obj);
+        obj != null && !TargetIsInvincible(obj);
 
     /// <summary>
     ///     Can be chained onto a <see cref="IGameObject" /> to make it a quick
     ///     boolean check for if the object has a cleansable debuff.
     /// </summary>
     public static bool IsCleansable(this IGameObject? obj) =>
-        obj != null && CustomComboFunctions.HasCleansableDebuff(obj);
+        obj != null && HasCleansableDebuff(obj);
 
     /// <summary>
     ///     Can be chained onto a <see cref="IGameObject" /> to make it a quick
@@ -294,10 +304,10 @@ public static class GameObjectExtensions
     {
         return obj.IsDead &&
                obj.IsAPlayer() &&
-               !CustomComboFunctions.HasStatusEffect(2648, obj, true) &&
-               !CustomComboFunctions.HasStatusEffect(148, obj, true) &&
+               !HasStatusEffect(2648, obj, true) &&
+               !HasStatusEffect(148, obj, true) &&
                obj.IsTargetable &&
-               (CustomComboFunctions.TimeSpentDead(obj.GameObjectId)
+               (TimeSpentDead(obj.GameObjectId)
                    .TotalSeconds > 2 || !obj.IsInParty());
     }
 }


### PR DESCRIPTION
All General Cleanup. Inverting IFs, Removing Deadspace;

Every job has seen at least one CC on full one button to ensure casual player readiness after all the inverting. 

- [x] Purify Slider and CD
- [x] AST
  - [x] Added re-targeting to existing Aspected Benefic Standalone
  - [x] Added Aspected Benefic option to burst with re-targeting
- [x] BLM
  - [x] Added MP Slider to Aethereal Manipulation Purify feature
- [x] BRD
- [x] DNC
- [x] DRG
- [x] DRK
- [x] GNB
- [x] MCH
- [x] MNK
- [x] NIN
- [x] PCT
- [x] PLD
  - [x] Added Slider for optional health missing threshold for Holy Spirit
- [x] RDM
  - [x] Added Purify MP Slider to Corps/Displacement Feature
- [x] RPR
- [x] SAM
- [x] SCH
  - [x] Added re-targeting Standalone
  - [x] upgraded Self Adlo in burst to have re-targeting Option
- [x] SGE
  - [x] Upgraded Standalone feature to allow re-targeting of Kardia
  - [x] Added Mobile Kardia Option to burst mode
- [x] SMN
- [x] VPR
- [x] WAR
- [x] WHM
  - [x] Upgraded Standalone feature to allow re-targeting of all 3 Heals
  - [x] Updated Burst Heal to include all 3 heals with re-targeting option