### PR TITLE
Tankbusters and Stuff

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationConfig.cs
+++ b/WrathCombo/AutoRotation/AutoRotationConfig.cs
@@ -55,5 +55,6 @@ public class HealerSettings
     public bool IncludeNPCs = false;
     public bool HealerAlwaysHardTarget = false;
     public bool HandleRaidwides = false;
+    public bool HandleTankbusters = false;
 
 }

--- a/WrathCombo/AutoRotation/AutoRotationConfigIPCWrapper.cs
+++ b/WrathCombo/AutoRotation/AutoRotationConfigIPCWrapper.cs
@@ -306,5 +306,7 @@ public class HealerSettingsIPCWrapper(HealerSettings settings)
     public bool AutoRezDPSJobsHealersOnly => settings.AutoRezDPSJobsHealersOnly;
 
     public bool HandleRaidwides => settings.HandleRaidwides;
+
+    public bool HandleTankbusters => settings.HandleTankbusters;
     #endregion
 }

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -50,6 +50,7 @@ internal unsafe class AutoRotationController
     public static IGameObject? AutorotHealTarget;
     public static bool AutorotRaidwiding;
     public static int AutorotRaidwides = 0;
+    public static bool TankbusterHandled = false;
 
     public AutoRotationController()
     {
@@ -151,10 +152,10 @@ internal unsafe class AutoRotationController
 
         if (cfg.HealerSettings.HandleRaidwides)
         {
-            if (isHealer && GroupDamageIncoming())
+            if (isHealer && GroupDamageIncoming(out var multi))
             {
                 AutorotRaidwiding = true;
-                HandleRaidwide();
+                HandleRaidwide(multi);
             }
             else
             {
@@ -167,6 +168,13 @@ internal unsafe class AutoRotationController
                 AutorotRaidwiding = false;
             }
         }
+
+        if (isHealer && TryGetTankBusterTarget(out var tbtarget))
+        {
+            HandleTankbuster(tbtarget.SafeGameObjectId);
+        }
+        else
+            TankbusterHandled = false;
 
         var healTarget = isHealer ? AutoRotationHelper.GetSingleTarget(cfg.HealerRotationMode) : null;
 
@@ -229,6 +237,39 @@ internal unsafe class AutoRotationController
         ProcessAutoActions(autoActions, ref _, canHeal, false);
     }
 
+    public static IEnumerable<uint> TankbusterActions =
+    [
+        WHM.Aquaveil,
+        WHM.DivineBenison,
+
+    ];
+
+    private static void HandleTankbuster(ulong? safeGameObjectId)
+    {
+        if (safeGameObjectId == null)
+            return;
+
+        foreach (var spell in TankbusterActions)
+        {
+            if (TankbusterHandled)
+                return;
+
+            if (AbleToCast(spell))
+            {
+                WouldLikeToGroundTarget = ActionSheet[spell].TargetArea;
+                ActionManager.Instance()->UseAction(ActionType.Action, spell, safeGameObjectId!.Value);
+                WouldLikeToGroundTarget = false;
+                TankbusterHandled = true;
+                return;
+            }
+        }
+    }
+
+    private static bool AbleToCast(uint spell)
+    {
+        return ActionReady(spell) && !JustUsed(spell, 10) && LocalPlayer.CastActionId != spell && (!IsMoving(true) || ActionManager.GetAdjustedCastTime(ActionType.Action, spell) == 0);
+    }
+
     public static IEnumerable<(uint Action, bool MultiHitOnly)> RaidwideActions =
     [
         (WHM.LiturgyOfTheBell.Retarget(SimpleTarget.Self), true),
@@ -258,21 +299,20 @@ internal unsafe class AutoRotationController
     ];
 
     public static List<uint> BlacklistedRaidwides = [];
