### PR TITLE
[VPR] Add death rattle on Basic combo

### DIFF
--- a/WrathCombo/Combos/PvE/VPR/VPR.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR.cs
@@ -666,7 +666,6 @@ internal partial class VPR : Melee
             if (actionID is not ReavingFangs)
                 return actionID;
 
-            // Death Rattle / Legacy Weaves
             if (DeathRattleWeave &&
                 LevelChecked(SerpentsTail) && InRange())
                 return OriginalHook(SerpentsTail);


### PR DESCRIPTION
- Since its a proc that gets lost when u do any other skill, it seems logical to add it to basic combo to be used when its there.
(It procs anytime u do ur 1-2-3)