### PR TITLE
[MCH] Updates on Reassemble 

### DIFF
--- a/WrathCombo/Combos/PvE/DRG/DRG.cs
+++ b/WrathCombo/Combos/PvE/DRG/DRG.cs
@@ -372,13 +372,13 @@ internal partial class DRG : Melee
                     {
                         if (IsEnabled(Preset.DRG_AoE_BattleLitany) &&
                             ActionReady(BattleLitany) &&
-                            GetTargetHPPercent() > DRG_AoE_BattleLitanyHPTreshold)
+                            GetTargetHPPercent() > DRG_AoE_BattleLitanyHPThreshold)
                             return BattleLitany;
 
                         //Lance Charge Feature
                         if (IsEnabled(Preset.DRG_AoE_LanceCharge) &&
                             ActionReady(LanceCharge) &&
-                            GetTargetHPPercent() > DRG_AoE_LanceChargeHPTreshold)
+                            GetTargetHPPercent() > DRG_AoE_LanceChargeHPThreshold)
                             return LanceCharge;
 
                         //Life Surge Feature
@@ -406,7 +406,7 @@ internal partial class DRG : Melee
                         if (IsEnabled(Preset.DRG_AoE_Geirskogul) &&
                             ActionReady(Geirskogul) &&
                             !LoTDTimerActive && InActionRange(Geirskogul) &&
-                            GetTargetHPPercent() > DRG_AoE_GeirskogulHPTreshold)
+                            GetTargetHPPercent() > DRG_AoE_GeirskogulHPThreshold)
                             return Geirskogul;
 
                         //Wyrmwind Thrust Feature
@@ -469,7 +469,7 @@ internal partial class DRG : Melee
                             (!DRG_AoE_DragonfireDiveMovingOrInRanged[0] || !IsMoving()) &&
                             (!DRG_AoE_DragonfireDiveMovingOrInRanged[1] || InMeleeRange()) &&
                             !HasStatusEffect(Buffs.DragonsFlight) &&
-                            GetTargetHPPercent() > DRG_AoE_DragonfireDiveHPTreshold &&
+                            GetTargetHPPercent() > DRG_AoE_DragonfireDiveHPThreshold &&
                             (LoTDTimerActive || !LevelChecked(Geirskogul)))
                             return DragonfireDive;
                     }

--- a/WrathCombo/Combos/PvE/DRG/DRG_Config.cs
+++ b/WrathCombo/Combos/PvE/DRG/DRG_Config.cs
@@ -138,17 +138,17 @@ internal partial class DRG
                     break;
 
                 case Preset.DRG_AoE_BattleLitany:
-                    DrawSliderInt(0, 100, DRG_AoE_BattleLitanyHPTreshold,
+                    DrawSliderInt(0, 100, DRG_AoE_BattleLitanyHPThreshold,
                         Generics.StopEnemyHpPercent);
                     break;
 
                 case Preset.DRG_AoE_LanceCharge:
-                    DrawSliderInt(0, 100, DRG_AoE_LanceChargeHPTreshold,
+                    DrawSliderInt(0, 100, DRG_AoE_LanceChargeHPThreshold,
                         Generics.StopEnemyHpPercent);
                     break;
 
                 case Preset.DRG_AoE_Geirskogul:
-                    DrawSliderInt(0, 100, DRG_AoE_GeirskogulHPTreshold,
+                    DrawSliderInt(0, 100, DRG_AoE_GeirskogulHPThreshold,
                         Generics.StopEnemyHpPercent);
                     break;
 
@@ -163,7 +163,7 @@ internal partial class DRG
                     break;
 
                 case Preset.DRG_AoE_DragonfireDive:
-                    DrawSliderInt(0, 100, DRG_AoE_DragonfireDiveHPTreshold,
+                    DrawSliderInt(0, 100, DRG_AoE_DragonfireDiveHPThreshold,
                         Generics.StopEnemyHpPercent);
 
                     DrawHorizontalMultiChoice(DRG_AoE_DragonfireDiveMovingOrInRanged,
@@ -218,10 +218,10 @@ internal partial class DRG
             DRG_ManualTN = new("DRG_ManualTN"),
             DRG_ST_SecondWindHPThreshold = new("DRG_ST_SecondWindHPThreshold", 40),
             DRG_ST_BloodbathHPThreshold = new("DRG_ST_BloodbathHPThreshold", 30),
-            DRG_AoE_BattleLitanyHPTreshold = new("DRG_AoE_BattleLitanyHPTreshold", 25),
-            DRG_AoE_LanceChargeHPTreshold = new("DRG_AoE_LanceChargeHPTreshold", 25),
-            DRG_AoE_GeirskogulHPTreshold = new("DRG_AoE_GeirskogulHPTreshold", 25),
-            DRG_AoE_DragonfireDiveHPTreshold = new("DRG_AoE_DragonfireDiveHPTreshold", 25),
+            DRG_AoE_BattleLitanyHPThreshold = new("DRG_AoE_BattleLitanyHPThreshold", 25),
+            DRG_AoE_LanceChargeHPThreshold = new("DRG_AoE_LanceChargeHPThreshold", 25),
+            DRG_AoE_GeirskogulHPThreshold = new("DRG_AoE_GeirskogulHPThreshold", 25),
+            DRG_AoE_DragonfireDiveHPThreshold = new("DRG_AoE_DragonfireDiveHPThreshold", 25),
             DRG_AoE_SecondWindHPThreshold = new("DRG_AoE_SecondWindHPThreshold", 40),
             DRG_AoE_BloodbathHPThreshold = new("DRG_AoE_BloodbathHPThreshold", 30);
 

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -187,10 +187,6 @@ internal partial class MCH : PhysicalRanged
                     if (ActionReady(OriginalHook(RookAutoturret)) && Battery is 100)
                         return OriginalHook(RookAutoturret);
 
-                    if (ActionReady(Reassemble) && !HasStatusEffect(Buffs.Reassembled) &&
-                        CanUseReassembleAoE())
-                        return Reassemble;
-
                     //gauss and ricochet outside HC
                     if (CanGaussRound &&
                         (!JustUsed(OriginalHook(GaussRound), 2.5f) || !LevelChecked(Ricochet)))
@@ -487,13 +483,6 @@ internal partial class MCH : PhysicalRanged
                         Battery >= MCH_AoE_TurretBatteryUsage &&
                         GetTargetHPPercent() > MCH_AoE_QueenHpThreshold)
                         return OriginalHook(RookAutoturret);
-
-                    if (IsEnabled(Preset.MCH_AoE_Adv_Reassemble) &&
-                        GetTargetHPPercent() > MCH_AoE_ReassembleHPThreshold &&
-                        ActionReady(Reassemble) && !HasStatusEffect(Buffs.Reassembled) &&
-                        GetRemainingCharges(Reassemble) > MCH_AoE_ReassemblePool &&
-                        CanUseReassembleAoE())
-                        return Reassemble;
 
                     //gauss and ricochet outside HC
                     if (IsEnabled(Preset.MCH_AoE_Adv_GaussRicochet))

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -39,7 +39,7 @@ internal partial class MCH : PhysicalRanged
                 if (TargetIsBoss() &&
                     CanApplyStatus(CurrentTarget, Debuffs.Wildfire) &&
                     ActionReady(Wildfire) && JustUsed(Hypercharge, GCD + 0.9f) &&
-                    !IsWildfireActive)
+                    !HasStatusEffect(Buffs.Wildfire))
                     return Wildfire;
 
                 // Hypercharge
@@ -61,18 +61,18 @@ internal partial class MCH : PhysicalRanged
                     // Reassemble
                     if (CanReassemble())
                         return Reassemble;
-
+                    
                     // BarrelStabilizer
                     if (ActionReady(BarrelStabilizer) &&
                         TargetIsBoss() &&
                         GetCooldownRemainingTime(Wildfire) <= 20 &&
                         !HasStatusEffect(Buffs.FullMetalMachinist))
                         return BarrelStabilizer;
-
+                    
                     // Queen
                     if (CanQueen())
                         return OriginalHook(RookAutoturret);
-
+                    
                     // Gauss Round and Ricochet outside HC
                     if (JustUsed(OriginalHook(AirAnchor), 2f) ||
                         JustUsed(Chainsaw, 2f) ||
@@ -122,7 +122,7 @@ internal partial class MCH : PhysicalRanged
 
                 if (ComboAction is SlugShot && !LevelChecked(Drill) &&
                     LevelChecked(CleanShot) && !HasStatusEffect(Buffs.Reassembled) &&
-                    !IsWildfireActive && ActionReady(Reassemble))
+                    ActionReady(Reassemble))
                     return Reassemble;
 
                 if (ComboAction is SlugShot && ActionReady(OriginalHook(CleanShot)))
@@ -182,7 +182,13 @@ internal partial class MCH : PhysicalRanged
                     if (ActionReady(OriginalHook(RookAutoturret)) && Battery is 100)
                         return OriginalHook(RookAutoturret);
 
-                    if (CanReassembleAoE())
+                    if (ActionReady(Reassemble) && !HasStatusEffect(Buffs.Wildfire) &&
+                        !HasStatusEffect(Buffs.Reassembled) && !JustUsed(Flamethrower, 10f) &&
+                        GetRemainingCharges(Reassemble) > MCH_AoE_ReassemblePool &&
+                        (LevelChecked(Scattergun) ||
+                         GetCooldownRemainingTime(AirAnchor) < GCD && LevelChecked(AirAnchor) ||
+                         GetCooldownRemainingTime(Chainsaw) < GCD && LevelChecked(Chainsaw) ||
+                         HasStatusEffect(Buffs.ExcavatorReady) && LevelChecked(Excavator)))
                         return Reassemble;
 
                     //gauss and ricochet outside HC
@@ -215,8 +221,19 @@ internal partial class MCH : PhysicalRanged
                     !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(3))
                     return Flamethrower;
 
-                if (CanUseAoETools(ref actionID))
-                    return actionID;
+                if (ActionReady(BioBlaster) && !HasStatusEffect(Debuffs.Bioblaster, CurrentTarget) &&
+                    !HasStatusEffect(Buffs.Reassembled) && CanApplyStatus(CurrentTarget, Debuffs.Bioblaster))
+                    return BioBlaster;
+
+                if (ActionReady(Excavator))
+                    return Excavator;
+
+                if (ActionReady(Chainsaw) &&
+                    !HasStatusEffect(Buffs.ExcavatorReady))
+                    return Chainsaw;
+
+                if (ActionReady(OriginalHook(AirAnchor)))
+                    return OriginalHook(AirAnchor);
             }
 
             if (ActionReady(OriginalHook(Heatblast)) && IsOverheated)
@@ -279,7 +296,7 @@ internal partial class MCH : PhysicalRanged
                     (MCH_ST_WildfireBossOption == 0 && GetTargetHPPercent() > HPThresholdWildFire || TargetIsBoss()) &&
                     CanApplyStatus(CurrentTarget, Debuffs.Wildfire) &&
                     ActionReady(Wildfire) && JustUsed(Hypercharge, GCD + 0.9f) &&
-                    !IsWildfireActive)
+                    !HasStatusEffect(Buffs.Wildfire))
                     return Wildfire;
 
                 // Hypercharge
