### PR TITLE
SCH: option to disable group mitigation in simple heals

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -6731,15 +6731,22 @@ public enum Preset
     [PossiblyRetargeted]
     SCH_Simple_ST_Heal = 16085,
 
+    [ParentCombo(SCH_Simple_ST_Heal)]
+    [CustomComboInfo("Disable Group Mitigation", "Removes Expedient and Sacred Soil from the simple healing rotation.", Job.SCH)]
+    SCH_Simple_ST_Heal_DisableGroupMit = 16090,
 
     [AutoAction(true, true)]
     [ReplaceSkill(SCH.Succor)]
     [ConflictingCombos(SCH_AoE_Heal)]
-    [CustomComboInfo("Simple Healing Mode - AoE", "Replaces Succor with a full one-button single target healing utility." +
+    [CustomComboInfo("Simple Healing Mode - AoE", "Replaces Succor with a full one-button AoE healing utility." +
                                                             "\nThis is the ideal option for newcomers to the job. Particularly with autorotation.", Job.SCH)]
     [SimpleCombo]
     [PossiblyRetargeted]
     SCH_Simple_AoE_Heal = 16084,
+
+    [ParentCombo(SCH_Simple_AoE_Heal)]
+    [CustomComboInfo("Disable Group Mitigation", "Removes Expedient and Sacred Soil from the simple healing rotation.", Job.SCH)]
+    SCH_Simple_AoE_Heal_DisableGroupMit = 16092,
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -168,7 +168,8 @@ internal partial class SCH : Healer
                 GetTargetHPPercent(healTarget) <= 50)
                 return Lustrate.RetargetIfEnabled(healTarget, Physick);
             
-            if (ActionReady(SacredSoil) && !InBossEncounter() &&
+            if (!IsEnabled(Preset.SCH_Simple_ST_Heal_DisableGroupMit) &&
+                ActionReady(SacredSoil) && !InBossEncounter() &&
                 TimeStoodStill >= TS.FromSeconds(5))
                 return SacredSoil.Retarget(Physick, SimpleTarget.Self);
             
@@ -196,7 +197,8 @@ internal partial class SCH : Healer
                     return Seraphism;
             }
 
-            if (ActionReady(Expedient) && !InBossEncounter())
+            if (!IsEnabled(Preset.SCH_Simple_ST_Heal_DisableGroupMit) &&
+                ActionReady(Expedient) && !InBossEncounter())
                 return Expedient;
             
             if (ActionReady(OriginalHook(Adloquium)))
@@ -220,10 +222,12 @@ internal partial class SCH : Healer
             if (EndAetherpact)
                 return DissolveUnion;
             
-            if (ActionReady(Expedient) && GroupDamageIncoming())
+            if (!IsEnabled(Preset.SCH_Simple_AoE_Heal_DisableGroupMit) &&
+                ActionReady(Expedient) && GroupDamageIncoming())
                 return Expedient;
-            
-            if (ActionReady(SacredSoil) && GroupDamageIncoming())
+
+            if (!IsEnabled(Preset.SCH_Simple_AoE_Heal_DisableGroupMit) &&
+                ActionReady(SacredSoil) && GroupDamageIncoming())
                 return SacredSoil.Retarget([Succor, Concitation], SimpleTarget.Self);
             
             if (ActionReady(Aetherflow) && !HasAetherflow &&


### PR DESCRIPTION
adds a checkbox to disable Expedient and Sacred Soil in the simple healing rotations - handy if you want to use them manually for raidwides instead of having the rotation burn them

also fixes "single target" to "AoE" in the simple aoe heal description

tested locally, and working as intended. great with the AoE mitigation feature :)