### PR TITLE
[RDM] First GCD Opener [SGE] Movement prio fix [WAR] Standalone bugfix

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -868,7 +868,7 @@ internal unsafe class AutoRotationController
                     return false;
                 }
 
-                if (cfg.DPSSettings.DPSAlwaysHardTarget && target != null)
+                if (cfg.DPSSettings.DPSAlwaysHardTarget && target is not null)
                     Svc.Targets.Target = target;
 
                 var canUseSelf = sheet.CanTargetSelf;
@@ -954,8 +954,11 @@ internal unsafe class AutoRotationController
             var canUse = (canUseSelf || canUseTarget || areaTargeted) && outAct.ActionAttackType() is { } type && ((type is ActionAttackType.Ability && AnimationLock == 0) || (type is not ActionAttackType.Ability && RemainingGCD <= cfg.QueueWindow));
             var isHeal = attributes.AutoAction!.IsHeal;
 
-            if ((!isHeal && cfg.DPSSettings.DPSAlwaysHardTarget && mode is not DPSRotationMode.Manual) || (isHeal && cfg.HealerSettings.HealerAlwaysHardTarget && mode is not HealerRotationMode.Manual) && target != null)
-                Svc.Targets.Target = target;
+            if (target is not null)
+            {
+                if ((!isHeal && cfg.DPSSettings.DPSAlwaysHardTarget && mode is not DPSRotationMode.Manual) || (isHeal && cfg.HealerSettings.HealerAlwaysHardTarget && mode is not HealerRotationMode.Manual))
+                    Svc.Targets.Target = target;
+            }
 
             var castTime = ActionManager.GetAdjustedCastTime(ActionType.Action, outAct);
             bool orbwalking = cfg.OrbwalkerIntegration && OrbwalkerIPC.CanOrbwalk;

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1767,13 +1767,13 @@ public enum Preset
 
     [AutoAction(false, false)]
     [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
-    [ConflictingCombos(BRD_ST_AdvMode)]
+    [ConflictingCombos(BRD_ST_AdvMode, BRD_OneButtonDots)]
     [JobInfo(Job.BRD)]
     [SimpleCombo]
     BRD_ST_SimpleMode = 3036,
 
     [AutoAction(true, false)]
-    [ConflictingCombos(BRD_AoE_AdvMode)]
+    [ConflictingCombos(BRD_AoE_AdvMode, BRD_OneButtonDots)]
     [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
     [JobInfo(Job.BRD)]
     [SimpleCombo]
@@ -1799,6 +1799,7 @@ public enum Preset
     BRD_Adv_Song = 3011,
 
     [ParentCombo(BRD_ST_AdvMode)]
+    [ConflictingCombos(BRD_OneButtonDots)]
     [JobInfo(Job.BRD)]
     BRD_Adv_DoT = 3010,
 
@@ -1859,6 +1860,7 @@ public enum Preset
 
     [ParentCombo(BRD_AoE_AdvMode)]
     [JobInfo(Job.BRD)]
+    [ConflictingCombos(BRD_OneButtonDots)]
     [Retargeted(BRD.Windbite, BRD.VenomousBite, BRD.IronJaws, BRD.CausticBite, BRD.Stormbite)]
     BRD_AoE_Adv_Multidot = 3065,
 
@@ -1963,6 +1965,7 @@ public enum Preset
     BRD_OneButtonSongs = 3014,
 
     [ReplaceSkill(BRD.VenomousBite, BRD.CausticBite)]
+    [ConflictingCombos(BRD_ST_SimpleMode, BRD_AoE_SimpleMode, BRD_Adv_DoT, BRD_AoE_Adv_Multidot)]
     [JobInfo(Job.BRD)]
     BRD_OneButtonDots = 3004,
 

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1767,13 +1767,13 @@ public enum Preset
 
     [AutoAction(false, false)]
     [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
-    [ConflictingCombos(BRD_ST_AdvMode, BRD_OneButtonDots)]
+    [ConflictingCombos(BRD_ST_AdvMode)]
     [JobInfo(Job.BRD)]
     [SimpleCombo]
     BRD_ST_SimpleMode = 3036,
 
     [AutoAction(true, false)]
-    [ConflictingCombos(BRD_AoE_AdvMode, BRD_OneButtonDots)]
+    [ConflictingCombos(BRD_AoE_AdvMode)]
     [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
     [JobInfo(Job.BRD)]
     [SimpleCombo]
@@ -1799,7 +1799,6 @@ public enum Preset
     BRD_Adv_Song = 3011,
 
     [ParentCombo(BRD_ST_AdvMode)]
-    [ConflictingCombos(BRD_OneButtonDots)]
     [JobInfo(Job.BRD)]
     BRD_Adv_DoT = 3010,
 
@@ -1860,7 +1859,6 @@ public enum Preset
 
     [ParentCombo(BRD_AoE_AdvMode)]
     [JobInfo(Job.BRD)]
-    [ConflictingCombos(BRD_OneButtonDots)]
     [Retargeted(BRD.Windbite, BRD.VenomousBite, BRD.IronJaws, BRD.CausticBite, BRD.Stormbite)]
     BRD_AoE_Adv_Multidot = 3065,
 
@@ -1965,7 +1963,6 @@ public enum Preset
     BRD_OneButtonSongs = 3014,
 
     [ReplaceSkill(BRD.VenomousBite, BRD.CausticBite)]
-    [ConflictingCombos(BRD_ST_SimpleMode, BRD_AoE_SimpleMode, BRD_Adv_DoT, BRD_AoE_Adv_Multidot)]
     [JobInfo(Job.BRD)]
     BRD_OneButtonDots = 3004,
 

--- a/WrathCombo/Combos/PvE/RDM/RDM.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM.cs
@@ -224,7 +224,7 @@ internal partial class RDM : Caster
             if (!InCombat() && RDM_Opener_Selection == 2 && HasAccelerate && Opener().OpenerStep == 2)
                 StatusManager.ExecuteStatusOff(Buffs.Acceleration);
 
-            if (IsEnabled(Preset.RDM_Balance_Opener) && HasBattleTarget() &&
+            if (IsEnabled(Preset.RDM_Balance_Opener) &&
                 Opener().FullOpener(ref actionID))
                 return actionID;
             

--- a/WrathCombo/Combos/PvE/RDM/RDM.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM.cs
@@ -2,8 +2,11 @@ using ECommons.GameFunctions;
 using System;
 using System.Linq;
 using Dalamud.Game.ClientState.Objects.Types;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using WrathCombo.Combos.PvE.Enums;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
+using WrathCombo.Data;
 using WrathCombo.Extensions;
 using static WrathCombo.Combos.PvE.RDM.Config;
 namespace WrathCombo.Combos.PvE;
@@ -217,9 +220,14 @@ internal partial class RDM : Caster
                 return actionID;
 
             #region Opener
+
+            if (!InCombat() && RDM_Opener_Selection == 2 && HasAccelerate && Opener().OpenerStep == 2)
+                StatusManager.ExecuteStatusOff(Buffs.Acceleration);
+
             if (IsEnabled(Preset.RDM_Balance_Opener) && HasBattleTarget() &&
                 Opener().FullOpener(ref actionID))
                 return actionID;
+            
             #endregion
 
             #region Special Content

--- a/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
@@ -19,6 +19,7 @@ internal partial class RDM
 
 
         public static UserInt
+            RDMFirstGCDOpenerAccelerationTime = new("RDMFirstGCDOpenerAccelerationTime", 10),
             RDM_ST_Lucid_Threshold = new("RDM_LucidDreaming_Threshold", 6500),
             RDM_AoE_Lucid_Threshold = new("RDM_AoE_Lucid_Threshold", 6500),
             RDM_BalanceOpener_Content = new("RDM_BalanceOpener_Content", 1),
@@ -78,6 +79,13 @@ internal partial class RDM
                         RDM_Config.RDMOpenerWarning, 0, descriptionAsTooltip: true);
                     DrawRadioButton(RDM_Opener_Selection, RDM_Config.RDMGapCloserOpener,
                         RDM_Config.RDMOpenerWarning, 1, descriptionAsTooltip: true);
+                    DrawRadioButton(RDM_Opener_Selection, RDM_Config.RDMFirstGCDOpener, 
+                        FormatAndCache(RDM_Config.RDMFirstGCDOpenerWarning, Acceleration.ActionName(), Veraero3.ActionName()), 2, descriptionAsTooltip: true);
+
+                    if (RDM_Opener_Selection == 2)
+                    {
+                        DrawSliderInt(7, 25, RDMFirstGCDOpenerAccelerationTime, RDM_Config.RDMFirstGCDOpenerWarningTimer);
+                    }
                     break;
 
                 case Preset.RDM_ST_ThunderAero:

--- a/WrathCombo/Combos/PvE/RDM/RDM_Helper.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM_Helper.cs
@@ -3,6 +3,7 @@ using Dalamud.Game.ClientState.JobGauge.Types;
 using ECommons.GameHelpers;
 using System;
 using System.Collections.Generic;
+using FFXIVClientStructs.FFXIV.Client.Game;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using static WrathCombo.Combos.PvE.RDM.Config;
@@ -258,11 +259,14 @@ internal partial class RDM
     #region Opener
     internal static Standard Opener1 = new();
     internal static GapClosing Opener2 = new();
+    internal static FirstGCD Opener3 = new();
+    
     internal static WrathOpener Opener()
     {
         if (RDM_Opener_Selection == 0 && Opener1.LevelChecked) return Opener1;
         if (RDM_Opener_Selection == 1 && Opener2.LevelChecked) return Opener2;
-
+        if (RDM_Opener_Selection == 2 && Opener2.LevelChecked) return Opener3;
+        
         return (Opener1.LevelChecked) ? Opener1 : WrathOpener.Dummy;
     }
     internal class Standard : WrathOpener
@@ -398,6 +402,86 @@ internal partial class RDM
                 GetRemainingCharges(Corpsacorps) < 2)
                 return false;
 
+            return true;
+        }
+    }
+     internal class FirstGCD : WrathOpener
+    {
+        public override List<uint> OpenerActions { get; set; } =
+        [
+            Acceleration,
+            Veraero3,
+            Veraero3,
+            Embolden,
+            GrandImpact, //5
+            Fleche, 
+            Manafication,
+            EnchantedRiposteManafication,
+            Corpsacorps,
+            EnchantedZwerchhauManafication, //10
+            Engagement,
+            EnchantedRedoublementManafication,
+            ContreSixte,
+            Verflare,
+            Engagement, //15
+            Corpsacorps,
+            Scorch,
+            Acceleration,
+            Role.Swiftcast,
+            Resolution, //20
+            Veraero3,
+            ViceOfThorns,
+            Prefulgence,
+            GrandImpact,
+            Verthunder3, //25
+            Verfire,
+            Verthunder3,
+            Fleche
+        ];
+        public override int MinOpenerLevel => 100;
+        public override int MaxOpenerLevel => 109;
+
+        public override List<(int[] Steps, uint NewAction, Func<bool> Condition)> SubstitutionSteps { get; set; } =
+        [
+            ([2], Jolt3, () => PartyInCombat() && !Player.Object.IsCasting)
+        ];
+        
+        public override List<(int[] Steps, Func<int> HoldDelay)> PrepullDelays
+        {
+            get;
+            set;
+        } =
+        [
+            ([2], () => RDMFirstGCDOpenerAccelerationTime - 6)
+        ];
+
+        public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
+        [
+            ([11, 15], () => !InMeleeRange())
+        ];
+
+        internal override UserData? ContentCheckConfig => RDM_BalanceOpener_Content;
+        public override Preset Preset => Preset.RDM_Balance_Opener;
+        public override bool HasCooldowns()
+        {
+            if (!ActionsReady([Role.Swiftcast, Fleche, Embolden, ContreSixte]))
+                return false;
+
+            if (!IsOffCooldown(Manafication))
+                return false;
+
+            if (GetRemainingCharges(Corpsacorps) < 2 || GetRemainingCharges(Engagement) < 2)
+                return false;
+            
+            if (GetRemainingCharges(Acceleration) < 2)
+                return false;
+
+            if (InCombat())
+                return false;
+
+            if (!CountdownActive)
+                return false;
+            
             return true;
         }
     }

--- a/WrathCombo/Combos/PvE/RDM/RDM_Helper.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM_Helper.cs
@@ -482,6 +482,9 @@ internal partial class RDM
             if (!CountdownActive)
                 return false;
             
+            if (CountdownRemaining > 25)
+                return false;
+            
             return true;
         }
     }

