### PR TITLE
[Core] Fix `SendActionDetour` Task errors on bad cast time returns

### DIFF
--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -262,16 +262,16 @@ public static class ActionWatching
                 }
 
                 var castTime = ActionManager.GetAdjustedCastTime((ActionType)actionType, actionId);
-                token = source.Token;
-                UpdateActionTask = Svc.Framework.RunOnTick(() =>
-                UpdateLastUsedAction(actionId, actionType, targetObjectId, castTime),
-                TimeSpan.FromMilliseconds(castTime), cancellationToken: token);
 
-                // Update Helpers
-                NIN.InMudra = NIN.MudraSigns.Contains(actionId);
-
-                if (castTime > 0)
+                if (castTime >= 0)
                 {
+                    token = source.Token;
+                    UpdateActionTask = Svc.Framework.RunOnTick(() =>
+                            UpdateLastUsedAction(actionId, actionType, targetObjectId, castTime),
+                        TimeSpan.FromMilliseconds(castTime), cancellationToken: token);
+
+                    NIN.InMudra = NIN.MudraSigns.Contains(actionId);
+
                     TimeLastActionUsed = DateTime.Now;
                     WrathOpener.CurrentOpener?.ProgressOpener(actionId);
                 }
@@ -281,6 +281,8 @@ public static class ActionWatching
                     $"[SendActionDetour] " +
                     $"Action: {actionId.ActionName()} (ID: {actionId}) | " +
                     $"Type: {actionType} | " +
+                    $"TSL: {DateTime.Now-TimeLastActionUsed} | " +
+                    $"Cast Time: {castTime} | " +
                     $"Sequence: {sequence} | " +
                     $"Target: {Svc.Objects.FirstOrDefault(x => x.GameObjectId == targetObjectId)?.Name ?? "Unknown"} | " +
                     $"Params: [{a5}, {a6}, {a7}, {a8}, {a9}]"


### PR DESCRIPTION
- [X] Fixes errors from bad cast time values in `SendActionDetour`\
      Closes #971
- [X] Also fixes an error where 0-cast time abilities didn't update `TimeLastActionUsed`\
      ... Not sure how that wasn't noticed.