### PR TITLE
[BRD] QUickfix

### DIFF
--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -696,7 +696,7 @@ internal partial class BRD : PhysicalRanged
                 return OriginalHook(StraightShot);
 
             #region Multidot Management
-            if (BRD_Adv_DoT_Options[3])
+            if (BRD_Adv_DoT_Options[3] && IsEnabled(Preset.BRD_Adv_DoT))
             {
                 #region Dottable Variables
 


### PR DESCRIPTION
- [x] Make ST ADV Multidot option require Dots actually being enabled. Suboption has been staying enabled when hidden. 