### PR TITLE
[PLD] Sheltron options + Passage of Arms Lockout

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -4697,7 +4697,7 @@ public enum Preset
     PLD_ST_AdvancedMode_Mitigation = 11038,
 
     [ParentCombo(PLD_ST_AdvancedMode_Mitigation)]
-    [CustomComboInfo("Sheltron Option", "Adds Sheltron.\n- Required gauge threshold:", Job.PLD)]
+    [CustomComboInfo("Sheltron Option", "Adds Sheltron.\n- Player HP must be at or under:", Job.PLD)]
     PLD_ST_AdvancedMode_Sheltron = 11007,
 
     [ParentCombo(PLD_ST_AdvancedMode_Mitigation)]
@@ -4801,7 +4801,7 @@ public enum Preset
     PLD_AoE_AdvancedMode_Mitigation = 11042,
 
     [ParentCombo(PLD_AoE_AdvancedMode_Mitigation)]
-    [CustomComboInfo("Sheltron Option", "Adds Sheltron.\n- Required gauge threshold:", Job.PLD)]
+    [CustomComboInfo("Sheltron Option", "Adds Sheltron.\n- Player HP must be at or under:", Job.PLD)]
     PLD_AoE_AdvancedMode_Sheltron = 11023,
 
     [ParentCombo(PLD_AoE_AdvancedMode_Mitigation)]

