### PR TITLE
[DNC] Fix Dance Partner more

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -691,8 +691,6 @@ internal unsafe static class AutoRotationController
             bool switched = SwitchOnDChole(attributes, outAct, ref target);
             if (outAct is DNC.ClosedPosition && DNC.DancePartnerResolver() is IBattleChara dp)
                 target = dp;
-            if (outAct is DNC.Ending)
-                target = Player.Object;
 
             var canUseSelf = NIN.MudraSigns.Contains(outAct)
                 ? target is not null && target.IsHostile()


### PR DESCRIPTION
- [X] Fixes possible erroneous return from `CurrentDancePartner`
- [X] Fixes flawed logic behind `CurrentPartnerNonOptimal`\
      (resolves DPs dropping)
- [X] Fixes Auto Rotation to allow both DP actions through, and sets the appropriate target for them\
      (resolves AutoRot not using them)