--- a/WrathCombo/Combos/PvE/SGE/SGE_Helper.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE_Helper.cs
@@ -310,9 +310,9 @@ internal partial class SGE
                   HasAddersting()),
         // Dyskrasia
         (OriginalHook(Dyskrasia), Preset.SGE_ST_DPS_Movement,
-            () => SGE_ST_DPS_Movement[1] &&
-                  ActionReady(Dyskrasia) &&
-                  InActionRange(Dyskrasia)),
+            () => SGE_ST_DPS_Movement[1] && 
+                  ActionReady(OriginalHook(Dyskrasia)) && 
+                  InActionRange(OriginalHook(Dyskrasia))),
         //Eukrasia
         (Eukrasia, Preset.SGE_ST_DPS_Movement,
             () => SGE_ST_DPS_Movement[2] &&

--- a/WrathCombo/Resources/Localization/JobConfigs/RDM_Config.Designer.cs
+++ b/WrathCombo/Resources/Localization/JobConfigs/RDM_Config.Designer.cs
@@ -105,7 +105,7 @@ namespace WrathCombo.Resources.Localization.JobConfigs {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Early Buff Opener. (Manual Prepull).
+        ///   Looks up a localized string similar to Early Buff Opener.
         /// </summary>
         internal static string RDMFirstGCDOpener {
             get {
@@ -114,7 +114,7 @@ namespace WrathCombo.Resources.Localization.JobConfigs {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Countdown must be used. Set below at what time you plan to manually push {0}. {1} will be blocked until 6 seconds on countdown..
+        ///   Looks up a localized string similar to Countdown must be used. Set below at what time you plan to push {0}. {1} will be blocked until 6 seconds on countdown..
         /// </summary>
         internal static string RDMFirstGCDOpenerWarning {
             get {

--- a/WrathCombo/Resources/Localization/JobConfigs/RDM_Config.Designer.cs
+++ b/WrathCombo/Resources/Localization/JobConfigs/RDM_Config.Designer.cs
@@ -105,6 +105,33 @@ namespace WrathCombo.Resources.Localization.JobConfigs {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Early Buff Opener. (Manual Prepull).
+        /// </summary>
+        internal static string RDMFirstGCDOpener {
+            get {
+                return ResourceManager.GetString("RDMFirstGCDOpener", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Countdown must be used. Set below at what time you plan to manually push {0}. {1} will be blocked until 6 seconds on countdown..
+        /// </summary>
+        internal static string RDMFirstGCDOpenerWarning {
+            get {
+                return ResourceManager.GetString("RDMFirstGCDOpenerWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Countdown time to start opener.
+        /// </summary>
+        internal static string RDMFirstGCDOpenerWarningTimer {
+            get {
+                return ResourceManager.GetString("RDMFirstGCDOpenerWarningTimer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Gap-Closing Adjusted Standard Opener.
         /// </summary>
         internal static string RDMGapCloserOpener {

--- a/WrathCombo/Resources/Localization/JobConfigs/RDM_Config.resx
+++ b/WrathCombo/Resources/Localization/JobConfigs/RDM_Config.resx
@@ -101,10 +101,10 @@
 		<value>Add {0}/{1} Finishers</value>
 	</data>
   <data name="RDMFirstGCDOpener" xml:space="preserve">
-	  <value>Early Buff Opener. (Manual Prepull)</value>
+	  <value>Early Buff Opener</value>
   </data>
   <data name="RDMFirstGCDOpenerWarning" xml:space="preserve">
-	  <value>Countdown must be used. Set below at what time you plan to manually push {0}. {1} will be blocked until 6 seconds on countdown.</value>
+	  <value>Countdown must be used. Set below at what time you plan to push {0}. {1} will be blocked until 6 seconds on countdown.</value>
   </data>
   <data name="RDMFirstGCDOpenerWarningTimer" xml:space="preserve">
 	  <value>Countdown time to start opener</value>

--- a/WrathCombo/Resources/Localization/JobConfigs/RDM_Config.resx
+++ b/WrathCombo/Resources/Localization/JobConfigs/RDM_Config.resx
@@ -100,6 +100,15 @@
   <data name="Add0/1Finishers" xml:space="preserve">
 		<value>Add {0}/{1} Finishers</value>
 	</data>
+  <data name="RDMFirstGCDOpener" xml:space="preserve">
+	  <value>Early Buff Opener. (Manual Prepull)</value>
+  </data>
+  <data name="RDMFirstGCDOpenerWarning" xml:space="preserve">
+	  <value>Countdown must be used. Set below at what time you plan to manually push {0}. {1} will be blocked until 6 seconds on countdown.</value>
+  </data>
+  <data name="RDMFirstGCDOpenerWarningTimer" xml:space="preserve">
+	  <value>Countdown time to start opener</value>
+  </data>
   <data name="RDMOpenerTimeoutWarning" xml:space="preserve">
     <value>Opener Failure Timeout (in Settings Tab) Must be set to 5+ seconds for opener to function due to long initial spell cast.</value>
   </data>


### PR DESCRIPTION
Added first gcd buffs opener
Auto will trigger acceleration up to 25 seconds early. Set the slider for when you plan to push acceleration
Veraero 3 will unlock at 6 seconds assuming you set the slider correctly for your countdown. 

Sage Bugfix
Added original hook to movement prio dyskrasia to fix it working at low levels but not working for dyskrasia 2

WAR Bugfix
Fixed missing level check from Storms Eye feature. 
Renamed Storms Eye feature to Storms Path to Eye feature to better reflect what it actually does.
Added missing conflict between this feature and the storms path standalone. 
