### PR TITLE
[ALL] Roles & Content Icon, Wrong PvP Warning

### DIFF
--- a/WrathCombo/Window/Icons.cs
+++ b/WrathCombo/Window/Icons.cs
@@ -66,7 +66,7 @@ internal static class Icons
     {
         uint iconID = job switch
         {
-            Job.ADV => 62146,
+            Job.ADV => 62147,
             Job.MIN or Job.BTN or Job.FSH => 82096,
             _ => (uint)ExcelJobHelper.GetIcon(job)
         };

--- a/WrathCombo/Window/Tabs/PvPFeatures.cs
+++ b/WrathCombo/Window/Tabs/PvPFeatures.cs
@@ -59,7 +59,7 @@ internal class PvPFeatures : FeaturesWindow
                         ImGuiEx.TextWrapped(ImGuiColors.DalamudRed, $"{FontAwesomeIcon.ExclamationTriangle.ToIconString()}");
                         ImGui.PopFont();
                         ImGui.SameLine();
-                        ImGuiEx.TextWrapped(ImGuiColors.DalamudRed, FeaturesUI.Info_pvpAutoRotationWarning);
+                        ImGuiEx.TextWrapped(ImGuiColors.DalamudRed, FeaturesUI.Info_pvpActionReplacingWarning);
                         ImGui.SameLine();
                         ImGui.PushFont(UiBuilder.IconFont);
                         ImGuiEx.TextWrapped(ImGuiColors.DalamudRed, $"{FontAwesomeIcon.ExclamationTriangle.ToIconString()}");


### PR DESCRIPTION
Updated the number to use the previous multi color icon
<img width="169" height="135" alt="image" src="https://github.com/user-attachments/assets/a799862a-0e7a-4ac0-8c8c-cc227019d671" />

Fixed wrong PvP warning being displayed for Action Replacing