### PR TITLE
[Core] Fix Conflict not showing for `Shield Bash`

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -36,12 +36,12 @@ public enum Preset
     [ConflictingCombos(PLD_RetargetShieldBash)]
     [ParentCombo(ALL_Tank_Menu)]
     [CustomComboInfo("Tank: Interrupt Feature",
-        "Replaces Low Blow (Stun) with Interject (Interrupt) when the target can be interrupted.\nPLDs can slot Shield Bash to have the feature to work with Shield Bash.",
+        "Replaces Low Blow (Stun) with Interject (Interrupt) when the target can be interrupted.\nFor PLDs this feature will add Shield Bash when Interject and Low Blow are on cooldown.",
         Job.ADV)]
     ALL_Tank_Interrupt = 100000,
 
     [ParentCombo(ALL_Tank_Interrupt)]
-    [Retargeted(RoleActions.Tank.Interject, RoleActions.Tank.LowBlow)]
+    [Retargeted(RoleActions.Tank.Interject, RoleActions.Tank.LowBlow, PLD.ShieldBash)]
     [CustomComboInfo("Retarget Interrupts", "Will retarget the interrupt if the caster is not your current target.", Job.ADV)]
     ALL_Tank_Interrupt_Retarget = 100005,
 

--- a/WrathCombo/Combos/PvE/ALL/ALL.cs
+++ b/WrathCombo/Combos/PvE/ALL/ALL.cs
@@ -56,16 +56,21 @@ internal partial class All
 
         protected override uint Invoke(uint actionID)
         {
+            if (actionID is not (RoleActions.Tank.Interject or RoleActions.Tank.LowBlow or PLD.ShieldBash))
+                return actionID;
+
             var tar = IsEnabled(Preset.ALL_Tank_Interrupt_Retarget) ? SimpleTarget.InterruptableEnemy : CurrentTarget;
             switch (actionID)
             {
                 case RoleActions.Tank.LowBlow or PLD.ShieldBash when CanInterruptEnemy(null, tar) && ActionReady(RoleActions.Tank.Interject):
                     return RoleActions.Tank.Interject.Retarget(actionID, tar);
 
-                case RoleActions.Tank.LowBlow or PLD.ShieldBash when TargetIsCasting() && ActionReady(RoleActions.Tank.LowBlow) && !TargetIsBoss():
+                case RoleActions.Tank.LowBlow or PLD.ShieldBash when TargetIsCasting() && ActionReady(RoleActions.Tank.LowBlow) && !TargetIsBoss() && !JustUsed(RoleActions.Tank.Interject):
                     return RoleActions.Tank.LowBlow.Retarget(actionID, tar);
 
-                case PLD.ShieldBash when IsOnCooldown(RoleActions.Tank.LowBlow):
+                case PLD.ShieldBash when IsOnCooldown(RoleActions.Tank.LowBlow) && !JustUsed(RoleActions.Tank.Interject) && !JustUsed(PLD.ShieldBash, 7):
+                    return PLD.ShieldBash.Retarget(actionID, tar);
+
                 default:
                     return actionID;
             }


### PR DESCRIPTION
- [X] Adds `Shield Bash` to the Retargeted list for the All: Tank: Interrupt Feature
- [X] Clarify the All: Tank: Interrupt Feature's description
- [X] Makes the Retargeting Option for the above Feature also apply to `Shield Bash`\
      (and makes it not go out of its way to return `Shield Bash` if used recently)