### PR TITLE
Add Opener Status to DTR

### DIFF
--- a/WrathCombo/Commands.cs
+++ b/WrathCombo/Commands.cs
@@ -127,15 +127,7 @@ public partial class WrathCombo
         Svc.Log.Debug($"{WrathOpener.CurrentOpener.Enabled}");
         if (WrathOpener.CurrentOpener is not null && WrathOpener.CurrentOpener != WrathOpener.Dummy && WrathOpener.CurrentOpener.Enabled)
         {
-            string status = WrathOpener.CurrentOpener.CurrentState switch
-            {
-                Combos.PvE.Enums.OpenerState.OpenerNotReady => $"Opener Not Ready Yet",
-                Combos.PvE.Enums.OpenerState.OpenerReady => "Opener Ready to Start",
-                Combos.PvE.Enums.OpenerState.InOpener => "In Progress",
-                Combos.PvE.Enums.OpenerState.OpenerFinished => "Finished",
-                Combos.PvE.Enums.OpenerState.FailedOpener => "Failed",
-                _ => "Unknown"
-            };
+            var status = WrathOpener.OpenerStatus();
             DuoLog.Information($"Opener status: {status}");
         }
         else

--- a/WrathCombo/Core/Configuration.cs
+++ b/WrathCombo/Core/Configuration.cs
@@ -70,6 +70,13 @@ public partial class Configuration : IPluginConfiguration
         defaultValue: "Off")]
     public bool ShortDTRText = false;
 
+    [SettingCategory(Main_UI_Options)]
+    [Setting("Opener Status in Server Info Bar",
+        "Shows the status of your current opener, if enabled and applicable.",
+        recommendedValue: "Preference", 
+        defaultValue: "Off")]
+    public bool ShowOpenerDtr = false;
+
     /// Hides the message of the day. Default: false.
     /// <seealso cref="WrathCombo.PrintLoginMessage"/>
     [SettingCategory(Main_UI_Options)]

--- a/WrathCombo/CustomCombo/WrathOpener.cs
+++ b/WrathCombo/CustomCombo/WrathOpener.cs
@@ -346,6 +346,22 @@ public abstract class WrathOpener
         }
     }
 
+    public static string OpenerStatus()
+    {
+        if (CurrentOpener is null || CurrentOpener == Dummy || !CurrentOpener.Enabled)
+            return "No valid opener active.";
+
+        return CurrentOpener?.CurrentState switch
+        {
+            OpenerState.OpenerNotReady => $"Opener Not Ready Yet",
+            OpenerState.OpenerReady => "Opener Ready to Start",
+            OpenerState.InOpener => "Opener In Progress",
+            OpenerState.OpenerFinished => "Opener Finished",
+            OpenerState.FailedOpener => "Opener Failed",
+            _ => "Unknown"
+        };
+    }
+
     public static WrathOpener Dummy = new DummyOpener();
 }
 

--- a/WrathCombo/Data/Conflicts/Conflicts.cs
+++ b/WrathCombo/Data/Conflicts/Conflicts.cs
@@ -18,6 +18,7 @@ public enum ConflictType
     Settings,
     WrathSetting,
     GameSetting,
+    Dalamud,
 }
 
 /// <summary>
@@ -77,9 +78,11 @@ public class Conflict
             _xiv = true;
         if (conflictType is ConflictType.WrathSetting)
             _wrath = true;
+        if (conflictType is ConflictType.Dalamud)
+            _dalamud = true;
 
         _plugin = search ??
-                  (_xiv || _wrath
+                  (_xiv || _wrath || _dalamud
                       ? null!
                       : throw new KeyNotFoundException(
                           $"Plugin with internal name '{internalName}' not found."));
@@ -91,8 +94,10 @@ public class Conflict
 
     private readonly bool _xiv;
 
+    private readonly bool _dalamud;
+
     /// The display name of the plugin.
-    public string Name => _xiv || _wrath ? "XIV" : _plugin.Name;
+    public string Name => _xiv || _wrath ? "XIV" : _dalamud ? "Dalamud" : _plugin.Name;
 
     /// <summary>
     ///     The internal name of the plugin, which can be used for getting a
@@ -133,6 +138,7 @@ public class Conflict
             ConflictType.Settings => [SettingsConflictStart, SettingsConflictEnd],
             ConflictType.WrathSetting => [WrathConflictStart, WrathConflictEnd],
             ConflictType.GameSetting => [GameConflictStart, GameConflictEnd],
+            ConflictType.Dalamud => [DalamudConflictStart, DalamudConflictEnd],
             _ => throw new ArgumentOutOfRangeException(nameof(ConflictType),
                 $"Unknown conflict type: {ConflictType}"),
         };
@@ -153,6 +159,9 @@ public class Conflict
 
     private const string GameConflictStart = "Conflicting Game";
     private const string GameConflictEnd = "Setting(s) Detected!";
