### PR TITLE
[PLD] Update Circle of Scorn to require at least 1 target

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -36,7 +36,6 @@ internal unsafe class AutoRotationController
     public static AutoRotationConfigIPCWrapper? cfg;
 
     public static long HealThrottle = 0;
-    static long LastRezAt = 0;
 
     static bool _lockedST = false;
     static bool _lockedAoE = false;

--- a/WrathCombo/Combos/PvE/PLD/PLD.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD.cs
@@ -87,7 +87,7 @@ internal partial class PLD : Tank
                         switch (CooldownFightOrFlight)
                         {
                             // Circle of Scorn / Spirits Within
-                            case > 15 when ActionReady(CircleOfScorn):
+                            case > 15 when ActionReady(CircleOfScorn) && NumberOfEnemiesInRange(CircleOfScorn) > 0:
                                 return CircleOfScorn;
 
                             case > 15 when ActionReady(SpiritsWithin):
@@ -231,7 +231,7 @@ internal partial class PLD : Tank
                         // Circle of Scorn / Spirits Within
                         switch (CooldownFightOrFlight)
                         {
-                            case > 15 when ActionReady(CircleOfScorn):
+                            case > 15 when ActionReady(CircleOfScorn) && NumberOfEnemiesInRange(CircleOfScorn) > 0:
                                 return CircleOfScorn;
 
                             case > 15 when ActionReady(SpiritsWithin):
@@ -354,7 +354,7 @@ internal partial class PLD : Tank
                         {
                             // Circle of Scorn / Spirits Within
                             case > 15 when IsEnabled(Preset.PLD_ST_AdvancedMode_CircleOfScorn) &&
-                                           ActionReady(CircleOfScorn):
+                                           ActionReady(CircleOfScorn) && NumberOfEnemiesInRange(CircleOfScorn) > 0:
                                 return CircleOfScorn;
 
                             case > 15 when IsEnabled(Preset.PLD_ST_AdvancedMode_SpiritsWithin) &&
@@ -516,7 +516,7 @@ internal partial class PLD : Tank
                         // Circle of Scorn / Spirits Within
                         switch (CooldownFightOrFlight)
                         {
-                            case > 15 when IsEnabled(Preset.PLD_AoE_AdvancedMode_CircleOfScorn) && ActionReady(CircleOfScorn):
+                            case > 15 when IsEnabled(Preset.PLD_AoE_AdvancedMode_CircleOfScorn) && ActionReady(CircleOfScorn) && NumberOfEnemiesInRange(CircleOfScorn) > 0:
                                 return CircleOfScorn;
 
                             case > 15 when IsEnabled(Preset.PLD_AoE_AdvancedMode_SpiritsWithin) && ActionReady(SpiritsWithin):

--- a/WrathCombo/CustomCombo/Functions/Target.cs
+++ b/WrathCombo/CustomCombo/Functions/Target.cs
@@ -705,6 +705,9 @@ internal abstract partial class CustomComboFunctions
 
         bool IsValidTarget(IGameObject o)
         {
+            if (!IsInLineOfSight(o))
+                return false;
+
             if (!enemies)
                 return o is IBattleChara &&
                        o.IsTargetable &&


### PR DESCRIPTION
Mainly for those using melee offsets so it doesn't trigger when out of range and wasting it.