### PR TITLE
[PCT] Fix premature motif usage when doing synced content

### DIFF
--- a/WrathCombo/Combos/PvE/PCT/PCT.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT.cs
@@ -111,7 +111,7 @@ internal partial class PCT : Caster
 
             #region Pre_Burst Motifs
             //Prepare for Burst
-            if (GetCooldownRemainingTime(ScenicMuse) <= 20)
+            if (LevelChecked(ScenicMuse) && GetCooldownRemainingTime(ScenicMuse) <= 20)
             {
                 if (LandscapeMotifReady && GetTargetHPPercent() > 10)
                     return OriginalHook(LandscapeMotif);
@@ -322,7 +322,7 @@ internal partial class PCT : Caster
 
             #region Pre_Burst Motifs
             //Prepare for Burst
-            if (GetCooldownRemainingTime(ScenicMuse) <= 20)
+            if (LevelChecked(ScenicMuse) && GetCooldownRemainingTime(ScenicMuse) <= 20)
             {
                 if (landscapeMotifEnabled && LandscapeMotifReady && GetTargetHPPercent() > landscapeStop)
                     return OriginalHook(LandscapeMotif);
@@ -486,7 +486,7 @@ internal partial class PCT : Caster
 
             #region Pre_Burst Motifs
             //Prepare for Burst
-            if (GetCooldownRemainingTime(ScenicMuse) <= 20)
+            if (LevelChecked(ScenicMuse) && GetCooldownRemainingTime(ScenicMuse) <= 20)
             {
                 if (LandscapeMotifReady && GetTargetHPPercent() > landscapeStop)
                     return OriginalHook(LandscapeMotif);
@@ -673,7 +673,7 @@ internal partial class PCT : Caster
 
             #region Pre_Burst Motifs
             //Prepare for Burst
-            if (GetCooldownRemainingTime(ScenicMuse) <= 20)
+            if (LevelChecked(ScenicMuse) && GetCooldownRemainingTime(ScenicMuse) <= 20)
             {
                 if (landscapeMotifEnabled && LandscapeMotifReady && GetTargetHPPercent() > landscapeStop)
                     return OriginalHook(LandscapeMotif);


### PR DESCRIPTION
There is an issue that, when we do synced content lower than level 70, casting motifs have priority over anything else because the `GetCooldownRemainingTime(ScenicMuse) <= 20` condition is always true. This fixes the issue by adding a level check.