### PR TITLE
[PLD] Fix Party Mit Feature

### DIFF
--- a/WrathCombo/Combos/PvE/PLD/PLD.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD.cs
@@ -891,6 +891,9 @@ internal partial class PLD : Tank
             if (ActionReady(Role.Reprisal))
                 return Role.Reprisal;
 
+            if (ActionReady(DivineVeil))
+                return DivineVeil;
+
             if (ActionReady(PassageOfArms) &&
                 IsEnabled(Preset.PLD_Mit_Party_Wings) &&
                 !HasStatusEffect(Buffs.PassageOfArms, anyOwner: true))


### PR DESCRIPTION
- [X] Now correctly uses `Divine Veil` before `Passage of Arms` in the Party Mit Feature