### PR TITLE
[AutoRot] Stop healing bells

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -863,7 +863,8 @@ internal unsafe static class AutoRotationController
         {
             if (Svc.Targets.Target == null) return null;
             var t = Svc.Targets.Target;
-            bool goodToHeal = t is IBattleChara or IBattleNpc &&
+            bool goodToHeal = t is IBattleChara &&
+                              t.IsFriendly() &&
                               GetTargetHPPercent(t) <=
                               (TargetHasExcog(t) ? cfg.HealerSettings.SingleTargetExcogHPP :
                                   TargetHasRegen(t) ? cfg.HealerSettings.SingleTargetRegenHPP :


### PR DESCRIPTION
- [X] Now checks that the manually-selected healing target is a battle object before healing them in Auto Rotation