### PR TITLE
[MCH] Rewrite Reassemble Logic

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -3716,22 +3716,6 @@ public enum Preset
     [ParentCombo(MCH_AoE_AdvancedMode)]
     [CustomComboInfo("Tools", "Adds Bioblaster, Air Anchor, Chainsaw and Excavator to the rotation.", Job.MCH)]
     MCH_AoE_Adv_Tools = 8315,
-
-    [ParentCombo(MCH_AoE_Adv_Tools)]
-    [CustomComboInfo("Bioblaster Option", "Adds Bioblaster to the rotation.", Job.MCH)]
-    MCH_AoE_Adv_Bioblaster = 8306,
-
-    [ParentCombo(MCH_AoE_Adv_Tools)]
-    [CustomComboInfo("Air Anchor Option", "Adds Air Anchor to the the rotation.", Job.MCH)]
-    MCH_AoE_Adv_AirAnchor = 8313,
-
-    [ParentCombo(MCH_AoE_Adv_Tools)]
-    [CustomComboInfo("Chain Saw Option", "Adds Chain Saw to the the rotation.", Job.MCH)]
-    MCH_AoE_Adv_Chainsaw = 8309,
-
-    [ParentCombo(MCH_AoE_Adv_Tools)]
-    [CustomComboInfo("Excavator Option", "Adds Excavator to the rotation.", Job.MCH)]
-    MCH_AoE_Adv_Excavator = 8310,
     
     #endregion
 

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -16,7 +16,9 @@ internal partial class MCH : PhysicalRanged
                 return actionID;
 
             //Reassemble
-            if (CanReassemble())
+            if (CanReassemble() &&
+                !InCombat() &&
+                HasBattleTarget())
                 return Reassemble;
 
             if (ContentSpecificActions.TryGet(out uint contentAction))
@@ -215,14 +217,14 @@ internal partial class MCH : PhysicalRanged
                     HasStatusEffect(Buffs.FullMetalMachinist))
                     return FullMetalField;
 
-                if (ActionReady(BioBlaster) && !HasStatusEffect(Debuffs.Bioblaster, CurrentTarget) &&
-                    !HasStatusEffect(Buffs.Reassembled) && CanApplyStatus(CurrentTarget, Debuffs.Bioblaster))
-                    return OriginalHook(BioBlaster);
-
                 if (ActionReady(Flamethrower) &&
                     !HasStatusEffect(Buffs.Reassembled) &&
                     !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(3))
                     return OriginalHook(Flamethrower);
+
+                if (ActionReady(BioBlaster) && !HasStatusEffect(Debuffs.Bioblaster, CurrentTarget) &&
+                    !HasStatusEffect(Buffs.Reassembled) && CanApplyStatus(CurrentTarget, Debuffs.Bioblaster))
+                    return OriginalHook(BioBlaster);
 
                 if (LevelChecked(Excavator) &&
                     HasStatusEffect(Buffs.ExcavatorReady))
@@ -268,6 +270,7 @@ internal partial class MCH : PhysicalRanged
 
             //Reassemble to start before combat
             if (IsEnabled(Preset.MCH_ST_Adv_Reassemble) &&
+                !InCombat() && HasBattleTarget() &&
                 CanReassemble())
                 return Reassemble;
 
@@ -389,7 +392,8 @@ internal partial class MCH : PhysicalRanged
                 return FullMetalField;
 
             //Tools
-            if (IsEnabled(Preset.MCH_ST_Adv_Tools) && GetTargetHPPercent() > HPThresholdTools &&
+            if (IsEnabled(Preset.MCH_ST_Adv_Tools) &&
+                GetTargetHPPercent() > HPThresholdTools &&
                 CanUseTools(ref actionID) && !IsOverheated)
                 return actionID;
 
@@ -479,10 +483,10 @@ internal partial class MCH : PhysicalRanged
                         ActionReady(Reassemble) && !HasStatusEffect(Buffs.Reassembled) &&
                         !JustUsed(Flamethrower, 10f) &&
                         GetRemainingCharges(Reassemble) > MCH_AoE_ReassemblePool &&
-                        (MCH_AoE_Reassembled[0] && LevelChecked(Scattergun) ||
-                         MCH_AoE_Reassembled[1] && GetCooldownRemainingTime(AirAnchor) < GCD && LevelChecked(AirAnchor) ||
-                         MCH_AoE_Reassembled[2] && GetCooldownRemainingTime(Chainsaw) < GCD && LevelChecked(Chainsaw) ||
-                         MCH_AoE_Reassembled[3] && GetCooldownRemainingTime(OriginalHook(Chainsaw)) < GCD && LevelChecked(Excavator)))
+                        (LevelChecked(Scattergun) ||
+                         GetCooldownRemainingTime(AirAnchor) < GCD && LevelChecked(AirAnchor) ||
+                         GetCooldownRemainingTime(Chainsaw) < GCD && LevelChecked(Chainsaw) ||
+                         GetCooldownRemainingTime(OriginalHook(Chainsaw)) < GCD && LevelChecked(Excavator)))
                         return Reassemble;
 
                     // Hypercharge