@@ -335,7 +352,7 @@ internal partial class MCH : PhysicalRanged
                     if (IsEnabled(Preset.MCH_ST_Adv_GaussRicochet) &&
                         (JustUsed(Drill, 2f) ||
                          JustUsed(OriginalHook(AirAnchor), 2f) ||
-                         JustUsed(Chainsaw, 2f) ||
+                         JustUsed(Chainsaw, 2f)||
                          JustUsed(Excavator, 2f)))
                     {
                         if (MCH_ST_GaussOnlyOrBoth == 0)
@@ -401,7 +418,7 @@ internal partial class MCH : PhysicalRanged
 
                 if (IsEnabled(Preset.MCH_ST_Adv_Reassemble) &&
                     ComboAction is SlugShot && !LevelChecked(Drill) && ActionReady(CleanShot) &&
-                    !HasStatusEffect(Buffs.Reassembled) && !IsWildfireActive && ActionReady(Reassemble))
+                    !HasStatusEffect(Buffs.Reassembled) && ActionReady(Reassemble))
                     return Reassemble;
 
                 if (ComboAction is SlugShot && ActionReady(OriginalHook(CleanShot)))
@@ -477,7 +494,13 @@ internal partial class MCH : PhysicalRanged
 
                     if (IsEnabled(Preset.MCH_AoE_Adv_Reassemble) &&
                         GetTargetHPPercent() > MCH_AoE_ReassembleHPThreshold &&
-                        CanReassembleAoE())
+                        ActionReady(Reassemble) && !HasStatusEffect(Buffs.Reassembled) &&
+                        !JustUsed(Flamethrower, 10f) &&
+                        GetRemainingCharges(Reassemble) > MCH_AoE_ReassemblePool &&
+                        (LevelChecked(Scattergun) ||
+                         GetCooldownRemainingTime(AirAnchor) < GCD && LevelChecked(AirAnchor) ||
+                         GetCooldownRemainingTime(Chainsaw) < GCD && LevelChecked(Chainsaw) ||
+                         HasStatusEffect(Buffs.ExcavatorReady) && LevelChecked(Excavator)))
                         return Reassemble;
 
                     //gauss and ricochet outside HC
@@ -517,9 +540,21 @@ internal partial class MCH : PhysicalRanged
                     return Flamethrower;
 
                 if (IsEnabled(Preset.MCH_AoE_Adv_Tools) &&
-                    GetTargetHPPercent() >= MCH_AoE_ToolsHPThreshold &&
-                    CanUseAoETools(ref actionID, MCH_AoE_AirAnchor))
-                    return actionID;
+                    GetTargetHPPercent() >= MCH_AoE_ToolsHPThreshold)
+                {
+                    if (ActionReady(BioBlaster) && !HasStatusEffect(Debuffs.Bioblaster, CurrentTarget) &&
+                        !HasStatusEffect(Buffs.Reassembled) && CanApplyStatus(CurrentTarget, Debuffs.Bioblaster))
+                        return BioBlaster;
+
+                    if (ActionReady(Excavator))
+                        return Excavator;
+
+                    if (ActionReady(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady))
+                        return Chainsaw;
+
+                    if (ActionReady(OriginalHook(AirAnchor)) && MCH_AoE_AirAnchor)
+                        return OriginalHook(AirAnchor);
+                }
             }
 
             if (ActionReady(OriginalHook(Heatblast)) && IsOverheated)
@@ -604,7 +639,7 @@ internal partial class MCH : PhysicalRanged
 
             if (IsEnabled(Preset.MCH_Heatblast_Wildfire) &&
                 ActionReady(Wildfire) && JustUsed(Hypercharge) &&
-                !IsWildfireActive &&
+                !HasStatusEffect(Buffs.Wildfire) &&
                 CanApplyStatus(CurrentTarget, Debuffs.Wildfire))
                 return Wildfire;
 

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -174,6 +174,11 @@ internal partial class MCH : PhysicalRanged
 
                 if (!IsOverheated)
                 {
+                    if (ActionReady(Reassemble) &&
+                        !HasStatusEffect(Buffs.Reassembled) &&
+                        CanUseReassembleAoE())
+                        return Reassemble;
+
                     // BarrelStabilizer
                     if (ActionReady(BarrelStabilizer) &&
                         !HasStatusEffect(Buffs.FullMetalMachinist))
@@ -182,7 +187,8 @@ internal partial class MCH : PhysicalRanged
                     if (ActionReady(OriginalHook(RookAutoturret)) && Battery is 100)
                         return OriginalHook(RookAutoturret);
 
-                    if (CanReassembleAoE())
+                    if (ActionReady(Reassemble) && !HasStatusEffect(Buffs.Reassembled) &&
+                        CanUseReassembleAoE())
                         return Reassemble;
 
                     //gauss and ricochet outside HC
@@ -215,19 +221,8 @@ internal partial class MCH : PhysicalRanged
                     !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(3))
                     return Flamethrower;
 
-                if (ActionReady(BioBlaster) && !HasStatusEffect(Debuffs.Bioblaster, CurrentTarget) &&
-                    !HasStatusEffect(Buffs.Reassembled) && CanApplyStatus(CurrentTarget, Debuffs.Bioblaster))
-                    return BioBlaster;
-
-                if (ActionReady(Excavator))
-                    return Excavator;
-
-                if (ActionReady(Chainsaw) &&
-                    !HasStatusEffect(Buffs.ExcavatorReady))
-                    return Chainsaw;
-
-                if (ActionReady(OriginalHook(AirAnchor)))
-                    return OriginalHook(AirAnchor);
+                if (CanUseAoETools(ref actionID))
+                    return actionID;
             }
 
             if (ActionReady(OriginalHook(Heatblast)) && IsOverheated)
@@ -474,6 +469,13 @@ internal partial class MCH : PhysicalRanged
 
                 if (!IsOverheated)
                 {
+                    if (IsEnabled(Preset.MCH_AoE_Adv_Reassemble) &&
+                        GetTargetHPPercent() > MCH_AoE_ReassembleHPThreshold &&
+                        ActionReady(Reassemble) && !HasStatusEffect(Buffs.Reassembled) &&
+                        GetRemainingCharges(Reassemble) > MCH_AoE_ReassemblePool &&
+                        CanUseReassembleAoE())
+                        return Reassemble;
+
                     // BarrelStabilizer
                     if (IsEnabled(Preset.MCH_AoE_Adv_Stabilizer) &&
                         ActionReady(BarrelStabilizer) && !HasStatusEffect(Buffs.FullMetalMachinist) &&
@@ -488,7 +490,9 @@ internal partial class MCH : PhysicalRanged
 
                     if (IsEnabled(Preset.MCH_AoE_Adv_Reassemble) &&
                         GetTargetHPPercent() > MCH_AoE_ReassembleHPThreshold &&
-                        CanReassembleAoE())
+                        ActionReady(Reassemble) && !HasStatusEffect(Buffs.Reassembled) &&
+                        GetRemainingCharges(Reassemble) > MCH_AoE_ReassemblePool &&
+                        CanUseReassembleAoE())
                         return Reassemble;
 
                     //gauss and ricochet outside HC
@@ -527,22 +531,10 @@ internal partial class MCH : PhysicalRanged
                     GetTargetHPPercent() > MCH_AoE_FlamethrowerHPOption)
                     return Flamethrower;
 
-                if (IsEnabled(Preset.MCH_AoE_Adv_Tools) &&
-                    GetTargetHPPercent() >= MCH_AoE_ToolsHPThreshold)
-                {
-                    if (ActionReady(BioBlaster) && !HasStatusEffect(Debuffs.Bioblaster, CurrentTarget) &&
-                        !HasStatusEffect(Buffs.Reassembled) && CanApplyStatus(CurrentTarget, Debuffs.Bioblaster))
-                        return BioBlaster;
-
-                    if (ActionReady(Excavator))
-                        return Excavator;
-
-                    if (ActionReady(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady))
-                        return Chainsaw;
-
-                    if (ActionReady(OriginalHook(AirAnchor)) && MCH_AoE_AirAnchor)
-                        return OriginalHook(AirAnchor);
-                }
+                if ((!IsEnabled(Preset.MCH_AoE_Adv_Tools) ||
+                     GetTargetHPPercent() >= MCH_AoE_ToolsHPThreshold) &&
+                    CanUseAoETools(ref actionID, MCH_AoE_AirAnchor))
+                    return actionID;
             }
 
             if (ActionReady(OriginalHook(Heatblast)) && IsOverheated)

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -39,7 +39,7 @@ internal partial class MCH : PhysicalRanged
                 if (TargetIsBoss() &&
                     CanApplyStatus(CurrentTarget, Debuffs.Wildfire) &&
                     ActionReady(Wildfire) && JustUsed(Hypercharge, GCD + 0.9f) &&
-                    !HasStatusEffect(Buffs.Wildfire))
+                    !IsWildfireActive)
                     return Wildfire;
 
                 // Hypercharge
@@ -61,18 +61,18 @@ internal partial class MCH : PhysicalRanged
                     // Reassemble
                     if (CanReassemble())
                         return Reassemble;
-                    
+
                     // BarrelStabilizer
                     if (ActionReady(BarrelStabilizer) &&
                         TargetIsBoss() &&
                         GetCooldownRemainingTime(Wildfire) <= 20 &&
                         !HasStatusEffect(Buffs.FullMetalMachinist))
                         return BarrelStabilizer;
-                    
+
                     // Queen
                     if (CanQueen())
                         return OriginalHook(RookAutoturret);
-                    
+
                     // Gauss Round and Ricochet outside HC
                     if (JustUsed(OriginalHook(AirAnchor), 2f) ||
                         JustUsed(Chainsaw, 2f) ||
@@ -122,7 +122,7 @@ internal partial class MCH : PhysicalRanged
 
                 if (ComboAction is SlugShot && !LevelChecked(Drill) &&
                     LevelChecked(CleanShot) && !HasStatusEffect(Buffs.Reassembled) &&
-                    ActionReady(Reassemble))
+                    !IsWildfireActive && ActionReady(Reassemble))
                     return Reassemble;
 
                 if (ComboAction is SlugShot && ActionReady(OriginalHook(CleanShot)))
@@ -182,13 +182,7 @@ internal partial class MCH : PhysicalRanged
                     if (ActionReady(OriginalHook(RookAutoturret)) && Battery is 100)
                         return OriginalHook(RookAutoturret);
 
