### PR TITLE
[Core] ActionReady Update

### DIFF
--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -139,7 +139,7 @@ internal partial class WHM : Healer
                 SimpleTarget.DottableEnemy(dotAction, dotDebuffID, 30, 3, 4);
 
             if (ActionReady(dotAction) && target != null)
-                return OriginalHook(Aero).Retarget([Holy, Holy3], target);
+                return dotAction.Retarget([Holy, Holy3], target);
 
             #endregion
 

--- a/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
@@ -257,7 +257,7 @@ internal partial class WHM
     internal static bool RaidwideTemperance()
     {
         return IsEnabled(Preset.WHM_Raidwide_Temperance) &&
-               ActionReady(OriginalHook(Temperance)) &&
+               ActionReady(Temperance) &&
                CanWeave() && GroupDamageIncoming();
     }
 

--- a/WrathCombo/CustomCombo/Functions/Action.cs
+++ b/WrathCombo/CustomCombo/Functions/Action.cs
@@ -164,15 +164,13 @@ internal abstract partial class CustomComboFunctions
     /// <param name="actionId"> The action ID. </param>
     public static unsafe bool ActionReady(uint actionId, bool recastCheck = false, bool castCheck = false)
     {
-        uint hookedId = OriginalHook(actionId);
-
-        if (ActionRequestIPCProvider.GetArtificialCooldown(ActionType.Action, hookedId) > 0)
+        if (ActionRequestIPCProvider.GetArtificialCooldown(ActionType.Action, actionId) > 0)
         {
             return false;
         }
 
-        return (HasCharges(hookedId) || (GetAttackType(hookedId) != ActionAttackType.Ability && GetCooldownRemainingTime(hookedId) <= RemainingGCD + BaseActionQueue)) &&
-            ActionManager.Instance()->GetActionStatus(ActionType.Action, hookedId, checkRecastActive: recastCheck, checkCastingActive: castCheck) is 0 or 582 or 580;
+        return (HasCharges(actionId) || (GetAttackType(actionId) != ActionAttackType.Ability && GetCooldownRemainingTime(actionId) <= RemainingGCD + BaseActionQueue)) &&
+            ActionManager.Instance()->GetActionStatus(ActionType.Action, actionId, checkRecastActive: recastCheck, checkCastingActive: castCheck) is 0 or 582 or 580;
     }
 
     /// <summary> Checks if all passed actions are ready to be used. </summary>


### PR DESCRIPTION
Change ActionReady to not do original hook on the action being passed to it. Main benefit of the change is to ensure the clarity between what's passed into it reflects correct intentions, particularly in the case of upgraded actions and any action change settings being used. Simple upgraded actions should be passed into the function as OriginalHook (as I'm sure they mostly do anyway) so that non-simple actions (actions that aren't strictly upgrades, part of a chain instead or optional action replaced settings etc.) can be passed in as the actual action we want to check.

Currently undertaking a review on all current usage of the function to try and find anything that relied on it handling the OriginalHook by itself to catch any oddities.