### PR TITLE
[PVP] Couple of movement fixes

### DIFF
--- a/WrathCombo/Combos/PvP/PCTPVP.cs
+++ b/WrathCombo/Combos/PvP/PCTPVP.cs
@@ -33,7 +33,8 @@ internal static class PCTPvP
             Starstruck = 4118,
             MooglePortrait = 4103,
             MadeenPortrait = 4104,
-            SubtractivePalette = 4102;
+            SubtractivePalette = 4102,
+            QuickSketch = 4324;
     }
     #endregion
 
@@ -44,6 +45,9 @@ internal static class PCTPvP
             PCTPvP_BurstHP = new("PCTPvP_BurstHP", 100),
             PCTPvP_TemperaHP = new("PCTPvP_TemperaHP", 50),
             PCTPvP_PhantomDartThreshold = new("PCTPvP_PhantomDartThreshold", 50);
+        
+        public static UserBool
+            PCTPvP_CreatureMotifEnforceNotMoving = new("PCTPvP_CreatureMotifEnforceNotMoving", true);
 
         internal static void Draw(Preset preset)
         {
@@ -58,6 +62,10 @@ internal static class PCTPvP
                     break;
 
                 case Preset.PCTPvP_TemperaCoat: DrawSliderInt(1, 100, PCTPvP_TemperaHP, "Player HP%", 200);
+                    break;
+                
+                case Preset.PCTPvP_CreatureMotif: DrawAdditionalBoolChoice(PCTPvP_CreatureMotifEnforceNotMoving, 
+                    "Enforce No Movement", "Will not attempt to use Creature Motif when moving unless you have Quick Sketch buff from Smudge.");
                     break;
             }
         }            
@@ -116,7 +124,8 @@ internal static class PCTPvP
                     return OriginalHook(HolyInWhite);
             }
             // Creature Motif
-            if (IsEnabled(Preset.PCTPvP_CreatureMotif) && !hasMotifDrawn && !isMoving)
+            if (IsEnabled(Preset.PCTPvP_CreatureMotif) && !hasMotifDrawn && 
+                (HasStatusEffect(Buffs.QuickSketch) || !isMoving || !PCTPvP_CreatureMotifEnforceNotMoving))
                 return OriginalHook(CreatureMotif);
 
             // Subtractive Palette

--- a/WrathCombo/Combos/PvP/RDMPVP.cs
+++ b/WrathCombo/Combos/PvP/RDMPVP.cs
@@ -222,8 +222,7 @@ internal static class RDMPvP
             }
 
             // Grand Impact / Jolt III
-            return hasGrandImpact || !isMoving ? OriginalHook(actionID) : All.SavageBlade;
-
+            return OriginalHook(actionID);
         }
     }
     internal class RDMPvP_Dash_Feature : CustomCombo

--- a/WrathCombo/Combos/PvP/SMNPvP.cs
+++ b/WrathCombo/Combos/PvP/SMNPvP.cs
@@ -121,7 +121,7 @@ internal static class SMNPvP
                     return MountainBuster;
 
                 // Garuda (check Slipstream cooldown)
-                if (IsEnabled(Preset.SMNPvP_BurstMode_Slipstream) && IsOffCooldown(Slipstream) && !IsMoving())
+                if (IsEnabled(Preset.SMNPvP_BurstMode_Slipstream) && IsOffCooldown(Slipstream))
                     return Slipstream;
             }
             return actionID;


### PR DESCRIPTION
- RDM
  - Removed movement code at the end locking out jolt while moving
- SMN
  - Removed not moving requirement from slipstream due to changes back in 7.1 its not needed. 