+
+    private const string DalamudConflictStart = "Dalamud Conflicts";
+    private const string DalamudConflictEnd = "Setting(s) Detected!";
 
     #endregion
 }

--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -11,6 +11,7 @@ using ECommons.Automation.LegacyTaskManager;
 using ECommons.DalamudServices;
 using ECommons.ExcelServices;
 using ECommons.GameHelpers;
+using Lumina.Excel.Sheets;
 using Newtonsoft.Json.Linq;
 using PunishLib;
 using System;
@@ -28,13 +29,12 @@ using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
 using WrathCombo.Data.Conflicts;
 using WrathCombo.Services;
-using WrathCombo.Services.IPC_Subscriber;
+using WrathCombo.Services.ActionRequestIPC;
 using WrathCombo.Services.IPC;
+using WrathCombo.Services.IPC_Subscriber;
 using WrathCombo.Window;
 using WrathCombo.Window.Tabs;
-using WrathCombo.Services.ActionRequestIPC;
 using GenericHelpers = ECommons.GenericHelpers;
-using Lumina.Excel.Sheets;
 
 namespace WrathCombo;
 
@@ -54,6 +54,7 @@ public sealed partial class WrathCombo : IDalamudPlugin
     };
     private readonly HttpClient httpClient = new(httpHandler) { Timeout = TimeSpan.FromSeconds(5) };
     private readonly IDtrBarEntry DtrBarEntry;
+    public readonly IDtrBarEntry OpenerDtr;
     internal Provider IPC;
     internal Search IPCSearch = null!;
     internal UIHelper UIHelper = null!;
@@ -213,6 +214,8 @@ public sealed partial class WrathCombo : IDalamudPlugin
         new TextPayload("Click to toggle Wrath Combo's Auto-Rotation.\n"),
         new TextPayload("Disable this icon in /xlsettings -> Server Info Bar"));
 
+        OpenerDtr ??= Svc.DtrBar.Get("Wrath Combo Opener");
+
         Svc.ClientState.Login += PrintLoginMessage;
         if (Svc.ClientState.IsLoggedIn) ResetFeatures();
 
@@ -227,13 +230,13 @@ public sealed partial class WrathCombo : IDalamudPlugin
             TimeSpan.FromSeconds(60));
 
 #if DEBUG
-        VfxManager.Logging  = true;
+        VfxManager.Logging = true;
         ConfigWindow.IsOpen = true;
         VfxManager.Logging = true;
         Svc.Framework.RunOnTick(() =>
         {
             if (Service.Configuration.OpenToCurrentJob && Player.Available)
-                HandleOpenCommand([""], forceOpen:true);
+                HandleOpenCommand([""], forceOpen: true);
         });
 #endif
     }
@@ -330,27 +333,36 @@ public sealed partial class WrathCombo : IDalamudPlugin
             #endregion
 
             // Skip the IPC checking if hidden
-            if (DtrBarEntry.UserHidden) return;
+            if (!DtrBarEntry.UserHidden)
+            {
+                #region DTR Bar Updating
 
-            #region DTR Bar Updating
+                var autoOn = IPC.GetAutoRotationState();
+                var icon = new IconPayload(autoOn
+                    ? BitmapFontIcon.SwordUnsheathed
+                    : BitmapFontIcon.SwordSheathed);
 
-            var autoOn = IPC.GetAutoRotationState();
-            var icon = new IconPayload(autoOn
-                ? BitmapFontIcon.SwordUnsheathed
-                : BitmapFontIcon.SwordSheathed);
+                var text = autoOn ? ": On" : ": Off";
+                if (!Service.Configuration.ShortDTRText && autoOn)
+                    text += $" ({P.IPCSearch.ActiveJobPresets} active)";
+                var ipcControlledText =
+                    P.UIHelper.AutoRotationStateControlled() is not null
+                        ? " (Locked)"
+                        : "";
 
-            var text = autoOn ? ": On" : ": Off";
-            if (!Service.Configuration.ShortDTRText && autoOn)
-                text += $" ({P.IPCSearch.ActiveJobPresets} active)";
-            var ipcControlledText =
-                P.UIHelper.AutoRotationStateControlled() is not null
-                    ? " (Locked)"
-                    : "";
+                var payloadText = new TextPayload(text + ipcControlledText);
+                DtrBarEntry.Text = new SeString(icon, payloadText);
 
-            var payloadText = new TextPayload(text + ipcControlledText);
-            DtrBarEntry.Text = new SeString(icon, payloadText);
+                #endregion
+            }
 
-            #endregion
+            if (Service.Configuration.ShowOpenerDtr)
+            {
+                var status = new TextPayload(WrathOpener.OpenerStatus());
+                OpenerDtr.Text = new SeString(status);
+            }
+            else
+                OpenerDtr.Text = "";
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
New option to have the opener status show in the DTR bar for easy access.

(Also introduces Dalamud conflict checks cause y'know, users be usering)