### PR TITLE
[Content] Add damage buff only usage for OC abilities

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -530,6 +530,10 @@ public enum Preset
     #endregion
 
     #region PHANTOM ACTIONS
+    [OccultCrescent]
+    [JobInfo(Job.ADV)]
+    Phantom_RestrictToBuff = 109999,
+
     [OccultCrescent(OccultCrescent.JobIDs.Freelancer)]
     [JobInfo(Job.ADV)]
     Phantom_Freelancer = 110000,

--- a/WrathCombo/Combos/PvE/ALL/Bursting.cs
+++ b/WrathCombo/Combos/PvE/ALL/Bursting.cs
@@ -78,8 +78,8 @@ public class Bursting
                     HasBuff.Target(NIN.Debuffs.TrickAttack) ||
                     HasBuff.Target(NIN.Debuffs.KunaisBane) ||
                     HasBuff.Target(BRD.Buffs.RagingStrikes) ||
-                    HasBuff.Target(BRD.Buffs.RagingStrikes) ||
                     HasBuff.Target(BRD.Buffs.RadiantFinale) ||
+                    HasBuff.Target(BRD.Buffs.WanderersMinuet) ||
                     HasBuff.Target(DNC.Buffs.Devilment) ||
                     HasBuff.Target(BLM.Buffs.LeyLines);
 

--- a/WrathCombo/Combos/PvE/ALL/Bursting.cs
+++ b/WrathCombo/Combos/PvE/ALL/Bursting.cs
@@ -67,7 +67,7 @@ public class Bursting
                 return field;
 
             field = PartyIsBursting ||
-                    HasBuff.Self(DRK.Buffs.Darkside) ||
+                    DRK.Gauge.DarksideTimeRemaining > 0 ||
                     HasBuff.Self(PLD.Buffs.FightOrFlight) ||
                     HasBuff.Self(WAR.Buffs.SurgingTempest) ||
                     HasBuff.Self(GNB.Buffs.NoMercy) ||

--- a/WrathCombo/Combos/PvE/ALL/Bursting.cs
+++ b/WrathCombo/Combos/PvE/ALL/Bursting.cs
@@ -96,7 +96,7 @@ public class Bursting
             field = Buffs.Self.Any(buff =>
                         HasBuff.Self(buff, anyOwner: false)) ||
                     Buffs.Target.Any(buff =>
-                        HasBuff.Self(buff, anyOwner: false)) ||
+                        HasBuff.Target(buff, anyOwner: false)) ||
                     GetCooldownRemainingTime(DRK.LivingShadow) > 98;
 
             return field;
@@ -117,7 +117,7 @@ public class Bursting
             field = Buffs.Self.Any(buff =>
                         HasBuff.Self(buff, anyOwner: true)) ||
                     Buffs.Target.Any(buff =>
-                        HasBuff.Self(buff, anyOwner: true));
+                        HasBuff.Target(buff, anyOwner: true));
 
             return field;
         }
@@ -133,7 +133,7 @@ public class Bursting
             var count = Buffs.Self.Count(buff =>
                             HasBuff.Self(buff, anyOwner: true)) +
                         Buffs.Target.Count(buff =>
-                            HasBuff.Self(buff, anyOwner: true)) +
+                            HasBuff.Target(buff, anyOwner: true)) +
                         (GetCooldownRemainingTime(DRK.LivingShadow) > 98
                             ? 1
                             : 0);

--- a/WrathCombo/Combos/PvE/ALL/Bursting.cs
+++ b/WrathCombo/Combos/PvE/ALL/Bursting.cs
@@ -70,6 +70,8 @@ public class Bursting
                     DRK.Gauge.DarksideTimeRemaining > 0 ||
                     HasBuff.Self(PLD.Buffs.FightOrFlight) ||
                     HasBuff.Self(WAR.Buffs.SurgingTempest) ||
+                    HasBuff.Self(WAR.Buffs.InnerReleaseBuff) ||
+                    HasBuff.Self(WAR.Buffs.Berserk) ||
                     HasBuff.Self(GNB.Buffs.NoMercy) ||
                     HasBuff.Self(AST.Buffs.BalanceBuff, anyOwner: true) ||
                     HasBuff.Self(AST.Buffs.SpearBuff, anyOwner: true) ||
@@ -79,6 +81,7 @@ public class Bursting
                     HasBuff.Self(BRD.Buffs.RagingStrikes) ||
                     HasBuff.Self(BRD.Buffs.RadiantFinale) ||
                     HasBuff.Self(BRD.Buffs.WanderersMinuet) ||
+                    HasBuff.Self(BRD.Buffs.MagesBallad) ||
                     HasBuff.Self(DNC.Buffs.Devilment) ||
                     HasBuff.Self(BLM.Buffs.LeyLines);
 

