### PR TITLE
Misc Updates

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -926,7 +926,7 @@ internal unsafe class AutoRotationController
             var target = GetSingleTarget(mode);
             OverrideTarget = target;
             var outAct = OriginalHook(InvokeCombo(preset, attributes, ref gameAct, target));
-            if (!CanQueue(outAct))
+            if (!ActionReady(outAct))
             {
                 return false;
             }
@@ -959,7 +959,7 @@ internal unsafe class AutoRotationController
             var acRangeCheck = ActionManager.GetActionInRangeOrLoS(outAct, player.GameObject(), target is null ? player.GameObject() : target.Struct());
             var inRange = acRangeCheck is 0 or 565 || canUseSelf;
 
-            var canUse = (canUseSelf || canUseTarget || areaTargeted) && outAct.ActionAttackType() is { } type && ((type is ActionAttackType.Ability && AnimationLock == 0) || (type is not ActionAttackType.Ability && RemainingGCD <= cfg.QueueWindow));
+            var canUse = (canUseSelf || canUseTarget || areaTargeted) && outAct.ActionAttackType() is { } type && ((type is ActionAttackType.Ability && AnimationLock <= cfg.QueueWindow) || (type is not ActionAttackType.Ability && RemainingGCD <= cfg.QueueWindow));
             var isHeal = attributes.AutoAction!.IsHeal;
 
             if ((!isHeal && cfg.DPSSettings.DPSAlwaysHardTarget && mode is not DPSRotationMode.Manual) || (isHeal && cfg.HealerSettings.HealerAlwaysHardTarget && mode is not HealerRotationMode.Manual) && target != null)

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -1117,6 +1117,7 @@ internal unsafe class AutoRotationController
                 .OrderByDescending(x => IsCombatPriority(x))
                 .ThenBy(x => GetTargetMaxHP(x))
                 .ThenBy(x => GetTargetHPPercent(x))
+                .ThenBy(x => GetTargetDistance(x))
                 .FirstOrDefault();
         }
 
@@ -1126,6 +1127,7 @@ internal unsafe class AutoRotationController
                 .OrderByDescending(x => IsCombatPriority(x))
                 .ThenByDescending(x => GetTargetMaxHP(x))
                 .ThenBy(x => GetTargetHPPercent(x))
+                .ThenBy(x => GetTargetDistance(x))
                 .FirstOrDefault();
         }
     }

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -20,6 +20,7 @@ using WrathCombo.Combos.PvE.Enums;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
+using WrathCombo.Data;
 using WrathCombo.Extensions;
 using WrathCombo.Services;
 using WrathCombo.Services.IPC_Subscriber;
