### PR TITLE
[RDM] Reprise Feature

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5283,6 +5283,11 @@ public enum Preset
     [CustomComboInfo("Include Riposte",
         "Adds Riposte to start the combo. Recommended for Auto Rotation. \n**Must be in melee range or have gap-close with Corps-a-corps enabled**", Job.RDM)]
     RDM_ST_MeleeCombo_IncludeRiposte = 13007,
+    
+    [ParentCombo(RDM_ST_MeleeCombo)]
+    [CustomComboInfo("Include Reprise",
+        "Adds Reprise when outside of range during the melee combo. Will retain enough mana in order to finish the current combo.", Job.RDM)]
+    RDM_ST_MeleeCombo_IncludeReprise = 13027,
 
     [ParentCombo(RDM_ST_MeleeCombo)]
     [CustomComboInfo("Gap-Close with Corps-a-corps Option",
@@ -5363,7 +5368,7 @@ public enum Preset
     [CustomComboInfo("Vercure Solo Option", "Adds Vercure on self when solo or in a party with no healers.", Job.RDM)]
     RDM_ST_VerCure = 13026,
 
-    //Last Used 13026
+    //Last Used 13027
     #endregion
 
     #region AoE DPS

--- a/WrathCombo/Combos/PvE/RDM/RDM.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM.cs
@@ -78,6 +78,13 @@ internal partial class RDM : Caster
                     (HasEnoughManaToStart || CanMagickedSwordplay))
                     return EnchantedRiposte;
             }
+            
+            if (LevelChecked(Reprise) &&
+                GetTargetDistance() >= 5 &&
+                (ComboAction is Zwerchhau or EnchantedZwerchhau && RedoublementRepriseMana || 
+                 ComboAction is  Riposte or EnchantedRiposte && ZwerchhauRepriseMana))
+                return EnchantedReprise;
+            
             #endregion
 
             #region GCD Casts
@@ -278,6 +285,13 @@ internal partial class RDM : Caster
 
             if (IsEnabled(Preset.RDM_ST_MeleeCombo))
             {
+                
+                if (IsEnabled(Preset.RDM_ST_MeleeCombo_IncludeReprise) && LevelChecked(Reprise) &&
+                    GetTargetDistance() >= RDM_ST_MeleeCombo_IncludeReprise_Distance && 
+                    (ComboAction is Zwerchhau or EnchantedZwerchhau && RedoublementRepriseMana || 
+                     ComboAction is  Riposte or EnchantedRiposte && ZwerchhauRepriseMana))
+                    return EnchantedReprise;
+                
                 if ((InMeleeRange() || IsEnabled(Preset.RDM_ST_MeleeCombo_MeleeCheck)) && (HasEnoughManaForCombo || CanMagickedSwordplay))
                 {
                     if (ComboAction is Zwerchhau or EnchantedZwerchhau && LevelChecked(Redoublement))

--- a/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
@@ -19,6 +19,7 @@ internal partial class RDM
             RDM_ST_Corpsacorps_Time = new("RDM_ST_Corpsacorps_Time", 0),
             RDM_ST_GapCloseCorpsacorps_Time = new("RDM_ST_GapCloseCorpsacorps_Time", 0),
             RDM_ST_VerCureThreshold = new("RDM_ST_VerCureThreshold", 40),
+            RDM_ST_MeleeCombo_IncludeReprise_Distance = new("RDM_ST_MeleeCombo_IncludeReprise_Distance", 5),
             RDM_AoE_Corpsacorps_Distance = new("RDM_AoE_Corpsacorps_Distance", 25),
             RDM_AoE_Corpsacorps_Time = new("RDM_AoE_Corpsacorps_Time", 0),
             RDM_AoE_GapCloseCorpsacorps_Time = new("RDM_AoE_GapCloseCorpsacorps_Time", 0),
@@ -87,6 +88,12 @@ internal partial class RDM
                     DrawSliderInt(0, 5, RDM_ST_GapCloseCorpsacorps_Time,
                         " How long you need to be stationary to use. Zero to disable");
                     break;
+                
+                case Preset.RDM_ST_MeleeCombo_IncludeReprise:
+                    DrawSliderInt(4, 25, RDM_ST_MeleeCombo_IncludeReprise_Distance,
+                        "Use when Distance from target is greater than or equal to:");
+                    break;
+                    
                 #endregion
 
                 #region AOE

--- a/WrathCombo/Combos/PvE/RDM/RDM_Helper.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM_Helper.cs
@@ -51,6 +51,7 @@ internal partial class RDM
         EnchantedMoulinetTrois = 37003,
         Corpsacorps = 7506,
         Displacement = 7515,
+        EnchantedReprise = 16528,
         Reprise = 16529,
         ViceOfThorns = 37005,
         GrandImpact = 37006,
@@ -120,6 +121,8 @@ internal partial class RDM
     internal static bool HasManaStacks => Gauge.ManaStacks == 3;
     internal static bool CanFlare => BlackHigher && Gauge.BlackMana - Gauge.WhiteMana < 18;
     internal static bool CanHoly => WhiteHigher && Gauge.WhiteMana - Gauge.BlackMana < 18;
+    internal static bool RedoublementRepriseMana => Gauge is { WhiteMana: >= 20, BlackMana: >= 20 };
+    internal static bool ZwerchhauRepriseMana => Gauge is { WhiteMana: >= 35, BlackMana: >= 35 };
     
     //Floats
     internal static float EmboldenCD => GetCooldownRemainingTime(Embolden);
@@ -163,7 +166,7 @@ internal partial class RDM
                 case > 80:
                     return 60; //Fresh out of Embolden window requiring slightly higher to keep a third melee combo from happening before a few of the procs can be used
                 case > 40 and <= 80:
-                    return 50; // Normal operating fire at 50
+                    return 55; // Normal operating fire at 50
                 case > 15 and <= 40:
                     return 70; // As it gets closer increases level so if we do a melee combo we still have enough for double melee burst
                 case <= 15:


### PR DESCRIPTION
- New feature (Reprise)
  - Out of range (Simple Mode 5 Yalms), will use Reprise to not break the melee combo as long as there is enough white and black mana to finish the combo after. 