### PR TITLE
[PCT] Edewen Changes

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -4277,14 +4277,14 @@ public enum Preset
 
     [AutoAction(false, false)]
     [ReplaceSkill(PCT.FireInRed)]
-    [ConflictingCombos(CombinedAetherhues, PCT_ST_AdvancedMode)]
+    [ConflictingCombos(PCT_ST_AdvancedMode)]
     [JobInfo(Job.PCT)]
     [SimpleCombo]
     PCT_ST_SimpleMode = 20000,
 
     [AutoAction(true, false)]
     [ReplaceSkill(PCT.FireIIinRed)]
-    [ConflictingCombos(CombinedAetherhues, PCT_AoE_AdvancedMode)]
+    [ConflictingCombos(PCT_AoE_AdvancedMode)]
     [JobInfo(Job.PCT)]
     [SimpleCombo]
     PCT_AoE_SimpleMode = 20001,
@@ -4295,7 +4295,7 @@ public enum Preset
 
     [AutoAction(false, false)]
     [ReplaceSkill(PCT.FireInRed)]
-    [ConflictingCombos(CombinedAetherhues, PCT_ST_SimpleMode)]
+    [ConflictingCombos(PCT_ST_SimpleMode)]
     [JobInfo(Job.PCT)]
     [AdvancedCombo]
     PCT_ST_AdvancedMode = 20005,
@@ -4414,7 +4414,7 @@ public enum Preset
 
     [AutoAction(true, false)]
     [ReplaceSkill(PCT.FireIIinRed)]
-    [ConflictingCombos(CombinedAetherhues, PCT_AoE_SimpleMode)]
+    [ConflictingCombos(PCT_AoE_SimpleMode)]
     [JobInfo(Job.PCT)]
     [AdvancedCombo]
     PCT_AoE_AdvancedMode = 20040,
@@ -4519,8 +4519,7 @@ public enum Preset
 
     #region Standalone Features
 
-    [ReplaceSkill(PCT.FireInRed, PCT.FireIIinRed)]
-    [ConflictingCombos(PCT_ST_SimpleMode, PCT_AoE_SimpleMode)]
+    [ReplaceSkill(PCT.BlizzardinCyan, PCT.BlizzardIIinCyan)]
     [JobInfo(Job.PCT)]
     CombinedAetherhues = 20002,
 

--- a/WrathCombo/Combos/PvE/PCT/PCT.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT.cs
@@ -181,20 +181,23 @@ internal partial class PCT : Caster
         protected internal override Preset Preset => Preset.CombinedAetherhues;
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is not (FireInRed or FireIIinRed))
+            if (actionID is not (BlizzardinCyan or BlizzardIIinCyan))
                 return actionID;
 
             int choice = CombinedAetherhueChoices;
 
-            if (actionID == FireInRed && choice is 0 or 1)
+            if (actionID == BlizzardinCyan && choice is 0 or 1)
             {
-                if (HasStatusEffect(Buffs.SubtractivePalette))
-                    return OriginalHook(BlizzardinCyan);
+                return HasStatusEffect(Buffs.SubtractivePalette)
+                    ? OriginalHook(BlizzardinCyan)
+                    : OriginalHook(FireInRed);
+                
             }
-            if (actionID == FireIIinRed && choice is 0 or 2)
+            if (actionID == BlizzardIIinCyan && choice is 0 or 2)
             {
-                if (HasStatusEffect(Buffs.SubtractivePalette))
-                    return OriginalHook(BlizzardIIinCyan);
+                return HasStatusEffect(Buffs.SubtractivePalette)
+                    ? OriginalHook(BlizzardIIinCyan)
+                    : OriginalHook(FireIIinRed);
             }
             return actionID;
         }

--- a/WrathCombo/Combos/PvE/PCT/PCT_Config.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT_Config.cs
@@ -157,11 +157,11 @@ internal partial class PCT
                 #region Standalone
                 case Preset.CombinedAetherhues:
                     DrawRadioButton(CombinedAetherhueChoices, "Both Single Target & AoE",
-                        $"Replaces both {FireInRed.ActionName()} & {FireIIinRed.ActionName()}", 0);
+                        $"Replaces both {BlizzardinCyan.ActionName()} & {BlizzardIIinCyan.ActionName()}", 0);
                     DrawRadioButton(CombinedAetherhueChoices, "Single Target Only",
-                        $"Replace only {FireInRed.ActionName()}", 1);
+                        $"Replace only {BlizzardinCyan.ActionName()}", 1);
                     DrawRadioButton(CombinedAetherhueChoices, "AoE Only",
-                        $"Replace only {FireIIinRed.ActionName()}", 2);
+                        $"Replace only {BlizzardIIinCyan.ActionName()}", 2);
                     break;
 
                 case Preset.CombinedMotifs:


### PR DESCRIPTION
- PCT
   - Adjusted Combined Aetherhues Standalone to now affect the Blizzard in Cyan buttons and removed their conflict with the Main combos. Users can now use this as a holding pattern kind of button like other casters do with downranked options. 