-    private static void HandleRaidwide()
+    private static void HandleRaidwide(bool multihit)
     {
-        GroupDamageIncoming(out bool isMultiHit);
         foreach (var (spell, multihitter) in RaidwideActions)
         {
             if (AutorotRaidwides >= 2)
                 return;
 
-            if (!isMultiHit && multihitter)
+            if (!multihit && multihitter)
                 continue;
 
             if (BlacklistedRaidwides.Contains(spell))
                 continue;
 
-            if (ActionReady(spell) && !JustUsed(spell, 10) && LocalPlayer.CastActionId != spell && (!IsMoving(true) || ActionManager.GetAdjustedCastTime(ActionType.Action, spell) == 0))
+            if (AbleToCast(spell))
             {
                 WouldLikeToGroundTarget = ActionSheet[spell].TargetArea;
                 ActionManager.Instance()->UseAction(ActionType.Action, spell);

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -169,12 +169,15 @@ internal unsafe class AutoRotationController
             }
         }
 
-        if (isHealer && TryGetTankBusterTarget(out var tbtarget))
+        if (cfg.HealerSettings.HandleTankbusters)
         {
-            HandleTankbuster(tbtarget.SafeGameObjectId);
+            if (isHealer && TryGetTankBusterTarget(out var tbtarget))
+            {
+                HandleTankbuster(tbtarget.SafeGameObjectId);
+            }
+            else
+                TankbusterHandled = false;
         }
-        else
-            TankbusterHandled = false;
 
         var healTarget = isHealer ? AutoRotationHelper.GetSingleTarget(cfg.HealerRotationMode) : null;
 
@@ -241,7 +244,16 @@ internal unsafe class AutoRotationController
     [
         WHM.Aquaveil,
         WHM.DivineBenison,
-
+        SCH.Protraction,
+        SCH.Adloquium,
+        SCH.Manifestation,
+        AST.Spire,
+        AST.Bole,
+        AST.CelestialIntersection,
+        AST.Exaltation,
+        SGE.Taurochole,
+        SGE.Eukrasia,
+        SGE.EukrasianDiagnosis,
     ];
 
     private static void HandleTankbuster(ulong? safeGameObjectId)
@@ -254,20 +266,21 @@ internal unsafe class AutoRotationController
             if (TankbusterHandled)
                 return;
 
-            if (AbleToCast(spell))
+            if (AbleToCast(spell, safeGameObjectId))
             {
                 WouldLikeToGroundTarget = ActionSheet[spell].TargetArea;
-                ActionManager.Instance()->UseAction(ActionType.Action, spell, safeGameObjectId!.Value);
+                ActionManager.Instance()->UseAction(ActionType.Action, spell is SGE.Eukrasia ? spell.Retarget(SimpleTarget.Self) : spell.Retarget(safeGameObjectId.GetObject()), safeGameObjectId!.Value);
                 WouldLikeToGroundTarget = false;
-                TankbusterHandled = true;
+                if (spell != SGE.Eukrasia)
+                    TankbusterHandled = true;
                 return;
             }
         }
     }
 
-    private static bool AbleToCast(uint spell)
+    private static bool AbleToCast(uint spell, ulong? safeGameObjectId = null)
     {
-        return ActionReady(spell) && !JustUsed(spell, 10) && LocalPlayer.CastActionId != spell && (!IsMoving(true) || ActionManager.GetAdjustedCastTime(ActionType.Action, spell) == 0);
+        return ActionReady(spell) && (safeGameObjectId != null ? JustUsedOn(spell, safeGameObjectId.GetObject(), 5) : !JustUsed(spell, 10)) && LocalPlayer.CastActionId != spell && (!IsMoving(true) || ActionManager.GetAdjustedCastTime(ActionType.Action, spell) == 0);
     }
 
     public static IEnumerable<(uint Action, bool MultiHitOnly)> RaidwideActions =
@@ -282,6 +295,7 @@ internal unsafe class AutoRotationController
         (SCH.Expedient, false),
         (SCH.Seraphism, false),
         (SCH.Succor, false),
+        (SCH.Accession, false),
         (SCH.Concitation, false),
         (AST.CollectiveUnconscious, false),
         (AST.SunSign, false),

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -268,10 +268,13 @@ internal unsafe class AutoRotationController
 
             if (AbleToCast(spell, safeGameObjectId))
             {
-                WouldLikeToGroundTarget = ActionSheet[spell].TargetArea;
-                ActionManager.Instance()->UseAction(ActionType.Action, spell is SGE.Eukrasia ? spell.Retarget(SimpleTarget.Self) : spell.Retarget(safeGameObjectId.GetObject()), safeGameObjectId!.Value);
+                var act = spell;
+                if (act == AST.Bole) act = AST.Play2;
+                if (act == AST.Spire) act = AST.Play3;
+                WouldLikeToGroundTarget = ActionSheet[act].TargetArea;
+                ActionManager.Instance()->UseAction(ActionType.Action, act is SGE.Eukrasia ? act.Retarget(SimpleTarget.Self) : act.Retarget(safeGameObjectId.GetObject()), safeGameObjectId!.Value);
                 WouldLikeToGroundTarget = false;
-                if (spell != SGE.Eukrasia)
+                if (act != SGE.Eukrasia)
                     TankbusterHandled = true;
                 return;
             }