--- a/WrathCombo/Combos/PvE/ALL/Bursting.cs
+++ b/WrathCombo/Combos/PvE/ALL/Bursting.cs
@@ -1,0 +1,221 @@
+#region
+
+using System.Linq;
+using ECommons.ExcelServices;
+using WrathCombo.Data;
+using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
+using EZ = ECommons.Throttlers.EzThrottler;
+using TS = System.TimeSpan;
+
+#endregion
+
+namespace WrathCombo.Combos.PvE;
+
+public class Bursting
+{
+    #region Burst Phase
+
+    public static bool InGoodBurstPhase
+    {
+        get
+        {
+            if (!EZ.Throttle("BurstCheck_GoodPhase", TS.FromSeconds(1)))
+                return field;
+
+            var threshold = ContentCheck.IsInBottomHalfContent()
+                ? BurstJobsInParty * 0.3
+                : BurstJobsInParty * 0.6;
+            var anyDeathDebuffs = GetPartyMembers().Any(member =>
+                HasStatusEffect(43, member.GameObject, true) || // weakness
+                HasStatusEffect(44, member.GameObject, true));  // brink
+
+            field = NumberOfPartyMembersBursting > threshold &&
+                    !anyDeathDebuffs;
+            return field;
+        }
+    }
+
+    public static bool InBurstPhase
+    {
+        get
+        {
+            if (!EZ.Throttle("BurstCheck_Phase", TS.FromSeconds(1)))
+                return field;
+
+            var threshold = ContentCheck.IsInBottomHalfContent()
+                ? BurstJobsInParty * 0.25
+                : BurstJobsInParty * 0.4;
+
+            field = NumberOfPartyMembersBursting > threshold;
+            return field;
+        }
+    }
+
+    #endregion
+
+    #region Self Checks
+
+    /// <summary>
+    ///     Similar to <see cref="PlayerIsBursting" /> but for any damage buff
+    ///     at all, e.g. <see cref="PLD.FightOrFlight" />.
+    /// </summary>
+    public static bool PlayerIsDamageBuffed
+    {
+        get
+        {
+            if (!EZ.Throttle("BurstCheck_Self_Any", TS.FromSeconds(2.5)))
+                return field;
+
+            field = PartyIsBursting ||
+                    HasBuff.Self(DRK.Buffs.Darkside) ||
+                    HasBuff.Self(PLD.Buffs.FightOrFlight) ||
+                    HasBuff.Self(WAR.Buffs.SurgingTempest) ||
+                    HasBuff.Self(GNB.Buffs.NoMercy) ||
+                    HasBuff.Self(AST.Buffs.BalanceBuff, anyOwner: true) ||
+                    HasBuff.Self(AST.Buffs.SpearBuff, anyOwner: true) ||
+                    HasBuff.Self(MNK.Buffs.RiddleOfFire) ||
+                    HasBuff.Self(DRG.Buffs.LanceCharge) ||
+                    HasBuff.Target(NIN.Debuffs.TrickAttack) ||
+                    HasBuff.Target(NIN.Debuffs.KunaisBane) ||
+                    HasBuff.Target(BRD.Buffs.RagingStrikes) ||
+                    HasBuff.Target(BRD.Buffs.RagingStrikes) ||
+                    HasBuff.Target(BRD.Buffs.RadiantFinale) ||
+                    HasBuff.Target(DNC.Buffs.Devilment) ||
+                    HasBuff.Target(BLM.Buffs.LeyLines);
+
+            return field;
+        }
+    }
+
+    public static bool PlayerIsBursting
+    {
+        get
+        {
+            if (!EZ.Throttle("BurstCheck_Self", TS.FromSeconds(1)))
+                return field;
+
+            field = Buffs.Self.Any(buff =>
+                        HasBuff.Self(buff, anyOwner: false)) ||
+                    Buffs.Target.Any(buff =>
+                        HasBuff.Self(buff, anyOwner: false)) ||
+                    GetCooldownRemainingTime(DRK.LivingShadow) > 98;
+
+            return field;
+        }
+    }
+
+    #endregion
+
+    #region Party Checks
+
+    public static bool PartyIsBursting
+    {
+        get
+        {
+            if (!EZ.Throttle("BurstCheck_Others", TS.FromSeconds(1.5)))
+                return field;
+
+            field = Buffs.Self.Any(buff =>
+                        HasBuff.Self(buff, anyOwner: true)) ||
+                    Buffs.Target.Any(buff =>
+                        HasBuff.Self(buff, anyOwner: true)) ||
+                    GetCooldownRemainingTime(DRK.LivingShadow) > 98;
+
+            return field;
+        }
+    }
+
+    public static int NumberOfPartyMembersBursting
+    {
+        get
+        {
+            if (!EZ.Throttle("BurstCheck_Others_Amount", TS.FromSeconds(2)))
+                return field;
+
+            var count = Buffs.Self.Count(buff =>
+                            HasBuff.Self(buff, anyOwner: true)) +
+                        Buffs.Target.Count(buff =>
+                            HasBuff.Self(buff, anyOwner: true)) +
+                        (GetCooldownRemainingTime(DRK.LivingShadow) > 98
+                            ? 1
+                            : 0);
+
+            field = count;
+            return field;
+        }
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static class Buffs
+    {
+        internal static readonly Job[] Jobs =
+        [
+            Job.AST,
+            Job.BRD,
+            Job.DNC,
+            Job.DRG,
+            Job.MNK,
+            Job.NIN,
+            Job.PCT,
+            Job.RDM,
+            Job.RPR,
+            Job.SCH,
+            Job.SMN,
+        ];
+
+        internal static readonly ushort[] Self =
+        [
+            AST.Buffs.Divination,
+            BRD.Buffs.BattleVoice,
+            DNC.Buffs.TechnicalFinish,
+            DRG.Buffs.BattleLitany,
+            MNK.Buffs.RiddleOfFire,
+            MNK.Buffs.Brotherhood,
+            PCT.Buffs.StarryMuse,
+            RDM.Buffs.Embolden,
+            RDM.Buffs.EmboldenOthers,
+            RPR.Buffs.ArcaneCircle,
+            SMN.Buffs.SearingLight,
+        ];
+
+        internal static readonly ushort[] Target =
+        [
+            NIN.Debuffs.Mug,
+            NIN.Debuffs.Dokumori,
+            SCH.Debuffs.ChainStratagem,
+        ];
+    }
+
+    private class HasBuff
+    {
+        protected internal static bool Target
+            (ushort buff, bool anyOwner = false) =>
+            GetPossessedStatusRemainingTime(buff, CurrentTarget,
+                anyOwner: anyOwner) > 0;
+
+        protected internal static bool Self
+            (ushort buff, bool anyOwner = false) =>
+            GetPossessedStatusRemainingTime(buff,
+                anyOwner: anyOwner) > 0;
+    }
+
+    private static int BurstJobsInParty
+    {
+        get
+        {
+            if (!EZ.Throttle("BurstCheck_BurstMembers", TS.FromSeconds(10)))
+                return field;
+
+            var count = GetPartyMembers().Count(member =>
+                Buffs.Jobs.Contains((Job) (member.RealJob?.RowId ?? 0)));
+
+            field = count;
+            return field;
+        }
+    }
+
+    #endregion
+}

--- a/WrathCombo/Combos/PvE/ALL/Bursting.cs
+++ b/WrathCombo/Combos/PvE/ALL/Bursting.cs
@@ -73,15 +73,14 @@ public class Bursting
                     HasBuff.Self(GNB.Buffs.NoMercy) ||
                     HasBuff.Self(AST.Buffs.BalanceBuff, anyOwner: true) ||
                     HasBuff.Self(AST.Buffs.SpearBuff, anyOwner: true) ||
-                    HasBuff.Self(MNK.Buffs.RiddleOfFire) ||
                     HasBuff.Self(DRG.Buffs.LanceCharge) ||
                     HasBuff.Target(NIN.Debuffs.TrickAttack) ||
                     HasBuff.Target(NIN.Debuffs.KunaisBane) ||
-                    HasBuff.Target(BRD.Buffs.RagingStrikes) ||
-                    HasBuff.Target(BRD.Buffs.RadiantFinale) ||
-                    HasBuff.Target(BRD.Buffs.WanderersMinuet) ||
-                    HasBuff.Target(DNC.Buffs.Devilment) ||
-                    HasBuff.Target(BLM.Buffs.LeyLines);
+                    HasBuff.Self(BRD.Buffs.RagingStrikes) ||
+                    HasBuff.Self(BRD.Buffs.RadiantFinale) ||
+                    HasBuff.Self(BRD.Buffs.WanderersMinuet) ||
+                    HasBuff.Self(DNC.Buffs.Devilment) ||
+                    HasBuff.Self(BLM.Buffs.LeyLines);
 
             return field;
         }