@@ -1150,39 +1151,30 @@ internal unsafe class AutoRotationController
         internal static IGameObject? GetHighestCurrent()
         {
             if (GetPartyMembers().Count == 0) return Player.Object;
-            var target = GetPartyMembers()
-                .Where(x => !x.BattleChara.IsDead &&
-                            x.BattleChara.IsTargetable &&
-                            GetTargetDistance(x.BattleChara) <= QueryRange &&
-                            !TargetHasImmortality(x.BattleChara) &&
-                            GetTargetHPPercent(x.BattleChara) <=
-                            (TargetHasExcog(x.BattleChara) ? cfg.HealerSettings.SingleTargetExcogHPP :
-                                TargetHasRegen(x.BattleChara) ? cfg.HealerSettings.SingleTargetRegenHPP :
-                                cfg.HealerSettings.SingleTargetHPP) &&
-                            IsInLineOfSight(x.BattleChara))
-                .OrderBy(x => TargetHasTrueInvuln(x.BattleChara))
-                .ThenByDescending(x => GetTargetHPPercent(x.BattleChara))
-                .FirstOrDefault();
-            return target?.BattleChara;
+            return HealTargets().ThenByDescending(x => GetTargetHPPercent(x)).FirstOrDefault();
         }
 
         internal static IGameObject? GetLowestCurrent()
         {
             if (GetPartyMembers().Count == 0) return Player.Object;
-            var target = GetPartyMembers()
+            return HealTargets().ThenBy(x => GetTargetHPPercent(x)).FirstOrDefault();
+        }
+
+        internal static IOrderedEnumerable<IGameObject?> HealTargets()
+        {
+            return GetPartyMembers()
                 .Where(x => !x.BattleChara.IsDead &&
                             x.BattleChara.IsTargetable &&
                             GetTargetDistance(x.BattleChara) <= QueryRange &&
                             !TargetHasImmortality(x.BattleChara) &&
+                            !x.BattleChara.StatusList.Any(x => StatusCache.DoNotHealStatuses.Contains(x.StatusId)) &&
                             GetTargetHPPercent(x.BattleChara) <=
                             (TargetHasExcog(x.BattleChara) ? cfg.HealerSettings.SingleTargetExcogHPP :
                                 TargetHasRegen(x.BattleChara) ? cfg.HealerSettings.SingleTargetRegenHPP :
                                 cfg.HealerSettings.SingleTargetHPP) &&
                             IsInLineOfSight(x.BattleChara))
-                .OrderBy(x => TargetHasTrueInvuln(x.BattleChara))
-                .ThenBy(x => GetTargetHPPercent(x.BattleChara))
-                .FirstOrDefault();
-            return target?.BattleChara;
+                .Select(x => x.BattleChara)
+                .OrderBy(x => TargetHasTrueInvuln(x));
         }
 
         internal static bool CanAoEHeal(uint outAct = 0)

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -353,7 +353,14 @@ internal unsafe class AutoRotationController
     {
         foreach (var (spell, multihitter) in RaidwideActions)
         {
-            if (AutorotRaidwides >= 2)
+            int numberOfCasts = GetPartyAvgHPPercent() switch
+            {
+                <= 30 => 3,
+                <= 60 => 2,
+                _ => 1
+            };
+
+            if (AutorotRaidwides >= numberOfCasts)
                 return;
 
             if (!multihit && multihitter)

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -1187,6 +1187,7 @@ internal unsafe class AutoRotationController
                                 !x.BattleChara.IsDead &&
                                 x.BattleChara.IsTargetable &&
                                 !x.IsOutOfPartyNPC &&
+                                !x.BattleChara.StatusList.Any(x => StatusCache.DoNotHealStatuses.Contains(x.StatusId)) &&
                                 (outAct == 0
                                     ? GetTargetDistance(x.BattleChara) <= 20f
                                     : InActionRange(outAct, x.BattleChara)) &&

--- a/WrathCombo/Combos/PvE/MNK/MNK.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK.cs
@@ -25,7 +25,7 @@ internal partial class MNK : Melee
                 return contentAction;
 
             // OGCDs
-            if (CanWeave() && InCombat())
+            if (CanWeave() && (InCombat() || ComboAction > 0))
             {
                 if (CanBrotherhood())
                     return Brotherhood;
@@ -94,7 +94,7 @@ internal partial class MNK : Melee
                 return contentAction;
 
             // OGCD's
-            if (CanWeave() && InCombat())
+            if (CanWeave() && (InCombat() || ComboAction > 0))
             {
                 if (CanBrotherhood())
                     return Brotherhood;
@@ -186,7 +186,7 @@ internal partial class MNK : Melee
                 return contentAction;
 
             // OGCDs
-            if (CanWeave() && InCombat())
+            if (CanWeave() && (InCombat() || ComboAction > 0))
             {
                 if (IsEnabled(Preset.MNK_STUseBuffs))
                 {
@@ -289,7 +289,7 @@ internal partial class MNK : Melee
                 return contentAction;
 
             // OGCD's
-            if (CanWeave() && InCombat())
+            if (CanWeave() && (InCombat() || ComboAction > 0))
             {
                 if (IsEnabled(Preset.MNK_AoEUseBuffs) &&
                     GetTargetHPPercent() >= MNK_AoE_BuffsHPThreshold)

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -31,11 +31,11 @@ internal partial class WHM
 
                 case Preset.WHM_ST_MainCombo:
                     DrawHorizontalRadioButton(WHM_ST_MainCombo_Actions, "On Stones/Glares", "Apply options to all Stones and Glares.", 0,
-                        descriptionColor:ImGuiColors.DalamudWhite);
+                        descriptionColor: ImGuiColors.DalamudWhite);
                     DrawHorizontalRadioButton(WHM_ST_MainCombo_Actions, "On Aeros/Dia", "Apply options to all Aeros And Dia.", 1,
-                        descriptionColor:ImGuiColors.DalamudWhite);
+                        descriptionColor: ImGuiColors.DalamudWhite);
                     DrawHorizontalRadioButton(WHM_ST_MainCombo_Actions, "On Stone II", "Apply options to Stone II.", 2,
-                        descriptionColor:ImGuiColors.DalamudWhite);
+                        descriptionColor: ImGuiColors.DalamudWhite);
                     break;
 
                 case Preset.WHM_ST_MainCombo_Opener:
@@ -90,8 +90,8 @@ internal partial class WHM
                     break;
 
                 case Preset.WHM_AoE_DPS_Misery:
-                    DrawHorizontalRadioButton(WHM_AoE_DPS_Misery_Option, "Hold for Burst", "Will attempt to hold for burst as long as possible without overcapping. \nWill prevent afflatus heals from being possible when at full Blood Lily stacks.", 0 ,descriptionColor: ImGuiColors.DalamudWhite);
-                    DrawHorizontalRadioButton(WHM_AoE_DPS_Misery_Option, "Use Immediately", "Will Use Immediately to make sure you are free to use Afflatus heals. ", 1 ,descriptionColor: ImGuiColors.DalamudWhite);
+                    DrawHorizontalRadioButton(WHM_AoE_DPS_Misery_Option, "Hold for Burst", "Will attempt to hold for burst as long as possible without overcapping. \nWill prevent afflatus heals from being possible when at full Blood Lily stacks.", 0, descriptionColor: ImGuiColors.DalamudWhite);
+                    DrawHorizontalRadioButton(WHM_AoE_DPS_Misery_Option, "Use Immediately", "Will Use Immediately to make sure you are free to use Afflatus heals. ", 1, descriptionColor: ImGuiColors.DalamudWhite);
                     break;
 
                 case Preset.WHM_AoE_DPS_LilyOvercap:
@@ -142,9 +142,9 @@ internal partial class WHM
                     break;
 
                 case Preset.WHM_STHeals_Aquaveil:
-                    DrawHorizontalMultiChoice(Generics.NonBosses,Generics.OnlyWeave, Generics.OnlyWeave, 3, 0);
-                    DrawHorizontalMultiChoice(Generics.NonBosses,Generics.NonBosses, Generics.NonBosses, 3, 1);
-                    DrawHorizontalMultiChoice(Generics.NonBosses,Generics.TanksOnly, Generics.NonBosses, 3, 2);
+                    DrawHorizontalMultiChoice(WHM_STHeals_AquaveilOptions, Generics.OnlyWeave, Generics.OnlyWeave, 3, 0);
+                    DrawHorizontalMultiChoice(WHM_STHeals_AquaveilOptions, Generics.NonBosses, Generics.NonBosses, 3, 1);
+                    DrawHorizontalMultiChoice(WHM_STHeals_AquaveilOptions, Generics.TanksOnly, Generics.TanksOnly, 3, 2);
                     DrawSliderInt(1, 100, WHM_STHeals_AquaveilHP,
                         Generics.StopFriendlyHpPercent100);
                     DrawPriorityInput(WHM_ST_Heals_Priority, 9, 3,
@@ -175,8 +175,8 @@ internal partial class WHM
                 case Preset.WHM_STHeals_Temperance:
                     DrawSliderInt(1, 100, WHM_STHeals_TemperanceHP,
                         Generics.StopFriendlyHpPercent100);
-                    DrawHorizontalMultiChoice(Generics.NonBosses,Generics.OnlyWeave, Generics.OnlyWeave, 2, 0);
-                    DrawHorizontalMultiChoice(Generics.NonBosses,Generics.NonBosses, Generics.NonBosses, 2, 1);
+                    DrawHorizontalMultiChoice(WHM_STHeals_TemperanceOptions, Generics.OnlyWeave, Generics.OnlyWeave, 2, 0);
+                    DrawHorizontalMultiChoice(WHM_STHeals_TemperanceOptions, Generics.NonBosses, Generics.NonBosses, 2, 1);
                     DrawPriorityInput(WHM_ST_Heals_Priority, 9, 6,
                         FormatAndCache(Generics.Action_Priority, Temperance.ActionName()));
                     break;
@@ -184,8 +184,8 @@ internal partial class WHM
                 case Preset.WHM_STHeals_Asylum:
                     DrawSliderInt(1, 100, WHM_STHeals_AsylumHP,
                         Generics.StopFriendlyHpPercent100);
-                    DrawHorizontalMultiChoice(Generics.NonBosses,Generics.OnlyWeave, Generics.OnlyWeave, 2, 0);
-                    DrawHorizontalMultiChoice(Generics.NonBosses,Generics.NonBosses, Generics.NonBosses, 2, 1);
+                    DrawHorizontalMultiChoice(WHM_STHeals_AsylumOptions, Generics.OnlyWeave, Generics.OnlyWeave, 2, 0);
+                    DrawHorizontalMultiChoice(WHM_STHeals_AsylumOptions, Generics.NonBosses, Generics.NonBosses, 2, 1);
                     DrawPriorityInput(WHM_ST_Heals_Priority, 9, 7,
                         FormatAndCache(Generics.Action_Priority, Asylum.ActionName()));
                     break;
@@ -193,8 +193,8 @@ internal partial class WHM
                 case Preset.WHM_STHeals_LiturgyOfTheBell:
                     DrawSliderInt(1, 100, WHM_STHeals_LiturgyOfTheBellHP,
                         Generics.StopFriendlyHpPercent100);
-                    DrawHorizontalMultiChoice(Generics.NonBosses,Generics.OnlyWeave, Generics.OnlyWeave, 2, 0);
-                    DrawHorizontalMultiChoice(Generics.NonBosses, Generics.NonBosses, Generics.NonBosses, 2, 1);
+                    DrawHorizontalMultiChoice(WHM_STHeals_LiturgyOfTheBellOptions, Generics.OnlyWeave, Generics.OnlyWeave, 2, 0);
+                    DrawHorizontalMultiChoice(WHM_STHeals_LiturgyOfTheBellOptions, Generics.NonBosses, Generics.NonBosses, 2, 1);
                     DrawPriorityInput(WHM_ST_Heals_Priority, 9, 8,
                         FormatAndCache(Generics.Action_Priority, LiturgyOfTheBell.ActionName()));
                     break;
@@ -334,11 +334,11 @@ internal partial class WHM
 
                 case Preset.WHM_Mit_ST:
                     DrawHorizontalMultiChoice(WHM_AquaveilOptions,
-                        FormatAndCache(Generics.Add0, DivineBenison.ActionName()), 
+                        FormatAndCache(Generics.Add0, DivineBenison.ActionName()),
                         FormatAndCache(Generics.Add0, DivineBenison.ActionName()), 2, 0);
                     ImGui.NewLine();
                     DrawHorizontalMultiChoice(WHM_AquaveilOptions,
-                        FormatAndCache(Generics.Add0, Tetragrammaton.ActionName()), 
+                        FormatAndCache(Generics.Add0, Tetragrammaton.ActionName()),
                         FormatAndCache(Generics.Add0, Tetragrammaton.ActionName()), 2, 1);
                     if (WHM_AquaveilOptions[1])
                     {
@@ -358,9 +358,9 @@ internal partial class WHM
                     ImGui.TextColored(ImGuiColors.DalamudGrey, "Options to try to Retarget Asylum to before Self:");
                     ImGui.Unindent();
                     DrawHorizontalMultiChoice(WHM_AsylumOptions,
-                        Generics.EnemyHardTarget,Generics.EnemyHardTarget, 3, 0);
+                        Generics.EnemyHardTarget, Generics.EnemyHardTarget, 3, 0);
                     DrawHorizontalMultiChoice(WHM_AsylumOptions,
-                        Generics.AllyHardTarget,Generics.AllyHardTarget, 3, 1);
+                        Generics.AllyHardTarget, Generics.AllyHardTarget, 3, 1);
                     break;
 
                 case Preset.WHM_Re_LiturgyOfTheBell:
@@ -368,9 +368,9 @@ internal partial class WHM
                     ImGui.TextColored(ImGuiColors.DalamudGrey, "Options to try to Retarget Liturgy of the Bell to before Self:");
                     ImGui.Unindent();
                     DrawHorizontalMultiChoice(WHM_LiturgyOfTheBellOptions,
-                        Generics.EnemyHardTarget,Generics.EnemyHardTarget, 2, 0);
+                        Generics.EnemyHardTarget, Generics.EnemyHardTarget, 2, 0);
                     DrawHorizontalMultiChoice(WHM_LiturgyOfTheBellOptions,
-                        Generics.AllyHardTarget,Generics.AllyHardTarget,  2, 1);
+                        Generics.AllyHardTarget, Generics.AllyHardTarget, 2, 1);
                     break;
 
 
@@ -611,7 +611,7 @@ internal partial class WHM
         ///     Priority order for single target healing abilities.
         /// </summary>
         public static UserIntArray WHM_ST_Heals_Priority =
-            new("WHM_ST_Heals_Priority", [1,7,6,5,9,8,2,3,4]);
+            new("WHM_ST_Heals_Priority", [1, 7, 6, 5, 9, 8, 2, 3, 4]);
 
         /// <summary>
         ///     Time threshold in seconds before refreshing Regen.
@@ -892,7 +892,7 @@ internal partial class WHM
         ///     Priority order for AoE healing abilities.
         /// </summary>
         public static UserIntArray WHM_AoE_Heals_Priority =
-            new("WHM_AoE_Heals_Priority",[9,8,6,5,3,4,7,2,1]);
+            new("WHM_AoE_Heals_Priority", [9, 8, 6, 5, 3, 4, 7, 2, 1]);
 
         /// <summary>
         ///     Number of Thin Air charges to reserve in AoE healing.
@@ -1216,7 +1216,7 @@ internal partial class WHM
         /// </value>
         /// <seealso cref="Preset.WHM_Re_LiturgyOfTheBell" />
         public static UserBoolArray WHM_LiturgyOfTheBellOptions =
-            new ("WHM_LiturgyOfTheBellOptions", [true, true]);
+            new("WHM_LiturgyOfTheBellOptions", [true, true]);
 
         /// <summary>
         ///     Options for Aquaveil Standalone Feature
@@ -1226,7 +1226,7 @@ internal partial class WHM
         /// </value>
         /// <seealso cref="Preset.WHM_Mit_ST" />
         public static UserBoolArray WHM_AquaveilOptions =
-            new ("WHM_AquaveilOptions", [true, true]);
+            new("WHM_AquaveilOptions", [true, true]);
 
         /// <summary>
         ///     Tetra threshold for Aquaveil standalone feature

--- a/WrathCombo/CustomCombo/Functions/Status.cs
+++ b/WrathCombo/CustomCombo/Functions/Status.cs
@@ -273,6 +273,12 @@ internal abstract partial class CustomComboFunctions
         // for specified areas
         switch (Content.TerritoryID)
         {
+            case 1045: // Ifrit Normal
+                return targetID == 207 && Svc.Objects.Any(x => x.BaseId == 208 && !x.IsDead);
+            case 292: // Ifrit Hard
+                return targetID == 209 && Svc.Objects.Any(x => x.BaseId == 210 && !x.IsDead);
+            case 295: // Ifrit Extreme
+                return targetID == 211 && Svc.Objects.Any(x => x.BaseId == 212 && !x.IsDead);
             case 174: // Labyrinth of the Ancients
                 // Thanatos, Spooky Ghosts Only
                 if (targetID is 2350) return !HasStatusEffect(398);

--- a/WrathCombo/CustomCombo/Functions/VFX.cs
+++ b/WrathCombo/CustomCombo/Functions/VFX.cs
@@ -38,8 +38,9 @@ internal abstract partial class CustomComboFunctions
 
     private static uint? CurrentCFC => Content.ContentFinderConditionRowId;
 
-    private static List<TTSData> TTSTankbusters = [];
-    private static List<TTSData> TTSGroupwides = [];
+    public static List<TTSData> TTSTankbusters = [];
+    public static List<TTSData> TTSGroupwides = [];
+    public static HashSet<long> HandledVFXIDs = [];
     private static bool CurrentRaidwideHandled = false;
 
     /// <summary>
@@ -255,7 +256,7 @@ internal abstract partial class CustomComboFunctions
         QuestToastOptions opts = new() { Position = QuestToastPosition.Centre, DisplayCheckmark = false };
         foreach (var vfx in VfxManager.TrackedEffects.FilterToTargeted().Where(x => IsTankBusterEffectPath(x) && x.TargetID.GetObject().IsInParty()))
         {
-            if (!TTSTankbusters.Any(x => x.VFX == vfx))
+            if (!HandledVFXIDs.Any(x => x == vfx.VfxID))
                 TTSTankbusters.Add(new TTSData() { VFX = vfx });
         }
 
@@ -267,10 +268,13 @@ internal abstract partial class CustomComboFunctions
             if (Service.Configuration.TankbusterToast)
                 Svc.Toasts.ShowQuest(string.Format(MiscStrings.TankbusterTTS, JoinNaturally(targets)), opts);
 
-            TTSTankbusters.ForEach(x => x.TTSHandled = true);
+            TTSTankbusters.ForEach(x =>
+            {
+                x.TTSHandled = true;
+                HandledVFXIDs.Add(x.VFX.VfxID);
+                Svc.Framework.RunOnTick(() => ClearTTSLists(x.VFX.VfxID), TimeSpan.FromMinutes(1));
+            });
         }
-
-        TTSTankbusters.RemoveAll(x => x.VFX.AgeSeconds >= 10);
     }
 
     public static void PlayGroupwideAlert()
@@ -281,11 +285,11 @@ internal abstract partial class CustomComboFunctions
         QuestToastOptions opts = new() { Position = QuestToastPosition.Centre, DisplayCheckmark = false };
         foreach (var vfx in VfxManager.TrackedEffects.Where(v => v.VfxID != 0 && (CheckPath(MHSharedDmgPaths, v.Path)) || CheckPath(SharedDmgPaths, v.Path)))
         {
-            if (!TTSGroupwides.Any(x => x.VFX == vfx))
+            if (!HandledVFXIDs.Any(x => x == vfx.VfxID))
                 TTSGroupwides.Add(new TTSData() { VFX = vfx });
         }
 
-        if (TTSGroupwides.Any(x => !x.TTSHandled))
+        if (TTSGroupwides.Count > 0 && TTSGroupwides.Any(x => !x.TTSHandled))
         {
             var multiHit = TTSGroupwides.Any(x => CheckPath(MHSharedDmgPaths, x.VFX.Path));
             var targets = TTSGroupwides.Where(x => !x.TTSHandled).Select(x => x.VFX.TargetID == Player.Object.GameObjectId ? "You" : x.VFX.TargetID.GetObject()?.Name.ToString()).ToList();
@@ -294,10 +298,12 @@ internal abstract partial class CustomComboFunctions
             if (Service.Configuration.AoEDamageToast)
                 Svc.Toasts.ShowQuest(string.Format(MiscStrings.StackTTS, (multiHit ? MiscStrings.MultiHit : ""), JoinNaturally(targets)), opts);
 
-            TTSGroupwides.ForEach(x => x.TTSHandled = true);
+            TTSGroupwides.ForEach(x => {
+                x.TTSHandled = true;
+                HandledVFXIDs.Add(x.VFX.VfxID);
+                Svc.Framework.RunOnTick(() => ClearTTSLists(x.VFX.VfxID), TimeSpan.FromMinutes(1));
+            });
         }
-
-        TTSGroupwides.RemoveAll(x => x.VFX.AgeSeconds >= 10);
 
         if (RaidwideCasting())
         {
@@ -315,6 +321,21 @@ internal abstract partial class CustomComboFunctions
             CurrentRaidwideHandled = false;
     }   
 
+    private static void ClearTTSLists(long vfxId)
+    {
+        try
+        {
+            TTSGroupwides.RemoveAll(x => x.VFX.VfxID == vfxId);
+            TTSTankbusters.RemoveAll(x => x.VFX.VfxID == vfxId);
+        }
+        catch (Exception ex)
+        {
+            Svc.Log.Error($"Error clearing TTS lists: {ex}");
+            TTSGroupwides.Clear();
+            TTSTankbusters.Clear();
+        }
+    }
+
     public static string JoinNaturally(IList<string?> items)
     {
         if (items == null || items.Count == 0)
@@ -330,7 +351,7 @@ internal abstract partial class CustomComboFunctions
                + " and " + items.Last();
     }
 
-    private class TTSData
+    public class TTSData
     {
         public VfxInfo VFX;
         public bool TTSHandled;

--- a/WrathCombo/Data/StatusCache.cs
+++ b/WrathCombo/Data/StatusCache.cs
@@ -146,6 +146,11 @@ internal class StatusCache
             })
             .ToFrozenSet();
 
