### PR TITLE
Add CoD Chaotic to Invicibility check

### DIFF
--- a/WrathCombo/CustomCombo/Functions/Status.cs
+++ b/WrathCombo/CustomCombo/Functions/Status.cs
@@ -346,8 +346,8 @@ internal abstract partial class CustomComboFunctions
                 // Atomos = 17952
                 // Inner Darkness = 4177
                 // Outer Darkness = 4178
-                if (targetID is 17950 && HasStatusEffect(4178, null, true)) return true; // If on the tiles
-                if (targetID is 17951 or 17952 && HasStatusEffect(4177, null, true)) return true; // If on platforms
+                if (targetID is 17950 && HasStatusEffect(4178, null, true)) return true; // If on the platforms
+                if (targetID is 17951 or 17952 && HasStatusEffect(4177, null, true)) return true; // If on tiles
 
                 return false;
             


### PR DESCRIPTION
Should fix the "Two target dotting" where it try to apply a DoT to the Add when you are on tiles, or to the boss when you are on the platform.

25/03/2026 : No issue on my side, I correctly DoT the Atomos/Adds when on the platform, and the Boss when on tiles