### PR TITLE
[SGE] Eukrasian Dykrasia Tweak

### DIFF
--- a/WrathCombo/Combos/PvE/SGE/SGE.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE.cs
@@ -145,7 +145,9 @@ internal partial class SGE : Healer
                     return Soteria;
             }
 
-            var hasDotTarget = EnemiesInRange(EukrasianDyskrasia).Any(x => GetPossessedStatusRemainingTime(Debuffs.EukrasianDyskrasia, x) is <= 4 or float.NaN && GetTargetHPPercent(x) > 25);
+            var hasDotTarget = EnemiesInRange(EukrasianDyskrasia).Any(x => (GetPossessedStatusRemainingTime(Debuffs.EukrasianDyskrasia, x) is <= 4 or float.NaN &&
+                                                                           GetPossessedStatusRemainingTime(DosisList[OriginalHook(Dosis)].Debuff,x) is <= 4 or float.NaN) &&
+                                                                           GetTargetHPPercent(x) > 25);
 
             //Eukrasia for DoT
             if (hasDotTarget && 

--- a/WrathCombo/Combos/PvE/SGE/SGE.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE.cs
@@ -1,4 +1,5 @@
 using Dalamud.Game.ClientState.Objects.Types;
+using ECommons.DalamudServices;
 using ECommons.GameFunctions;
 using System.Linq;
 using WrathCombo.Core;
@@ -144,16 +145,13 @@ internal partial class SGE : Healer
                     return Soteria;
             }
 
+            var hasDotTarget = EnemiesInRange(EukrasianDyskrasia).Any(x => GetPossessedStatusRemainingTime(Debuffs.EukrasianDyskrasia, x) is <= 4 or float.NaN && GetTargetHPPercent(x) > 25);
+
             //Eukrasia for DoT
-            if (IsOffCooldown(Eukrasia) &&
-                !JustUsedOn(EukrasianDyskrasia, CurrentTarget) && //AoE DoT can be slow to take affect, doesn't apply to target first before others
-                TraitLevelChecked(Traits.OffensiveMagicMasteryII) &&
-                HasBattleTarget() && InActionRange(Dyskrasia) &&
-                CanApplyStatus(CurrentTarget, Debuffs.EukrasianDyskrasia) &&
-                GetTargetHPPercent() > 25 &&
-                (DyskrasiaDebuff is null && DosisDebuff is null ||
-                 DyskrasiaDebuff?.RemainingTime <= 4 ||
-                 DosisDebuff?.RemainingTime <= 4))
+            if (hasDotTarget && 
+                IsOffCooldown(Eukrasia) &&
+                !JustUsed(EukrasianDyskrasia) && //AoE DoT can be slow to take affect, doesn't apply to target first before others
+                TraitLevelChecked(Traits.OffensiveMagicMasteryII))
                 return Eukrasia;
 
             //Phlegma

--- a/WrathCombo/Combos/PvE/SGE/SGE.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE.cs
@@ -373,17 +373,16 @@ internal partial class SGE : Healer
                     return Soteria;
             }
 
+            var hasDotTarget = EnemiesInRange(EukrasianDyskrasia).Any(x => (GetPossessedStatusRemainingTime(Debuffs.EukrasianDyskrasia, x) is <= 4 or float.NaN &&
+                                                               GetPossessedStatusRemainingTime(DosisList[OriginalHook(Dosis)].Debuff, x) is <= 4 or float.NaN) &&
+                                                               GetTargetHPPercent(x) > 25);
+
             //Eukrasia for DoT
             if (IsEnabled(Preset.SGE_AoE_DPS_EDyskrasia) &&
+                hasDotTarget &&
                 IsOffCooldown(Eukrasia) &&
-                !JustUsedOn(EukrasianDyskrasia, CurrentTarget) && //AoE DoT can be slow to take affect, doesn't apply to target first before others
-                TraitLevelChecked(Traits.OffensiveMagicMasteryII) &&
-                HasBattleTarget() && InActionRange(Dyskrasia) &&
-                CanApplyStatus(CurrentTarget, Debuffs.EukrasianDyskrasia) &&
-                GetTargetHPPercent() > 25 &&
-                (DyskrasiaDebuff is null && DosisDebuff is null ||
-                 DyskrasiaDebuff?.RemainingTime <= 4 ||
-                 DosisDebuff?.RemainingTime <= 4))
+                !JustUsed(EukrasianDyskrasia) && //AoE DoT can be slow to take affect, doesn't apply to target first before others
+                TraitLevelChecked(Traits.OffensiveMagicMasteryII))
                 return Eukrasia;
 
             //Phlegma

--- a/WrathCombo/Combos/PvE/SGE/SGE.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE.cs
@@ -145,9 +145,9 @@ internal partial class SGE : Healer
                     return Soteria;
             }
 
-            var hasDotTarget = EnemiesInRange(EukrasianDyskrasia).Any(x => (GetPossessedStatusRemainingTime(Debuffs.EukrasianDyskrasia, x) is <= 4 or float.NaN &&
+            var hasDotTarget = EnemiesInRange(EukrasianDyskrasia).Count(x => (GetPossessedStatusRemainingTime(Debuffs.EukrasianDyskrasia, x) is <= 4 or float.NaN &&
                                                                            GetPossessedStatusRemainingTime(DosisList[OriginalHook(Dosis)].Debuff,x) is <= 4 or float.NaN) &&
-                                                                           GetTargetHPPercent(x) > 25);
+                                                                           GetTargetHPPercent(x) > 25) >= 4;
 
             //Eukrasia for DoT
             if (hasDotTarget && 
@@ -373,9 +373,9 @@ internal partial class SGE : Healer
                     return Soteria;
             }
 
-            var hasDotTarget = EnemiesInRange(EukrasianDyskrasia).Any(x => (GetPossessedStatusRemainingTime(Debuffs.EukrasianDyskrasia, x) is <= 4 or float.NaN &&
+            var hasDotTarget = EnemiesInRange(EukrasianDyskrasia).Count(x => (GetPossessedStatusRemainingTime(Debuffs.EukrasianDyskrasia, x) is <= 4 or float.NaN &&
                                                                GetPossessedStatusRemainingTime(DosisList[OriginalHook(Dosis)].Debuff, x) is <= 4 or float.NaN) &&
-                                                               GetTargetHPPercent(x) > 25);
+                                                               GetTargetHPPercent(x) > 25) >= 4;
 
             //Eukrasia for DoT
             if (IsEnabled(Preset.SGE_AoE_DPS_EDyskrasia) &&


### PR DESCRIPTION
- Updates Eukrasian Dykrasia check on simple AoE to not require a target and just evaluates targets around the player.