### PR TITLE
[UI] Add Search Bar

### DIFF
--- a/WrathCombo/Commands.cs
+++ b/WrathCombo/Commands.cs
@@ -689,6 +689,10 @@ public partial class WrathCombo
     {
         argument ??= [""];
 
+        // Clear any searches
+        ConfigWindow.Search = String.Empty;
+        ConfigWindow.SearchDescription = true;
+
         // Toggle the window state
         ConfigWindow.IsOpen = !ConfigWindow.IsOpen;
 

--- a/WrathCombo/Core/PluginConfiguration.cs
+++ b/WrathCombo/Core/PluginConfiguration.cs
@@ -135,6 +135,16 @@ public class PluginConfiguration : IPluginConfiguration
 
     public bool UIShowSearchBar = true;
 
+    public SearchMode SearchBehavior = SearchMode.Filter;
+
+    public enum SearchMode
+    {
+        Filter,
+        Highlight,
+    }
+    
+    public bool SearchPreserveHierarchy = false; // only applicable to Filter mode
+
     #endregion
 
     #region AutoAction Settings

--- a/WrathCombo/Core/PluginConfiguration.cs
+++ b/WrathCombo/Core/PluginConfiguration.cs
@@ -133,6 +133,8 @@ public class PluginConfiguration : IPluginConfiguration
         
     public bool UILeftColumnCollapsed = false;
 
+    public bool UIShowSearchBar = true;
+
     #endregion
 
     #region AutoAction Settings

--- a/WrathCombo/Window/ConfigWindow.cs
+++ b/WrathCombo/Window/ConfigWindow.cs
@@ -77,7 +77,16 @@ internal class ConfigWindow : Dalamud.Interface.Windowing.Window
                 .OrderBy(tpl => tpl.Info.Order).ToArray())!;
     }
 
-    public OpenWindow OpenWindow { get; set; } = OpenWindow.PvE;
+    public OpenWindow OpenWindow
+    {
+        get;
+        set
+        {
+            field = value;
+            Search = string.Empty;
+            SearchDescription = true;
+        }
+    } = OpenWindow.PvE;
 
     /// <summary> Initializes a new instance of the <see cref="ConfigWindow"/> class. </summary>
     public ConfigWindow() : base($"{P.Name} {P.GetType().Assembly.GetName().Version}###WrathCombo")
@@ -123,6 +132,16 @@ internal class ConfigWindow : Dalamud.Interface.Windowing.Window
         }
 
         DrawCollapseButton();
+    }
+
+    public override void OnClose()
+    {
+        // Clear any searches
+        Search = string.Empty;
+        SearchDescription = true;
+
+        // Normal close
+        base.OnClose();
     }
 
     private void DrawSidebar(float topLeftSideHeight)
@@ -243,8 +262,7 @@ internal class ConfigWindow : Dalamud.Interface.Windowing.Window
             case OpenWindow.AutoRotation:
                 AutoRotationTab.Draw();
                 break;
-        }
-        ;
+        };
     }
 
     private static void DrawCollapseButton()

