### PR TITLE
[VPRPVP] LImit break fix for performance mode

### DIFF
--- a/WrathCombo/Combos/PvP/VPRPVP.cs
+++ b/WrathCombo/Combos/PvP/VPRPVP.cs
@@ -98,7 +98,7 @@ internal static class VPRPvP
                 // Slither
                 case Preset.VPRPvP_Slither:
                     DrawSliderInt(0, 1, VPRPvP_Slither_Charges, "Charges to Keep");
-                    DrawSliderInt(6, 10, VPRPvP_Slither_Range, "Maximum Range");
+                    DrawSliderInt(6, 20, VPRPvP_Slither_Range, "Maximum Range");
                     break;
 
                 // Smite

--- a/WrathCombo/Combos/PvP/VPRPVP.cs
+++ b/WrathCombo/Combos/PvP/VPRPVP.cs
@@ -109,7 +109,7 @@ internal static class VPRPvP
             }
         }
     }
-        #endregion     
+    #endregion     
 
     internal class VPRPvP_Burst : CustomCombo
     {
@@ -117,7 +117,8 @@ internal static class VPRPvP
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is not (SteelFangs or HuntersSting or BarbarousSlice or PiercingFangs or SwiftskinsSting or RavenousBite)) 
+            if (actionID is not (SteelFangs or HuntersSting or BarbarousSlice or PiercingFangs or SwiftskinsSting or 
+                RavenousBite or FirstGeneration or SecondGeneration or ThirdGeneration or FourthGeneration)) 
                 return actionID;
 
             #region Variables


### PR DESCRIPTION
- added First through Fourth generation to action ID check. So that in performance mod it doesnt ignore the combo during lb and the ogcd legacy attacks go off. 