--- a/WrathCombo/Combos/PvE/ALL/Bursting.cs
+++ b/WrathCombo/Combos/PvE/ALL/Bursting.cs
@@ -118,8 +118,7 @@ public class Bursting
             field = Buffs.Self.Any(buff =>
                         HasBuff.Self(buff, anyOwner: true)) ||
                     Buffs.Target.Any(buff =>
-                        HasBuff.Self(buff, anyOwner: true)) ||
-                    GetCooldownRemainingTime(DRK.LivingShadow) > 98;
+                        HasBuff.Self(buff, anyOwner: true));
 
             return field;
         }

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent.cs
@@ -431,13 +431,13 @@ internal partial class OccultCrescent
                 actionID = HerosRime; // burst song
                 return true;
             }
+        }
 
-            if (IsEnabledAndUsable(Preset.Phantom_Bard_OffensiveAria, OffensiveAria) &&
-                !HasStatusEffect(Buffs.OffensiveAria) && !HasStatusEffect(Buffs.HerosRime, anyOwner: true))
-            {
-                actionID = OffensiveAria; // off-song
-                return true;
-            }
+        if (IsEnabledAndUsable(Preset.Phantom_Bard_OffensiveAria, OffensiveAria) &&
+            !HasStatusEffect(Buffs.OffensiveAria) && !HasStatusEffect(Buffs.HerosRime, anyOwner: true))
+        {
+            actionID = OffensiveAria; // off-song
+            return true;
         }
 
         if (IsEnabledAndUsable(Preset.Phantom_Bard_RomeosBallad, RomeosBallad) &&
@@ -462,12 +462,15 @@ internal partial class OccultCrescent
         if (!IsEnabled(Preset.Phantom_Oracle))
             return false;
 
-        if (IsEnabledAndUsable(Preset.Phantom_Oracle_Predict, Predict) && InCombatNow && !CanWeaveNow &&
-            !HasStatusEffect(Buffs.PredictionOfJudgment) && !HasStatusEffect(Buffs.PredictionOfCleansing) &&
-            !HasStatusEffect(Buffs.PredictionOfBlessing) && !HasStatusEffect(Buffs.PredictionOfStarfall))
+        if (!IsEnabled(Preset.Phantom_RestrictToBuff) || Bursting.PlayerIsDamageBuffed)
         {
-            actionID = Predict; // start of the chain
-            return true;
+            if (IsEnabledAndUsable(Preset.Phantom_Oracle_Predict, Predict) && InCombatNow && !CanWeaveNow &&
+                !HasStatusEffect(Buffs.PredictionOfJudgment) && !HasStatusEffect(Buffs.PredictionOfCleansing) &&
+                !HasStatusEffect(Buffs.PredictionOfBlessing) && !HasStatusEffect(Buffs.PredictionOfStarfall))
+            {
+                actionID = Predict; // start of the chain
+                return true;
+            }
         }
 
         // Skip things we want to weave, if not in a weave window
@@ -677,10 +680,13 @@ internal partial class OccultCrescent
         if (!IsEnabled(Preset.Phantom_Dancer))
             return false;
 
-        if (IsEnabledAndUsable(Preset.Phantom_Dancer_Dance, Dance) && CanWeave())
+        if (!IsEnabled(Preset.Phantom_RestrictToBuff) || Bursting.PlayerIsDamageBuffed)
         {
-            actionID = Dance;
-            return true;
+            if (IsEnabledAndUsable(Preset.Phantom_Dancer_Dance, Dance) && CanWeave())
+            {
+                actionID = Dance;
+                return true;
+            }
         }
 
         if (IsEnabledAndUsable(Preset.Phantom_Dancer_Mesmerize, Mesmerize) && InCombat() && CanWeave())
@@ -733,12 +739,15 @@ internal partial class OccultCrescent
     private static bool TryGetGladiatorAction(ref uint actionID)
     {
         if (CanWeaveNow) return false;
-
-        if (IsEnabledAndUsable(Preset.Phantom_Gladiator_Finisher, Finisher) && HasBattleTarget() && InMeleeRange())
+        if (!IsEnabled(Preset.Phantom_RestrictToBuff) || Bursting.PlayerIsDamageBuffed)
         {
-            actionID = Finisher;
-            return true;
+            if (IsEnabledAndUsable(Preset.Phantom_Gladiator_Finisher, Finisher) && HasBattleTarget() && InMeleeRange())
+            {
+                actionID = Finisher;
+                return true;
+            }
         }
+
         if (IsEnabledAndUsable(Preset.Phantom_Gladiator_Defend, Defend) && InCombat())
         {
             actionID = Defend;

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent.cs
@@ -115,6 +115,11 @@ internal partial class OccultCrescent
             return true;
         }
 
+        // Skip if no damage buff, and user wants things under buffs
+        if (IsEnabled(Preset.Phantom_RestrictToBuff) &&
+            !Bursting.PlayerIsDamageBuffed)
+            return false;
+
         if (IsEnabledAndUsable(Preset.Phantom_Monk_PhantomKick, PhantomKick) &&
             !IsMovingNow && InActionRange(PhantomKick))
         {
@@ -163,6 +168,11 @@ internal partial class OccultCrescent
                 return true;
             }
 
+            // Skip if no damage buff, and user wants things under buffs
+            if (IsEnabled(Preset.Phantom_RestrictToBuff) &&
+                !Bursting.PlayerIsDamageBuffed)
+                return false;
+
             if (IsEnabledAndUsable(Preset.Phantom_Thief_PilferWeapon, PilferWeapon) &&
                 !HasStatusEffect(Debuffs.WeaponPlifered, CurrentTarget))
             {
@@ -196,6 +206,11 @@ internal partial class OccultCrescent
                 return true;
             }
 
+            // Skip if no damage buff, and user wants things under buffs
+            if (IsEnabled(Preset.Phantom_RestrictToBuff) &&
+                !Bursting.PlayerIsDamageBuffed)
+                return false;
+
             if (IsEnabledAndUsable(Preset.Phantom_Samurai_Zeninage, Zeninage) &&
                 ActionWatching.NumberOfGcdsUsed > 4)
             {
@@ -220,6 +235,11 @@ internal partial class OccultCrescent
             return false;
 
         if (!HasTargetNow) return false;
+
+        // Skip if no damage buff, and user wants things under buffs
+        if (IsEnabled(Preset.Phantom_RestrictToBuff) &&
+            !Bursting.PlayerIsDamageBuffed)
+            return false;
 
         if (IsEnabledAndUsable(Preset.Phantom_Berserker_Rage, Rage) &&
             InActionRange(Rage) && CanWeaveNow)
@@ -252,6 +272,11 @@ internal partial class OccultCrescent
             actionID = OccultUnicorn; // heal
             return true;
         }
+
+        // Skip if no damage buff, and user wants things under buffs
+        if (IsEnabled(Preset.Phantom_RestrictToBuff) &&
+            !Bursting.PlayerIsDamageBuffed)
+            return false;
 
         if (IsEnabledAndUsable(Preset.Phantom_Ranger_PhantomAim, PhantomAim) &&
             TargetHP >= Phantom_Ranger_PhantomAim_Stop)
@@ -295,6 +320,12 @@ internal partial class OccultCrescent
 
         if (IsEnabledAndUsable(Preset.Phantom_TimeMage_OccultComet, OccultComet))
         {
+
+            // Skip if no damage buff, and user wants things under buffs
+            if (IsEnabled(Preset.Phantom_RestrictToBuff) &&
+                !Bursting.PlayerIsDamageBuffed)
+                return false;
+
             // Make the comet fast
             if (Phantom_TimeMage_Comet_RequireSpeed &&
                 Phantom_TimeMage_Comet_UseSpeed &&
@@ -388,17 +419,25 @@ internal partial class OccultCrescent
 
         if (!CanWeaveNow) return false;
 
-        if (IsEnabledAndUsable(Preset.Phantom_Bard_HerosRime, HerosRime))
-        {
-            actionID = HerosRime; // burst song
-            return true;
-        }
+        // Skip if no damage buff, and user wants things under buffs
+        if (IsEnabled(Preset.Phantom_RestrictToBuff) &&
+            !Bursting.PlayerIsDamageBuffed)
+            return false;
 
-        if (IsEnabledAndUsable(Preset.Phantom_Bard_OffensiveAria, OffensiveAria) &&
-            !HasStatusEffect(Buffs.OffensiveAria) && !HasStatusEffect(Buffs.HerosRime, anyOwner: true))
+        if (!IsEnabled(Preset.Phantom_RestrictToBuff) || Bursting.PlayerIsDamageBuffed)
         {
-            actionID = OffensiveAria; // off-song
-            return true;
+            if (IsEnabledAndUsable(Preset.Phantom_Bard_HerosRime, HerosRime))
+            {
+                actionID = HerosRime; // burst song
+                return true;
+            }
+
+            if (IsEnabledAndUsable(Preset.Phantom_Bard_OffensiveAria, OffensiveAria) &&
+                !HasStatusEffect(Buffs.OffensiveAria) && !HasStatusEffect(Buffs.HerosRime, anyOwner: true))
+            {
+                actionID = OffensiveAria; // off-song
+                return true;
+            }
         }
 
         if (IsEnabledAndUsable(Preset.Phantom_Bard_RomeosBallad, RomeosBallad) &&
@@ -441,6 +480,11 @@ internal partial class OccultCrescent
             return true;
         }
 
+        // Skip if no damage buff, and user wants things under buffs
+        if (IsEnabled(Preset.Phantom_RestrictToBuff) &&
+            !Bursting.PlayerIsDamageBuffed)
+            return false;
+
         if (IsEnabledAndUsable(Preset.Phantom_Oracle_PhantomJudgment, PhantomJudgment) &&
             HasStatusEffect(Buffs.PredictionOfJudgment))
         {
@@ -472,6 +516,11 @@ internal partial class OccultCrescent
 
         // GCDs
         if (CanWeaveNow || !HasTargetNow) return false;
+
+        // Skip if no damage buff, and user wants things under buffs
+        if (IsEnabled(Preset.Phantom_RestrictToBuff) &&
+            !Bursting.PlayerIsDamageBuffed)
+            return false;
 
         if (IsEnabledAndUsable(Preset.Phantom_Cannoneer_SilverCannon, SilverCannon) &&
             ((!HasStatusEffect(Debuffs.SilverSickness, CurrentTarget, true) ||
@@ -515,7 +564,8 @@ internal partial class OccultCrescent
             }
 
             if (IsEnabledAndUsable(Preset.Phantom_Geomancer_AetherialGain, AetherialGain) &&
-                !HasStatusEffect(Buffs.AetherialGain))
+                !HasStatusEffect(Buffs.AetherialGain) &&
+                (!IsEnabled(Preset.Phantom_RestrictToBuff) || Bursting.PlayerIsDamageBuffed))
             {
                 actionID = AetherialGain; // damage buff
                 return true;
@@ -592,6 +642,11 @@ internal partial class OccultCrescent
 
         if (CanWeaveNow) return false;
 
+        // Skip if no damage buff, and user wants things under buffs
+        if (IsEnabled(Preset.Phantom_RestrictToBuff) &&
+            !Bursting.PlayerIsDamageBuffed)
+            return false;
+
         if (IsEnabledAndUsable(Preset.Phantom_MysticKnight_BlazingSpellblade, BlazingSpellblade) && !CanWeave() &&
             HasBattleTarget() && InActionRange(BlazingSpellblade) &&
             (!HasStatusEffect(Buffs.BlazingSpellblade) || GetStatusEffectRemainingTime(Buffs.BlazingSpellblade) <= 15))
@@ -636,30 +691,35 @@ internal partial class OccultCrescent
 
         if (CanWeaveNow) return false;
 
-        #region Dances
+        // Skip if no damage buff, and user wants things under buffs
+        if (!IsEnabled(Preset.Phantom_RestrictToBuff) ||
+            Bursting.PlayerIsDamageBuffed)
+        {
+            #region Dances
 
-        if (IsEnabled(Preset.Phantom_Dancer_Dance) && HasStatusEffect(Buffs.PoisedToSwordDance))
-        {
-            actionID = PoisedToSwordDance;
-            return true;
-        }
-        if (IsEnabled(Preset.Phantom_Dancer_Dance) && HasStatusEffect(Buffs.TemptedToTango))
-        {
-            actionID = TemptedToTango;
-            return true;
-        }
-        if (IsEnabled(Preset.Phantom_Dancer_Dance) && HasStatusEffect(Buffs.Jitterbugged))
-        {
-            actionID = Jitterbug;
-            return true;
-        }
-        if (IsEnabled(Preset.Phantom_Dancer_Dance) && HasStatusEffect(Buffs.WillingToWaltz))
-        {
-            actionID = WillingToWaltz;
-            return true;
-        }
+            if (IsEnabled(Preset.Phantom_Dancer_Dance) && HasStatusEffect(Buffs.PoisedToSwordDance))
+            {
+                actionID = PoisedToSwordDance;
+                return true;
+            }
+            if (IsEnabled(Preset.Phantom_Dancer_Dance) && HasStatusEffect(Buffs.TemptedToTango))
+            {
+                actionID = TemptedToTango;
+                return true;
+            }
+            if (IsEnabled(Preset.Phantom_Dancer_Dance) && HasStatusEffect(Buffs.Jitterbugged))
+            {
+                actionID = Jitterbug;
+                return true;
+            }
+            if (IsEnabled(Preset.Phantom_Dancer_Dance) && HasStatusEffect(Buffs.WillingToWaltz))
+            {
+                actionID = WillingToWaltz;
+                return true;
+            }
 
-        #endregion
+            #endregion
+        }
 
         if (IsEnabledAndUsable(Preset.Phantom_Dancer_QuickStep, Quickstep) && !HasStatusEffect(Buffs.Quickstep))
         {
@@ -684,6 +744,12 @@ internal partial class OccultCrescent
             actionID = Defend;
             return true;
         }
+
+        // Skip if no damage buff, and user wants things under buffs
+        if (IsEnabled(Preset.Phantom_RestrictToBuff) &&
+            !Bursting.PlayerIsDamageBuffed)
+            return false;
+        
         if (IsEnabledAndUsable(Preset.Phantom_Gladiator_LongReach, LongReach) && HasBattleTarget())
         {
             actionID = LongReach;

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Config.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Config.cs
@@ -133,6 +133,10 @@ internal partial class OccultCrescent
                     ImGui.Indent();
                     ImGuiEx.TextWrapped(ImGuiColors.DalamudYellow,
                         Resources.Localization.Content.OccultCrescent.BuffOnlyNotRecommended);
+                    ImGuiEx.TextWrapped(ImGuiColors.DalamudRed,
+                        Resources.Localization.Content.OccultCrescent.BuffOnlyDont);
+                    ImGuiEx.TextWrapped(ImGuiColors.DalamudGrey,
+                        Resources.Localization.Content.OccultCrescent.BuffOnlyList);
                     ImGui.Unindent();
                     break;
             }

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Config.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Config.cs
@@ -113,6 +113,13 @@ internal partial class OccultCrescent
                         ImGui.Unindent();
                     }
                     break;
+
+                case Preset.Phantom_RestrictToBuff:
+                    ImGui.Indent();
+                    ImGuiEx.TextWrapped(ImGuiColors.DalamudYellow,
+                        Resources.Localization.Content.OccultCrescent.BuffOnlyNotRecommended);
+                    ImGui.Unindent();
+                    break;
             }
         }
         #region Variables

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Config.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Config.cs
@@ -77,12 +77,27 @@ internal partial class OccultCrescent
                         Generics.PlayerHPGreaterOrEqual, 200);
                     break;
 
+                case Preset.Phantom_Samurai_Zeninage:
+                    ImGui.Indent();
+                    ImGuiEx.TextWrapped(ImGuiColors.DalamudRed, Resources
+                        .Localization.Content.OccultCrescent.Costly);
+                    ImGui.Unindent();
+                    break;
+
                 case Preset.Phantom_Chemist_OccultPotion:
+                    ImGui.Indent();
+                    ImGuiEx.TextWrapped(ImGuiColors.DalamudRed, Resources
+                        .Localization.Content.OccultCrescent.Costly);
+                    ImGui.Unindent();
                     DrawSliderInt(1, 100, Phantom_Chemist_OccultPotion_Health,
                         Generics.StopFriendlyHpPercent100, 200);
                     break;
 
                 case Preset.Phantom_Chemist_OccultEther:
+                    ImGui.Indent();
+                    ImGuiEx.TextWrapped(ImGuiColors.DalamudRed, Resources
+                        .Localization.Content.OccultCrescent.Costly);
+                    ImGui.Unindent();
                     DrawSliderInt(1, 10000, Phantom_Chemist_OccultEther_MP,
                         Generics.MPLessOrEqual, sliderIncrement: SliderIncrements.Hundreds);
                     break;

--- a/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
@@ -436,7 +436,7 @@ internal partial class DRK
         public const ushort EnhancedDelirium = 3836;
 
         /// The increased damage buff that should always be up - checked through gauge
-        public const ushort Darkside = 741;
+        public const ushort Darkside = 751;
 
         #endregion
 

--- a/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
@@ -39,7 +39,7 @@ internal partial class DRK
     /// <summary>
     ///     DRK's job gauge.
     /// </summary>
-    private static DRKGauge Gauge => GetJobGauge<DRKGauge>();
+    internal static DRKGauge Gauge => GetJobGauge<DRKGauge>();
 
     /// <summary>
     ///     DRK's GCD, truncated to two decimal places.
@@ -434,9 +434,8 @@ internal partial class DRK
 
         /// Different from Delirium, to do the Scarlet Delirium chain
         public const ushort EnhancedDelirium = 3836;
-
-        /// The increased damage buff that should always be up - checked through gauge
-        public const ushort Darkside = 751;
+        
+        // Darkside is checked through the gauge
 
         #endregion
 

--- a/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
@@ -56,41 +56,6 @@ internal partial class DRK
     /// When the current burst phase is set to end.
     private static long burstEndTime;
 
-    /// <summary>
-    ///     Whether the player is being affected by other jobs' buffs.
-    /// </summary>
-    private static bool HasOtherJobsBuffs
-    {
-        get
-        {
-            // Only run every 1 seconds at most (should be every other burst check)
-            if (!EZ.Throttle("drkBurstBuffCheck", TS.FromSeconds(1)))
-                return field;
-
-            field = TargetBuffRemainingTime(SCH.Debuffs.ChainStratagem) > 0 ||
-                    BuffRemainingTime(AST.Buffs.Divination) > 0 ||
-                    BuffRemainingTime(DRG.Buffs.BattleLitany) > 0 ||
-                    TargetBuffRemainingTime(NIN.Debuffs.Mug) > 0 ||
-                    TargetBuffRemainingTime(NIN.Debuffs.Dokumori) > 0 ||
-                    BuffRemainingTime(MNK.Buffs.Brotherhood) > 0 ||
-                    BuffRemainingTime(RPR.Buffs.ArcaneCircle) > 0 ||
-                    BuffRemainingTime(BRD.Buffs.BattleVoice) > 0 ||
-                    BuffRemainingTime(DNC.Buffs.TechnicalFinish) > 0 ||
-                    BuffRemainingTime(SMN.Buffs.SearingLight) > 0 ||
-                    BuffRemainingTime(RDM.Buffs.Embolden) > 0 ||
-                    BuffRemainingTime(RDM.Buffs.EmboldenOthers) > 0 ||
-                    BuffRemainingTime(PCT.Buffs.StarryMuse) > 0;
-
-            return field;
-
-            // Just a shorter name for the methods
-            double TargetBuffRemainingTime(ushort buff) =>
-                GetStatusEffectRemainingTime(buff, CurrentTarget, anyOwner:true);
-            double BuffRemainingTime(ushort buff) =>
-                GetStatusEffectRemainingTime(buff, anyOwner:true);
-        }
-    }
-
     #endregion
 
     /// <summary>
@@ -131,8 +96,9 @@ internal partial class DRK
                     burstEndTime = Environment.TickCount64 + 30000;
 
                 // Set to bursting
-                if ((burstStartTime > 0 && Environment.TickCount64 > burstStartTime) ||
-                    HasOtherJobsBuffs)
+                if ((burstStartTime > 0 &&
+                     Environment.TickCount64 > burstStartTime) ||
+                    Bursting.PartyIsBursting)
                 {
                     burstStartTime = 0;
                     field = true;
@@ -333,7 +299,7 @@ internal partial class DRK
             ([4], () =>
                 DRK_ST_OpenerAction != (int)PullAction.Unmend),
             // Skip the late LivingShadow and aligning HardSlash, if Standard
-            ([6, 9], () => HasOtherJobsBuffs ||
+            ([6, 9], () => Bursting.PartyIsBursting ||
                 DRK_ST_OpenerAction == (int)PullAction.Unmend),
             // Skip Salted Earth
             ([11], () =>

--- a/WrathCombo/Resources/Localization/Content/OccultCrescent.Designer.cs
+++ b/WrathCombo/Resources/Localization/Content/OccultCrescent.Designer.cs
@@ -87,15 +87,32 @@ namespace WrathCombo.Resources.Localization.Content {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Not Recommended!
-        ///Many jobs do not have self buffs that are up regularly, many burst phases cannot accommodate extra Phantom Abilities, and many Phantom Abilities are up more often than this on would be on many jobs!.
+        ///   Looks up a localized string similar to If you are NOT one of the jobs that regularly damage buffs themselves, or do not party up in OC, then this will SKIP using Phantom Abilities until burst time is detected (which might be never on a buff-less job)!.
+        /// </summary>
+        internal static string BuffOnlyDont {
+            get {
+                return ResourceManager.GetString("BuffOnlyDont", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DRK, PLD, WAR, AST, MNK, DRG, NIN, BRD, are the only jobs this is likely to be a good option for.
+        /// </summary>
+        internal static string BuffOnlyList {
+            get {
+                return ResourceManager.GetString("BuffOnlyList", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Many jobs do not have self buffs that are up regularly, many burst phases cannot accommodate extra Phantom Abilities, and many Phantom Abilities are up more often than this on would be on many jobs!.
         /// </summary>
         internal static string BuffOnlyNotRecommended {
             get {
                 return ResourceManager.GetString("BuffOnlyNotRecommended", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to This is a costly Feature!.
         /// </summary>
@@ -104,7 +121,7 @@ namespace WrathCombo.Resources.Localization.Content {
                 return ResourceManager.GetString("Costly", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Not advisable in most situations!.
         /// </summary>

--- a/WrathCombo/Resources/Localization/Content/OccultCrescent.Designer.cs
+++ b/WrathCombo/Resources/Localization/Content/OccultCrescent.Designer.cs
@@ -87,6 +87,25 @@ namespace WrathCombo.Resources.Localization.Content {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Not Recommended!
+        ///Many jobs do not have self buffs that are up regularly, many burst phases cannot accommodate extra Phantom Abilities, and many Phantom Abilities are up more often than this on would be on many jobs!.
+        /// </summary>
+        internal static string BuffOnlyNotRecommended {
+            get {
+                return ResourceManager.GetString("BuffOnlyNotRecommended", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This is a costly Feature!.
+        /// </summary>
+        internal static string Costly {
+            get {
+                return ResourceManager.GetString("Costly", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Not advisable in most situations!.
         /// </summary>
         internal static string NotAdvised {

--- a/WrathCombo/Resources/Localization/Content/OccultCrescent.resx
+++ b/WrathCombo/Resources/Localization/Content/OccultCrescent.resx
@@ -141,4 +141,11 @@
   <data name="VeryCostly" xml:space="preserve">
     <value>This is a VERY costly Feature!</value>
   </data>
+  <data name="BuffOnlyNotRecommended" xml:space="preserve">
+      <value>Not Recommended!
+Many jobs do not have self buffs that are up regularly, many burst phases cannot accommodate extra Phantom Abilities, and many Phantom Abilities are up more often than this on would be on many jobs!</value>
+  </data>
+  <data name="Costly" xml:space="preserve">
+      <value>This is a costly Feature!</value>
+  </data>
 </root>

--- a/WrathCombo/Resources/Localization/Content/OccultCrescent.resx
+++ b/WrathCombo/Resources/Localization/Content/OccultCrescent.resx
@@ -142,10 +142,15 @@
     <value>This is a VERY costly Feature!</value>
   </data>
   <data name="BuffOnlyNotRecommended" xml:space="preserve">
-      <value>Not Recommended!
-Many jobs do not have self buffs that are up regularly, many burst phases cannot accommodate extra Phantom Abilities, and many Phantom Abilities are up more often than this on would be on many jobs!</value>
+      <value>Many jobs do not have self buffs that are up regularly, many burst phases cannot accommodate extra Phantom Abilities, and many Phantom Abilities are up more often than this on would be on many jobs!</value>
   </data>
   <data name="Costly" xml:space="preserve">
       <value>This is a costly Feature!</value>
+  </data>
+  <data name="BuffOnlyDont" xml:space="preserve">
+      <value>If you are NOT one of the jobs that regularly damage buffs themselves, or do not party up in OC, then this will SKIP using Phantom Abilities until burst time is detected (which might be never on a buff-less job)!</value>
+  </data>
+  <data name="BuffOnlyList" xml:space="preserve">
+      <value>DRK, PLD, WAR, AST, MNK, DRG, NIN, BRD, are the only jobs this is likely to be a good option for</value>
   </data>
 </root>

--- a/WrathCombo/Resources/Localization/Misc/MiscStrings.resx
+++ b/WrathCombo/Resources/Localization/Misc/MiscStrings.resx
@@ -110,4 +110,7 @@
 	<data name="MultiHit" xml:space="preserve">
 		<value>Multi-hit </value>
 	</data>
+    <data name="BuffOnlyList" xml:space="preserve">
+        <value />
+    </data>
 </root>

--- a/WrathCombo/Resources/Localization/Presets/CustomComboPresets.Designer.cs
+++ b/WrathCombo/Resources/Localization/Presets/CustomComboPresets.Designer.cs
@@ -17511,6 +17511,24 @@ namespace WrathCombo.Resources.Localization.Presets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Will restrict damaging Phantom Abilities to when you or your party have damage buffs (including minor ones on yourself, like Paladin&apos;s Fight or Flight)..
+        /// </summary>
+        internal static string Phantom_RestrictToBuff_Desc {
+            get {
+                return ResourceManager.GetString("Phantom_RestrictToBuff_Desc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Restrict Damaging Phantom Abilities to Buff Windows.
+        /// </summary>
+        internal static string Phantom_RestrictToBuff_Name {
+            get {
+                return ResourceManager.GetString("Phantom_RestrictToBuff_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enable this to add Samurai-specific actions into the rotation..
         /// </summary>
         internal static string Phantom_Samurai_Desc {

--- a/WrathCombo/Resources/Localization/Presets/CustomComboPresets.Designer.cs
+++ b/WrathCombo/Resources/Localization/Presets/CustomComboPresets.Designer.cs
@@ -17511,7 +17511,9 @@ namespace WrathCombo.Resources.Localization.Presets {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Will restrict damaging Phantom Abilities to when you or your party have damage buffs (including minor ones on yourself, like Paladin&apos;s Fight or Flight)..
+        ///   Looks up a localized string similar to Will restrict damaging Phantom Abilities to when you or your party have damage buffs (including minor ones on yourself, like Paladin&apos;s Fight or Flight).
+        ///
+        ///NOT RECOMMENDED!.
         /// </summary>
         internal static string Phantom_RestrictToBuff_Desc {
             get {

--- a/WrathCombo/Resources/Localization/Presets/CustomComboPresets.resx
+++ b/WrathCombo/Resources/Localization/Presets/CustomComboPresets.resx
@@ -11381,4 +11381,10 @@ This is the ideal option for newcomers to the job.</value>
   <data name="SMN_Rekindle_Desc" xml:space="preserve">
     <value>Retargets Rekindle to Target's Target > Tank in need > A party member in need > Self</value>
   </data>
+  <data name="Phantom_RestrictToBuff_Name" xml:space="preserve">
+      <value>Restrict Damaging Phantom Abilities to Buff Windows</value>
+  </data>
+  <data name="Phantom_RestrictToBuff_Desc" xml:space="preserve">
+      <value>Will restrict damaging Phantom Abilities to when you or your party have damage buffs (including minor ones on yourself, like Paladin's Fight or Flight).</value>
+  </data>
 </root>

--- a/WrathCombo/Resources/Localization/Presets/CustomComboPresets.resx
+++ b/WrathCombo/Resources/Localization/Presets/CustomComboPresets.resx
@@ -11385,6 +11385,8 @@ This is the ideal option for newcomers to the job.</value>
       <value>Restrict Damaging Phantom Abilities to Buff Windows</value>
   </data>
   <data name="Phantom_RestrictToBuff_Desc" xml:space="preserve">
-      <value>Will restrict damaging Phantom Abilities to when you or your party have damage buffs (including minor ones on yourself, like Paladin's Fight or Flight).</value>
+      <value>Will restrict damaging Phantom Abilities to when you or your party have damage buffs (including minor ones on yourself, like Paladin's Fight or Flight).
+
+NOT RECOMMENDED!</value>
   </data>
 </root>


### PR DESCRIPTION
- [X] Add global Bursting detection
- [X] Moves DRK's checking for Burst Phase to use new detection
- [X] Adds feature to limit all damaging Phantom abilities to be within a buff of any sort (including smaller stuff, like PLD's FoF)
- [X] Adds warning to other costly OC features
- [X] Removes DRK's bait Darkside status check (it can only be checked through the gauge)

(tested by requesting user)