@@ -518,42 +522,31 @@ internal partial class MCH : PhysicalRanged
                     LevelChecked(FullMetalField) && HasStatusEffect(Buffs.FullMetalMachinist))
                     return FullMetalField;
 
-                if (IsEnabled(Preset.MCH_AoE_Adv_Tools) &&
-                    IsEnabled(Preset.MCH_AoE_Adv_Bioblaster) &&
-                    GetTargetHPPercent() >= MCH_AoE_ToolsHPThreshold &&
-                    ActionReady(BioBlaster) && !HasStatusEffect(Debuffs.Bioblaster, CurrentTarget) &&
-                    !HasStatusEffect(Buffs.Reassembled) && CanApplyStatus(CurrentTarget, Debuffs.Bioblaster))
-                    return OriginalHook(BioBlaster);
-
                 if (IsEnabled(Preset.MCH_AoE_Adv_FlameThrower) &&
                     ActionReady(Flamethrower) &&
                     !HasStatusEffect(Buffs.Reassembled) &&
                     (MCH_AoE_FlamethrowerMovement == 1 ||
-                     MCH_AoE_FlamethrowerMovement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(MCH_AoE_FlamethrowerTimeStill)) &&
+                     MCH_AoE_FlamethrowerMovement == 0 && !IsMoving() &&
+                     TimeStoodStill > TimeSpan.FromSeconds(MCH_AoE_FlamethrowerTimeStill)) &&
                     GetTargetHPPercent() > MCH_AoE_FlamethrowerHPOption)
                     return OriginalHook(Flamethrower);
 
                 if (IsEnabled(Preset.MCH_AoE_Adv_Tools) &&
                     GetTargetHPPercent() >= MCH_AoE_ToolsHPThreshold)
                 {
-                    if (IsEnabled(Preset.MCH_AoE_Adv_Excavator) &&
-                        ReassembledExcavatorAoE &&
-                        LevelChecked(Excavator) && HasStatusEffect(Buffs.ExcavatorReady))
+                    if (ActionReady(BioBlaster) && !HasStatusEffect(Debuffs.Bioblaster, CurrentTarget) &&
+                        !HasStatusEffect(Buffs.Reassembled) && CanApplyStatus(CurrentTarget, Debuffs.Bioblaster))
+                        return OriginalHook(BioBlaster);
+
+                    if (LevelChecked(Excavator) && HasStatusEffect(Buffs.ExcavatorReady))
                         return Excavator;
 
-                    if (IsEnabled(Preset.MCH_AoE_Adv_Chainsaw) &&
-                        ReassembledChainsawAoE &&
-                        ActionReady(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady))
+                    if (ActionReady(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady))
                         return Chainsaw;
 
-                    if (IsEnabled(Preset.MCH_AoE_Adv_AirAnchor) &&
-                        ReassembledAirAnchorAoE &&
-                        LevelChecked(AirAnchor) && IsOffCooldown(AirAnchor))
+                    if (LevelChecked(AirAnchor) && IsOffCooldown(AirAnchor))
                         return AirAnchor;
                 }
-
-                if (ReassembledScattergunAoE)
-                    return OriginalHook(Scattergun);
             }
 
             if (ActionReady(BlazingShot) && IsOverheated)

--- a/WrathCombo/Combos/PvE/MCH/MCH_Config.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Config.cs
@@ -12,7 +12,6 @@ internal partial class MCH
         {
             switch (preset)
             {
-
                 #region ST
 
                 case Preset.MCH_ST_Adv_Opener:
@@ -169,11 +168,6 @@ internal partial class MCH
 
                     DrawSliderInt(0, 2, MCH_AoE_ReassemblePool,
                         "Number of Charges to Save for Manual Use");
-
-                    DrawHorizontalMultiChoice(MCH_AoE_Reassembled, $"Use on {SpreadShot.ActionName()}/{Scattergun.ActionName()}", "", 4, 0);
-                    DrawHorizontalMultiChoice(MCH_AoE_Reassembled, $"Use on {AirAnchor.ActionName()}", "", 4, 1);
-                    DrawHorizontalMultiChoice(MCH_AoE_Reassembled, $"Use on {Chainsaw.ActionName()}", "", 4, 2);
-                    DrawHorizontalMultiChoice(MCH_AoE_Reassembled, $"Use on {Excavator.ActionName()}", "", 4, 3);
                     break;
 
                 case Preset.MCH_AoE_Adv_QueenOverdrive:
@@ -279,10 +273,7 @@ internal partial class MCH
 
         public static UserFloat
             MCH_AoE_FlamethrowerTimeStill = new("MCH_AoE_FlamethrowerTimeStill", 2.5f);
-        public static UserBoolArray
-            MCH_AoE_Reassembled = new("MCH_AoE_Reassembled");
 
         #endregion
-
     }
 }


### PR DESCRIPTION
- Reassemble now treated as a 60s CD for the sake of simplicity.
- Once 2 charges are obtained, will only be used once both are available to try and line up with the 2 minute window.
- Remove selection of what actions to use Reassemble on, they're all basically the same with different CDs.
- Remove choice of what tools can be added to combos, they're all basically the same with different CDs.