--- a/WrathCombo/Combos/PvE/PLD/PLD.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD.cs
@@ -9,28 +9,7 @@ namespace WrathCombo.Combos.PvE;
 
 internal partial class PLD : Tank
 {
-    internal class PLD_ST_BasicCombo : CustomCombo
-    {
-        protected internal override Preset Preset => Preset.PLD_ST_BasicCombo;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not RageOfHalone)
-                return actionID;
-
-            if (ComboTimer > 0)
-            {
-                if (ComboAction is FastBlade && LevelChecked(RiotBlade))
-                    return RiotBlade;
-
-                if (ComboAction is RiotBlade && LevelChecked(RageOfHalone))
-                    return OriginalHook(RageOfHalone);
-            }
-
-            return FastBlade;
-        }
-    }
-
+    #region Simple Modes
     internal class PLD_ST_SimpleMode : CustomCombo
     {
         protected internal override Preset Preset => Preset.PLD_ST_SimpleMode;
@@ -40,6 +19,9 @@ internal partial class PLD : Tank
         {
             if (actionID is not FastBlade)
                 return actionID;
+            
+            if (HasStatusEffect(Buffs.PassageOfArms))
+                return All.SavageBlade;
 
             #region Variables
 
@@ -241,6 +223,9 @@ internal partial class PLD : Tank
         {
             if (actionID is not TotalEclipse)
                 return actionID;
+            
+            if (HasStatusEffect(Buffs.PassageOfArms))
+                return All.SavageBlade;
 
             #region Variables
 
@@ -364,7 +349,9 @@ internal partial class PLD : Tank
             return actionID;
         }
     }
-
+    #endregion
+    
+    #region Advanced Modes
     internal class PLD_ST_AdvancedMode : CustomCombo
     {
         protected internal override Preset Preset => Preset.PLD_ST_AdvancedMode;
@@ -374,6 +361,9 @@ internal partial class PLD : Tank
         {
             if (actionID is not FastBlade)
                 return actionID;
+
+            if (HasStatusEffect(Buffs.PassageOfArms))
+                return All.SavageBlade;
 
             #region Variables
 
@@ -483,33 +473,35 @@ internal partial class PLD : Tank
                     if (IsEnabled(Preset.PLD_ST_AdvancedMode_BladeOfHonor) && LevelChecked(BladeOfHonor) && OriginalHook(Requiescat) == BladeOfHonor)
                         return OriginalHook(Requiescat);
 
-                    // Mitigation
-                    if (IsEnabled(Preset.PLD_ST_AdvancedMode_Mitigation) && IsPlayerTargeted() && !hasJustUsedMitigation && InCombat())
+                    #region Mitigation
+                    if (IsEnabled(Preset.PLD_ST_AdvancedMode_Mitigation) && !hasJustUsedMitigation && InCombat())
                     {
                         // Hallowed Ground
-                        if (IsEnabled(Preset.PLD_ST_AdvancedMode_HallowedGround) && ActionReady(HallowedGround) &&
-                            PlayerHealthPercentageHp() < PLD_ST_HallowedGround_Health && (PLD_ST_HallowedGround_SubOption == 1 ||
-                                                                                                 TargetIsBoss() && PLD_ST_HallowedGround_SubOption == 2))
+                        if (IsEnabled(Preset.PLD_ST_AdvancedMode_HallowedGround) && ActionReady(HallowedGround) && IsPlayerTargeted() &&
+                            PlayerHealthPercentageHp() < PLD_ST_HallowedGround_Health && 
+                            (PLD_ST_HallowedGround_SubOption == 1 || TargetIsBoss() && PLD_ST_HallowedGround_SubOption == 2))
                             return HallowedGround;
 
                         // Sentinel / Guardian
-                        if (IsEnabled(Preset.PLD_ST_AdvancedMode_Sentinel) && ActionReady(OriginalHook(Sentinel)) &&
-                            PlayerHealthPercentageHp() < PLD_ST_Sentinel_Health && (PLD_ST_Sentinel_SubOption == 1 ||
-                                                                                           TargetIsBoss() && PLD_ST_Sentinel_SubOption == 2))
+                        if (IsEnabled(Preset.PLD_ST_AdvancedMode_Sentinel) && ActionReady(OriginalHook(Sentinel)) && IsPlayerTargeted() &&
+                            PlayerHealthPercentageHp() < PLD_ST_Sentinel_Health && 
+                            (PLD_ST_Sentinel_SubOption == 1 || TargetIsBoss() && PLD_ST_Sentinel_SubOption == 2))
                             return OriginalHook(Sentinel);
 
                         // Rampart
-                        if (IsEnabled(Preset.PLD_ST_AdvancedMode_Rampart) &&
-                            Role.CanRampart(PLD_ST_Rampart_Health) && (PLD_ST_Rampart_SubOption == 1 ||
-                                                                              TargetIsBoss() && PLD_ST_Rampart_SubOption == 2))
+                        if (IsEnabled(Preset.PLD_ST_AdvancedMode_Rampart) && IsPlayerTargeted() &&
+                            Role.CanRampart(PLD_ST_Rampart_Health) && 
+                            (PLD_ST_Rampart_SubOption == 1 || TargetIsBoss() && PLD_ST_Rampart_SubOption == 2))
                             return Role.Rampart;
 
                         // Sheltron
-                        if (IsEnabled(Preset.PLD_ST_AdvancedMode_Sheltron) && LevelChecked(Sheltron) &&
-                            Gauge.OathGauge >= PLD_ST_SheltronOption && PlayerHealthPercentageHp() < 95 &&
+                        if (IsEnabled(Preset.PLD_ST_AdvancedMode_Sheltron) && LevelChecked(Sheltron) && 
+                            (IsPlayerTargeted() || !PLD_ST_Sheltron_Threat) &&
+                            Gauge.OathGauge >= PLD_ST_SheltronOption && PlayerHealthPercentageHp() <= PLD_ST_Sheltron_Health &&
                             !HasStatusEffect(Buffs.Sheltron) && !HasStatusEffect(Buffs.HolySheltron))
                             return OriginalHook(Sheltron);
                     }
+                    #endregion
                 }
 
                 // Requiescat Phase
@@ -586,6 +578,9 @@ internal partial class PLD : Tank
         {
             if (actionID is not TotalEclipse)
                 return actionID;
+            
+            if (HasStatusEffect(Buffs.PassageOfArms))
+                return All.SavageBlade;
 
             #region Variables
 
@@ -664,33 +659,35 @@ internal partial class PLD : Tank
                     if (IsEnabled(Preset.PLD_AoE_AdvancedMode_BladeOfHonor) && LevelChecked(BladeOfHonor) && OriginalHook(Requiescat) == BladeOfHonor)
                         return OriginalHook(Requiescat);
 
-                    // Mitigation
-                    if (IsEnabled(Preset.PLD_AoE_AdvancedMode_Mitigation) && IsPlayerTargeted() && !hasJustUsedMitigation && InCombat())
+                    #region Mitigation
+                    if (IsEnabled(Preset.PLD_AoE_AdvancedMode_Mitigation) && !hasJustUsedMitigation && InCombat())
                     {
                         // Hallowed Ground
-                        if (IsEnabled(Preset.PLD_AoE_AdvancedMode_HallowedGround) && ActionReady(HallowedGround) &&
-                            PlayerHealthPercentageHp() < PLD_AoE_HallowedGround_Health && (PLD_AoE_HallowedGround_SubOption == 1 ||
-                                                                                                  TargetIsBoss() && PLD_AoE_HallowedGround_SubOption == 2))
+                        if (IsEnabled(Preset.PLD_AoE_AdvancedMode_HallowedGround) && ActionReady(HallowedGround) && IsPlayerTargeted() &&
+                            PlayerHealthPercentageHp() < PLD_AoE_HallowedGround_Health && 
+                            (PLD_AoE_HallowedGround_SubOption == 1 || TargetIsBoss() && PLD_AoE_HallowedGround_SubOption == 2))
                             return HallowedGround;
 
                         // Sentinel / Guardian
-                        if (IsEnabled(Preset.PLD_AoE_AdvancedMode_Sentinel) && ActionReady(OriginalHook(Sentinel)) &&
-                            PlayerHealthPercentageHp() < PLD_AoE_Sentinel_Health && (PLD_AoE_Sentinel_SubOption == 1 ||
-                                                                                            TargetIsBoss() && PLD_AoE_Sentinel_SubOption == 2))
+                        if (IsEnabled(Preset.PLD_AoE_AdvancedMode_Sentinel) && ActionReady(OriginalHook(Sentinel)) && IsPlayerTargeted() &&
+                            PlayerHealthPercentageHp() < PLD_AoE_Sentinel_Health && 
+                            (PLD_AoE_Sentinel_SubOption == 1 || TargetIsBoss() && PLD_AoE_Sentinel_SubOption == 2))
                             return OriginalHook(Sentinel);
 
                         // Rampart
-                        if (IsEnabled(Preset.PLD_AoE_AdvancedMode_Rampart) &&
-                            Role.CanRampart(PLD_AoE_Rampart_Health) && (PLD_AoE_Rampart_SubOption == 1 ||
-                                                                               TargetIsBoss() && PLD_AoE_Rampart_SubOption == 2))
+                        if (IsEnabled(Preset.PLD_AoE_AdvancedMode_Rampart) && IsPlayerTargeted() &&
+                            Role.CanRampart(PLD_AoE_Rampart_Health) && 
+                            (PLD_AoE_Rampart_SubOption == 1 || TargetIsBoss() && PLD_AoE_Rampart_SubOption == 2))
                             return Role.Rampart;
 
                         // Sheltron
-                        if (IsEnabled(Preset.PLD_AoE_AdvancedMode_Sheltron) && LevelChecked(Sheltron) &&
-                            Gauge.OathGauge >= PLD_AoE_SheltronOption && PlayerHealthPercentageHp() < 95 &&
+                        if (IsEnabled(Preset.PLD_AoE_AdvancedMode_Sheltron) && LevelChecked(Sheltron) && 
+                            (IsPlayerTargeted() || !PLD_AoE_Sheltron_Threat) &&
+                            Gauge.OathGauge >= PLD_AoE_SheltronOption && PlayerHealthPercentageHp() <= PLD_AoE_Sheltron_Health &&
                             !HasStatusEffect(Buffs.Sheltron) && !HasStatusEffect(Buffs.HolySheltron))
                             return OriginalHook(Sheltron);
                     }
+                    #endregion
                 }
 
                 // Confiteor & Blades
@@ -711,7 +708,85 @@ internal partial class PLD : Tank
             return actionID;
         }
     }
+    #endregion
+    
+    #region Standalones
+    
+    #region One-Button Mitigation
 
+    internal class PLD_Mit_OneButton : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.PLD_Mit_OneButton;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not Bulwark)
+                return actionID;
+
+            if (IsEnabled(Preset.PLD_Mit_HallowedGround_Max) &&
+                ActionReady(HallowedGround) &&
+                PlayerHealthPercentageHp() <= PLD_Mit_HallowedGround_Max_Health &&
+                ContentCheck.IsInConfiguredContent(
+                    PLD_Mit_HallowedGround_Max_Difficulty,
+                    PLD_Mit_HallowedGround_Max_DifficultyListSet
+                ))
+                return HallowedGround;
+
+            foreach (int priority in PLD_Mit_Priorities.Items.OrderBy(x => x))
+            {
+                int index = PLD_Mit_Priorities.IndexOf(priority);
+                if (CheckMitigationConfigMeetsRequirements(index, out uint action))
+                    return action;
+            }
+
+            return actionID;
+        }
+    }
+
+    internal class PLD_Mit_OneButton_Party : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.PLD_Mit_Party;
+
+        protected override uint Invoke(uint action)
+        {
+            if (action is not DivineVeil)
+                return action;
+
+            if (ActionReady(Role.Reprisal))
+                return Role.Reprisal;
+
+            if (ActionReady(PassageOfArms) &&
+                IsEnabled(Preset.PLD_Mit_Party_Wings) &&
+                !HasStatusEffect(Buffs.PassageOfArms, anyOwner: true))
+                return PassageOfArms;
+
+            return action;
+        }
+    }
+    #endregion
+    
+    internal class PLD_ST_BasicCombo : CustomCombo
+    {
+        protected internal override Preset Preset => Preset.PLD_ST_BasicCombo;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not RageOfHalone)
+                return actionID;
+
+            if (ComboTimer > 0)
+            {
+                if (ComboAction is FastBlade && LevelChecked(RiotBlade))
+                    return RiotBlade;
+
+                if (ComboAction is RiotBlade && LevelChecked(RageOfHalone))
+                    return OriginalHook(RageOfHalone);
+            }
+
+            return FastBlade;
+        }
+    }
+    
     internal class PLD_Requiescat_Confiteor : CustomCombo
     {
         protected internal override Preset Preset => Preset.PLD_Requiescat_Options;
@@ -811,6 +886,7 @@ internal partial class PLD : Tank
                 : actionID;
         }
     }
