### PR TITLE
[MCH] Optimize Burst

### DIFF
--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -1,4 +1,3 @@
-using Dalamud.Game.ClientState.Statuses;
 using System;
 using WrathCombo.CustomComboNS;
 using static WrathCombo.Combos.PvE.MCH.Config;
@@ -104,11 +103,7 @@ internal partial class MCH : PhysicalRanged
             }
 
             // Full Metal Field
-            if (HasStatusEffect(Buffs.FullMetalMachinist, out IStatus? fullMetal) &&
-                !IsOverheated &&
-                (ActionReady(Wildfire) ||
-                 GetCooldownRemainingTime(Wildfire) > 90 ||
-                 fullMetal.RemainingTime <= 6))
+            if (CanUseFullMetalField)
                 return FullMetalField;
 
             //Tools
@@ -392,11 +387,7 @@ internal partial class MCH : PhysicalRanged
 
             // Full Metal Field
             if (IsEnabled(Preset.MCH_ST_Adv_Stabilizer_FullMetalField) &&
-                HasStatusEffect(Buffs.FullMetalMachinist, out IStatus? fullMetal) &&
-                !IsOverheated &&
-                (ActionReady(Wildfire) ||
-                 GetCooldownRemainingTime(Wildfire) > 90 ||
-                 fullMetal.RemainingTime <= 6))
+                CanUseFullMetalField)
                 return FullMetalField;
 
             //Tools

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -10,6 +10,18 @@ namespace WrathCombo.Combos.PvE;
 
 internal partial class MCH
 {
+    #region Misc
+
+    private static bool CanUseFullMetalField =>
+        HasStatusEffect(Buffs.FullMetalMachinist) &&
+        !IsOverheated &&
+        (ActionReady(Wildfire) ||
+         GetCooldownRemainingTime(Wildfire) > 90 ||
+         GetCooldownRemainingTime(Wildfire) <= GCD ||
+         GetStatusEffectRemainingTime(Buffs.FullMetalMachinist) <= 6);
+
+    #endregion
+
     #region Hypercharge
 
     private static bool CanHypercharge(bool onAoE = false)
@@ -23,6 +35,7 @@ internal partial class MCH
                 !HasStatusEffect(Buffs.ExcavatorReady) &&
                 !HasStatusEffect(Buffs.FullMetalMachinist) &&
                 (ActionReady(Wildfire) ||
+                 JustUsed(FullMetalField, GCD / 2) ||
                  MCH_ST_WildfireBossOption == 1 && !TargetIsBoss() ||
                  GetCooldownRemainingTime(Wildfire) > GCD * 15 ||
                  Heat is 100 && GetCooldownRemainingTime(Wildfire) > 10 ||


### PR DESCRIPTION
- [x] Adjust `Barrel Stabilizer` to be used within 20 secs of `Wildfire` to make it not drift
- [x] Adjust Hypercharge to be right after eachother if it wont break combo.