### PR TITLE
[PvP] Action Replacing Off Warning

### DIFF
--- a/WrathCombo/Window/Tabs/PvPFeatures.cs
+++ b/WrathCombo/Window/Tabs/PvPFeatures.cs
@@ -28,7 +28,7 @@ internal class PvPFeatures : FeaturesWindow
                 var userwarned = false;
 
                 //Auto-Rotation warning
-                if (Service.Configuration.RotationConfig.Enabled)
+                if (P.IPC.GetAutoRotationState())
                 {
                     ImGuiEx.LineCentered($"pvpWarning", () =>
                     {


### PR DESCRIPTION
Displays warning if action replacing is off for PvP settings.
<img width="385" height="88" alt="image" src="https://github.com/user-attachments/assets/9149e16e-1b92-491d-9ee0-e0cfe2647f0b" />