@@ -280,7 +283,7 @@ internal unsafe class AutoRotationController
 
     private static bool AbleToCast(uint spell, ulong? safeGameObjectId = null)
     {
-        return ActionReady(spell) && (safeGameObjectId != null ? JustUsedOn(spell, safeGameObjectId.GetObject(), 5) : !JustUsed(spell, 10)) && LocalPlayer.CastActionId != spell && (!IsMoving(true) || ActionManager.GetAdjustedCastTime(ActionType.Action, spell) == 0);
+        return ActionReady(spell) && (safeGameObjectId != null ? !JustUsedOn(spell, safeGameObjectId.GetObject(), 5) : !JustUsed(spell, 10)) && LocalPlayer.CastActionId != spell && (!IsMoving(true) || ActionManager.GetAdjustedCastTime(ActionType.Action, spell) == 0);
     }
 
     public static IEnumerable<(uint Action, bool MultiHitOnly)> RaidwideActions =

--- a/WrathCombo/Core/Configuration.cs
+++ b/WrathCombo/Core/Configuration.cs
@@ -129,6 +129,13 @@ public partial class Configuration : IPluginConfiguration
     [Setting(Setting.Type.Toggle)]
     public bool TankbusterTTS = false;
 
+    /// <summary>
+    /// Whether to play TTS when Raidwides/Group Damages are detected. Default: false.
+    /// </summary>
+    [SettingCategory(Main_UI_Options)]
+    [Setting(Setting.Type.Toggle)]
+    public bool AoEDamageTTS = false;
+
     #region Future Search Settings
 
     /// The preferred search behavior. Default: Filter.

--- a/WrathCombo/Core/Configuration.cs
+++ b/WrathCombo/Core/Configuration.cs
@@ -122,6 +122,13 @@ public partial class Configuration : IPluginConfiguration
     [Setting(Setting.Type.Toggle)]
     public bool UIShowSearchBar = true;
 
+    /// <summary>
+    /// Whether to play TTS when Tankbusters are detected. Default: false.
+    /// </summary>
+    [SettingCategory(Main_UI_Options)]
+    [Setting(Setting.Type.Toggle)]
+    public bool TankbusterTTS = false;
+
     #region Future Search Settings
 
     /// The preferred search behavior. Default: Filter.

--- a/WrathCombo/CustomCombo/Functions/VFX.cs
+++ b/WrathCombo/CustomCombo/Functions/VFX.cs
@@ -24,6 +24,8 @@ internal abstract partial class CustomComboFunctions
     private static uint? CurrentCFC => Content.ContentFinderConditionRowId;
 
     private static List<TTSData> TTSTankbusters = [];
+    private static List<TTSData> TTSGroupwides = [];
+    private static bool CurrentRaidwideHandled = false;
 
     /// <summary>
     /// Determines whether a VFX path matches any list of VFX paths.<br/>