+    internal static readonly FrozenSet<uint> DoNotHealStatuses = new uint[]
+    {
+        2852,
+    }.ToFrozenSet();
+
     public static class PausingStatuses
     {
         internal static readonly FrozenSet<uint> AccelerationBombs =

--- a/WrathCombo/Resources/Localization/UI/AutoRotation/AutoRotationUI.Designer.cs
+++ b/WrathCombo/Resources/Localization/UI/AutoRotation/AutoRotationUI.Designer.cs
@@ -465,7 +465,7 @@ namespace WrathCombo.Resources.Localization.UI.AutoRotation {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Will try to use actions before detected raidwides or group damage to either mitigate or top-off party members. Max 2 actions (excluding {0} for setup).
+        ///   Looks up a localized string similar to Will try to use actions before detected raidwides or group damage to either mitigate or top-off party members. Max 3 actions (excluding {0} for setup).
         /// </summary>
         internal static string HelpText_HandleRaidwides {
             get {

--- a/WrathCombo/Resources/Localization/UI/AutoRotation/AutoRotationUI.ja.resx
+++ b/WrathCombo/Resources/Localization/UI/AutoRotation/AutoRotationUI.ja.resx
@@ -117,96 +117,248 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Checkbox_BypassFATETargets" xml:space="preserve"><value>FATE 対象時は非戦闘時制限を解除</value></data>
-  <data name="Checkbox_BypassQuestTargets" xml:space="preserve"><value>クエスト対象時は非戦闘時制限を解除</value></data>
-  <data name="Checkbox_BypassSelfUse" xml:space="preserve"><value>自己対象アクション提案時は制限を解除</value></data>
-  <data name="Checkbox_DisableInstanceExit" xml:space="preserve"><value>インスタンス退出後に無効化</value></data>
-  <data name="Checkbox_EnableAutoRotation" xml:space="preserve"><value>自動ローテーションを有効化</value></data>
-  <data name="Checkbox_EnableInstancedEnter" xml:space="preserve"><value>インスタンスコンテンツで自動的に有効化</value></data>
-  <data name="Checkbox_EnforceBestAoETarget" xml:space="preserve"><value>最適な AoE 対象選択を強制</value></data>
-  <data name="Checkbox_OnlyInCombat" xml:space="preserve"><value>戦闘中のみ</value></data>
-  <data name="Label_DamageSettings" xml:space="preserve"><value>攻撃設定</value></data>
-  <data name="HelpText_AoETargetCount" xml:space="preserve"><value>これを無効にすると AoE 攻撃機能を使わなくなります。有効時は、AoE 攻撃を使うために必要な対象数が射程内にいることを要求します。全ロールの AoE ダメージ系機能に適用されます。</value></data>
-  <data name="HelpText_BypassFATETargets" xml:space="preserve"><value>FATE にレベルシンクしている場合を除き、非戦闘時は自動モードを無効にします。</value></data>
-  <data name="HelpText_BypassQuestTargets" xml:space="preserve"><value>クエスト対象が射程内にいる場合を除き、非戦闘時は自動モードを無効にします。</value></data>
-  <data name="HelpText_BypassSelfUse" xml:space="preserve"><value>一部ジョブには、{0} や {1} のように非戦闘時に使いたいアクションがあります。この設定を有効にすると、戦闘外でもそれらを使えるようになります。</value></data>
-  <data name="HelpText_DPSTargettingMode" xml:space="preserve"><value>手動 - 対象選択をすべて手動で行います。
+  <data name="Checkbox_BypassFATETargets" xml:space="preserve">
+    <value>FATE 対象時は非戦闘時制限を解除</value>
+  </data>
+  <data name="Checkbox_BypassQuestTargets" xml:space="preserve">
+    <value>クエスト対象時は非戦闘時制限を解除</value>
+  </data>
+  <data name="Checkbox_BypassSelfUse" xml:space="preserve">
+    <value>自己対象アクション提案時は制限を解除</value>
+  </data>
+  <data name="Checkbox_DisableInstanceExit" xml:space="preserve">
+    <value>インスタンス退出後に無効化</value>
+  </data>
+  <data name="Checkbox_EnableAutoRotation" xml:space="preserve">
+    <value>自動ローテーションを有効化</value>
+  </data>
+  <data name="Checkbox_EnableInstancedEnter" xml:space="preserve">
+    <value>インスタンスコンテンツで自動的に有効化</value>
+  </data>
+  <data name="Checkbox_EnforceBestAoETarget" xml:space="preserve">
+    <value>最適な AoE 対象選択を強制</value>
+  </data>
+  <data name="Checkbox_OnlyInCombat" xml:space="preserve">
+    <value>戦闘中のみ</value>
+  </data>
+  <data name="Label_DamageSettings" xml:space="preserve">
+    <value>攻撃設定</value>
+  </data>
+  <data name="HelpText_AoETargetCount" xml:space="preserve">
+    <value>これを無効にすると AoE 攻撃機能を使わなくなります。有効時は、AoE 攻撃を使うために必要な対象数が射程内にいることを要求します。全ロールの AoE ダメージ系機能に適用されます。</value>
+  </data>
+  <data name="HelpText_BypassFATETargets" xml:space="preserve">
+    <value>FATE にレベルシンクしている場合を除き、非戦闘時は自動モードを無効にします。</value>
+  </data>
+  <data name="HelpText_BypassQuestTargets" xml:space="preserve">
+    <value>クエスト対象が射程内にいる場合を除き、非戦闘時は自動モードを無効にします。</value>
+  </data>
+  <data name="HelpText_BypassSelfUse" xml:space="preserve">
+    <value>一部ジョブには、{0} や {1} のように非戦闘時に使いたいアクションがあります。この設定を有効にすると、戦闘外でもそれらを使えるようになります。</value>
+  </data>
+  <data name="HelpText_DPSTargettingMode" xml:space="preserve">
+    <value>手動 - 対象選択をすべて手動で行います。
 最大HPが高い対象 - 最大HPが最も高い敵を優先します。
 最大HPが低い対象 - 最大HPが最も低い敵を優先します。
 現在HPが高い対象 - 現在HPが最も高い敵を優先します。
 現在HPが低い対象 - 現在HPが最も低い敵を優先します。
 タンクの対象 - パーティ内先頭タンクと同じ対象を優先します。
 最も近い対象 - 自分に最も近い対象を優先します。
-最も遠い対象 - 自分から最も遠い対象を優先します。</value></data>
-  <data name="HelpText_EnforceBestAoETarget" xml:space="preserve"><value>ほかのターゲットモードでは、AoE は命中対象数が最も多い対象を優先します。手動では、このチェックを入れた場合のみ同じ挙動になります。</value></data>
-  <data name="HelpText_QueueWindow" xml:space="preserve"><value>次のウェポンスキルまたは魔法を、GCD 終了のどれだけ前からキューに入れるかを決めます。回線状況によって実行アクションが変わる場合があるため、例えば MP 更新が間に合わずブリザジャを二重に撃ってしまうような場合はこの値を調整してください。</value></data>
-  <data name="Info_Header" xml:space="preserve"><value>ここでは自動ローテーションの動作条件を設定できます。
-「自動モード」チェックのある機能は、自動ローテーションで使用できます。</value></data>
-  <data name="Input_AoETargetCount" xml:space="preserve"><value>AoE 攻撃機能に必要な対象数</value></data>
-  <data name="Input_AutoRotationDelay" xml:space="preserve"><value>戦闘開始後に自動ローテーションを開始するまでの遅延（秒）</value></data>
-  <data name="Input_QueueWindow" xml:space="preserve"><value>キュー受付時間（秒）</value></data>
-  <data name="Label_DPSTargetingMode" xml:space="preserve"><value>攻撃対象モード</value></data>
-  <data name="Label_DPSMaxTargetDistance" xml:space="preserve"><value>最大対象距離</value></data>
-  <data name="HelpText_DPSMaxTargetDistance" xml:space="preserve"><value>手動以外の各対象モードが探索する最大距離です。1〜30 の値のみ有効です。</value></data>
-  <data name="Label_IgnoreRangeInBoss" xml:space="preserve"><value>ボス戦では最大対象距離を無視</value></data>
-  <data name="HelpText_IgnoreRangeInBoss" xml:space="preserve"><value>ボス戦中のみ、距離に関係なく対象を攻撃候補にします。</value></data>
-  <data name="Checkbox_FATEPriority" xml:space="preserve"><value>FATE 対象を優先</value></data>
-  <data name="Checkbox_QuestPriority" xml:space="preserve"><value>クエスト対象を優先</value></data>
-  <data name="Checkbox_PreferNonCombat" xml:space="preserve"><value>非戦闘中の対象を優先</value></data>
-  <data name="Checkbox_OnlyAttackInCombat" xml:space="preserve"><value>すでに戦闘中の対象のみ攻撃</value></data>
-  <data name="Checkbox_UnTargetAndDisableForPenalty" xml:space="preserve"><value>行動ペナルティ系ギミック時はターゲット解除して停止</value></data>
-  <data name="Checkbox_DPSAlwaysHardTarget" xml:space="preserve"><value>常にハードターゲットを設定</value></data>
-  <data name="Label_IgnoredNPCs" xml:space="preserve"><value>無視する NPC</value></data>
-  <data name="HelpText_UnTargetAndDisableForPenalty" xml:space="preserve"><value>パイレティクスや加速度爆弾など、行動すると不利益を受けるギミックを検知した場合、現在のターゲットを解除し、自動ローテーションのアクション実行を停止します。</value></data>
-  <data name="HelpText_DPSAlwaysHardTarget" xml:space="preserve"><value>自動ローテーションは敵を明示的にターゲットしなくても動作しますが、この設定を有効にすると攻撃実行時に常にハードターゲットを設定します。</value></data>
-  <data name="HelpText_IgnoredNPCs" xml:space="preserve"><value>ここに登録した NPC は自動ローテーションの対象外になります。
+最も遠い対象 - 自分から最も遠い対象を優先します。</value>
+  </data>
+  <data name="HelpText_EnforceBestAoETarget" xml:space="preserve">
+    <value>ほかのターゲットモードでは、AoE は命中対象数が最も多い対象を優先します。手動では、このチェックを入れた場合のみ同じ挙動になります。</value>
+  </data>
+  <data name="HelpText_QueueWindow" xml:space="preserve">
+    <value>次のウェポンスキルまたは魔法を、GCD 終了のどれだけ前からキューに入れるかを決めます。回線状況によって実行アクションが変わる場合があるため、例えば MP 更新が間に合わずブリザジャを二重に撃ってしまうような場合はこの値を調整してください。</value>
+  </data>
+  <data name="Info_Header" xml:space="preserve">
+    <value>ここでは自動ローテーションの動作条件を設定できます。
+「自動モード」チェックのある機能は、自動ローテーションで使用できます。</value>
+  </data>
+  <data name="Input_AoETargetCount" xml:space="preserve">
+    <value>AoE 攻撃機能に必要な対象数</value>
+  </data>
+  <data name="Input_AutoRotationDelay" xml:space="preserve">
+    <value>戦闘開始後に自動ローテーションを開始するまでの遅延（秒）</value>
+  </data>
+  <data name="Input_QueueWindow" xml:space="preserve">
+    <value>キュー受付時間（秒）</value>
+  </data>
+  <data name="Label_DPSTargetingMode" xml:space="preserve">
+    <value>攻撃対象モード</value>
+  </data>
+  <data name="Label_DPSMaxTargetDistance" xml:space="preserve">
+    <value>最大対象距離</value>
+  </data>
+  <data name="HelpText_DPSMaxTargetDistance" xml:space="preserve">
+    <value>手動以外の各対象モードが探索する最大距離です。1〜30 の値のみ有効です。</value>
+  </data>
+  <data name="Label_IgnoreRangeInBoss" xml:space="preserve">
+    <value>ボス戦では最大対象距離を無視</value>
+  </data>
+  <data name="HelpText_IgnoreRangeInBoss" xml:space="preserve">
+    <value>ボス戦中のみ、距離に関係なく対象を攻撃候補にします。</value>
+  </data>
+  <data name="Checkbox_FATEPriority" xml:space="preserve">
+    <value>FATE 対象を優先</value>
+  </data>
+  <data name="Checkbox_QuestPriority" xml:space="preserve">
+    <value>クエスト対象を優先</value>
+  </data>
+  <data name="Checkbox_PreferNonCombat" xml:space="preserve">
+    <value>非戦闘中の対象を優先</value>
+  </data>
+  <data name="Checkbox_OnlyAttackInCombat" xml:space="preserve">
+    <value>すでに戦闘中の対象のみ攻撃</value>
+  </data>
+  <data name="Checkbox_UnTargetAndDisableForPenalty" xml:space="preserve">
+    <value>行動ペナルティ系ギミック時はターゲット解除して停止</value>
+  </data>
+  <data name="Checkbox_DPSAlwaysHardTarget" xml:space="preserve">
+    <value>常にハードターゲットを設定</value>
+  </data>
+  <data name="Label_IgnoredNPCs" xml:space="preserve">
+    <value>無視する NPC</value>
+  </data>
+  <data name="HelpText_UnTargetAndDisableForPenalty" xml:space="preserve">
+    <value>パイレティクスや加速度爆弾など、行動すると不利益を受けるギミックを検知した場合、現在のターゲットを解除し、自動ローテーションのアクション実行を停止します。</value>
+  </data>
+  <data name="HelpText_DPSAlwaysHardTarget" xml:space="preserve">
+    <value>自動ローテーションは敵を明示的にターゲットしなくても動作しますが、この設定を有効にすると攻撃実行時に常にハードターゲットを設定します。</value>
+  </data>
+  <data name="HelpText_IgnoredNPCs" xml:space="preserve">
+    <value>ここに登録した NPC は自動ローテーションの対象外になります。
 同じ NPC の全出現個体が自動ターゲットから除外されます（手動は引き続き利用可能です）。
 一覧から削除するには対象を選んで下の削除ボタンを押してください。
-追加するには NPC をターゲットした状態で /wrath ignore を実行します。</value></data>
-  <data name="Button_DeleteFromIgnored" xml:space="preserve"><value>無視リストから削除</value></data>
-  <data name="Header_HealingSettings" xml:space="preserve"><value>回復設定</value></data>
-  <data name="Label_HealingTargetingMode" xml:space="preserve"><value>回復対象モード</value></data>
-  <data name="HelpText_HealerTargetingMode" xml:space="preserve"><value>手動 - 手動で選択した対象のみ回復します。下の回復閾値を満たさない場合は、攻撃が有効なら回復せず攻撃を行います。
+追加するには NPC をターゲットした状態で /wrath ignore を実行します。</value>
+  </data>
+  <data name="Button_DeleteFromIgnored" xml:space="preserve">
+    <value>無視リストから削除</value>
+  </data>
+  <data name="Header_HealingSettings" xml:space="preserve">
+    <value>回復設定</value>
+  </data>
+  <data name="Label_HealingTargetingMode" xml:space="preserve">
+    <value>回復対象モード</value>
+  </data>
+  <data name="HelpText_HealerTargetingMode" xml:space="preserve">
+    <value>手動 - 手動で選択した対象のみ回復します。下の回復閾値を満たさない場合は、攻撃が有効なら回復せず攻撃を行います。
 現在HP%が高い対象 - 現在HP% が最も高いパーティメンバーを優先します。
-現在HP%が低い対象 - 現在HP% が最も低いパーティメンバーを優先します。</value></data>
-  <data name="Slider_SingleTargetHPP" xml:space="preserve"><value>単体回復 HP% 閾値</value></data>
-  <data name="Slider_SingleTargetRegenHPP" xml:space="preserve"><value>単体回復 HP% 閾値（対象にリジェネ / アスペクト・ベネフィクがある場合）</value></data>
-  <data name="HelpText_SingleTargetRegenHPP" xml:space="preserve"><value>通常は上の設定より低めにするのがおすすめです。</value></data>
-  <data name="Slider_SingleTargetExcogHPP" xml:space="preserve"><value>単体回復 HP% 閾値（対象に深謀遠慮の策がある場合）</value></data>
-  <data name="HelpText_SingleTargetExcogHPP" xml:space="preserve"><value>通常は上の設定より低めにするのがおすすめです。</value></data>
-  <data name="Slider_AoETargetHPP" xml:space="preserve"><value>AoE 回復 HP% 閾値</value></data>
-  <data name="Input_AoEHealTargetCount" xml:space="preserve"><value>AoE 回復機能に必要な対象数</value></data>
-  <data name="HelpText_AoEHealTargetCount" xml:space="preserve"><value>これを無効にすると AoE 回復機能を使わなくなります。有効時は、AoE 回復を使うために必要な対象数が範囲内にいることを要求します。</value></data>
-  <data name="Input_HealDelay" xml:space="preserve"><value>条件成立後に回復開始するまでの遅延（秒）</value></data>
-  <data name="HelpText_HealDelay" xml:space="preserve"><value>高くしすぎないでください。1〜2 秒程度なら自然な反応として扱いやすいです。</value></data>
-  <data name="Checkbox_AutoRez" xml:space="preserve"><value>自動蘇生</value></data>
-  <data name="HelpText_AutoRez" xml:space="preserve"><value>戦闘不能のパーティメンバーを蘇生しようとします。
-{0}、{1}、{2}、{3}、{4} に加え、{5} の {6} では {7} にも適用されます。</value></data>
-  <data name="Checkbox_AutoRezOutOfParty" xml:space="preserve"><value>パーティ外メンバーにも適用</value></data>
-  <data name="Checkbox_AutoRezRequireSwift" xml:space="preserve"><value>蘇生時に {0}/{1} を必須にする</value></data>
-  <data name="HelpText_AutoRezRequireSwift" xml:space="preserve"><value>パーティメンバーを蘇生する際、詠唱蘇生を避けるため {0} または {1} の {2} が使用可能であることを要求します。</value></data>
-  <data name="Checkbox_AutoRezDPSJobs" xml:space="preserve"><value>{0} と {1} にも適用</value></data>
-  <data name="HelpText_AutoRezDPSJobs" xml:space="preserve"><value>{0} または {1} のときも、戦闘不能のパーティメンバーを蘇生しようとします。{2} は {3} または {4} が有効なときのみ蘇生します。</value></data>
-  <data name="Checkbox_AutoRezDPSJobsHealersOnly" xml:space="preserve"><value>蘇生持ちのみを蘇生</value></data>
-  <data name="HelpText_AutoRezDPSJobsHealersOnly" xml:space="preserve"><value>{0} または {1} のとき、ヒーラーと蘇生持ちのみを蘇生対象にします。</value></data>
-  <data name="Checkbox_AutoCleanse" xml:space="preserve"><value>自動{0}</value></data>
-  <data name="HelpText_AutoCleanse" xml:space="preserve"><value>解除可能なデバフに {0} を使用します（回復を優先）。</value></data>
-  <data name="Checkbox_ManageKardia" xml:space="preserve"><value>[{0}] {1} を自動管理</value></data>
-  <data name="HelpText_ManageKardia" xml:space="preserve"><value>{0} を、敵に狙われているパーティメンバーへ付け替えます。複数いる場合はタンクを優先します。</value></data>
-  <data name="Checkbox_KardiaTanksOnly" xml:space="preserve"><value>{0} の付け替えをタンクのみに制限</value></data>
-  <data name="Checkbox_PreEmptiveHoT" xml:space="preserve"><value>[{0}/{1}/{2}/{3}] フォーカスターゲットへ事前に継続回復 / バリアを付与</value></data>
-  <data name="HelpText_PreEmptiveHoT" xml:space="preserve"><value>非戦闘時、フォーカスターゲットが敵から 30m 以内にいる場合に {0}/{1}/{2}/{3} を付与します（「戦闘中のみ」設定を無視します）。</value></data>
-  <data name="Checkbox_IncludeNPCs" xml:space="preserve"><value>友好的 NPC も回復対象にする</value></data>
-  <data name="HelpText_IncludeNPCs" xml:space="preserve"><value>ヒーラークエストのように、直接パーティへ入らない NPC を回復する必要がある場面で有効です。</value></data>
-  <data name="Checkbox_HealerAlwaysHardTarget" xml:space="preserve"><value>常にハードターゲットを設定###HealerHardTarget</value></data>
-  <data name="HelpText_HealerAlwaysHardTarget" xml:space="preserve"><value>自動ローテーションは味方を明示的にターゲットしなくても動作しますが、この設定を有効にすると回復実行時に常にハードターゲットを設定します。</value></data>
-  <data name="Label_Advanced" xml:space="preserve"><value>詳細設定</value></data>
-  <data name="Input_ThrottleDelay" xml:space="preserve"><value>スロットル間隔（ms）</value></data>
-  <data name="HelpText_ThrottleDelay" xml:space="preserve"><value>自動ローテーションはパフォーマンスのため、一定ミリ秒ごとにのみ実行するスロットルを内蔵しています。フレームレートに問題がある場合は値を上げてください。ただし高すぎると GCD が噛む副作用があるため、様子を見ながら調整してください。</value></data>
-  <data name="Checkbox_Orbwalker" xml:space="preserve"><value>Orbwalker 連携を有効化</value></data>
-  <data name="HelpText_Orbwalker" xml:space="preserve"><value>Orbwalker が詠唱中の移動をロックするため、移動中でも詠唱アクションを使えるようになります。必要に応じて Orbwalker 側の「Buffer Initial Cast」を有効にしてください。Orbwalker系プラグインの導入と有効化が必要です。</value></data>
-  <data name="Checkbox_HandleRaidwides" xml:space="preserve"><value>検知した全体攻撃に対応</value></data>
-  <data name="HelpText_HandleRaidwides" xml:space="preserve"><value>検知した全体攻撃や全体ダメージの前に、軽減や戻しのためのアクションを使おうとします。セットアップ用の {0} を除き、最大 2 アクションまで使用します。</value></data>
+現在HP%が低い対象 - 現在HP% が最も低いパーティメンバーを優先します。</value>
+  </data>
+  <data name="Slider_SingleTargetHPP" xml:space="preserve">
+    <value>単体回復 HP% 閾値</value>
+  </data>
+  <data name="Slider_SingleTargetRegenHPP" xml:space="preserve">
+    <value>単体回復 HP% 閾値（対象にリジェネ / アスペクト・ベネフィクがある場合）</value>
+  </data>
+  <data name="HelpText_SingleTargetRegenHPP" xml:space="preserve">
+    <value>通常は上の設定より低めにするのがおすすめです。</value>
+  </data>
+  <data name="Slider_SingleTargetExcogHPP" xml:space="preserve">
+    <value>単体回復 HP% 閾値（対象に深謀遠慮の策がある場合）</value>
+  </data>
+  <data name="HelpText_SingleTargetExcogHPP" xml:space="preserve">
+    <value>通常は上の設定より低めにするのがおすすめです。</value>
+  </data>
+  <data name="Slider_AoETargetHPP" xml:space="preserve">
+    <value>AoE 回復 HP% 閾値</value>
+  </data>
+  <data name="Input_AoEHealTargetCount" xml:space="preserve">
+    <value>AoE 回復機能に必要な対象数</value>
+  </data>
+  <data name="HelpText_AoEHealTargetCount" xml:space="preserve">
+    <value>これを無効にすると AoE 回復機能を使わなくなります。有効時は、AoE 回復を使うために必要な対象数が範囲内にいることを要求します。</value>
+  </data>
+  <data name="Input_HealDelay" xml:space="preserve">
+    <value>条件成立後に回復開始するまでの遅延（秒）</value>
+  </data>
+  <data name="HelpText_HealDelay" xml:space="preserve">
+    <value>高くしすぎないでください。1〜2 秒程度なら自然な反応として扱いやすいです。</value>
+  </data>
+  <data name="Checkbox_AutoRez" xml:space="preserve">
+    <value>自動蘇生</value>
+  </data>
+  <data name="HelpText_AutoRez" xml:space="preserve">
+    <value>戦闘不能のパーティメンバーを蘇生しようとします。
+{0}、{1}、{2}、{3}、{4} に加え、{5} の {6} では {7} にも適用されます。</value>
+  </data>
+  <data name="Checkbox_AutoRezOutOfParty" xml:space="preserve">
+    <value>パーティ外メンバーにも適用</value>
+  </data>
+  <data name="Checkbox_AutoRezRequireSwift" xml:space="preserve">
+    <value>蘇生時に {0}/{1} を必須にする</value>
+  </data>
+  <data name="HelpText_AutoRezRequireSwift" xml:space="preserve">
+    <value>パーティメンバーを蘇生する際、詠唱蘇生を避けるため {0} または {1} の {2} が使用可能であることを要求します。</value>
+  </data>
+  <data name="Checkbox_AutoRezDPSJobs" xml:space="preserve">
+    <value>{0} と {1} にも適用</value>
+  </data>
+  <data name="HelpText_AutoRezDPSJobs" xml:space="preserve">
+    <value>{0} または {1} のときも、戦闘不能のパーティメンバーを蘇生しようとします。{2} は {3} または {4} が有効なときのみ蘇生します。</value>
+  </data>
+  <data name="Checkbox_AutoRezDPSJobsHealersOnly" xml:space="preserve">
+    <value>蘇生持ちのみを蘇生</value>
+  </data>
+  <data name="HelpText_AutoRezDPSJobsHealersOnly" xml:space="preserve">
+    <value>{0} または {1} のとき、ヒーラーと蘇生持ちのみを蘇生対象にします。</value>
+  </data>
+  <data name="Checkbox_AutoCleanse" xml:space="preserve">
+    <value>自動{0}</value>
+  </data>
+  <data name="HelpText_AutoCleanse" xml:space="preserve">
+    <value>解除可能なデバフに {0} を使用します（回復を優先）。</value>
+  </data>
+  <data name="Checkbox_ManageKardia" xml:space="preserve">
+    <value>[{0}] {1} を自動管理</value>
+  </data>
+  <data name="HelpText_ManageKardia" xml:space="preserve">
+    <value>{0} を、敵に狙われているパーティメンバーへ付け替えます。複数いる場合はタンクを優先します。</value>
+  </data>
+  <data name="Checkbox_KardiaTanksOnly" xml:space="preserve">
+    <value>{0} の付け替えをタンクのみに制限</value>
+  </data>
+  <data name="Checkbox_PreEmptiveHoT" xml:space="preserve">
+    <value>[{0}/{1}/{2}/{3}] フォーカスターゲットへ事前に継続回復 / バリアを付与</value>
+  </data>
+  <data name="HelpText_PreEmptiveHoT" xml:space="preserve">
+    <value>非戦闘時、フォーカスターゲットが敵から 30m 以内にいる場合に {0}/{1}/{2}/{3} を付与します（「戦闘中のみ」設定を無視します）。</value>
+  </data>
+  <data name="Checkbox_IncludeNPCs" xml:space="preserve">
+    <value>友好的 NPC も回復対象にする</value>
+  </data>
+  <data name="HelpText_IncludeNPCs" xml:space="preserve">
+    <value>ヒーラークエストのように、直接パーティへ入らない NPC を回復する必要がある場面で有効です。</value>
+  </data>
+  <data name="Checkbox_HealerAlwaysHardTarget" xml:space="preserve">
+    <value>常にハードターゲットを設定###HealerHardTarget</value>
+  </data>
+  <data name="HelpText_HealerAlwaysHardTarget" xml:space="preserve">
+    <value>自動ローテーションは味方を明示的にターゲットしなくても動作しますが、この設定を有効にすると回復実行時に常にハードターゲットを設定します。</value>
+  </data>
+  <data name="Label_Advanced" xml:space="preserve">
+    <value>詳細設定</value>
+  </data>
+  <data name="Input_ThrottleDelay" xml:space="preserve">
+    <value>スロットル間隔（ms）</value>
+  </data>
+  <data name="HelpText_ThrottleDelay" xml:space="preserve">
+    <value>自動ローテーションはパフォーマンスのため、一定ミリ秒ごとにのみ実行するスロットルを内蔵しています。フレームレートに問題がある場合は値を上げてください。ただし高すぎると GCD が噛む副作用があるため、様子を見ながら調整してください。</value>
+  </data>
+  <data name="Checkbox_Orbwalker" xml:space="preserve">
+    <value>Orbwalker 連携を有効化</value>
+  </data>
+  <data name="HelpText_Orbwalker" xml:space="preserve">
+    <value>Orbwalker が詠唱中の移動をロックするため、移動中でも詠唱アクションを使えるようになります。必要に応じて Orbwalker 側の「Buffer Initial Cast」を有効にしてください。Orbwalker系プラグインの導入と有効化が必要です。</value>
+  </data>
+  <data name="Checkbox_HandleRaidwides" xml:space="preserve">
+    <value>検知した全体攻撃に対応</value>
+  </data>
+  <data name="HelpText_HandleRaidwides" xml:space="preserve">
+    <value>検知した全体攻撃や全体ダメージの前に、軽減や戻しのためのアクションを使おうとします。セットアップ用の {0} を除き、最大 3 アクションまで使用します。</value>
+  </data>
   <data name="Checkbox_HandleTankbusters" xml:space="preserve">
     <value>検知したタンク強攻撃に対応</value>
   </data>

--- a/WrathCombo/Resources/Localization/UI/AutoRotation/AutoRotationUI.ko.resx
+++ b/WrathCombo/Resources/Localization/UI/AutoRotation/AutoRotationUI.ko.resx
@@ -358,7 +358,7 @@
     <value>감지된 광역 공격 처리</value>
   </data>
   <data name="HelpText_HandleRaidwides" xml:space="preserve">
-    <value>감지된 광역 공격이나 파티 전체 피해 전에 기술을 사용해 피해를 완화하거나 파티원의 체력을 회복(최대치로 보충) 합니다. 준비용 {0}을 제외하고 최대 2개의 기술을 사용합니다.</value>
+    <value>감지된 광역 공격이나 파티 전체 피해 전에 기술을 사용해 피해를 완화하거나 파티원의 체력을 회복(최대치로 보충) 합니다. 준비용 {0}을 제외하고 최대 3개의 기술을 사용합니다.</value>
   </data>
   <data name="Checkbox_HandleTankbusters" xml:space="preserve">
     <value>감지된 탱커 버스터 대응</value>

--- a/WrathCombo/Resources/Localization/UI/AutoRotation/AutoRotationUI.resx
+++ b/WrathCombo/Resources/Localization/UI/AutoRotation/AutoRotationUI.resx
@@ -357,7 +357,7 @@ Applies to {0}, {1}, {2}, {3}, {4}, and {5} {6} {7}</value>
     <value>Handle Detected Raidwides</value>
   </data>
   <data name="HelpText_HandleRaidwides" xml:space="preserve">
-    <value>Will try to use actions before detected raidwides or group damage to either mitigate or top-off party members. Max 2 actions (excluding {0} for setup)</value>
+    <value>Will try to use actions before detected raidwides or group damage to either mitigate or top-off party members. Max 3 actions (excluding {0} for setup)</value>
   </data>
   <data name="Checkbox_HandleTankbusters" xml:space="preserve">
     <value>Handle Detected Tankbusters</value>

--- a/WrathCombo/Window/Functions/UserConfig.cs
+++ b/WrathCombo/Window/Functions/UserConfig.cs
@@ -95,9 +95,10 @@ public static class UserConfig
                 ImGui.SameLine();
                 ImGui.SetCursorPosX(currentPos.X);
                 ImGui.PushItemWidth(itemWidth);
-                inputChanged |= ImGui.SliderInt($"{newLines}###{config}", ref output, minValue, maxValue);
+                if (ImGui.SliderInt($"{newLines}###{config}", ref output, minValue, maxValue))
+                    Configuration.CustomIntValues[config] = output;
 
-                if (inputChanged)
+                if (ImGui.IsItemDeactivatedAfterEdit())
                 {
                     if (output % sliderIncrement != 0)
                     {
@@ -107,9 +108,10 @@ public static class UserConfig
                     }
 
                     Configuration.SetCustomIntValue(config, output);
+                    return true;
                 }
 
-                return inputChanged;
+                return false;
             }
         };
 
@@ -165,7 +167,6 @@ public static class UserConfig
             IsSubBox = true,
             ContentsAction = () =>
             {
-                bool inputChanged = false;
                 Vector2 currentPos = ImGui.GetCursorPos();
                 ImGui.SetCursorPosX(currentPos.X + itemWidth);
                 ImGui.PushTextWrapPos(wrapPos);
@@ -210,9 +211,10 @@ public static class UserConfig
                 ImGui.SameLine();
                 ImGui.SetCursorPosX(currentPos.X);
                 ImGui.PushItemWidth(itemWidth);
-                inputChanged |= ImGui.SliderFloat($"{newLines}###{config}", ref output, minValue, maxValue, format);
+                if (ImGui.SliderFloat($"{newLines}###{config}", ref output, minValue, maxValue, format))
+                    Configuration.CustomFloatValues[config] = output;
 
-                if (inputChanged)
+                if (ImGui.IsItemDeactivatedAfterEdit())
                     Configuration.SetCustomFloatValue(config, output);
             }
         };

--- a/WrathCombo/Window/Tabs/Debug.cs
+++ b/WrathCombo/Window/Tabs/Debug.cs
@@ -1003,6 +1003,22 @@ internal class Debug : ConfigWindow, IDisposable
             ImGui.Unindent();
         }
 