-                    if (ActionReady(Reassemble) && !HasStatusEffect(Buffs.Wildfire) &&
-                        !HasStatusEffect(Buffs.Reassembled) && !JustUsed(Flamethrower, 10f) &&
-                        GetRemainingCharges(Reassemble) > MCH_AoE_ReassemblePool &&
-                        (LevelChecked(Scattergun) ||
-                         GetCooldownRemainingTime(AirAnchor) < GCD && LevelChecked(AirAnchor) ||
-                         GetCooldownRemainingTime(Chainsaw) < GCD && LevelChecked(Chainsaw) ||
-                         HasStatusEffect(Buffs.ExcavatorReady) && LevelChecked(Excavator)))
+                    if (CanReassembleAoE())
                         return Reassemble;
 
                     //gauss and ricochet outside HC
@@ -221,19 +215,8 @@ internal partial class MCH : PhysicalRanged
                     !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(3))
                     return Flamethrower;
 
-                if (ActionReady(BioBlaster) && !HasStatusEffect(Debuffs.Bioblaster, CurrentTarget) &&
-                    !HasStatusEffect(Buffs.Reassembled) && CanApplyStatus(CurrentTarget, Debuffs.Bioblaster))
-                    return BioBlaster;
-
-                if (ActionReady(Excavator))
-                    return Excavator;
-
-                if (ActionReady(Chainsaw) &&
-                    !HasStatusEffect(Buffs.ExcavatorReady))
-                    return Chainsaw;
-
-                if (ActionReady(OriginalHook(AirAnchor)))
-                    return OriginalHook(AirAnchor);
+                if (CanUseAoETools(ref actionID))
+                    return actionID;
             }
 
             if (ActionReady(OriginalHook(Heatblast)) && IsOverheated)
@@ -296,7 +279,7 @@ internal partial class MCH : PhysicalRanged
                     (MCH_ST_WildfireBossOption == 0 && GetTargetHPPercent() > HPThresholdWildFire || TargetIsBoss()) &&
                     CanApplyStatus(CurrentTarget, Debuffs.Wildfire) &&
                     ActionReady(Wildfire) && JustUsed(Hypercharge, GCD + 0.9f) &&
-                    !HasStatusEffect(Buffs.Wildfire))
+                    !IsWildfireActive)
                     return Wildfire;
 
                 // Hypercharge
@@ -352,7 +335,7 @@ internal partial class MCH : PhysicalRanged
                     if (IsEnabled(Preset.MCH_ST_Adv_GaussRicochet) &&
                         (JustUsed(Drill, 2f) ||
                          JustUsed(OriginalHook(AirAnchor), 2f) ||
-                         JustUsed(Chainsaw, 2f)||
+                         JustUsed(Chainsaw, 2f) ||
                          JustUsed(Excavator, 2f)))
                     {
                         if (MCH_ST_GaussOnlyOrBoth == 0)
@@ -418,7 +401,7 @@ internal partial class MCH : PhysicalRanged
 
                 if (IsEnabled(Preset.MCH_ST_Adv_Reassemble) &&
                     ComboAction is SlugShot && !LevelChecked(Drill) && ActionReady(CleanShot) &&
-                    !HasStatusEffect(Buffs.Reassembled) && ActionReady(Reassemble))
+                    !HasStatusEffect(Buffs.Reassembled) && !IsWildfireActive && ActionReady(Reassemble))
                     return Reassemble;
 
                 if (ComboAction is SlugShot && ActionReady(OriginalHook(CleanShot)))
@@ -494,13 +477,7 @@ internal partial class MCH : PhysicalRanged
 
                     if (IsEnabled(Preset.MCH_AoE_Adv_Reassemble) &&
                         GetTargetHPPercent() > MCH_AoE_ReassembleHPThreshold &&
-                        ActionReady(Reassemble) && !HasStatusEffect(Buffs.Reassembled) &&
-                        !JustUsed(Flamethrower, 10f) &&
-                        GetRemainingCharges(Reassemble) > MCH_AoE_ReassemblePool &&
-                        (LevelChecked(Scattergun) ||
-                         GetCooldownRemainingTime(AirAnchor) < GCD && LevelChecked(AirAnchor) ||
-                         GetCooldownRemainingTime(Chainsaw) < GCD && LevelChecked(Chainsaw) ||
-                         HasStatusEffect(Buffs.ExcavatorReady) && LevelChecked(Excavator)))
+                        CanReassembleAoE())
                         return Reassemble;
 
                     //gauss and ricochet outside HC
@@ -540,21 +517,9 @@ internal partial class MCH : PhysicalRanged
                     return Flamethrower;
 
                 if (IsEnabled(Preset.MCH_AoE_Adv_Tools) &&
-                    GetTargetHPPercent() >= MCH_AoE_ToolsHPThreshold)
-                {
-                    if (ActionReady(BioBlaster) && !HasStatusEffect(Debuffs.Bioblaster, CurrentTarget) &&
-                        !HasStatusEffect(Buffs.Reassembled) && CanApplyStatus(CurrentTarget, Debuffs.Bioblaster))
-                        return BioBlaster;
-
-                    if (ActionReady(Excavator))
-                        return Excavator;
-
-                    if (ActionReady(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady))
-                        return Chainsaw;
-
-                    if (ActionReady(OriginalHook(AirAnchor)) && MCH_AoE_AirAnchor)
-                        return OriginalHook(AirAnchor);
-                }
+                    GetTargetHPPercent() >= MCH_AoE_ToolsHPThreshold &&
+                    CanUseAoETools(ref actionID, MCH_AoE_AirAnchor))
+                    return actionID;
             }
 
             if (ActionReady(OriginalHook(Heatblast)) && IsOverheated)
@@ -639,7 +604,7 @@ internal partial class MCH : PhysicalRanged
 
             if (IsEnabled(Preset.MCH_Heatblast_Wildfire) &&
                 ActionReady(Wildfire) && JustUsed(Hypercharge) &&
-                !HasStatusEffect(Buffs.Wildfire) &&
+                !IsWildfireActive &&
                 CanApplyStatus(CurrentTarget, Debuffs.Wildfire))
                 return Wildfire;
 
@@ -689,7 +654,7 @@ internal partial class MCH : PhysicalRanged
                 CanWeave() && JustUsed(OriginalHook(AutoCrossbow), 1f) && !HasWeaved())
             {
                 if (ActionReady(OriginalHook(GaussRound)) &&
-                    CanGaussRound || !LevelChecked(Ricochet))
+                    (CanGaussRound || !LevelChecked(Ricochet)))
                     return OriginalHook(GaussRound);
 
                 if (ActionReady(OriginalHook(Ricochet)) && CanRicochet)

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -182,13 +182,7 @@ internal partial class MCH : PhysicalRanged
                     if (ActionReady(OriginalHook(RookAutoturret)) && Battery is 100)
                         return OriginalHook(RookAutoturret);
 
-                    if (ActionReady(Reassemble) && !HasStatusEffect(Buffs.Wildfire) &&
-                        !HasStatusEffect(Buffs.Reassembled) && !JustUsed(Flamethrower, 10f) &&
-                        GetRemainingCharges(Reassemble) > MCH_AoE_ReassemblePool &&
-                        (LevelChecked(Scattergun) ||
-                         GetCooldownRemainingTime(AirAnchor) < GCD && LevelChecked(AirAnchor) ||
-                         GetCooldownRemainingTime(Chainsaw) < GCD && LevelChecked(Chainsaw) ||
-                         HasStatusEffect(Buffs.ExcavatorReady) && LevelChecked(Excavator)))
+                    if (CanReassembleAoE())
                         return Reassemble;
 
                     //gauss and ricochet outside HC
@@ -494,13 +488,7 @@ internal partial class MCH : PhysicalRanged
 
                     if (IsEnabled(Preset.MCH_AoE_Adv_Reassemble) &&
                         GetTargetHPPercent() > MCH_AoE_ReassembleHPThreshold &&
-                        ActionReady(Reassemble) && !HasStatusEffect(Buffs.Reassembled) &&
-                        !JustUsed(Flamethrower, 10f) &&
-                        GetRemainingCharges(Reassemble) > MCH_AoE_ReassemblePool &&
-                        (LevelChecked(Scattergun) ||
-                         GetCooldownRemainingTime(AirAnchor) < GCD && LevelChecked(AirAnchor) ||
-                         GetCooldownRemainingTime(Chainsaw) < GCD && LevelChecked(Chainsaw) ||
-                         HasStatusEffect(Buffs.ExcavatorReady) && LevelChecked(Excavator)))
+                        CanReassembleAoE())
                         return Reassemble;
 
                     //gauss and ricochet outside HC

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -61,18 +61,18 @@ internal partial class MCH : PhysicalRanged
                     // Reassemble
                     if (CanReassemble())
                         return Reassemble;
-                    
+
                     // BarrelStabilizer
                     if (ActionReady(BarrelStabilizer) &&
                         TargetIsBoss() &&
                         GetCooldownRemainingTime(Wildfire) <= 20 &&
                         !HasStatusEffect(Buffs.FullMetalMachinist))
                         return BarrelStabilizer;
-                    
+
                     // Queen
                     if (CanQueen())
                         return OriginalHook(RookAutoturret);
-                    
+
                     // Gauss Round and Ricochet outside HC
                     if (JustUsed(OriginalHook(AirAnchor), 2f) ||
                         JustUsed(Chainsaw, 2f) ||
@@ -259,7 +259,7 @@ internal partial class MCH : PhysicalRanged
 
             // Opener
             if (IsEnabled(Preset.MCH_ST_Adv_Opener) &&
-                HasBattleTarget() &&
+                (MCH_HaveTarget == 1 || HasBattleTarget()) &&
                 Opener().FullOpener(ref actionID))
                 return actionID;
 
@@ -352,7 +352,7 @@ internal partial class MCH : PhysicalRanged
                     if (IsEnabled(Preset.MCH_ST_Adv_GaussRicochet) &&
                         (JustUsed(Drill, 2f) ||
                          JustUsed(OriginalHook(AirAnchor), 2f) ||
-                         JustUsed(Chainsaw, 2f)||
+                         JustUsed(Chainsaw, 2f) ||
                          JustUsed(Excavator, 2f)))
                     {
                         if (MCH_ST_GaussOnlyOrBoth == 0)

--- a/WrathCombo/Combos/PvE/MCH/MCH_Config.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Config.cs
@@ -40,11 +40,11 @@ internal partial class MCH
 
                 case Preset.MCH_ST_Adv_WildFire:
                     DrawHorizontalRadioButton(MCH_ST_WildfireBossOption,
-                        Generics.AllContent,
-                        FormatAndCache(Generics.Use0RegardlessOfContent, Wildfire.ActionName()), 0);
+                        Generics.AllEnemies,
+                        FormatAndCache(Generics.Use0RegardlessOfTarget, Wildfire.ActionName()), 0);
 
                     DrawHorizontalRadioButton(MCH_ST_WildfireBossOption,
-                        Generics.BossOnlyContent,
+                        Generics.OnlyBoss,
                         FormatAndCache(Generics.OnlyUseWhenTargetIsBoss, Wildfire.ActionName()), 1);
 
                     if (MCH_ST_WildfireBossOption == 0)
@@ -69,11 +69,11 @@ internal partial class MCH
 
                 case Preset.MCH_ST_Adv_Stabilizer:
                     DrawHorizontalRadioButton(MCH_ST_BarrelStabilizerBossOption,
-                        Generics.AllContent,
-                        FormatAndCache(Generics.Use0RegardlessOfContent, BarrelStabilizer.ActionName()), 0);
+                        Generics.AllEnemies,
+                        FormatAndCache(Generics.Use0RegardlessOfTarget, BarrelStabilizer.ActionName()), 0);
 
                     DrawHorizontalRadioButton(MCH_ST_BarrelStabilizerBossOption,
-                        Generics.BossOnlyContent,
+                        Generics.OnlyBoss,
                         FormatAndCache(Generics.OnlyUseWhenTargetIsBoss, BarrelStabilizer.ActionName()), 1);
 
                     if (MCH_ST_BarrelStabilizerBossOption == 0)