@@ -232,6 +234,9 @@ internal abstract partial class CustomComboFunctions
 
     public static void PlayTankbusterTTS()
     {
+        if (!EzThrottler.Throttle("TankbusterTTS", 100))
+            return;
+
         foreach (var vfx in VfxManager.TrackedEffects.FilterToTargeted().Where(x => IsTankBusterEffectPath(x) && x.TargetID.GetObject().IsInParty()))
         {
             if (!TTSTankbusters.Any(x => x.VFX == vfx))
@@ -240,11 +245,44 @@ internal abstract partial class CustomComboFunctions
 
         if (TTSTankbusters.Any(x => !x.TTSHandled))
         {
-            var targets = TTSTankbusters.Where(x => !x.TTSHandled).Select(x => x.VFX.TargetID.GetObject()?.Name.ToString()).ToList();
+            var targets = TTSTankbusters.Where(x => !x.TTSHandled).Select(x => x.VFX.TargetID == Player.Object.GameObjectId ? "You" : x.VFX.TargetID.GetObject()?.Name.ToString()).ToList();
             TTS.SpeakAsync($"Tankbuster on {JoinNaturally(targets)}");
             TTSTankbusters.ForEach(x => x.TTSHandled = true);
         }
 
+        TTSTankbusters.RemoveAll(x => x.VFX.AgeSeconds >= 10);
+    }
+
+    public static void PlayGroupwideTTS()
+    {
+        if (!EzThrottler.Throttle("RaidwideTTS", 100))
+            return;
+
+        foreach (var vfx in VfxManager.TrackedEffects.Where(v => v.VfxID != 0 && (CheckPath(MHSharedDmgPaths, v.Path)) || CheckPath(SharedDmgPaths, v.Path)))
+        {
+            if (!TTSGroupwides.Any(x => x.VFX == vfx))
+                TTSGroupwides.Add(new TTSData() { VFX = vfx });
+        }
+
+        if (TTSGroupwides.Any(x => !x.TTSHandled))
+        {
+            var multiHit = TTSGroupwides.Any(x => CheckPath(MHSharedDmgPaths, x.VFX.Path));
+            var targets = TTSGroupwides.Where(x => !x.TTSHandled).Select(x => x.VFX.TargetID == Player.Object.GameObjectId ? "You" : x.VFX.TargetID.GetObject()?.Name.ToString()).ToList();
+            TTS.SpeakAsync($"{(multiHit ? "Multi-hit " : "")}Stack marker on {JoinNaturally(targets)}");
+            TTSGroupwides.ForEach(x => x.TTSHandled = true);
+        }
+
+        TTSGroupwides.RemoveAll(x => x.VFX.AgeSeconds >= 10);
+
+        if (RaidwideCasting())
+        {
+            if (!CurrentRaidwideHandled)
+                TTS.SpeakAsync("Group damage incoming");
+
+            CurrentRaidwideHandled = true;
+        }
+        else
+            CurrentRaidwideHandled = false;
     }
 
     public static string JoinNaturally(IList<string?> items)

--- a/WrathCombo/CustomCombo/Functions/VFX.cs
+++ b/WrathCombo/CustomCombo/Functions/VFX.cs
@@ -8,18 +8,22 @@ using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
+using System.Speech.Synthesis;
 using WrathCombo.Extensions;
 
 namespace WrathCombo.CustomComboNS.Functions;
 
 internal abstract partial class CustomComboFunctions
 {
+    public static SpeechSynthesizer TTS = new();
     private const StringComparison Lower = StringComparison.OrdinalIgnoreCase;
 
     private static readonly StringComparer Lowerer =
         StringComparer.FromComparison(Lower);
 
     private static uint? CurrentCFC => Content.ContentFinderConditionRowId;
+
+    private static List<TTSData> TTSTankbusters = [];
 
     /// <summary>
     /// Determines whether a VFX path matches any list of VFX paths.<br/>
@@ -147,10 +151,10 @@ internal abstract partial class CustomComboFunctions
         if (AoEEffects.Count == 0)
             return false;
 
-        #if DEBUG
+#if DEBUG
         if (EzThrottler.Throttle("DebugSharedDamageEffectVFX1", 5000))
             Svc.Log.Debug($"Found Incoming Shared Damage Effects {AoEEffects.Count}");
-		#endif
+#endif
 
         // Expected Outcome from the LINQ:
         // Multi - hit on party member, Closest in your party
@@ -166,9 +170,9 @@ internal abstract partial class CustomComboFunctions
             bestTarget = AoEEffects[0].TargetID.GetObject();
         else
         {
-            #if DEBUG
+#if DEBUG
             if (Svc.Condition[ConditionFlag.DutyRecorderPlayback]) PlaybackClosest = true; //Trick to allow alliance targets during ARR recording Playback.
-            #endif
+#endif
             bestTarget = AoEEffects //Note this will fail on Player based ARR Recordings. Trust Recordings are fine
                 .Select(vfx => vfx.TargetID.GetObject())
                 .OfType<IBattleChara>()
@@ -183,12 +187,12 @@ internal abstract partial class CustomComboFunctions
         if (bestTarget is null)
             return false;
 
-        #if DEBUG
+#if DEBUG
         if (EzThrottler.Throttle("DebugSharedDamageEffectVFX2", 5000))
         {
             Svc.Log.Debug($"Found Shared Damage Effects. Name:{bestTarget.Name} MH:{MH} Party:{bestTarget.IsInParty()}");
         }
-        #endif
+#endif
 
         //return only party member object (Don't want to illegally dash to Alliance or NPCs)
         isMultiHit = MH;
@@ -222,7 +226,46 @@ internal abstract partial class CustomComboFunctions
             return false;
 
         target = battleChara;
+
         return true;
+    }
+
+    public static void PlayTankbusterTTS()
+    {
+        foreach (var vfx in VfxManager.TrackedEffects.FilterToTargeted().Where(x => IsTankBusterEffectPath(x) && x.TargetID.GetObject().IsInParty()))
+        {
+            if (!TTSTankbusters.Any(x => x.VFX == vfx))
+                TTSTankbusters.Add(new TTSData() { VFX = vfx });
+        }
+
+        if (TTSTankbusters.Any(x => !x.TTSHandled))
+        {
+            var targets = TTSTankbusters.Where(x => !x.TTSHandled).Select(x => x.VFX.TargetID.GetObject()?.Name.ToString()).ToList();
+            TTS.SpeakAsync($"Tankbuster on {JoinNaturally(targets)}");
+            TTSTankbusters.ForEach(x => x.TTSHandled = true);
+        }
+
+    }
+
+    public static string JoinNaturally(IList<string?> items)
+    {
+        if (items == null || items.Count == 0)
+            return string.Empty;
+
+        if (items.Count == 1)
+            return items[0]!;
+
+        if (items.Count == 2)
+            return $"{items[0]} and {items[1]}";
+
+        return string.Join(", ", items.Take(items.Count - 1))
+               + " and " + items.Last();
+    }
+
+    private class TTSData
+    {
+        public VfxInfo VFX;
+        public bool TTSHandled;
     }
 
     /// <summary>

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -470,19 +470,19 @@ public static class ActionWatching
                     Service.ActionReplacer.EnableActionReplacingIfRequired();
 
                 var targetObject = targetId.GetObject();
-                if (targetObject is null)
+                if (targetObject is null && targetId != 0xE000_0000)
                 {
                     Service.ActionReplacer.EnableActionReplacingIfRequired();
                     return UseActionHook.Original(actionManager, actionType, actionId, targetId, extraParam, mode, comboRouteId, outOptAreaTargeted);
                 }
 
-                //if (changed && !areaTargeted) //Check if the action can be used on the target, and if not revert to original
-                if (!ActionManager.CanUseActionOnTarget(replacedWith,
-                        targetObject.Struct()))
-                    targetId = originalTargetId;
+                if (changed && !areaTargeted) //Check if the action can be used on the target, and if not revert to original
+                    if (!ActionManager.CanUseActionOnTarget(replacedWith,
+                            targetObject.Struct()))
+                        targetId = originalTargetId;
 
                 // Support Retargeted ground actions
-                if ((changed && areaTargeted) || AutoRotationController.WouldLikeToGroundTarget)
+                if ((areaTargeted && changed) || AutoRotationController.WouldLikeToGroundTarget)
                 {
                     var location = Player.Position;
                     replacedWith = Service.ActionReplacer.LastActionInvokeFor.TryGetValue(actionId, out var replacedGT) ? replacedGT : replacedWith;

--- a/WrathCombo/Resources/Localization/UI/AutoRotation/AutoRotationUI.Designer.cs
+++ b/WrathCombo/Resources/Localization/UI/AutoRotation/AutoRotationUI.Designer.cs
@@ -214,6 +214,15 @@ namespace WrathCombo.Resources.Localization.UI.AutoRotation {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Handle Detected Tankbusters.
+        /// </summary>
+        internal static string Checkbox_HandleTankbusters {
+            get {
+                return ResourceManager.GetString("Checkbox_HandleTankbusters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Always Set Hard Target###HealerHardTarget.
         /// </summary>
         internal static string Checkbox_HealerAlwaysHardTarget {
@@ -461,6 +470,15 @@ namespace WrathCombo.Resources.Localization.UI.AutoRotation {
         internal static string HelpText_HandleRaidwides {
             get {
                 return ResourceManager.GetString("HelpText_HandleRaidwides", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Will try to use actions before detected tankbusters to mitigate damage on targeted member. Max 1 action (excluding {0} for setup).
+        /// </summary>
+        internal static string HelpText_HandleTankbusters {
+            get {
+                return ResourceManager.GetString("HelpText_HandleTankbusters", resourceCulture);
             }
         }
         

--- a/WrathCombo/Resources/Localization/UI/AutoRotation/AutoRotationUI.resx
+++ b/WrathCombo/Resources/Localization/UI/AutoRotation/AutoRotationUI.resx
@@ -359,4 +359,10 @@ Applies to {0}, {1}, {2}, {3}, {4}, and {5} {6} {7}</value>
   <data name="HelpText_HandleRaidwides" xml:space="preserve">
     <value>Will try to use actions before detected raidwides or group damage to either mitigate or top-off party members. Max 2 actions (excluding {0} for setup)</value>
   </data>
+  <data name="Checkbox_HandleTankbusters" xml:space="preserve">
+    <value>Handle Detected Tankbusters</value>
+  </data>
+  <data name="HelpText_HandleTankbusters" xml:space="preserve">
+    <value>Will try to use actions before detected tankbusters to mitigate damage on targeted member. Max 1 action (excluding {0} for setup)</value>
+  </data>
 </root>

--- a/WrathCombo/Resources/Localization/UI/Settings/SettingsCfgUI.Designer.cs
+++ b/WrathCombo/Resources/Localization/UI/Settings/SettingsCfgUI.Designer.cs
@@ -151,6 +151,42 @@ namespace WrathCombo.Resources.Localization.UI.Settings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Off.
+        /// </summary>
+        internal static string AoEDamageTTS_defaultValue {
+            get {
+                return ResourceManager.GetString("AoEDamageTTS_defaultValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Will play a text-to-speech sound clip whenever a stack/group damage cast is detected, including who it is targeting if applicable..
+        /// </summary>
+        internal static string AoEDamageTTS_helpMark {
+            get {
+                return ResourceManager.GetString("AoEDamageTTS_helpMark", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Play TTS on Group Damage.
+        /// </summary>
+        internal static string AoEDamageTTS_Name {
+            get {
+                return ResourceManager.GetString("AoEDamageTTS_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Preference.
+        /// </summary>
+        internal static string AoEDamageTTS_recommendedValue {
+            get {
+                return ResourceManager.GetString("AoEDamageTTS_recommendedValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to On, cause it&apos;s that type of day y&apos;know.
         /// </summary>
         internal static string AprilFools2026_defaultValue {

--- a/WrathCombo/Resources/Localization/UI/Settings/SettingsCfgUI.Designer.cs
+++ b/WrathCombo/Resources/Localization/UI/Settings/SettingsCfgUI.Designer.cs
@@ -1292,6 +1292,42 @@ namespace WrathCombo.Resources.Localization.UI.Settings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Off.
+        /// </summary>
+        internal static string TankbusterTTS_defaultValue {
+            get {
+                return ResourceManager.GetString("TankbusterTTS_defaultValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Will play a text-to-speech sound clip whenever a tankbuster is detected, including who it is targeting..
+        /// </summary>
+        internal static string TankbusterTTS_helpMark {
+            get {
+                return ResourceManager.GetString("TankbusterTTS_helpMark", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Play TTS on Tankbuster.
+        /// </summary>
+        internal static string TankbusterTTS_Name {
+            get {
+                return ResourceManager.GetString("TankbusterTTS_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Preference.
+        /// </summary>
+        internal static string TankbusterTTS_recommendedValue {
+            get {
+                return ResourceManager.GetString("TankbusterTTS_recommendedValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to #808080FF.
         /// </summary>
         internal static string TargetHighlightColor_defaultValue {

--- a/WrathCombo/Resources/Localization/UI/Settings/SettingsCfgUI.resx
+++ b/WrathCombo/Resources/Localization/UI/Settings/SettingsCfgUI.resx
@@ -702,4 +702,16 @@ It is recommended to enable this if you are a keyboard+mouse user and enable Ret
   <data name="TankbusterTTS_defaultValue" xml:space="preserve">
     <value>Off</value>
   </data>
+  <data name="AoEDamageTTS_Name" xml:space="preserve">
+    <value>Play TTS on Group Damage</value>
+  </data>
+  <data name="AoEDamageTTS_helpMark" xml:space="preserve">
+    <value>Will play a text-to-speech sound clip whenever a stack/group damage cast is detected, including who it is targeting if applicable.</value>
+  </data>
+  <data name="AoEDamageTTS_recommendedValue" xml:space="preserve">
+    <value>Preference</value>
+  </data>
+  <data name="AoEDamageTTS_defaultValue" xml:space="preserve">
+    <value>Off</value>
+  </data>
 </root>

--- a/WrathCombo/Resources/Localization/UI/Settings/SettingsCfgUI.resx
+++ b/WrathCombo/Resources/Localization/UI/Settings/SettingsCfgUI.resx
@@ -690,4 +690,16 @@ It is recommended to enable this if you are a keyboard+mouse user and enable Ret
   <data name="AprilFools2026_defaultValue" xml:space="preserve">
     <value>On, cause it's that type of day y'know</value>
   </data>
+  <data name="TankbusterTTS_Name" xml:space="preserve">
+    <value>Play TTS on Tankbuster</value>
+  </data>
+  <data name="TankbusterTTS_helpMark" xml:space="preserve">
+    <value>Will play a text-to-speech sound clip whenever a tankbuster is detected, including who it is targeting.</value>
+  </data>
+  <data name="TankbusterTTS_recommendedValue" xml:space="preserve">
+    <value>Preference</value>
+  </data>
+  <data name="TankbusterTTS_defaultValue" xml:space="preserve">
+    <value>Off</value>
+  </data>
 </root>

--- a/WrathCombo/Window/Tabs/AutoRotationTab.cs
+++ b/WrathCombo/Window/Tabs/AutoRotationTab.cs
@@ -374,6 +374,11 @@ internal class AutoRotationTab : ConfigWindow
                 ref cfg.HealerSettings.HandleRaidwides);
             ImGuiComponents.HelpMarker(Text.FormatAndCache(AutoRotationUI.HelpText_HandleRaidwides, SGE.Eukrasia.ActionName()));
 
+            changed |= P.UIHelper.ShowIPCControlledCheckboxIfNeeded(
+                AutoRotationUI.Checkbox_HandleTankbusters,
+                ref cfg.HealerSettings.HandleTankbusters);
+            ImGuiComponents.HelpMarker(Text.FormatAndCache(AutoRotationUI.HelpText_HandleTankbusters, SGE.Eukrasia.ActionName()));
+
         }
 
         ImGuiEx.TextUnderlined(AutoRotationUI.Label_Advanced);

--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -383,9 +383,10 @@ public sealed partial class WrathCombo : IDalamudPlugin
                 OpenerDtr.Text = "";
 
             if (Service.Configuration.TankbusterTTS)
-            {
-               CustomComboFunctions.PlayTankbusterTTS();
-            }
+                CustomComboFunctions.PlayTankbusterTTS();
+
+            if (Service.Configuration.AoEDamageTTS)
+                CustomComboFunctions.PlayGroupwideTTS();
         }
         catch (Exception ex)
         {

--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -381,6 +381,11 @@ public sealed partial class WrathCombo : IDalamudPlugin
             }
             else
                 OpenerDtr.Text = "";
+
+            if (Service.Configuration.TankbusterTTS)
+            {
+               CustomComboFunctions.PlayTankbusterTTS();
+            }
         }
         catch (Exception ex)
         {

--- a/WrathCombo/WrathCombo.csproj
+++ b/WrathCombo/WrathCombo.csproj
@@ -72,6 +72,7 @@
     <!-- Dalamud Packaging -->
     <ItemGroup>
         <PackageReference Include="DalamudPackager" Version="14.0.1" />
+        <PackageReference Include="System.Speech" Version="10.0.5" />
     </ItemGroup>
 
     <!-- Dependencies -->


### PR DESCRIPTION
Goal initially started out as adding tankbuster actioning for healers for autorot, similar to raidwides, but then I got sidetracked and had an idea to leverage our detection to replicate some cactbot features. Namely that of firing of TTS messages whenever something is detected.

- [X] Add Tankbuster actioning to autorot for healers.
- [x] Add new option to output detected Tankbusters as a TTS clips.
- [x] Add new option to output detected raidwides/group damage as TTS clips. 