+        if (ImGui.CollapsingHeader("Auto-Rotation Info"))
+        {
+            ImGui.Indent();
+            if (ImGui.CollapsingHeader("Heal Targets"))
+            {
+                ImGui.Indent();
+                foreach (var t in AutoRotationController.HealerTargeting.HealTargets())
+                {
+                    if (ImGui.CollapsingHeader($"{t.Name}###{t.SafeGameObjectId}"))
+                    DrawTargetInfo(t);
+                }
+                ImGui.Unindent();
+            }
+            ImGui.Unindent();
+        }
+
         #endregion
 
         ImGuiEx.Spacing(new Vector2(0f, SpacingSmall));


### PR DESCRIPTION
Status checks
- New set of statuses added for "do not heal" (ala Windwurst final boss with a 99% recovery down debuff). Currently only debuff, however may be expanded if there's other checks where healing someone based on a status is a bad idea.
- Add all ARR Ifrits to invincibility checks when the nails are up.

Auto-rotation
- Refactored the heal target code slightly to be less redundant, and added in the check for the do not heal statuses.
- Highest/Lowest Max final tie breaker will be distance when multiple targets exist with the same max and current HP.
- Now allows abilities to be queued according to the setting rather than whenever animation lock is over. (This is for you MNK psychos)

MNK
- Added a combo action check to the weave actions as an optional for InCombat as it gets set earlier if solo.

WHM
- Fixed borked configs, which were also causing constant save calls due to being misconfigured.

Configs
- Sliders now only save to the config once the input is finished being edited, rather than constantly whilst the slider is being dragged.

TTS Alerts
- No longer plays any lingering alerts if 10s have passed and the VFX is lingering.