### PR TITLE
Queue Overwrite Setting

### DIFF
--- a/WrathCombo/Core/Configuration.cs
+++ b/WrathCombo/Core/Configuration.cs
@@ -306,6 +306,13 @@ public partial class Configuration : IPluginConfiguration
         sliderMax: 2.5f)]
     public float QueueAdjustThreshold = 1.5f;
 
+    [SettingCategory(Rotation_Behavior_Options)]
+    [Setting("Overwrite Queue",
+        "This will allow you to overwrite whatever is currently queued up with another action.",
+        recommendedValue: "On",
+        defaultValue: "Off")]
+    public bool OverwriteQueue = false;
+
     /// The throttle for how often the hotbar gets walked. Default: 50.
     /// <seealso cref="ActionChanging"/>
     /// <seealso cref="ActionReplacer.GetAdjustedActionDetour"/>

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -354,6 +354,8 @@ public static class ActionWatching
         }
     }
 
+    public unsafe static bool CanQueueCS(uint actionId) => CanQueueActionDetour(ActionManager.Instance(), 1, actionId);
+
     private static unsafe bool CanQueueActionDetour(ActionManager* actionManager, uint actionType, uint actionID)
     {
         float threshold = Service.Configuration.QueueAdjust ? Service.Configuration.QueueAdjustThreshold : 0.5f;
@@ -454,6 +456,9 @@ public static class ActionWatching
                     return ActionManager.Instance()->UseActionLocation
                         (actionType, replacedWith, location: &location);
                 }
+
+                if (Service.Configuration.OverwriteQueue && actionManager->QueuedActionId != 0 && CanQueueCS(actionId))
+                    actionManager->QueuedActionId = actionId;
 
                 //Important to pass actionId here and not replaced.
                 var hookResult = changed ? UseActionHook.Original(actionManager, actionType, actionId, targetId, extraParam, mode, comboRouteId, outOptAreaTargeted) :


### PR DESCRIPTION
Allows actions already in the queue to be overwritten for more reactive gameplay when combined with bigger queue windows.