### PR TITLE
[PLD] Adjustments on Requiescat Spender and Spirits within / Circle of Scorn Features

### DIFF
--- a/WrathCombo/Combos/PvE/PLD/PLD.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD.cs
@@ -604,8 +604,14 @@ internal partial class PLD : Tank
             bool canFightOrFlight = OriginalHook(FightOrFlight) is FightOrFlight && ActionReady(FightOrFlight);
 
             // Fight or Flight
-            if (PLD_Requiescat_SubOption == 2 && (!LevelChecked(Requiescat) || canFightOrFlight && ActionReady(OriginalHook(Requiescat))))
-                return OriginalHook(FightOrFlight);
+            if (PLD_Requiescat_SubOption == 1)
+            {
+                if (!LevelChecked(Requiescat) || canFightOrFlight && ActionReady(OriginalHook(Requiescat)))
+                    return OriginalHook(FightOrFlight);
+
+                if (HasStatusEffect(Buffs.GoringBladeReady))
+                    return OriginalHook(GoringBlade);
+            }
 
             // Confiteor & Blades
             if (HasStatusEffect(Buffs.ConfiteorReady) || LevelChecked(BladeOfFaith) && OriginalHook(Confiteor) != Confiteor)
@@ -634,8 +640,8 @@ internal partial class PLD : Tank
                 return OriginalHook(SpiritsWithin);
 
             if (ActionReady(CircleOfScorn) &&
-                (PLD_SpiritsWithin_SubOption == 1 ||
-                 PLD_SpiritsWithin_SubOption == 2 && JustUsed(OriginalHook(SpiritsWithin), 5f)))
+                (PLD_SpiritsWithin_SubOption == 0 ||
+                 PLD_SpiritsWithin_SubOption == 1 && JustUsed(OriginalHook(SpiritsWithin), 5f)))
                 return CircleOfScorn;
 
             return actionID;


### PR DESCRIPTION
Today I was playing PLD and noticed the Requiescat Spender and Spirits Within / Circle of Scorn features weren't working properly. After some investigation, I observed that those options start at 0 instead of 1, so I adjusted the logic accordingly. I also added Goring Blade to the Requiescat Spender when using the Add Fight or Flight option because I think it makes sense, but I can remove that if necessary.