### PR TITLE
[Tanks] Mitigation tweaks

### DIFF
--- a/WrathCombo/Combos/PvE/DRK/DRK_ActionLogic.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_ActionLogic.cs
@@ -390,6 +390,7 @@ internal partial class DRK
             if (JustUsedMitigation) return false;
 
             var numberOfEnemies = NumberOfEnemiesInRange(Role.Reprisal);
+            var pre70Mitigation = !LevelChecked(BlackestNight) && numberOfEnemies >= 3;
 
             #region TBN
 
@@ -405,7 +406,7 @@ internal partial class DRK
 
             if (IsEnabled(Preset.DRK_Mitigation_NonBoss_DarkMissionary) &&
                 ActionReady(DarkMissionary) &&
-                numberOfEnemies > 4 &&
+                (numberOfEnemies >= 5 || pre70Mitigation) &&
                 !JustUsed(OriginalHook(ShadowWall), 15f))
                 return (action = DarkMissionary) != 0;
 
@@ -432,7 +433,7 @@ internal partial class DRK
 
             #region Mitigation 5+
 
-            if (numberOfEnemies >= 5)
+            if (numberOfEnemies >= 5 || pre70Mitigation)
             {
                 if (IsEnabled(Preset.DRK_Mitigation_NonBoss_ShadowWall) &&
                     ActionReady(OriginalHook(ShadowWall)))

--- a/WrathCombo/Combos/PvE/GNB/GNB_Helper.cs
+++ b/WrathCombo/Combos/PvE/GNB/GNB_Helper.cs
@@ -105,6 +105,7 @@ internal partial class GNB : Tank
             JustUsed(Superbolide);
         
         var numberOfEnemies = NumberOfEnemiesInRange(Role.Reprisal);
+        var pre68Mitigation = !LevelChecked(HeartOfStone) && numberOfEnemies >= 3;
         #endregion
         
         #region Initial Bailout
@@ -147,7 +148,8 @@ internal partial class GNB : Tank
         #endregion
         
         #region Heart of Light Overlapping 5+
-        if (numberOfEnemies >= 5 && IsEnabled(Preset.GNB_Mit_Advanced_NonBoss_HeartOfLight) && 
+        if ((numberOfEnemies >= 5 || pre68Mitigation) && 
+            IsEnabled(Preset.GNB_Mit_Advanced_NonBoss_HeartOfLight) && 
             ActionReady(HeartOfLight) && !HasStatusEffect(Buffs.Superbolide))
         {
             actionID = HeartOfLight;
@@ -167,7 +169,7 @@ internal partial class GNB : Tank
         if (mitigationRunning || numberOfEnemies <= 2) return false; //Bail if already Mitted or too few enemies
         
         #region Mitigation 5+
-        if (numberOfEnemies >= 5)
+        if (numberOfEnemies >= 5 || pre68Mitigation)
         {
             if (ActionReady(Superbolide) && IsEnabled(Preset.GNB_Mit_Advanced_NonBoss_Superbolide))
             {

--- a/WrathCombo/Combos/PvE/WAR/WAR_Helper.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR_Helper.cs
@@ -493,6 +493,7 @@ internal partial class WAR : Tank
     {
         #region Variables
         var numberOfEnemies = NumberOfEnemiesInRange(Role.Reprisal);
+        var pre56Mitigation = !LevelChecked(RawIntuition) && numberOfEnemies >= 3;
         
         var mitigationRunning = HasStatusEffect(Role.Buffs.ArmsLength) ||
                                 HasStatusEffect(Role.Buffs.Rampart) || 
@@ -575,7 +576,7 @@ internal partial class WAR : Tank
         if (mitigationRunning || numberOfEnemies <= 2) return false; //Bail if already Mitted or too few enemies
         
         #region Mitigation 5+
-        if (numberOfEnemies >= 5)
+        if (numberOfEnemies >= 5 || pre56Mitigation)
         {
             if (ActionReady(OriginalHook(Vengeance)) && IsEnabled(Preset.WAR_Mitigation_NonBoss_Vengeance))
             {


### PR DESCRIPTION
- WAR, GNB, DRK
   - Added Logic to the mitigation system to allow mitigations that require 5 targets, to only require 3 targets before the short tank cooldowns (Heart of Stone - Raw Intuition - Blackest Night) are learned to smooth out those areas in leveled down content. 