### PR TITLE
[PLD] Add Option to block combos for Wings

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -4566,6 +4566,11 @@ public enum Preset
 
     #region PALADIN
 
+    [ReplaceSkill(PLD.PassageOfArms)]
+    [CustomComboInfo("Block Combos for Passage of Arms",
+        "Will block the main Combos with Savage Blade to prevent actions from those combos cancelling Passage of Arms early.\nThis will leave it up to you to cancel Passage of Arms via other actions or movement (or letting it be used fully).", Job.PLD)]
+    PLD_BlockForWings = 11073,
+
     #region Simple Mode
 
     // Simple Modes
@@ -4943,7 +4948,7 @@ public enum Preset
 
     #endregion
 
-    //// Last value = 11072
+    //// Last value = 11073
 
     #endregion
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -4568,8 +4568,8 @@ public enum Preset
 
     [ReplaceSkill(PLD.PassageOfArms)]
     [CustomComboInfo("Block Combos for Passage of Arms",
-        "Will block the main Combos with Savage Blade to prevent actions from those combos cancelling Passage of Arms early.\nThis will leave it up to you to cancel Passage of Arms via other actions or movement (or letting it be used fully).", Job.PLD)]
-    PLD_BlockForWings = 11073,
+        "Will block the main Combos with Savage Blade while Passage of Arms is still active, to prevent actions from those combos cancelling Passage of Arms early.\nThis will leave it up to you to cancel Passage of Arms via other actions or movement (or letting it be used fully).", Job.PLD)]
+    PLD_BlockForWings = 11074,
 
     #region Simple Mode
 
@@ -4948,7 +4948,7 @@ public enum Preset
 
     #endregion
 
-    //// Last value = 11073
+    //// Last value = 11074
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/PLD/PLD.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD.cs
@@ -596,7 +596,7 @@ internal partial class PLD : Tank
             if (actionID is not TotalEclipse)
                 return actionID;
             
-            if (IsEnabled(Preset.PLD_BlockForWings) && (HasStatusEffect(Buffs.PassageOfArms) || JustUsed(PassageOfArms)))
+            if (IsEnabled(Preset.PLD_BlockForWings) && (HasStatusEffect(Buffs.PassageOfArms) || JustUsed(PassageOfArms, 1f)))
                 return All.SavageBlade;
 
             #region Variables

--- a/WrathCombo/Combos/PvE/PLD/PLD.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD.cs
@@ -40,6 +40,9 @@ internal partial class PLD : Tank
         {
             if (actionID is not FastBlade)
                 return actionID;
+            
+            if (IsEnabled(Preset.PLD_BlockForWings) && (HasStatusEffect(Buffs.PassageOfArms) || JustUsed(PassageOfArms)))
+                return All.SavageBlade;
 
             #region Variables
 
@@ -241,6 +244,9 @@ internal partial class PLD : Tank
         {
             if (actionID is not TotalEclipse)
                 return actionID;
+            
+            if (IsEnabled(Preset.PLD_BlockForWings) && (HasStatusEffect(Buffs.PassageOfArms) || JustUsed(PassageOfArms)))
+                return All.SavageBlade;
 
             #region Variables
 
@@ -374,6 +380,9 @@ internal partial class PLD : Tank
         {
             if (actionID is not FastBlade)
                 return actionID;
+            
+            if (IsEnabled(Preset.PLD_BlockForWings) && (HasStatusEffect(Buffs.PassageOfArms) || JustUsed(PassageOfArms)))
+                return All.SavageBlade;
 
             #region Variables
 
@@ -586,6 +595,9 @@ internal partial class PLD : Tank
         {
             if (actionID is not TotalEclipse)
                 return actionID;
+            
+            if (IsEnabled(Preset.PLD_BlockForWings) && (HasStatusEffect(Buffs.PassageOfArms) || JustUsed(PassageOfArms)))
+                return All.SavageBlade;
 
             #region Variables
 


### PR DESCRIPTION
- [X] Adds an option to block the main combos with Savage Blade during Passage of Arms, to prevent Auto/continued mashing from cancelling the effect early.
  Closes [this Discord issue](https://discord.com/channels/1001823907193552978/1375870934929379380)