--- a/WrathCombo/Combos/PvE/MCH/MCH_Config.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Config.cs
@@ -25,6 +25,16 @@ internal partial class MCH
                         FormatAndCache(MCH_Config.Early0Opener, Wildfire.ActionName()),
                         FormatAndCache(MCH_Config.UseEarly0Opener, Wildfire.ActionName()), 1);
 
+                    ImGui.NewLine();
+
+                    DrawHorizontalRadioButton(MCH_HaveTarget,
+                        Generics.HaveBattleTarget,
+                        Generics.RequireTarget, 0);
+
+                    DrawHorizontalRadioButton(MCH_HaveTarget,
+                        Generics.NoTarget,
+                        Generics.NoRequireTarget, 1);
+
                     DrawBossOnlyChoice(MCH_Balance_Content);
                     break;
 
@@ -306,6 +316,7 @@ internal partial class MCH
             //ST
             MCH_Balance_Content = new("MCH_Balance_Content", 1),
             MCH_SelectedOpener = new("MCH_SelectedOpener"),
+            MCH_HaveTarget = new("MCH_HaveTarget"),
             MCH_ST_QueenOverDriveHPThreshold = new("MCH_ST_QueenOverDrive", 1),
             MCH_ST_BarrelStabilizerBossOption = new("MCH_ST_BarrelStabilizerBossOption", 1),
             MCH_ST_BarrelStabilizerHPOption = new("MCH_ST_BarrelStabilizerHPOption", 10),

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -95,11 +95,47 @@ internal partial class MCH
 
     private static int HPThresholdQueen =>
         MCH_ST_QueenBossOption == 1 ||
-        !InBossEncounter() ? MCH_ST_QueenHPOption : 0;
+        !TargetIsBoss() ? MCH_ST_QueenHPOption : 0;
 
     #endregion
 
     #region Reassembled
+
+    private static uint _trackedReassembleCharges = uint.MaxValue;
+    private static bool _spendPairedReassemble;
+
+    /// <summary>
+    ///     Tracks 0/2 charge transitions so Reassemble is spent as a pair after reaching 2 charges,
+    ///     but not as a lone charge after regen from 0 (Enhanced Reassemble / 2-max only).
+    /// </summary>
+    private static void UpdateReassembleChargeTracking()
+    {
+        uint charges = GetRemainingCharges(Reassemble);
+        if (charges == _trackedReassembleCharges)
+            return;
+
+        if (HasPairedReassembleCharges)
+        {
+            switch (charges)
+            {
+                case 2 when _trackedReassembleCharges != 2:
+                    _spendPairedReassemble = true;
+                    break;
+                case 0:
+                case 1 when _trackedReassembleCharges == 0:
+                    _spendPairedReassemble = false;
+                    break;
+            }
+        }
+        else
+            _spendPairedReassemble = false;
+
+        _trackedReassembleCharges = charges;
+    }
+
+    private static bool HasPairedReassembleCharges => GetMaxCharges(Reassemble) >= 2;
+
+    private static bool IsWildfireActive => HasStatusEffect(Buffs.Wildfire);
 
     private static int ReadyTools()
     {
@@ -108,12 +144,10 @@ internal partial class MCH
         if (ActionReady(Drill))
             numberOfReadyTools += (int)GetRemainingCharges(Drill);
 
-        if (ActionReady(Chainsaw))
-        {
+        if (HasStatusEffect(Buffs.ExcavatorReady) && ActionReady(Excavator))
             numberOfReadyTools++;
-            if (LevelChecked(Excavator))
-                numberOfReadyTools++;
-        }
+        else if (ActionReady(Chainsaw))
+            numberOfReadyTools++;
 
         if (ActionReady(OriginalHook(AirAnchor)))
             numberOfReadyTools++;
@@ -121,12 +155,26 @@ internal partial class MCH
         return numberOfReadyTools;
     }
 