+    
     internal class PLD_RetargetSheltron : CustomCombo
     {
         protected internal override Preset Preset => Preset.PLD_RetargetSheltron;
@@ -844,59 +920,6 @@ internal partial class PLD : Tank
             return action;
         }
     }
-    #region One-Button Mitigation
-
-    internal class PLD_Mit_OneButton : CustomCombo
-    {
-        protected internal override Preset Preset => Preset.PLD_Mit_OneButton;
-
-        protected override uint Invoke(uint actionID)
-        {
-            if (actionID is not Bulwark)
-                return actionID;
-
-            if (IsEnabled(Preset.PLD_Mit_HallowedGround_Max) &&
-                ActionReady(HallowedGround) &&
-                PlayerHealthPercentageHp() <= PLD_Mit_HallowedGround_Max_Health &&
-                ContentCheck.IsInConfiguredContent(
-                    PLD_Mit_HallowedGround_Max_Difficulty,
-                    PLD_Mit_HallowedGround_Max_DifficultyListSet
-                ))
-                return HallowedGround;
-
-            foreach (int priority in PLD_Mit_Priorities.Items.OrderBy(x => x))
-            {
-                int index = PLD_Mit_Priorities.IndexOf(priority);
-                if (CheckMitigationConfigMeetsRequirements(index, out uint action))
-                    return action;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class PLD_Mit_OneButton_Party : CustomCombo
-    {
-        protected internal override Preset Preset => Preset.PLD_Mit_Party;
-
-        protected override uint Invoke(uint action)
-        {
-            if (action is not DivineVeil)
-                return action;
-
-            if (ActionReady(Role.Reprisal))
-                return Role.Reprisal;
-
-            if (ActionReady(PassageOfArms) &&
-                IsEnabled(Preset.PLD_Mit_Party_Wings) &&
-                !HasStatusEffect(Buffs.PassageOfArms, anyOwner: true))
-                return PassageOfArms;
-
-            return action;
-        }
-    }
-
-    #endregion
 
     internal class PLD_RetargetShieldBash : CustomCombo
     {
@@ -917,4 +940,6 @@ internal partial class PLD : Tank
             return actionID;
         }
     }
+    
+    #endregion
 }

--- a/WrathCombo/Combos/PvE/PLD/PLD_Config.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD_Config.cs
@@ -18,7 +18,7 @@ internal partial class PLD
             PLD_ST_FoF_Trigger = new("PLD_ST_FoF_Trigger", 0),
             PLD_AoE_FoF_Trigger = new("PLD_AoE_FoF_Trigger", 0),
             PLD_ST_SheltronOption = new("PLD_ST_SheltronOption", 50),
-            PLD_ST_Sheltron_SubOption = new("PLD_ST_Sheltron_SubOption", 1),
+            PLD_ST_Sheltron_Health = new("PLD_ST_Sheltron_Health", 95),
             PLD_ST_Rampart_Health = new("PLD_ST_Rampart_Health", 80),
             PLD_ST_Rampart_SubOption = new("PLD_ST_Rampart_SubOption", 1),
             PLD_ST_Sentinel_Health = new("PLD_ST_Sentinel_Health", 60),
@@ -26,7 +26,7 @@ internal partial class PLD
             PLD_ST_HallowedGround_Health = new("PLD_ST_HallowedGround_Health", 30),
             PLD_ST_HallowedGround_SubOption = new("PLD_ST_HallowedGround_SubOption", 1),
             PLD_AoE_SheltronOption = new("PLD_AoE_SheltronOption", 50),
-            PLD_AoE_Sheltron_SubOption = new("PLD_AoE_Sheltron_SubOption", 1),
+            PLD_AoE_Sheltron_Health = new("PLD_AoE_Sheltron_Health", 95),
             PLD_AoE_Rampart_Health = new("PLD_AoE_Rampart_Health", 80),
             PLD_AoE_Rampart_SubOption = new("PLD_AoE_Rampart_SubOption", 1),
             PLD_AoE_Sentinel_Health = new("PLD_AoE_Sentinel_Health", 60),
@@ -61,7 +61,9 @@ internal partial class PLD
 
 
         public static UserBool
-            PLD_RetargetStunLockout = new("PLD_RetargetStunLockout");
+            PLD_RetargetStunLockout = new("PLD_RetargetStunLockout"),
+            PLD_ST_Sheltron_Threat = new("PLD_ST_Sheltron_Threat"),
+            PLD_AoE_Sheltron_Threat = new("PLD_AoE_Sheltron_Threat");
 
         public static UserIntArray
             PLD_Mit_Priorities = new("PLD_Mit_Priorities");
@@ -99,25 +101,15 @@ internal partial class PLD
 
                 // Sheltron
                 case Preset.PLD_ST_AdvancedMode_Sheltron:
-                    DrawSliderInt(50, 100, PLD_ST_SheltronOption, "Oath Gauge", 200, 5);
-
-                    DrawHorizontalRadioButton(PLD_ST_Sheltron_SubOption, "All Enemies",
-                        "Uses Sheltron regardless of targeted enemy type.", 1);
-
-                    DrawHorizontalRadioButton(PLD_ST_Sheltron_SubOption, "Bosses Only",
-                        "Only uses Sheltron when the targeted enemy is a boss.", 2);
-
+                    DrawSliderInt(1, 100, PLD_ST_Sheltron_Health, "Player HP%", 200);
+                    DrawSliderInt(50, 100, PLD_ST_SheltronOption, "Minimum Oath Gauge", 200, 5);
+                    DrawAdditionalBoolChoice(PLD_ST_Sheltron_Threat, "Require threat", "Will only work when Tanking");
                     break;
 
                 case Preset.PLD_AoE_AdvancedMode_Sheltron:
-                    DrawSliderInt(50, 100, PLD_AoE_SheltronOption, "Oath Gauge", 200, 5);
-
-                    DrawHorizontalRadioButton(PLD_AoE_Sheltron_SubOption, "All Enemies",
-                        "Uses Sheltron regardless of targeted enemy type.", 1);
-
-                    DrawHorizontalRadioButton(PLD_AoE_Sheltron_SubOption, "Bosses Only",
-                        "Only uses Sheltron when the targeted enemy is a boss.", 2);
-
+                    DrawSliderInt(1, 100, PLD_AoE_Sheltron_Health, "Player HP%", 200);
+                    DrawSliderInt(50, 100, PLD_AoE_SheltronOption, "Minimum Oath Gauge", 200, 5);
+                    DrawAdditionalBoolChoice(PLD_AoE_Sheltron_Threat, "Require threat", "Will only work when Tanking");
                     break;
 
                 // Rampart


### PR DESCRIPTION
Currently Autorotation not working for intervention in a dps combo likely due to it being considered a targeted heal. These choices allow people to set up something like a reaction stack to use intervention as overcap when offtanking while still having the ability to retain current functionality. Choice is good. 

- Added HP slider to Sheltron in place of locking it to 95% health
- Added Option for Sheltron to not require being the target
- Removed the all enemies/boss only configs from Sheltron. They were never wired up, nor should the be for the tiny cd. 
- Added Passage of Arms Lockout with Savage Blade at top of all main combos. Just take a step to break it and continue rotation. 