--- a/WrathCombo/Window/ConfigWindow.cs
+++ b/WrathCombo/Window/ConfigWindow.cs
@@ -28,8 +28,12 @@ internal class ConfigWindow : Dalamud.Interface.Windowing.Window
 {
     internal static readonly Dictionary<Job, List<(Preset Preset, CustomComboInfoAttribute Info)>> groupedPresets = GetGroupedPresets();
     internal static readonly Dictionary<Preset, (Preset Preset, CustomComboInfoAttribute Info)[]> presetChildren = GetPresetChildren();
+
     internal static int currentPreset = 1;
     internal static float lastLeftColumnWidth;
+    internal static string Search = string.Empty;
+    internal static bool SearchDescription = true;
+
     internal static Dictionary<Job, List<(Preset Preset, CustomComboInfoAttribute Info)>> GetGroupedPresets()
     {
         return Enum

--- a/WrathCombo/Window/Tabs/PvEFeatures.cs
+++ b/WrathCombo/Window/Tabs/PvEFeatures.cs
@@ -20,6 +20,7 @@ internal class PvEFeatures : ConfigWindow
 {
     internal static Job? OpenJob;
     internal static int ColCount = 1;
+
     internal static new void Draw()
     {
         //#if !DEBUG
@@ -103,8 +104,9 @@ internal class PvEFeatures : ConfigWindow
             {
                 var id = groupedPresets[OpenJob.Value].First().Info.Job;
                 IDalamudTextureWrap? icon = Icons.GetJobIcon(id);
+                var width = ImGui.GetContentRegionAvail().X;
 
-                using (ImRaii.Child("HeadingTab", new Vector2(ImGui.GetContentRegionAvail().X, iconMaxSize)))
+                using (ImRaii.Child("HeadingTab", new Vector2(width, iconMaxSize)))
                 {
                     if (ImGui.Button("Back", new Vector2(0, 24f.Scale())))
                     {
@@ -138,8 +140,9 @@ internal class PvEFeatures : ConfigWindow
                         P.UIHelper
                             .ShowIPCControlledIndicatorIfNeeded(id);
                     }
-
                 }
+
+                DrawSearchBar();
 
                 using (ImRaii.Child("Contents", new Vector2(0)))
                 {
@@ -316,5 +319,46 @@ internal class PvEFeatures : ConfigWindow
         var job = Player.Job.GetUpgradedJob();
         if (groupedPresets.ContainsKey(job))
             OpenJob = job;
+    }
+
+    internal static void DrawSearchBar()
+    {
+        if (!Service.Configuration.UIShowSearchBar)
+            return;
+        
+        var width = ImGui.GetContentRegionAvail().X;
+        var letterWidth = ImGui.CalcTextSize("W").X.Scale();
+
+        using var id = ImRaii.Child("SearchBar",
+            new Vector2(width, 22f.Scale()));
+        if (!id)
+            return;
+        
+        var searchLabelText = "Search:";
+        var searchHintText = "Option name, ID, Internal Name, Description, etc";
+        var searchDescriptionText = "Descriptions";
+
+        var searchWidth = letterWidth * 25 + 4f.Scale();
+        // line width for the search bar
+        var lineWidth = searchWidth
+                        // label
+                        + ImGui.CalcTextSize(searchLabelText).X
+                        + ImGui.GetStyle().ItemSpacing.X
+                        // checkbox
+                        + ImGui.GetStyle().ItemSpacing.X * 2
+                        + ImGui.GetFrameHeight()
+                        + ImGui.GetStyle().FramePadding.X * 2
+                        + ImGui.CalcTextSize(searchDescriptionText).X;
+        ImGui.SetCursorPosX((width - lineWidth) / 2f);
+                        
+        ImGui.Text(searchLabelText);
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(letterWidth*30+8f.Scale());
+        ImGui.InputTextWithHint(
+            "", searchHintText,
+            ref Search, 30,
+            ImGuiInputTextFlags.AutoSelectAll);
+        ImGui.SameLine();
+        ImGui.Checkbox(searchDescriptionText, ref SearchDescription);
     }
 }

--- a/WrathCombo/Window/Tabs/PvPFeatures.cs
+++ b/WrathCombo/Window/Tabs/PvPFeatures.cs
@@ -130,8 +130,9 @@ internal class PvPFeatures : ConfigWindow
                         ImGuiEx.Spacing(new Vector2(0, verticalCenteringPadding-2f.Scale()));
                         ImGuiEx.Text($"{OpenJob.Value.Name()}");
                     });
-
                 }
+
+                PvEFeatures.DrawSearchBar();
 
                 using (ImRaii.Child("Contents", new Vector2(0)))
                 {


### PR DESCRIPTION
Let them be lost no more.\
This PR seeks to add (at least) Preset searching, to help keep up with our ever-growing list of presets, and even just top-level Presets.

## Current state
<img width="705" height="220" alt="image" src="https://github.com/user-attachments/assets/5d06b39c-707c-4b40-a23b-3685cdaa9ae9" />

(useless search bar)

## MVP:
- [X] Add a Search Bar
  - [X] Add quick-setting for searching Preset descriptions
  - [ ] Add settings for hiding Search
- [ ] Add searching functionality
  - [ ] Search Preset titles
  - [ ] Search Preset IDs (when only numbers)
  - [ ] Search Preset descriptions (optionally)
  - [ ] Search Preset Internal names

## Ambitious:
- [ ] Expand searching
  - [ ] Commands
    - [ ] `auto` to search for Auto-Mode Presets
    - [ ] `hidden` to search for Hidden Presets (if they are enabled)
    - [ ] `combo` to only show main Combos
    - [ ] `feature` to only show non-main Combos
  - [ ] Hints?\
        e.g.: `feature|advanced` to show (or search) Presets that are Features or Advanced Combos; would probably entail a "Default Hints" Setting for Search
  - [ ] Ability names for Replaced Actions?
- [ ] Improve searching options
  - [ ] Add option to Preserve Hierarchy when in Filter Mode for Search\
        (would show only direct parents, to give context)
  - [ ] Add Highlight searching
        (very tedious - would entail breaking strings, injecting a backgrounded-text [styled, disabled button?], and resuming strings)
- [ ] Add more searching!
  - [ ] Settings
  - [ ] Debug
  - [ ] Auto-Rotation?\
        (maybe wait until I eventually rework autorot ...)
  - [ ] Jumping?\
        If you know the internal ID of a Preset, it would let you jump there, filtering out everything else on the page(?)\
        Probably a Setting to show a small search bar for this along the list of tabs?

## Possibilities:
- [ ] Investigate Option searching\
      (would have to buffer and search the ImGui text they output somehow ... I think that's possible though[?])\
      (stop putting important controls for combos in Config code smh)
- [ ] Investigate adding Fuzzy searching\
      (don't really want to add a whole library for this though)