+    private static bool InReassembleActionRange() =>
+        LevelChecked(Drill) && InActionRange(Drill) ||
+        LevelChecked(AirAnchor) && InActionRange(AirAnchor) ||
+        LevelChecked(Chainsaw) && InActionRange(Chainsaw) ||
+        LevelChecked(HotShot) && InActionRange(HotShot) ||
+        InActionRange(AoESpreadAction);
+
+    private static int AoEEnemyCount =>
+        HasBattleTarget() ? NumberOfEnemiesInRange(OriginalHook(SpreadShot), CurrentTarget) : 0;
+
+    private static uint AoESpreadAction => OriginalHook(SpreadShot);
+
     private static bool CanReassemble()
     {
+        UpdateReassembleChargeTracking();
+
         uint remainingCharges = GetRemainingCharges(Reassemble);
 
-        if (HasStatusEffect(Buffs.Reassembled) || !HasBattleTarget() ||
-            !InActionRange(Drill) || JustUsed(Reassemble, 2f))
+        if (HasStatusEffect(Buffs.Reassembled) || IsWildfireActive || !HasBattleTarget() ||
+            !InReassembleActionRange() || JustUsed(Reassemble, 2f))
             return false;
 
         if (remainingCharges == 0)
@@ -135,18 +183,15 @@ internal partial class MCH
         if (MCH_ST_Adv_ReassembleChoice == 0)
         {
             int numberOfReadyTools = ReadyTools();
-
             bool enoughToolsForBurst = numberOfReadyTools >= remainingCharges;
 
-            if (!LevelChecked(Excavator))
+            if (!HasPairedReassembleCharges)
                 return enoughToolsForBurst;
 
-            switch (remainingCharges)
-            {
-                case 2 when enoughToolsForBurst:
-                case 1 when enoughToolsForBurst && JustUsed(Reassemble, 10):
-                    return true;
-            }
+            if (!_spendPairedReassemble)
+                return false;
+
+            return enoughToolsForBurst;
         }
 
         if (MCH_ST_Adv_ReassembleChoice == 1)
@@ -163,8 +208,177 @@ internal partial class MCH
             if (ActionReady(Drill) && (!LevelChecked(AirAnchor) || GetCooldownRemainingTime(AirAnchor) > GCD * 2))
                 return true;
 
-            if (!LevelChecked(CleanShot) && ActionReady(HotShot))
+            if (ActionReady(HotShot) && !LevelChecked(Drill))
                 return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     Picks the weaponskill that should receive Reassembled in AoE by level and enemy count.
+    /// </summary>
+    private static bool TryGetAoEReassembleTarget(out uint action)
+    {
+        action = 0;
+
+        if (!HasBattleTarget())
+            return false;
+
+        int enemies = AoEEnemyCount;
+
+        if (LevelChecked(Chainsaw))
+            return false;
+
+        if (LevelChecked(Scattergun))
+        {
+            switch (enemies)
+            {
+                case >= 5 when ActionReady(AoESpreadAction) && InActionRange(AoESpreadAction):
+                    action = AoESpreadAction;
+                    return true;
+
+                case >= 1 and <= 4 when ActionReady(AirAnchor) && InActionRange(AirAnchor):
+                    action = AirAnchor;
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        if (LevelChecked(AirAnchor))
+        {
+            switch (enemies)
+            {
+                case >= 6 when ActionReady(AoESpreadAction) && InActionRange(AoESpreadAction):
+                    action = AoESpreadAction;
+                    return true;
+                
+                case >= 1 and <= 5 when ActionReady(AirAnchor) && InActionRange(AirAnchor):
+                    action = AirAnchor;
+                    return true;
+                
+                default:
+                    return false;
+            }
+        }
+
+        if (LevelChecked(BioBlaster))
+        {
+            switch (enemies)
+            {
+                case >= 3 when ActionReady(AoESpreadAction) && InActionRange(AoESpreadAction):
+                    action = AoESpreadAction;
+                    return true;
+                
+                default:
+                    return false;
+            }
+        }
+
+        if (LevelChecked(Drill))
+        {
+            switch (enemies)
+            {
+                case >= 6 when ActionReady(AoESpreadAction) && InActionRange(AoESpreadAction):
+                    action = AoESpreadAction;
+                    return true;
+                
+                case >= 1 and <= 5 when ActionReady(Drill) && InActionRange(Drill):
+                    action = Drill;
+                    return true;
+                
+                default:
+                    return false;
+            }
+        }
+
+        switch (enemies)
+        {
+            case >= 3 when ActionReady(AoESpreadAction) && InActionRange(AoESpreadAction):
+                action = AoESpreadAction;
+                return true;
+            
+            default:
+                return false;
+        }
+    }
+
+    private static bool HasAoEReassembleToolWindow90Plus() =>
+        LevelChecked(Scattergun) ||
+        GetCooldownRemainingTime(AirAnchor) < GCD && LevelChecked(AirAnchor) ||
+        GetCooldownRemainingTime(Chainsaw) < GCD && LevelChecked(Chainsaw) ||
+        HasStatusEffect(Buffs.ExcavatorReady) && LevelChecked(Excavator);
+
+    private static bool HasAoEReassembleToolWindow() =>
+        LevelChecked(Chainsaw)
+            ? HasAoEReassembleToolWindow90Plus()
+            : TryGetAoEReassembleTarget(out var _);
+
+    private static bool CanReassembleAoE()
+    {
+        UpdateReassembleChargeTracking();
+
+        if (HasStatusEffect(Buffs.Reassembled) || IsWildfireActive || !HasBattleTarget() ||
+            JustUsed(Reassemble, 2f) || JustUsed(Flamethrower, 10f))
+            return false;
+
+        uint remainingCharges = GetRemainingCharges(Reassemble);
+        if (!ActionReady(Reassemble) || remainingCharges == 0 ||
+            remainingCharges <= MCH_AoE_ReassemblePool)
+            return false;
+
+        if (!HasAoEReassembleToolWindow())
+            return false;
+
+        if (HasPairedReassembleCharges && !_spendPairedReassemble)
+            return false;
+
+        return true;
+    }
+
+    private static bool CanUseAoETools(ref uint actionID, bool allowAirAnchor = true)
+    {
+        if (HasStatusEffect(Buffs.Reassembled) && !IsWildfireActive &&
+            !LevelChecked(Chainsaw) &&
+            TryGetAoEReassembleTarget(out uint reassembleTarget) &&
+            ActionReady(reassembleTarget))
+        {
+            actionID = reassembleTarget;
+            return true;
+        }
+
+        if (LevelChecked(Drill) && !LevelChecked(BioBlaster) &&
+            AoEEnemyCount is > 0 and < 6 && ActionReady(Drill) && InActionRange(Drill))
+        {
+            actionID = Drill;
+            return true;
+        }
+
+        if (ActionReady(BioBlaster) && !HasStatusEffect(Debuffs.Bioblaster, CurrentTarget) &&
+            !HasStatusEffect(Buffs.Reassembled) && CanApplyStatus(CurrentTarget, Debuffs.Bioblaster))
+        {
+            actionID = BioBlaster;
+            return true;
+        }
+
+        if (HasStatusEffect(Buffs.ExcavatorReady) && ActionReady(Excavator))
+        {
+            actionID = Excavator;
+            return true;
+        }
+
+        if (ActionReady(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady))
+        {
+            actionID = Chainsaw;
+            return true;
+        }
+
+        if (allowAirAnchor && ActionReady(OriginalHook(AirAnchor)))
+        {
+            actionID = OriginalHook(AirAnchor);
+            return true;
         }
 
         return false;
@@ -211,11 +425,11 @@ internal partial class MCH
 
     private static int HPThresholdBarrelStabilizer =>
         MCH_ST_BarrelStabilizerHPBossOption == 1 ||
-        !TargetIsBoss() ? MCH_ST_BarrelStabilizerHPBossOption : 0;
+        !TargetIsBoss() ? MCH_ST_BarrelStabilizerHPOption : 0;
 
     private static int HPThresholdWildFire =>
         MCH_ST_WildfireBossHPOption == 1 ||
-        !TargetIsBoss() ? MCH_ST_WildfireBossHPOption : 0;
+        !TargetIsBoss() ? MCH_ST_WildfireHPOption : 0;
 
     #endregion
 
@@ -234,39 +448,52 @@ internal partial class MCH
         !LevelChecked(Chainsaw) ||
         LevelChecked(Chainsaw) && GetCooldownRemainingTime(Chainsaw) >= 9;
 
-    private static bool CanUseTools(ref uint actionID)
+    private static bool TryGetSTReassembleTarget(out uint action)
     {
-        if (ActionReady(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady))
+        action = 0;
+
+        if (ActionReady(Excavator) && HasStatusEffect(Buffs.ExcavatorReady))
         {
-            actionID = Chainsaw;
+            action = Excavator;
             return true;
         }
 
-        if (ActionReady(Excavator))
+        if (ActionReady(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady))
         {
-            actionID = Excavator;
+            action = Chainsaw;
             return true;
         }
 
         if (ActionReady(AirAnchor))
         {
-            actionID = AirAnchor;
-            return true;
-        }
-
-        if (ActionReady(HotShot) && !LevelChecked(AirAnchor))
-        {
-            actionID = HotShot;
+            action = AirAnchor;
             return true;
         }
 
         if (ActionReady(Drill))
         {
-            actionID = Drill;
+            action = Drill;
+            return true;
+        }
+
+        if (ActionReady(HotShot) && !LevelChecked(AirAnchor))
+        {
+            action = HotShot;
             return true;
         }
 
         return false;
+    }
+
+    private static bool CanUseTools(ref uint actionID)
+    {
+        if (HasStatusEffect(Buffs.Reassembled) && TryGetSTReassembleTarget(out uint reassembleTarget))
+        {
+            actionID = reassembleTarget;
+            return true;
+        }
+
+        return TryGetSTReassembleTarget(out actionID);
     }
 
     #endregion

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -95,7 +95,7 @@ internal partial class MCH
 
     private static int HPThresholdQueen =>
         MCH_ST_QueenBossOption == 1 ||
-        !TargetIsBoss() ? MCH_ST_QueenHPOption : 0;
+        !InBossEncounter() ? MCH_ST_QueenHPOption : 0;
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -101,42 +101,42 @@ internal partial class MCH
 
     #region Reassembled
 
-    private static uint TrackedReassembleCharges = uint.MaxValue;
-    private static bool SpendPairedReassemble;
+    private static uint CurrentReassembleCharges = uint.MaxValue;
+    private static bool UseBothCharges;
 
-    private static bool HasPairedReassembleCharges => GetMaxCharges(Reassemble) >= 2;
+    private static bool TwoChargesUnlocked => GetMaxCharges(Reassemble) >= 2;
 
     private static bool IsWildfireActive => HasStatusEffect(Buffs.Wildfire);
     
     private static void UpdateReassembleChargeTracking()
     {
         uint charges = GetRemainingCharges(Reassemble);
-        if (charges == TrackedReassembleCharges)
+        if (charges == CurrentReassembleCharges)
             return;
 
-        if (HasPairedReassembleCharges)
+        if (TwoChargesUnlocked)
         {
             switch (charges)
             {
-                case 2 when TrackedReassembleCharges != 2:
-                    SpendPairedReassemble = true;
+                case 2 when CurrentReassembleCharges != 2:
+                    UseBothCharges = true;
                     break;
 
                 case 0:
 
-                case 1 when TrackedReassembleCharges == 0:
-                    SpendPairedReassemble = false;
+                case 1 when CurrentReassembleCharges == 0:
+                    UseBothCharges = false;
                     break;
             }
         }
         else
-            SpendPairedReassemble = false;
+            UseBothCharges = false;
 
-        TrackedReassembleCharges = charges;
+        CurrentReassembleCharges = charges;
     }
 
     private static bool ShouldReassemble() =>
-        !HasPairedReassembleCharges || SpendPairedReassemble;
+        !TwoChargesUnlocked || UseBothCharges;
 
     private static int ReadyTools()
     {

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -101,6 +101,43 @@ internal partial class MCH
 
     #region Reassembled
 
+    private static uint TrackedReassembleCharges = uint.MaxValue;
+    private static bool SpendPairedReassemble;
+
+    private static bool HasPairedReassembleCharges => GetMaxCharges(Reassemble) >= 2;
+
+    private static bool IsWildfireActive => HasStatusEffect(Buffs.Wildfire);
+    
+    private static void UpdateReassembleChargeTracking()
+    {
+        uint charges = GetRemainingCharges(Reassemble);
+        if (charges == TrackedReassembleCharges)
+            return;
+
+        if (HasPairedReassembleCharges)
+        {
+            switch (charges)
+            {
+                case 2 when TrackedReassembleCharges != 2:
+                    SpendPairedReassemble = true;
+                    break;
+
+                case 0:
+
+                case 1 when TrackedReassembleCharges == 0:
+                    SpendPairedReassemble = false;
+                    break;
+            }
+        }
+        else
+            SpendPairedReassemble = false;
+
+        TrackedReassembleCharges = charges;
+    }
+
+    private static bool ShouldSpendReassembleCharges() =>
+        !HasPairedReassembleCharges || SpendPairedReassemble;
+
     private static int ReadyTools()
     {
         int numberOfReadyTools = 0;
@@ -121,32 +158,35 @@ internal partial class MCH
         return numberOfReadyTools;
     }
 
+    private static bool InReassembleActionRange() =>
+        LevelChecked(Drill) && InActionRange(Drill) ||
+        LevelChecked(AirAnchor) && InActionRange(AirAnchor) ||
+        LevelChecked(Chainsaw) && InActionRange(Chainsaw) ||
+        LevelChecked(Scattergun) && InActionRange(OriginalHook(SpreadShot));
+
+    private static bool HasAoEReassembleToolWindow() =>
+        LevelChecked(Scattergun) ||
+        GetCooldownRemainingTime(AirAnchor) < GCD && LevelChecked(AirAnchor) ||
+        GetCooldownRemainingTime(Chainsaw) < GCD && LevelChecked(Chainsaw) ||
+        HasStatusEffect(Buffs.ExcavatorReady) && LevelChecked(Excavator);
+
     private static bool CanReassemble()
     {
+        UpdateReassembleChargeTracking();
+
         uint remainingCharges = GetRemainingCharges(Reassemble);
 
-        if (HasStatusEffect(Buffs.Reassembled) || !HasBattleTarget() ||
-            !InActionRange(Drill) || JustUsed(Reassemble, 2f))
+        if (HasStatusEffect(Buffs.Reassembled) || IsWildfireActive || !HasBattleTarget() ||
+            !InReassembleActionRange() || JustUsed(Reassemble, 2f))
             return false;
 
-        if (remainingCharges == 0)
+        if (remainingCharges == 0 || !ShouldSpendReassembleCharges())
             return false;
 
         if (MCH_ST_Adv_ReassembleChoice == 0)
         {
             int numberOfReadyTools = ReadyTools();
-
-            bool enoughToolsForBurst = numberOfReadyTools >= remainingCharges;
-
-            if (!LevelChecked(Excavator))
-                return enoughToolsForBurst;
-
-            switch (remainingCharges)
-            {
-                case 2 when enoughToolsForBurst:
-                case 1 when enoughToolsForBurst && JustUsed(Reassemble, 10):
-                    return true;
-            }
+            return numberOfReadyTools >= remainingCharges;
         }
 
         if (MCH_ST_Adv_ReassembleChoice == 1)
@@ -165,6 +205,22 @@ internal partial class MCH
         }
 
         return false;
+    }
+
+    private static bool CanReassembleAoE()
+    {
+        UpdateReassembleChargeTracking();
+
+        if (HasStatusEffect(Buffs.Reassembled) || IsWildfireActive || !HasBattleTarget() ||
+            JustUsed(Reassemble, 2f) || JustUsed(Flamethrower, 10f))
+            return false;
+
+        uint remainingCharges = GetRemainingCharges(Reassemble);
+        if (!ActionReady(Reassemble) || remainingCharges == 0 ||
+            remainingCharges <= MCH_AoE_ReassemblePool || !ShouldSpendReassembleCharges())
+            return false;
+
+        return HasAoEReassembleToolWindow();
     }
 
     #endregion

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -262,7 +262,7 @@ internal partial class MCH
             actionID = HotShot;
             return true;
         }
-        
+
         return false;
     }
 

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -135,7 +135,7 @@ internal partial class MCH
         TrackedReassembleCharges = charges;
     }
 
-    private static bool ShouldSpendReassembleCharges() =>
+    private static bool ShouldReassemble() =>
         !HasPairedReassembleCharges || SpendPairedReassemble;
 
     private static int ReadyTools()
@@ -162,13 +162,13 @@ internal partial class MCH
         return numberOfReadyTools;
     }
 
