### PR TITLE
[Autorotation & Misc] New Content Adjustments

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -83,6 +83,7 @@ internal unsafe class AutoRotationController
                 {
                     pauseWarningFound = true;
                     UnpauseSeconds = 20;
+                    Svc.Targets.Target = null; //Stop auto-attacks
                 }
             break;
             default:

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -3,11 +3,13 @@
 using Dalamud.Game.ClientState.Objects.Types;
 using ECommons;
 using ECommons.DalamudServices;
+using ECommons.DalamudServices.Legacy;
 using ECommons.ExcelServices;
 using ECommons.GameFunctions;
 using ECommons.GameHelpers;
 using ECommons.Throttlers;
 using FFXIVClientStructs.FFXIV.Client.Game;
+using Lumina.Excel.Sheets;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -45,7 +47,8 @@ internal unsafe class AutoRotationController
     const float QueryRange = 30f;
 
     public static bool WouldLikeToGroundTarget;
-    public static bool PausedForError;
+    public static bool Paused;
+    public static int UnpauseSeconds;
 
     public static IGameObject? AutorotHealTarget;
     public static bool AutorotRaidwiding;
@@ -55,17 +58,54 @@ internal unsafe class AutoRotationController
     public AutoRotationController()
     {
         OnPartyCombatChanged += ResetError;
+        Svc.Chat.ChatMessage += ScanForWarnings;
+        OnStatusChanged += StatusChanged;
+    }
+
+    private void StatusChanged(uint statusId, bool onPlayer)
+    {
+        if (statusId == 5191 && !onPlayer)
+            Paused = false;
+    }
+
+    private void ScanForWarnings(Dalamud.Game.Chat.IHandleableChatMessage message)
+    {
+        if (message.LogKind != Dalamud.Game.Text.XivChatType.SystemMessage)
+            return;
+
+        bool pauseWarningFound = false;
+        bool raidwideWarningFound = false;
+        var logMessages = Svc.Data.Excel.GetSheet<LogMessage>();
+        switch (Content.TerritoryID)
+        {
+            case 1345:
+                if (message.Message.TextValue == logMessages.GetRow(11531).Text)
+                {
+                    pauseWarningFound = true;
+                    UnpauseSeconds = 20;
+                }
+            break;
+            default:
+                break;
+        }
+
+        if (pauseWarningFound)
+        {
+            Paused = true;
+            Svc.Framework.RunOnTick(() => Paused = false, TimeSpan.FromSeconds(UnpauseSeconds));
+        }
     }
 
     public void Dispose()
     {
         OnPartyCombatChanged -= ResetError;
+        Svc.Chat.ChatMessage -= ScanForWarnings;
     }
 
     private void ResetError(bool state)
     {
         if (!state)
-            PausedForError = false;
+            Paused = false;
     }
 
     static Func<WrathPartyMember, bool> RezQuery => x =>
@@ -115,7 +155,7 @@ internal unsafe class AutoRotationController
                || !EzThrottler.Throttle("Autorot", cfg.Throttler)
                || (cfg.DPSSettings.UnTargetAndDisableForPenalty && PlayerHasActionPenalty())
                || (ActionManager.Instance()->QueuedActionId > 0)
-               || PausedForError;
+               || Paused;
     }
 
     internal static void Run()

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -64,6 +64,7 @@ internal unsafe class AutoRotationController
 
     private void StatusChanged(uint statusId, bool onPlayer)
     {
+        Svc.Log.Verbose($"[AutoRotStatusCheck] {((ushort)statusId).StatusName()} {(onPlayer ? "Gained" : "Lost")}");
         if (statusId == 5191 && !onPlayer)
             Paused = false;
     }

--- a/WrathCombo/CustomCombo/Functions/Timer.cs
+++ b/WrathCombo/CustomCombo/Functions/Timer.cs
@@ -17,6 +17,8 @@ internal abstract partial class CustomComboFunctions
     private static DateTime partyCombat = DateTime.Now;
     private static DateTime? castFinishedAt;
     private static uint castId;
+    private static HashSet<uint> onPlayerStatuses = [];
+
     public static bool PartyInCombatCheck
     {
         get => field;
@@ -37,6 +39,9 @@ internal abstract partial class CustomComboFunctions
     public delegate void OnPartyCombatChangedDelegate(bool state);
     public static event OnPartyCombatChangedDelegate? OnPartyCombatChanged;
 
+    public delegate void OnStatusChangedDelegate(uint statusId, bool onPlayer);
+    public static event OnStatusChangedDelegate? OnStatusChanged;
+
     public static Dictionary<ulong, long> Deadtionary { get; set; } = new();
 
     /// <summary> Tells the elapsed time since the combat started. </summary>
@@ -55,6 +60,35 @@ internal abstract partial class CustomComboFunctions
         Svc.Framework.Update += UpdatePartyTimer;
         Svc.Framework.Update += UpdateDeadtionary;
         Svc.Framework.Update += CheckInterruptedCasts;
+        Svc.Framework.Update += CheckStatuses;
+    }
+
+    private static void CheckStatuses(IFramework framework)
+    {
+        if (!Player.Available) return;
+        foreach (var status in LocalPlayer.StatusList)
+        {
+            if (status.StatusId == 0)
+                continue;
+
+            if (!onPlayerStatuses.Contains(status.StatusId))
+                OnStatusChanged.Invoke(status.StatusId, true);
+
+            onPlayerStatuses.Add(status.StatusId);
+        }
+
+        if (onPlayerStatuses.Count == 0)
+            return;
+
+        var clonedList = onPlayerStatuses.ToList();
+        foreach (var status in clonedList)
+        {
+            if (!LocalPlayer.StatusList.Any(x => x.StatusId == status))
+            {
+                OnStatusChanged.Invoke(status, false);
+                onPlayerStatuses.Remove(status);
+            }
+        }
     }
 
     private static void CheckInterruptedCasts(IFramework framework)
@@ -124,6 +158,7 @@ internal abstract partial class CustomComboFunctions
         Svc.Framework.Update -= UpdatePartyTimer;
         Svc.Framework.Update -= UpdateDeadtionary;
         Svc.Framework.Update -= CheckInterruptedCasts;
+        Svc.Framework.Update -= CheckStatuses;
     }
 
     internal static void OnCombat(ConditionFlag flag, bool value)
@@ -133,7 +168,7 @@ internal abstract partial class CustomComboFunctions
             if (value)
             {
                 combatStart = DateTime.Now;
-                AutoRotationController.PausedForError = false;
+                AutoRotationController.Paused = false;
             }
         }
     }

--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -265,7 +265,7 @@ public sealed partial class WrathCombo : IDalamudPlugin
         if (Svc.Data.GetExcelSheet<LogMessage>().TryGetFirst(x => x.Text == txt, out var row))
         {
             if (row.RowId == 2288) //Aetherial Interference
-                AutoRotationController.PausedForError = true;
+                AutoRotationController.Paused = true;
         }
     }
 


### PR DESCRIPTION
- Adds a way to pause auto-rotation based on system messages sent (for use in places like the Clyteum's Motion Tracking mechanic). May also expand this in the future for other mechanics and raidwides that don't have casts but put as a system message instead.
- New event can be subscribed to whenever a status is gained or lost on the player. Main use again will be for auto-rotation to control the pause states.