### PR TITLE
ECommons New Player Object Fix

### DIFF
--- a/WrathCombo/Commands.cs
+++ b/WrathCombo/Commands.cs
@@ -609,7 +609,7 @@ public partial class WrathCombo
                         //Retrieve final ClassJob
                         job = jobSearch.GetJob().GetUpgradedJob().GetData();
 
-                        if (job.Value.RowId != Player.JobId)
+                        if (job.Value.RowId != Player.ClassJob.RowId)
                             DuoLog.Warning($"You are not on {job.Value.Name()}");
                     }
                 }


### PR DESCRIPTION
New ECommon's Player Object doesn't have JobID (yet?). So pulling the job ID from the ClassJob object (Same expression code from LegacyPlayer). Works with existing submodule revision.