-    private static bool InReassembleActionRange() =>
+    private static bool InReassembleRange() =>
         LevelChecked(Drill) && InActionRange(Drill) ||
         LevelChecked(AirAnchor) && InActionRange(AirAnchor) ||
         LevelChecked(Chainsaw) && InActionRange(Chainsaw) ||
         LevelChecked(Scattergun) && InActionRange(OriginalHook(SpreadShot));
 
-    private static bool HasAoEReassembleToolWindow() =>
+    private static bool AoEReassemble() =>
         LevelChecked(Scattergun) ||
         GetCooldownRemainingTime(AirAnchor) < GCD && LevelChecked(AirAnchor) ||
         GetCooldownRemainingTime(Chainsaw) < GCD && LevelChecked(Chainsaw) ||
@@ -181,10 +181,10 @@ internal partial class MCH
         uint remainingCharges = GetRemainingCharges(Reassemble);
 
         if (HasStatusEffect(Buffs.Reassembled) || IsWildfireActive || !HasBattleTarget() ||
-            !InReassembleActionRange() || JustUsed(Reassemble, 2f))
+            !InReassembleRange() || JustUsed(Reassemble, 2f))
             return false;
 
-        if (remainingCharges == 0 || !ShouldSpendReassembleCharges())
+        if (remainingCharges == 0 || !ShouldReassemble())
             return false;
 
         if (MCH_ST_Adv_ReassembleChoice == 0)
@@ -221,10 +221,10 @@ internal partial class MCH
 
         uint remainingCharges = GetRemainingCharges(Reassemble);
         if (!ActionReady(Reassemble) || remainingCharges == 0 ||
-            remainingCharges <= MCH_AoE_ReassemblePool || !ShouldSpendReassembleCharges())
+            remainingCharges <= MCH_AoE_ReassemblePool || !ShouldReassemble())
             return false;
 
-        return HasAoEReassembleToolWindow();
+        return AoEReassemble();
     }
 
     #endregion

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -101,44 +101,6 @@ internal partial class MCH
 
     #region Reassembled
 
