### PR TITLE
[Core] Re-enable VFX Tracking to match changes to ECommons

### DIFF
--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -169,8 +169,7 @@ public sealed partial class WrathCombo : IDalamudPlugin
     {
         P = this;
         pluginInterface.Create<Service>();
-        ECommonsMain.Init(pluginInterface, this, Module.All);
-        ECommonsMain.Init(pluginInterface, this, Module.VfxTracking);
+        ECommonsMain.Init(pluginInterface, this, Module.All, Module.VfxTracking);
         PunishLibMain.Init(pluginInterface, "Wrath Combo");
 
         ActionRequestIPCProvider.Initialize();


### PR DESCRIPTION
Currently all VFX checks (TB / Shared) are broken because VFX Manager was placed into it's own module. Current release is not tracking anything

Relevant Ecommons [Commit](https://github.com/NightmareXIV/ECommons/commit/b3f8ded4c63b31b222417f32699e07c671af3f24)