### PR TITLE
[OC] Fix Gladiator spamming Defend out of fight

### DIFF
--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent.cs
@@ -687,7 +687,7 @@ internal partial class OccultCrescent
             actionID = Finisher;
             return true;
         }
-        if (IsEnabledAndUsable(Preset.Phantom_Gladiator_Defend, Defend))
+        if (IsEnabledAndUsable(Preset.Phantom_Gladiator_Defend, Defend) && InCombat())
         {
             actionID = Defend;
             return true;


### PR DESCRIPTION
Defend was spammed on CD even if you were AFK.
-> Force the InCombat flag to use it.

The buff is preserved as long as you don't get hit by an auto, which should not happen if you are out of combat.