-    private static uint TrackedReassembleCharges = uint.MaxValue;
-    private static bool SpendPairedReassemble;
-
-    /// <summary>
-    ///     Tracks 0/2 charge transitions so Reassemble is spent as a pair after reaching 2 charges,
-    ///     but not as a lone charge after regen from 0 (Enhanced Reassemble / 2-max only).
-    /// </summary>
-    private static void UpdateReassembleChargeTracking()
-    {
-        uint charges = GetRemainingCharges(Reassemble);
-        if (charges == TrackedReassembleCharges)
-            return;
-
-        if (HasPairedReassembleCharges)
-        {
-            switch (charges)
-            {
-                case 2 when TrackedReassembleCharges != 2:
-                    SpendPairedReassemble = true;
-                    break;
-
-                case 0:
-
-                case 1 when TrackedReassembleCharges == 0:
-                    SpendPairedReassemble = false;
-                    break;
-            }
-        }
-        else
-            SpendPairedReassemble = false;
-
-        TrackedReassembleCharges = charges;
-    }
-
-    private static bool HasPairedReassembleCharges => GetMaxCharges(Reassemble) >= 2;
-
-    private static bool IsWildfireActive => HasStatusEffect(Buffs.Wildfire);
-
     private static int ReadyTools()
     {
         int numberOfReadyTools = 0;
@@ -146,11 +108,7 @@ internal partial class MCH
         if (ActionReady(Drill))
             numberOfReadyTools += (int)GetRemainingCharges(Drill);
 
-        // Excavator is only usable with ExcavatorReady, but Chainsaw + follow-up Excavator counts as 2 for burst planning.
-        if (HasStatusEffect(Buffs.ExcavatorReady))
-            numberOfReadyTools++;
-
-        else if (ActionReady(Chainsaw))
+        if (ActionReady(Chainsaw))
         {
             numberOfReadyTools++;
             if (LevelChecked(Excavator))
@@ -163,26 +121,12 @@ internal partial class MCH
         return numberOfReadyTools;
     }
 
-    private static bool InReassembleActionRange() =>
-        LevelChecked(Drill) && InActionRange(Drill) ||
-        LevelChecked(AirAnchor) && InActionRange(AirAnchor) ||
-        LevelChecked(Chainsaw) && InActionRange(Chainsaw) ||
-        LevelChecked(HotShot) && InActionRange(HotShot) ||
-        InActionRange(AoESpreadAction);
-
-    private static int AoEEnemyCount =>
-        HasBattleTarget() ? NumberOfEnemiesInRange(OriginalHook(SpreadShot), CurrentTarget) : 0;
-
-    private static uint AoESpreadAction => OriginalHook(SpreadShot);
-
     private static bool CanReassemble()
     {
-        UpdateReassembleChargeTracking();
-
         uint remainingCharges = GetRemainingCharges(Reassemble);
 
-        if (HasStatusEffect(Buffs.Reassembled) || IsWildfireActive || !HasBattleTarget() ||
-            !InReassembleActionRange() || JustUsed(Reassemble, 2f))
+        if (HasStatusEffect(Buffs.Reassembled) || !HasBattleTarget() ||
+            !InActionRange(Drill) || JustUsed(Reassemble, 2f))
             return false;
 
         if (remainingCharges == 0)
@@ -191,15 +135,18 @@ internal partial class MCH
         if (MCH_ST_Adv_ReassembleChoice == 0)
         {
             int numberOfReadyTools = ReadyTools();
+
             bool enoughToolsForBurst = numberOfReadyTools >= remainingCharges;
 
-            if (!HasPairedReassembleCharges)
+            if (!LevelChecked(Excavator))
                 return enoughToolsForBurst;
 
-            if (!SpendPairedReassemble)
-                return false;
-
-            return enoughToolsForBurst;
+            switch (remainingCharges)
+            {
+                case 2 when enoughToolsForBurst:
+                case 1 when enoughToolsForBurst && JustUsed(Reassemble, 10):
+                    return true;
+            }
         }
 
         if (MCH_ST_Adv_ReassembleChoice == 1)
@@ -215,178 +162,6 @@ internal partial class MCH
 
             if (ActionReady(Drill) && (!LevelChecked(AirAnchor) || GetCooldownRemainingTime(AirAnchor) > GCD * 2))
                 return true;
-
-            if (ActionReady(HotShot) && !LevelChecked(Drill))
-                return true;
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    ///     Picks the weaponskill that should receive Reassembled in AoE by level and enemy count.
-    /// </summary>
-    private static bool TryGetAoEReassembleTarget(out uint action)
-    {
-        action = 0;
-
-        if (!HasBattleTarget())
-            return false;
-
-        int enemies = AoEEnemyCount;
-
-        if (LevelChecked(Chainsaw))
-            return false;
-
-        if (LevelChecked(Scattergun))
-        {
-            switch (enemies)
-            {
-                case >= 5 when ActionReady(AoESpreadAction) && InActionRange(AoESpreadAction):
-                    action = AoESpreadAction;
-                    return true;
-
-                case >= 1 and <= 4 when ActionReady(AirAnchor) && InActionRange(AirAnchor):
-                    action = AirAnchor;
-                    return true;
-
-                default:
-                    return false;
-            }
-        }
-
-        if (LevelChecked(AirAnchor))
-        {
-            switch (enemies)
-            {
-                case >= 6 when ActionReady(AoESpreadAction) && InActionRange(AoESpreadAction):
-                    action = AoESpreadAction;
-                    return true;
-
-                case >= 1 and <= 5 when ActionReady(AirAnchor) && InActionRange(AirAnchor):
-                    action = AirAnchor;
-                    return true;
-
-                default:
-                    return false;
-            }
-        }
-
-        if (LevelChecked(BioBlaster))
-        {
-            switch (enemies)
-            {
-                case >= 3 when ActionReady(AoESpreadAction) && InActionRange(AoESpreadAction):
-                    action = AoESpreadAction;
-                    return true;
-
-                default:
-                    return false;
-            }
-        }
-
-        if (LevelChecked(Drill))
-        {
-            switch (enemies)
-            {
-                case >= 6 when ActionReady(AoESpreadAction) && InActionRange(AoESpreadAction):
-                    action = AoESpreadAction;
-                    return true;
-
-                case >= 1 and <= 5 when ActionReady(Drill) && InActionRange(Drill):
-                    action = Drill;
-                    return true;
-
-                default:
-                    return false;
-            }
-        }
-
-        switch (enemies)
-        {
-            case >= 3 when ActionReady(AoESpreadAction) && InActionRange(AoESpreadAction):
-                action = AoESpreadAction;
-                return true;
-
-            default:
-                return false;
-        }
-    }
-
-    private static bool HasAoEReassembleToolWindow90Plus() =>
-        LevelChecked(Scattergun) ||
-        GetCooldownRemainingTime(AirAnchor) < GCD && LevelChecked(AirAnchor) ||
-        GetCooldownRemainingTime(Chainsaw) < GCD && LevelChecked(Chainsaw) ||
-        HasStatusEffect(Buffs.ExcavatorReady) && LevelChecked(Excavator);
-
-    private static bool HasAoEReassembleToolWindow() =>
-        LevelChecked(Chainsaw)
-            ? HasAoEReassembleToolWindow90Plus()
-            : TryGetAoEReassembleTarget(out uint _);
-
-    private static bool CanReassembleAoE()
-    {
-        UpdateReassembleChargeTracking();
-
-        if (HasStatusEffect(Buffs.Reassembled) || IsWildfireActive || !HasBattleTarget() ||
-            JustUsed(Reassemble, 2f) || JustUsed(Flamethrower, 10f))
-            return false;
-
-        uint remainingCharges = GetRemainingCharges(Reassemble);
-        if (!ActionReady(Reassemble) || remainingCharges == 0 ||
-            remainingCharges <= MCH_AoE_ReassemblePool)
-            return false;
-
-        if (!HasAoEReassembleToolWindow())
-            return false;
-
-        if (HasPairedReassembleCharges && !SpendPairedReassemble)
-            return false;
-
-        return true;
-    }
-
-    private static bool CanUseAoETools(ref uint actionID, bool allowAirAnchor = true)
-    {
-        if (HasStatusEffect(Buffs.Reassembled) && !IsWildfireActive &&
-            !LevelChecked(Chainsaw) &&
-            TryGetAoEReassembleTarget(out uint reassembleTarget) &&
-            ActionReady(reassembleTarget))
-        {
-            actionID = reassembleTarget;
-            return true;
-        }
-
-        if (LevelChecked(Drill) && !LevelChecked(BioBlaster) &&
-            AoEEnemyCount is > 0 and < 6 && ActionReady(Drill) && InActionRange(Drill))
-        {
-            actionID = Drill;
-            return true;
-        }
-
-        if (ActionReady(BioBlaster) && !HasStatusEffect(Debuffs.Bioblaster, CurrentTarget) &&
-            !HasStatusEffect(Buffs.Reassembled) && CanApplyStatus(CurrentTarget, Debuffs.Bioblaster))
-        {
-            actionID = BioBlaster;
-            return true;
-        }
-
-        if (HasStatusEffect(Buffs.ExcavatorReady) && ActionReady(Excavator))
-        {
-            actionID = Excavator;
-            return true;
-        }
-
-        if (ActionReady(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady))
-        {
-            actionID = Chainsaw;
-            return true;
-        }
-
-        if (allowAirAnchor && ActionReady(OriginalHook(AirAnchor)))
-        {
-            actionID = OriginalHook(AirAnchor);
-            return true;
         }
 
         return false;
@@ -456,52 +231,39 @@ internal partial class MCH
         !LevelChecked(Chainsaw) ||
         LevelChecked(Chainsaw) && GetCooldownRemainingTime(Chainsaw) >= 9;
 
-    private static bool TryGetSTReassembleTarget(out uint action)
+    private static bool CanUseTools(ref uint actionID)
     {
-        action = 0;
-
-        if (ActionReady(Excavator) && HasStatusEffect(Buffs.ExcavatorReady))
+        if (ActionReady(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady))
         {
-            action = Excavator;
+            actionID = Chainsaw;
             return true;
         }
 
-        if (ActionReady(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady))
+        if (ActionReady(Excavator))
         {
-            action = Chainsaw;
+            actionID = Excavator;
             return true;
         }
 
         if (ActionReady(AirAnchor))
         {
-            action = AirAnchor;
+            actionID = AirAnchor;
             return true;
         }
 
         if (ActionReady(Drill))
         {
-            action = Drill;
+            actionID = Drill;
             return true;
         }
 
-        if (ActionReady(HotShot) && !LevelChecked(AirAnchor))
+        if (ActionReady(HotShot) && !LevelChecked(AirAnchor) && !HasStatusEffect(Buffs.Reassembled))
         {
-            action = HotShot;
+            actionID = HotShot;
             return true;
         }
-
+        
         return false;
-    }
-
-    private static bool CanUseTools(ref uint actionID)
-    {
-        if (HasStatusEffect(Buffs.Reassembled) && TryGetSTReassembleTarget(out uint reassembleTarget))
-        {
-            actionID = reassembleTarget;
-            return true;
-        }
-
-        return TryGetSTReassembleTarget(out actionID);
     }
 
     #endregion

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -107,7 +107,7 @@ internal partial class MCH
     private static bool TwoChargesUnlocked => GetMaxCharges(Reassemble) >= 2;
 
     private static bool IsWildfireActive => HasStatusEffect(Buffs.Wildfire);
-    
+
     private static void UpdateReassembleChargeTracking()
     {
         uint charges = GetRemainingCharges(Reassemble);
@@ -162,17 +162,20 @@ internal partial class MCH
         return numberOfReadyTools;
     }
 
+    private static bool CanUseReassembleAoE() =>
+        LevelChecked(Drill) && GetCooldownRemainingTime(Drill) < GCD ||
+        LevelChecked(AirAnchor) && GetCooldownRemainingTime(AirAnchor) < GCD ||
+        LevelChecked(Chainsaw) && GetCooldownRemainingTime(Chainsaw) < GCD ||
+        LevelChecked(Excavator) && HasStatusEffect(Buffs.ExcavatorReady) ||
+        LevelChecked(Scattergun) && ActionReady(Scattergun) ||
+        ActionReady(OriginalHook(SpreadShot));
+
     private static bool InReassembleRange() =>
         LevelChecked(Drill) && InActionRange(Drill) ||
         LevelChecked(AirAnchor) && InActionRange(AirAnchor) ||
         LevelChecked(Chainsaw) && InActionRange(Chainsaw) ||
-        LevelChecked(Scattergun) && InActionRange(OriginalHook(SpreadShot));
-
-    private static bool AoEReassemble() =>
-        LevelChecked(Scattergun) ||
-        GetCooldownRemainingTime(AirAnchor) < GCD && LevelChecked(AirAnchor) ||
-        GetCooldownRemainingTime(Chainsaw) < GCD && LevelChecked(Chainsaw) ||
-        HasStatusEffect(Buffs.ExcavatorReady) && LevelChecked(Excavator);
+        LevelChecked(Scattergun) && InActionRange(OriginalHook(SpreadShot)) ||
+        !LevelChecked(Drill) && InActionRange(OriginalHook(SpreadShot));
 
     private static bool CanReassemble()
     {
@@ -209,22 +212,6 @@ internal partial class MCH
         }
 
         return false;
-    }
-
-    private static bool CanReassembleAoE()
-    {
-        UpdateReassembleChargeTracking();
-
-        if (HasStatusEffect(Buffs.Reassembled) || IsWildfireActive || !HasBattleTarget() ||
-            JustUsed(Reassemble, 2f) || JustUsed(Flamethrower, 10f))
-            return false;
-
-        uint remainingCharges = GetRemainingCharges(Reassemble);
-        if (!ActionReady(Reassemble) || remainingCharges == 0 ||
-            remainingCharges <= MCH_AoE_ReassemblePool || !ShouldReassemble())
-            return false;
-
-        return AoEReassemble();
     }
 
     #endregion
@@ -320,6 +307,49 @@ internal partial class MCH
         if (ActionReady(HotShot) && !LevelChecked(AirAnchor) && !HasStatusEffect(Buffs.Reassembled))
         {
             actionID = HotShot;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool CanUseAoETools(ref uint actionID, bool useAirAnchor = true)
+    {
+        if (ActionReady(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady))
+        {
+            actionID = Chainsaw;
+            return true;
+        }
+
+        if (ActionReady(Excavator))
+        {
+            actionID = Excavator;
+            return true;
+        }
+
+        if (useAirAnchor && ActionReady(OriginalHook(AirAnchor)))
+        {
+            actionID = OriginalHook(AirAnchor);
+            return true;
+        }
+
+        if (ActionReady(Drill))
+        {
+            actionID = Drill;
+            return true;
+        }
+
+        if (LevelChecked(BioBlaster) && ActionReady(BioBlaster) &&
+            !HasStatusEffect(Debuffs.Bioblaster, CurrentTarget) &&
+            CanApplyStatus(CurrentTarget, Debuffs.Bioblaster))
+        {
+            actionID = BioBlaster;
+            return true;
+        }
+
+        if (HasStatusEffect(Buffs.Reassembled) && ActionReady(OriginalHook(SpreadShot)))
+        {
+            actionID = OriginalHook(SpreadShot);
             return true;
         }
 

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -101,8 +101,8 @@ internal partial class MCH
 
     #region Reassembled
 
-    private static uint _trackedReassembleCharges = uint.MaxValue;
-    private static bool _spendPairedReassemble;
+    private static uint TrackedReassembleCharges = uint.MaxValue;
+    private static bool SpendPairedReassemble;
 
     /// <summary>
     ///     Tracks 0/2 charge transitions so Reassemble is spent as a pair after reaching 2 charges,
@@ -111,26 +111,28 @@ internal partial class MCH
     private static void UpdateReassembleChargeTracking()
     {
         uint charges = GetRemainingCharges(Reassemble);
-        if (charges == _trackedReassembleCharges)
+        if (charges == TrackedReassembleCharges)
             return;
 
         if (HasPairedReassembleCharges)
         {
             switch (charges)
             {
-                case 2 when _trackedReassembleCharges != 2:
-                    _spendPairedReassemble = true;
+                case 2 when TrackedReassembleCharges != 2:
+                    SpendPairedReassemble = true;
                     break;
+
                 case 0:
-                case 1 when _trackedReassembleCharges == 0:
-                    _spendPairedReassemble = false;
+
+                case 1 when TrackedReassembleCharges == 0:
+                    SpendPairedReassemble = false;
                     break;
             }
         }
         else
-            _spendPairedReassemble = false;
+            SpendPairedReassemble = false;
 
-        _trackedReassembleCharges = charges;
+        TrackedReassembleCharges = charges;
     }
 
     private static bool HasPairedReassembleCharges => GetMaxCharges(Reassemble) >= 2;
@@ -144,10 +146,16 @@ internal partial class MCH
         if (ActionReady(Drill))
             numberOfReadyTools += (int)GetRemainingCharges(Drill);
 
-        if (HasStatusEffect(Buffs.ExcavatorReady) && ActionReady(Excavator))
+        // Excavator is only usable with ExcavatorReady, but Chainsaw + follow-up Excavator counts as 2 for burst planning.
+        if (HasStatusEffect(Buffs.ExcavatorReady))
             numberOfReadyTools++;
+
         else if (ActionReady(Chainsaw))
+        {
             numberOfReadyTools++;
+            if (LevelChecked(Excavator))
+                numberOfReadyTools++;
+        }
 
         if (ActionReady(OriginalHook(AirAnchor)))
             numberOfReadyTools++;
@@ -188,7 +196,7 @@ internal partial class MCH
             if (!HasPairedReassembleCharges)
                 return enoughToolsForBurst;
 
-            if (!_spendPairedReassemble)
+            if (!SpendPairedReassemble)
                 return false;
 
             return enoughToolsForBurst;
@@ -254,11 +262,11 @@ internal partial class MCH
                 case >= 6 when ActionReady(AoESpreadAction) && InActionRange(AoESpreadAction):
                     action = AoESpreadAction;
                     return true;
-                
+
                 case >= 1 and <= 5 when ActionReady(AirAnchor) && InActionRange(AirAnchor):
                     action = AirAnchor;
                     return true;
-                
+
                 default:
                     return false;
             }
@@ -271,7 +279,7 @@ internal partial class MCH
                 case >= 3 when ActionReady(AoESpreadAction) && InActionRange(AoESpreadAction):
                     action = AoESpreadAction;
                     return true;
-                
+
                 default:
                     return false;
             }
@@ -284,11 +292,11 @@ internal partial class MCH
                 case >= 6 when ActionReady(AoESpreadAction) && InActionRange(AoESpreadAction):
                     action = AoESpreadAction;
                     return true;
-                
+
                 case >= 1 and <= 5 when ActionReady(Drill) && InActionRange(Drill):
                     action = Drill;
                     return true;
-                
+
                 default:
                     return false;
             }
@@ -299,7 +307,7 @@ internal partial class MCH
             case >= 3 when ActionReady(AoESpreadAction) && InActionRange(AoESpreadAction):
                 action = AoESpreadAction;
                 return true;
-            
+
             default:
                 return false;
         }
@@ -314,7 +322,7 @@ internal partial class MCH
     private static bool HasAoEReassembleToolWindow() =>
         LevelChecked(Chainsaw)
             ? HasAoEReassembleToolWindow90Plus()
-            : TryGetAoEReassembleTarget(out var _);
+            : TryGetAoEReassembleTarget(out uint _);
 
     private static bool CanReassembleAoE()
     {
@@ -332,7 +340,7 @@ internal partial class MCH
         if (!HasAoEReassembleToolWindow())
             return false;
 
-        if (HasPairedReassembleCharges && !_spendPairedReassemble)
+        if (HasPairedReassembleCharges && !SpendPairedReassemble)
             return false;
 
         return true;

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -151,6 +151,10 @@ internal partial class MCH
             if (LevelChecked(Excavator))
                 numberOfReadyTools++;
         }
