### PR TITLE
[RDM] Riposte combo change

### DIFF
--- a/WrathCombo/Combos/PvE/RDM/RDM.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM.cs
@@ -619,19 +619,16 @@ internal partial class RDM : Caster
                 if (HasManaStacks)
                     return UseHolyFlare(actionID);
             }
+            
+            if (ComboAction is Zwerchhau or EnchantedZwerchhau && LevelChecked(Redoublement))
+                return OriginalHook(Redoublement);
 
-            if (HasEnoughManaForCombo || CanMagickedSwordplay)
-            {
-                if (ComboAction is Zwerchhau or EnchantedZwerchhau && LevelChecked(Redoublement))
-                    return EnchantedRedoublement;
-
-                if (ComboAction is Riposte or EnchantedRiposte && LevelChecked(Zwerchhau))
-                    return EnchantedZwerchhau;
-            }
-
+            if (ComboAction is Riposte or EnchantedRiposte && LevelChecked(Zwerchhau))
+                return OriginalHook(Zwerchhau);
+            
             if (IsEnabled(Preset.RDM_Riposte_NoWaste) && !HasEnoughManaToStartStandalone && !CanMagickedSwordplay)
                 return All.SavageBlade;
-
+            
             return actionID;
         }
     }


### PR DESCRIPTION
- Allows the riposte combo to continue the combo even unenchanted. Savage blade protection still prevents it from starting the combo when under the set threshold.

closes #852 