### PR TITLE
Rebalances

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -231,8 +231,8 @@ internal unsafe class AutoRotationController
 
     public static IEnumerable<(uint Action, bool MultiHitOnly)> RaidwideActions =
     [
-        (WHM.PlenaryIndulgence, false),
         (WHM.LiturgyOfTheBell.Retarget(SimpleTarget.Self), true),
+        (WHM.PlenaryIndulgence, false),
         (WHM.Temperance, false),
         (WHM.DivineCaress, false),
         (WHM.Asylum.Retarget(SimpleTarget.Self), false),
@@ -247,11 +247,11 @@ internal unsafe class AutoRotationController
         (AST.CelestialOpposition, false),
         (AST.AspectedHelios, false),
         (AST.HeliosConjuction, false),
+        (SGE.Panhaima, true),
         (SGE.Kerachole, false),
         (SGE.Physis, false),
         (SGE.Physis2, false),
         (SGE.Holos, false),
-        (SGE.Panhaima, true),
         (SGE.Eukrasia, false),
         (SGE.EukrasianPrognosis, false),
         (SGE.EukrasianPrognosis2, false),
@@ -263,17 +263,17 @@ internal unsafe class AutoRotationController
         GroupDamageIncoming(out bool isMultiHit);
         foreach (var (spell, multihitter) in RaidwideActions)
         {
+            if (AutorotRaidwides >= 2)
+                return;
+
             if (!isMultiHit && multihitter)
                 continue;
 
             if (BlacklistedRaidwides.Contains(spell))
                 continue;
 
-            if (ActionReady(spell) && !JustUsed(spell, 5) && LocalPlayer.CastActionId != spell && (!IsMoving(true) || ActionManager.GetAdjustedCastTime(ActionType.Action, spell) == 0))
+            if (ActionReady(spell) && !JustUsed(spell, 10) && LocalPlayer.CastActionId != spell && (!IsMoving(true) || ActionManager.GetAdjustedCastTime(ActionType.Action, spell) == 0))
             {
-                if (AutorotRaidwides >= 2)
-                    return;
-
                 WouldLikeToGroundTarget = ActionSheet[spell].TargetArea;
                 ActionManager.Instance()->UseAction(ActionType.Action, spell);
                 WouldLikeToGroundTarget = false;

--- a/WrathCombo/Combos/PvE/Content/Variant/Variant_Helper.cs
+++ b/WrathCombo/Combos/PvE/Content/Variant/Variant_Helper.cs
@@ -1,4 +1,5 @@
 ﻿using ECommons.DalamudServices;
+using System.Linq;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 
 namespace WrathCombo.Combos.PvE
@@ -60,7 +61,7 @@ namespace WrathCombo.Combos.PvE
 
         private static bool CheckSpiritDart(Preset preset) =>
             IsEnabled(preset) && ActionReady(SpiritDart) &&
-            HasBattleTarget() && GetStatusEffectRemainingTime(Debuffs.SustainedDamage, CurrentTarget) <= 3;
+            HasBattleTarget() && EnemiesInRange(SpiritDart).Any(x => GetStatusEffectRemainingTime(Debuffs.SustainedDamage, x) <= 3);
 
         private static bool CheckCure(Preset preset, int healthpercent) =>
             IsEnabled(preset) && ActionReady(Cure) &&

--- a/WrathCombo/CustomCombo/Functions/Target.cs
+++ b/WrathCombo/CustomCombo/Functions/Target.cs
@@ -15,6 +15,7 @@ using WrathCombo.Data;
 using WrathCombo.Extensions;
 using WrathCombo.Services;
 using ObjectKind = Dalamud.Game.ClientState.Objects.Enums.ObjectKind;
+using FFXIVClientStructs.FFXIV.Client.Game.Object;
 namespace WrathCombo.CustomComboNS.Functions;
 
 internal abstract partial class CustomComboFunctions
@@ -364,30 +365,33 @@ internal abstract partial class CustomComboFunctions
     public static int NumberOfEnemiesInRange
         (uint aoeSpell, IGameObject? target = null, bool checkIgnoredList = false)
     {
+        return EnemiesInRange(aoeSpell, target, checkIgnoredList).Count();
+    }
+
+    public static IEnumerable<IGameObject> EnemiesInRange(uint aoeSpell, IGameObject? target = null, bool checkIgnoredList = false)
+    {
         if (!ActionWatching.ActionSheet.TryGetValue(aoeSpell, out var sheetSpell))
-            return 0;
+            return Enumerable.Empty<IGameObject>();
 
         if (sheetSpell.CanTargetHostile &&
             ((target ??= CurrentTarget) is null ||
              GetTargetDistance(target) > GetActionRange(sheetSpell.RowId)))
-            return 0;
+            return Enumerable.Empty<IGameObject>();
 
-        var count = sheetSpell.CastType switch
+        return sheetSpell.CastType switch
         {
-            1 => 1,
+            1 => Enumerable.Empty<IGameObject>(),
             2 => sheetSpell.CanTargetSelf
-                ? NumberOfObjectsInRange<SelfCircle>(sheetSpell.EffectRange,
+                ? ObjectsInRange<SelfCircle>(sheetSpell.EffectRange,
                     checkIgnoredList: checkIgnoredList)
-                : NumberOfObjectsInRange<Circle>(sheetSpell.EffectRange, target,
+                : ObjectsInRange<Circle>(sheetSpell.EffectRange, target,
                     checkIgnoredList: checkIgnoredList),
-            3 => NumberOfObjectsInRange<Cone>(sheetSpell.Range, target,
+            3 => ObjectsInRange<Cone>(sheetSpell.Range, target,
                 checkIgnoredList: checkIgnoredList),
-            4 => NumberOfObjectsInRange<Line>(sheetSpell.Range, target,
+            4 => ObjectsInRange<Line>(sheetSpell.Range, target,
                 sheetSpell.XAxisModifier, checkIgnoredList: checkIgnoredList),
-            _ => 0,
+            _ => Enumerable.Empty<IGameObject>(),
         };
-
-        return count;
     }
 
     /// <summary>
@@ -740,32 +744,44 @@ internal abstract partial class CustomComboFunctions
         bool checkInvincible = true)
         where T : IAoeShape
     {
+        return ObjectsInRange<T>(size, target, width, checkIgnoredList, enemies, checkInvincible).Count();
+    }
+
+    internal static IEnumerable<IGameObject> ObjectsInRange<T>
+    (float size,
+        IGameObject? target = null,
+        float width = 0f,
+        bool checkIgnoredList = false,
+        bool enemies = true,
+        bool checkInvincible = true)
+        where T : IAoeShape
+    {
         // Bail if the player is not available
         if (LocalPlayer is not { } player)
-            return 0;
+            return Enumerable.Empty<IGameObject>();
 
         // Bail if the target is required and not available
         if (typeof(T) != typeof(SelfCircle) && (target ??= CurrentTarget) is null)
-            return 0;
+            return Enumerable.Empty<IGameObject>();
 
         // Get all possible enemies to search for the positions of
-        var targets = Svc.Objects.Where(IsValidTarget);
+        var targets = Svc.Objects.Where(x => IsValidTarget(x, enemies, checkInvincible, checkIgnoredList));
 
         // Circle AoEs positioned on self
         if (typeof(T) == typeof(SelfCircle))
-            return targets.Count(o =>
+            return targets.Where(o =>
                 PointInCircle(o.Position - player.Position,
                     size + o.HitboxRadius));
 
         // Circle AoEs centered on a target
         if (typeof(T) == typeof(Circle))
-            return targets.Count(o =>
+            return targets.Where(o =>
                 PointInCircle(o.Position - target.Position,
                     size + o.HitboxRadius));
 
         // Cone AoEs
         if (typeof(T) == typeof(Cone))
-            return targets.Count(o =>
+            return targets.Where(o =>
                 GetTargetDistance(o) <= size &&
                 PointInCone(o.Position - player.Position,
                     PositionalMath.GetDirection(player.Position, target.Position),
@@ -773,33 +789,33 @@ internal abstract partial class CustomComboFunctions
 
         // Line AoEs
         if (typeof(T) == typeof(Line))
-            return targets.Count(o =>
+            return targets.Where(o =>
                 GetTargetDistance(o) <= size &&
                 HitboxInRect(o,
                     PositionalMath.GetRotation(player.Position, target.Position),
                     size * 0.5f, width * 0.5f));
 
         // If it was not a supported type
-        return 0;
+        return Enumerable.Empty<IGameObject>();
+    }
 
-        bool IsValidTarget(IGameObject o)
-        {
-            if (!enemies)
-                return o is IBattleChara &&
-                       o.IsTargetable &&
-                       o.IsWithinRange(60f) &&
-                       o.IsFriendly() &&
-                       IsInLineOfSight(o);
-
-            return o is { ObjectKind: ObjectKind.BattleNpc, IsTargetable: true } &&
+    static bool IsValidTarget(IGameObject o, bool enemies, bool checkInvincible, bool checkIgnoredList)
+    {
+        if (!enemies)
+            return o is IBattleChara &&
+                   o.IsTargetable &&
                    o.IsWithinRange(60f) &&
-                   o.IsHostile() &&
-                   (!checkInvincible ||
-                    !TargetIsInvincible(o)) &&
-                   (!checkIgnoredList ||
-                    !Service.Configuration.IgnoredNPCs.ContainsKey(o.BaseId)) &&
+                   o.IsFriendly() &&
                    IsInLineOfSight(o);
-        }
+
+        return o is { ObjectKind: ObjectKind.BattleNpc, IsTargetable: true } &&
+               o.IsWithinRange(60f) &&
+               o.IsHostile() &&
+               (!checkInvincible ||
+                !TargetIsInvincible(o)) &&
+               (!checkIgnoredList ||
+                !Service.Configuration.IgnoredNPCs.ContainsKey(o.BaseId)) &&
+               IsInLineOfSight(o);
     }
 
     public static bool TargetInSelfCircle(IGameObject? target, float size)

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -329,8 +329,8 @@ public static class ActionWatching
                 token = source.Token;
                 UpdatingActions = true;
                 UpdateActionTask = Svc.Framework.RunOnTick(() =>
-                UpdateLastUsedAction(actionId, actionType, targetObjectId, castTime),
-                TimeSpan.FromMilliseconds(castTime), cancellationToken: token);
+                UpdateLastUsedAction(actionId, actionType, targetObjectId, Math.Max(castTime - 480, 0)),
+                TimeSpan.FromMilliseconds(Math.Max(castTime - 480, 0)), cancellationToken: token);
 
                 // Update Helpers
                 NIN.InMudra = NIN.MudraSigns.Contains(actionId);

--- a/WrathCombo/Window/Tabs/Debug.cs
+++ b/WrathCombo/Window/Tabs/Debug.cs
@@ -829,6 +829,23 @@ internal class Debug : ConfigWindow, IDisposable
                         CustomStyleText("Number of Targets Hit:", $"{NumberOfEnemiesInRange(_debugSpell.Value.RowId, target)}");
                 }
 
+                if (_debugSpell.Value.CastType != 1)
+                {
+                    ImGui.Spacing();
+                    if (ImGui.CollapsingHeader("Enemies in Range"))
+                    {
+                        ImGui.Indent();
+                        foreach (var e in EnemiesInRange(_debugSpell.Value.RowId))
+                        {
+                            if (ImGui.CollapsingHeader($"{e?.Name}###{e?.SafeGameObjectId}"))
+                            {
+                                DrawTargetInfo(e);
+                            }
+                        }
+                        ImGui.Unindent();
+                    }
+                }
+
                 if (ImGui.TreeNode("Data Dump"))
                 {
                     Util.ShowObject(_debugSpell.Value);

--- a/WrathCombo/Window/Tabs/Debug.cs
+++ b/WrathCombo/Window/Tabs/Debug.cs
@@ -414,7 +414,7 @@ internal class Debug : ConfigWindow, IDisposable
                     $"content:{Content.ContentName ?? "??"}, territory:{Content.TerritoryName ?? "??"}");
                 CustomStyleText("Content IDs:",
                     $"territory:{Content.TerritoryID}, cfc:{Content.ContentFinderConditionRow?.RowId.ToString() ?? "??"}, map:{Content.MapID}");
-                CustomStyleText("Content Type:", Content.ContentType?.ToString() ?? "??");
+                CustomStyleText("Content Type:", $"{(Content.ContentType.ToString() ?? "??")} {Content.ContentTypeRowId}");
                 CustomStyleText("Intended Use:", Content.TerritoryIntendedUse?.ToString() ?? "??");
                 CustomStyleText("Difficulty:",
                     $"from name:{Content.ContentDifficultyFromName ?? "??"}, determined:{Content.ContentDifficulty?.ToString() ?? "??"}");


### PR DESCRIPTION
- Re-order autorot raidwides slightly to put the multihit ones first as they'll only trigger during multihit attacks.
- Actions with cast times now classed as being completed during the slidecast window (for things like JustUsed)
- Expose list of enemies in range, refactoring count methods to use this. Allows to do additional logic on enemies in range such as...
- Variant Spirit dart updated to fire if an enemy able to be hit from your current target is missing the debuff rather than just being a check on the current target.