+        else if (HasStatusEffect(Buffs.ExcavatorReady))
+        {
+            numberOfReadyTools++;
+        }
 
         if (ActionReady(OriginalHook(AirAnchor)))
             numberOfReadyTools++;

--- a/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
@@ -86,7 +86,7 @@ internal partial class MNK
 
                 // Low level
                 if ((JustUsed(OriginalHook(Bootshine), GCD * 3) || JustUsed(DragonKick, GCD * 3)) &&
-                    (HasStatusEffect(Buffs.RiddleOfFire) && !LevelChecked(Brotherhood) ||
+                    ((HasStatusEffect(Buffs.RiddleOfFire) && !LevelChecked(Brotherhood)) ||
                      !LevelChecked(RiddleOfFire)))
                     return true;
                 break;
@@ -111,7 +111,7 @@ internal partial class MNK
                     return true;
 
                 // Low level
-                if (HasStatusEffect(Buffs.RiddleOfFire) && !LevelChecked(Brotherhood) ||
+                if ((HasStatusEffect(Buffs.RiddleOfFire) && !LevelChecked(Brotherhood)) ||
                     !LevelChecked(RiddleOfFire))
                     return true;
                 break;

--- a/WrathCombo/Resources/Localization/JobConfigs/Generics.Designer.cs
+++ b/WrathCombo/Resources/Localization/JobConfigs/Generics.Designer.cs
@@ -158,6 +158,7 @@ namespace WrathCombo.Resources.Localization.JobConfigs {
             }
         }
         
+        /// <summary>
         ///   Looks up a localized string similar to Add {0} when applicable..
         /// </summary>
         internal static string Add0WhenApplicable {
@@ -505,6 +506,15 @@ namespace WrathCombo.Resources.Localization.JobConfigs {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Require a battle target..
+        /// </summary>
+        internal static string HaveBattleTarget {
+            get {
+                return ResourceManager.GetString("HaveBattleTarget", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Hold {0} for {1}.
         /// </summary>
         internal static string Hold0For1 {
@@ -785,11 +795,29 @@ namespace WrathCombo.Resources.Localization.JobConfigs {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Will start the opener regardless of having a target..
+        /// </summary>
+        internal static string NoRequireTarget {
+            get {
+                return ResourceManager.GetString("NoRequireTarget", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Normal Targeting.
         /// </summary>
         internal static string NormalTargeting {
             get {
                 return ResourceManager.GetString("NormalTargeting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Don&apos;t require a battle target..
+        /// </summary>
+        internal static string NoTarget {
+            get {
+                return ResourceManager.GetString("NoTarget", resourceCulture);
             }
         }
         
@@ -987,7 +1015,16 @@ namespace WrathCombo.Resources.Localization.JobConfigs {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to Requires a battle target to start the opener..
+        /// </summary>
+        internal static string RequireTarget {
+            get {
+                return ResourceManager.GetString("RequireTarget", resourceCulture);
+            }
+        }
         
+        /// <summary>
         ///   Looks up a localized string similar to Replaces {0} with {1} to disable and prevent wasted use..
         /// </summary>
         internal static string SavageBladeWaste {
@@ -1243,19 +1280,20 @@ namespace WrathCombo.Resources.Localization.JobConfigs {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use {0} before {1}.
-        /// </summary>
-        internal static string Use0Before1 {
-            get {
-                return ResourceManager.GetString("Use0Before1", resourceCulture);
-            }
-        }
-        
         ///   Looks up a localized string similar to Use {0} and {1}..
         /// </summary>
         internal static string Use0And1 {
             get {
                 return ResourceManager.GetString("Use0And1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use {0} before {1}.
+        /// </summary>
+        internal static string Use0Before1 {
+            get {
+                return ResourceManager.GetString("Use0Before1", resourceCulture);
             }
         }
         

--- a/WrathCombo/Resources/Localization/JobConfigs/Generics.Designer.cs
+++ b/WrathCombo/Resources/Localization/JobConfigs/Generics.Designer.cs
@@ -840,6 +840,15 @@ namespace WrathCombo.Resources.Localization.JobConfigs {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Boss Only.
+        /// </summary>
+        internal static string OnlyBoss {
+            get {
+                return ResourceManager.GetString("OnlyBoss", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Only use {0}.
         /// </summary>
         internal static string OnlyUse0 {
@@ -1321,6 +1330,15 @@ namespace WrathCombo.Resources.Localization.JobConfigs {
         internal static string Use0RegardlessOfContent {
             get {
                 return ResourceManager.GetString("Use0RegardlessOfContent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use {0} regardless of target..
+        /// </summary>
+        internal static string Use0RegardlessOfTarget {
+            get {
+                return ResourceManager.GetString("Use0RegardlessOfTarget", resourceCulture);
             }
         }
         

--- a/WrathCombo/Resources/Localization/JobConfigs/Generics.resx
+++ b/WrathCombo/Resources/Localization/JobConfigs/Generics.resx
@@ -379,6 +379,9 @@ Set to Zero to disable this check.</value>
     <value>On {0}</value>
     <comment>Used for simple "On {Action}" strings</comment>
   </data>
+  <data name="OnlyBoss" xml:space="preserve">
+    <value>Boss Only</value>
+  </data>
   <data name="OnlyUse0" xml:space="preserve">
     <value>Only use {0}</value>
   </data>
@@ -548,6 +551,9 @@ Set to 100 to disable this check.</value>
   </data>
   <data name="Use0RegardlessOfContent" xml:space="preserve">
     <value>Use {0} regardless of content.</value>
+  </data>
+  <data name="Use0RegardlessOfTarget" xml:space="preserve">
+    <value>Use {0} regardless of target.</value>
   </data>
   <data name="Use0When1ChargesAreAvailable" xml:space="preserve">
     <value>Use {0} when {1} charges are available.</value>

--- a/WrathCombo/Resources/Localization/JobConfigs/Generics.resx
+++ b/WrathCombo/Resources/Localization/JobConfigs/Generics.resx
@@ -195,7 +195,7 @@
   </data>
   <data name="BlockStun" xml:space="preserve">
     <value>Block {0} when with Savage Blade when no stunnable targets are found.</value>
-  </data> 
+  </data>
   <data name="BossEncounterNonBossHpPercent" xml:space="preserve">
     <value>Boss Encounter Non Bosses. Stop using at Enemy HP %.</value>
   </data>
@@ -259,13 +259,16 @@ Set to Zero to disable this check.</value>
   </data>
   <data name="FocusTarget" xml:space="preserve">
     <value>Focus Target</value>
-  </data>  
+  </data>
   <data name="GapcloserUse" xml:space="preserve">
     <value>Use {0} in Opener</value>
   </data>
   <data name="GapcloseSkip" xml:space="preserve">
     <value>Skip {0} in Opener</value>
-  </data>  
+  </data>
+  <data name="HaveBattleTarget" xml:space="preserve">
+    <value>Require a battle target.</value>
+  </data>
   <data name="Hold0For1" xml:space="preserve">
     <value>Hold {0} for {1}</value>
   </data>
@@ -342,11 +345,11 @@ Set to Zero to disable this check.</value>
   <data name="MovementOption" xml:space="preserve">
     <value>Movement Option</value>
   </data>
-  <data name="MPLessOrEqual" xml:space="preserve">
-    <value>Player MP to be less than or equal to:</value>
-  </data>
   <data name="MPGreaterOrEqual" xml:space="preserve">
     <value>Player MP to be greater than or equal to:</value>
+  </data>
+  <data name="MPLessOrEqual" xml:space="preserve">
+    <value>Player MP to be less than or equal to:</value>
   </data>
   <data name="NoMovement" xml:space="preserve">
     <value>No Movement</value>
@@ -360,8 +363,14 @@ Set to Zero to disable this check.</value>
   <data name="NonBossHpPercent" xml:space="preserve">
     <value>Non boss encounter. Stop using at Enemy HP %.</value>
   </data>
+  <data name="NoRequireTarget" xml:space="preserve">
+    <value>Will start the opener regardless of having a target.</value>
+  </data>
   <data name="NormalTargeting" xml:space="preserve">
     <value>Normal Targeting</value>
+  </data>
+  <data name="NoTarget" xml:space="preserve">
+    <value>Don't require a battle target.</value>
   </data>
   <data name="NotInBossEncounters" xml:space="preserve">
     <value>Not In Boss Encounters</value>
@@ -413,14 +422,13 @@ Set to 100 to disable this check.</value>
         - You could also mouseover yourself in the party to use Sheltron in this case.
         - If you don't, intervention would replace the combo, and it would go to the main tank.
         - If you don't use those Features for your personal mitigation, you may not want to enable this.</value>
-  </data>  
+  </data>
   <data name="PrioBuffUpkeep" xml:space="preserve">
     <value>Prio buff upkeep</value>
   </data>
   <data name="Prioritize" xml:space="preserve">
     <value>Prioritize {0} </value>
   </data>
-    
   <data name="Priority" xml:space="preserve">
     <value>Priority: </value>
   </data>
@@ -432,6 +440,9 @@ Set to 100 to disable this check.</value>
   </data>
   <data name="RequireParty" xml:space="preserve">
     <value>Requires a Party to use.</value>
+  </data>
+  <data name="RequireTarget" xml:space="preserve">
+    <value>Requires a battle target to start the opener.</value>
   </data>
   <data name="SavageBladeWaste" xml:space="preserve">
     <value>Replaces {0} with {1} to disable and prevent wasted use.</value>
@@ -526,11 +537,11 @@ Set to 100 to disable this check.</value>
   <data name="Use0And1" xml:space="preserve">
     <value>Use {0} and {1}.</value>
   </data>
+  <data name="Use0Before1" xml:space="preserve">
+    <value>Use {0} before {1}</value>
+  </data>
   <data name="Use0In1" xml:space="preserve">
     <value>Use {0} in {1}</value>
-  </data>
-    <data name="Use0Before1" xml:space="preserve">
-    <value>Use {0} before {1}</value>
   </data>
   <data name="Use0Or1" xml:space="preserve">
     <value>Use {0} / {1}</value>

--- a/WrathCombo/WrathCombo.csproj
+++ b/WrathCombo/WrathCombo.csproj
@@ -71,7 +71,7 @@
 
     <!-- Dalamud Packaging -->
     <ItemGroup>
-        <PackageReference Include="DalamudPackager" Version="14.0.1" />
+        <PackageReference Include="DalamudPackager" Version="15.0.0" />
         <PackageReference Include="System.Speech" Version="10.0.5" />
     </ItemGroup>
 


### PR DESCRIPTION
- Fix `Reassemble` going off on `Hotshot`.
- Rewrote `Reassemble` logic so it always uses it right after eachother in even windows.
- Add option for opener to start without battletarget
- Update AoE `Reassemble` usage