### PR TITLE
[WHM]Fix WHM Alternative Raise behavior on Swiftcast cooldown

### DIFF
--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -711,17 +711,18 @@ internal partial class WHM : Healer
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID != Role.Swiftcast)
+            if (actionID != RoleActions.Magic.Swiftcast)
                 return actionID;
 
-            var canThinAir = !HasStatusEffect(Buffs.ThinAir) && ActionReady
-                (ThinAir);
+            if (IsOnCooldown(actionID) || HasStatusEffect(RoleActions.Magic.Buffs.Swiftcast))
+            {
+                if (IsEnabled(Preset.WHM_ThinAirRaise) && !HasStatusEffect(Buffs.ThinAir) && ActionReady(ThinAir))
+                    return ThinAir;
 
-            if (HasStatusEffect(Role.Buffs.Swiftcast))
-                return IsEnabled(Preset.WHM_ThinAirRaise) && canThinAir ? ThinAir :
-                    IsEnabled(Preset.WHM_Raise_Retarget) ? Raise.Retarget(
-                        Role.Swiftcast,
-                        SimpleTarget.Stack.AllyToRaise) : Raise;
+                return IsEnabled(Preset.WHM_Raise_Retarget)
+                    ? Raise.Retarget(actionID, SimpleTarget.Stack.AllyToRaise)
+                    : Raise;
+            }
 
             return actionID;
         }

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -711,16 +711,16 @@ internal partial class WHM : Healer
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID != RoleActions.Magic.Swiftcast)
+            if (actionID != Role.Swiftcast)
                 return actionID;
 
-            if (IsOnCooldown(actionID) || HasStatusEffect(RoleActions.Magic.Buffs.Swiftcast))
+            if (IsOnCooldown(Role.Swiftcast) || HasStatusEffect(Role.Buffs.Swiftcast))
             {
                 if (IsEnabled(Preset.WHM_ThinAirRaise) && !HasStatusEffect(Buffs.ThinAir) && ActionReady(ThinAir))
                     return ThinAir;
 
                 return IsEnabled(Preset.WHM_Raise_Retarget)
-                    ? Raise.Retarget(actionID, SimpleTarget.Stack.AllyToRaise)
+                    ? Raise.Retarget(Role.Swiftcast, SimpleTarget.Stack.AllyToRaise)
                     : Raise;
             }
 


### PR DESCRIPTION
 Fixing WHM's alternative raise behavior to work similar to how it does with other healers.

Currently, the button gets stuck on the Swiftcast icon when its on cooldown, and only allows usage with swift which prevents the ability to hard cast the same way AST SGE SCH can.  I've updated the logic to check for the cooldown state so it swaps over to Raise as soon as Swiftcast is used

i assume this looks good. it works for me, but if you see that it should be handed different please reject this. But do know that its an issue with WHM that currently exists using its alt raise feature. 