### PR TITLE
[UI] Align PvP with PvE, make Child Preset Borders hide-able

### DIFF
--- a/WrathCombo/Window/Tabs/PvEFeatures.cs
+++ b/WrathCombo/Window/Tabs/PvEFeatures.cs
@@ -81,7 +81,6 @@ internal class PvEFeatures : ConfigWindow
                                 ImGui.Dummy(new Vector2(iconMaxSize, iconMaxSize));
                             }
                             ImGui.SameLine(indentwidth2);
-
                             ImGuiEx.Spacing(new Vector2(0, verticalCenteringPadding));
                             ImGui.Text($"{header} {(disabled ? "(Disabled due to update)" : "")}");
 

--- a/WrathCombo/Window/Tabs/PvPFeatures.cs
+++ b/WrathCombo/Window/Tabs/PvPFeatures.cs
@@ -25,6 +25,8 @@ internal class PvPFeatures : ConfigWindow
         {
             var indentwidth = 12f.Scale();
             var indentwidth2 = indentwidth + 42f.Scale();
+            var iconMaxSize = 34f.Scale();
+            var verticalCenteringPadding = (iconMaxSize - ImGui.GetTextLineHeight()) / 2f;
 
             if (OpenJob is null)
             {
@@ -65,19 +67,29 @@ internal class PvPFeatures : ConfigWindow
                         string header = string.IsNullOrEmpty(abbreviation) ? jobName : $"{jobName} - {abbreviation}";
                         var id = groupedPresets[job].First().Info.Job;
                         IDalamudTextureWrap? icon = Icons.GetJobIcon(id);
+                        ImGuiEx.Spacing(new Vector2(0, 2f.Scale()));
                         using (var disabled = ImRaii.Disabled(DisabledJobsPVP.Any(x => x == id)))
                         {
-                            if (ImGui.Selectable($"###{header}", OpenJob == job, ImGuiSelectableFlags.None,
-                                icon == null ? new Vector2(0, 32).Scale() : new Vector2(0, icon.Size.Y / 2f).Scale()))
+                            if (ImGui.Selectable($"###{header}", OpenJob == job, ImGuiSelectableFlags.None, new Vector2(0, iconMaxSize)))
                             {
                                 OpenJob = job;
                             }
                             ImGui.SameLine(indentwidth);
                             if (icon != null)
                             {
-                                ImGui.Image(icon.Handle, new Vector2(icon.Size.X, icon.Size.Y).Scale() / 2f);
-                                ImGui.SameLine(indentwidth2);
+                                var scale = Math.Min(iconMaxSize / icon.Size.X, iconMaxSize / icon.Size.Y);
+                                var imgSize = new Vector2(icon.Size.X * scale, icon.Size.Y * scale);
+                                var padSize = (iconMaxSize - imgSize.X) / 2f;
+                                if (padSize > 0)
+                                    ImGui.SetCursorPosX(ImGui.GetCursorPosX() + padSize);
+                                ImGui.Image(icon.Handle, imgSize);
                             }
+                            else
+                            {
+                                ImGui.Dummy(new Vector2(iconMaxSize, iconMaxSize));
+                            }
+                            ImGui.SameLine(indentwidth2);
+                            ImGuiEx.Spacing(new Vector2(0, verticalCenteringPadding));
                             ImGui.Text($"{header} {(disabled ? "(Disabled due to update)" : "")}");
                         }
 
@@ -90,7 +102,7 @@ internal class PvPFeatures : ConfigWindow
                 var id = groupedPresets[OpenJob.Value].First().Info.Job;
                 IDalamudTextureWrap? icon = Icons.GetJobIcon(id);
 
-                using (var headingTab = ImRaii.Child("PvPHeadingTab", new Vector2(ImGui.GetContentRegionAvail().X, icon is null ? 24f.Scale() : (icon.Size.Y / 2f).Scale() + 4f)))
+                using (ImRaii.Child("PvPHeadingTab", new Vector2(ImGui.GetContentRegionAvail().X, iconMaxSize)))
                 {
                     if (ImGui.Button("Back", new Vector2(0, 24f.Scale())))
                     {
@@ -102,9 +114,19 @@ internal class PvPFeatures : ConfigWindow
                     {
                         if (icon != null)
                         {
-                            ImGui.Image(icon.Handle, new Vector2(icon.Size.X, icon.Size.Y).Scale() / 2f);
-                            ImGui.SameLine();
+                            var scale = Math.Min(iconMaxSize / icon.Size.X, iconMaxSize / icon.Size.Y);
+                            var imgSize = new Vector2(icon.Size.X * scale, icon.Size.Y * scale);
+                            var padSize = (iconMaxSize - imgSize.X) / 2f;
+                            if (padSize > 0)
+                                ImGui.SetCursorPosX(ImGui.GetCursorPosX() + padSize);
+                            ImGui.Image(icon.Handle, imgSize);
                         }
+                        else
+                        {
+                            ImGui.Dummy(new Vector2(iconMaxSize, iconMaxSize));
+                        }
+                        ImGui.SameLine();
+                        ImGuiEx.Spacing(new Vector2(0, verticalCenteringPadding-2f.Scale()));
                         ImGuiEx.Text($"{OpenJob.Value.Name()}");
                     });
 


### PR DESCRIPTION
- [X] Align PvP's styling with PvE's
  - [X] Icon Sizing
  - [X] Text Spacing
  - [X] Selectable Spacing
- [ ] Make nested Preset Boxes' borders hide-able
  - [ ] Add an option to hide them
  - [ ] Use dalamud style border color for color
  - [ ] Use dalamud style border width for width