### PR TITLE
[WAR][MNK-PvP] Edewen Fixes

### DIFF
--- a/WrathCombo/Combos/PvE/WAR/WAR.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR.cs
@@ -184,29 +184,53 @@ internal partial class WAR
         {
             if (action is not (InnerBeast or FellCleave))
                 return action;
-            if (IsEnabled(Preset.WAR_FC_InnerRelease) && ActionReady(OriginalHook(Berserk)) && CanWeave() && !HasWrathful && Minimal && GetTargetHPPercent() >= WAR_FC_IRStop && (HasSurgingTempest || !LevelChecked(StormsEye)))
-                return OriginalHook(Berserk);
-            if (IsEnabled(Preset.WAR_FC_Infuriate) && ActionReady(Infuriate) && CanWeave() && !HasNascentChaos && Minimal && !JustUsed(Infuriate) && !HasIR.Stacks && BeastGauge <= WAR_FC_Infuriate_Gauge && GetRemainingCharges(Infuriate) > WAR_FC_Infuriate_Charges)
-                return Infuriate;
-            if (IsEnabled(Preset.WAR_FC_Upheaval) && ActionReady(Upheaval) && CanWeave() && HasSurgingTempest && InMeleeRange() && Minimal)
-                return Upheaval;
-            if (IsEnabled(Preset.WAR_FC_PrimalWrath) && LevelChecked(PrimalWrath) && CanWeave() && HasWrathful && HasSurgingTempest && Minimal && GetTargetDistance() <= 4.99f)
-                return PrimalWrath;
-            if (IsEnabled(Preset.WAR_FC_Onslaught) && (!IsEnabled(Preset.WAR_FC_InnerRelease) || (IsEnabled(Preset.WAR_FC_InnerRelease) && IR.Cooldown > 40)) &&
-                ActionReady(Onslaught) && GetRemainingCharges(Onslaught) > WAR_FC_Onslaught_Charges && GetTargetDistance() <= WAR_FC_Onslaught_Distance && 
-                WAR_FC_Onslaught_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(WAR_FC_Onslaught_TimeStill) && CanWeave() && HasSurgingTempest)
-                return Onslaught;
-            if (IsEnabled(Preset.WAR_FC_PrimalRend) && 
-                HasStatusEffect(Buffs.PrimalRendReady) && 
-                HasSurgingTempest &&
-                GetTargetDistance() <= WAR_FC_PrimalRend_Distance && 
-                (WAR_FC_PrimalRend_Movement == 1 || 
-                 WAR_FC_PrimalRend_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(WAR_FC_PrimalRend_TimeStill)) && 
-                (WAR_FC_PrimalRend_EarlyLate == 0 || 
-                 WAR_FC_PrimalRend_EarlyLate == 1 && (GetStatusEffectRemainingTime(Buffs.PrimalRendReady) <= 15 || !HasIR.Stacks && !HasBF.Stacks && !HasWrathful)))
-                return PrimalRend;
-            if (IsEnabled(Preset.WAR_FC_PrimalRuination) && LevelChecked(PrimalRuination) && HasSurgingTempest && Minimal && HasStatusEffect(Buffs.PrimalRuinationReady))
-                return PrimalRuination;
+
+            if (InCombat() && HasBattleTarget())
+            {
+                if (IsEnabled(Preset.WAR_FC_InnerRelease) && ActionReady(OriginalHook(Berserk)) && 
+                    CanWeave() && !HasWrathful &&
+                    GetTargetHPPercent() >= WAR_FC_IRStop && HasSurgingTempest)
+                    return OriginalHook(Berserk);
+            
+                if (IsEnabled(Preset.WAR_FC_Infuriate) && ActionReady(Infuriate) && 
+                    CanWeave() && !HasNascentChaos &&  !JustUsed(Infuriate) && !HasIR.Stacks && 
+                    BeastGauge <= WAR_FC_Infuriate_Gauge && 
+                    GetRemainingCharges(Infuriate) > WAR_FC_Infuriate_Charges)
+                    return Infuriate;
+                
+                if (IsEnabled(Preset.WAR_FC_Upheaval) && ActionReady(Upheaval) && 
+                    CanWeave() && HasSurgingTempest && InMeleeRange())
+                    return Upheaval;
+            
+                if (IsEnabled(Preset.WAR_FC_PrimalWrath) && LevelChecked(PrimalWrath) && 
+                    CanWeave() && HasWrathful && HasSurgingTempest &&
+                    GetTargetDistance() <= 4.99f)
+                    return PrimalWrath;
+            
+                if (IsEnabled(Preset.WAR_FC_Onslaught) && ActionReady(Onslaught) && 
+                    CanWeave() && HasSurgingTempest &&
+                    (!IsEnabled(Preset.WAR_FC_InnerRelease) || IsEnabled(Preset.WAR_FC_InnerRelease) && IR.Cooldown > 40) &&
+                    GetRemainingCharges(Onslaught) > WAR_FC_Onslaught_Charges && 
+                    GetTargetDistance() <= WAR_FC_Onslaught_Distance && 
+                    WAR_FC_Onslaught_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(WAR_FC_Onslaught_TimeStill))
+                    return Onslaught;
+            
+                if (IsEnabled(Preset.WAR_FC_PrimalRend) && HasStatusEffect(Buffs.PrimalRendReady) && 
+                    HasSurgingTempest &&
+                    GetTargetDistance() <= WAR_FC_PrimalRend_Distance && 
+                    (WAR_FC_PrimalRend_Movement == 1 || 
+                     WAR_FC_PrimalRend_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(WAR_FC_PrimalRend_TimeStill)) && 
+                    (WAR_FC_PrimalRend_EarlyLate == 0 || 
+                     WAR_FC_PrimalRend_EarlyLate == 1 && (GetStatusEffectRemainingTime(Buffs.PrimalRendReady) <= 15 || !HasIR.Stacks && !HasBF.Stacks && !HasWrathful)))
+                    return PrimalRend;
+            
+                if (IsEnabled(Preset.WAR_FC_PrimalRuination) && HasStatusEffect(Buffs.PrimalRuinationReady) &&
+                    HasSurgingTempest)
+                    return PrimalRuination;
+            }
+            
+            
+            
             return action;
         }
     }

--- a/WrathCombo/Combos/PvE/WAR/WAR.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR.cs
@@ -196,10 +196,14 @@ internal partial class WAR
                 ActionReady(Onslaught) && GetRemainingCharges(Onslaught) > WAR_FC_Onslaught_Charges && GetTargetDistance() <= WAR_FC_Onslaught_Distance && 
                 WAR_FC_Onslaught_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(WAR_FC_Onslaught_TimeStill) && CanWeave() && HasSurgingTempest)
                 return Onslaught;
-            if (IsEnabled(Preset.WAR_FC_PrimalRend) && HasStatusEffect(Buffs.PrimalRendReady) && HasSurgingTempest &&
+            if (IsEnabled(Preset.WAR_FC_PrimalRend) && 
+                HasStatusEffect(Buffs.PrimalRendReady) && 
+                HasSurgingTempest &&
                 GetTargetDistance() <= WAR_FC_PrimalRend_Distance && 
-                WAR_FC_PrimalRend_Movement == 1 || (WAR_FC_PrimalRend_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(WAR_FC_PrimalRend_TimeStill) && 
-                (WAR_FC_PrimalRend_EarlyLate == 0 || (WAR_FC_PrimalRend_EarlyLate == 1 && (GetStatusEffectRemainingTime(Buffs.PrimalRendReady) <= 15 || (!HasIR.Stacks && !HasBF.Stacks && !HasWrathful))))))
+                (WAR_FC_PrimalRend_Movement == 1 || 
+                 WAR_FC_PrimalRend_Movement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(WAR_FC_PrimalRend_TimeStill)) && 
+                (WAR_FC_PrimalRend_EarlyLate == 0 || 
+                 WAR_FC_PrimalRend_EarlyLate == 1 && (GetStatusEffectRemainingTime(Buffs.PrimalRendReady) <= 15 || !HasIR.Stacks && !HasBF.Stacks && !HasWrathful)))
                 return PrimalRend;
             if (IsEnabled(Preset.WAR_FC_PrimalRuination) && LevelChecked(PrimalRuination) && HasSurgingTempest && Minimal && HasStatusEffect(Buffs.PrimalRuinationReady))
                 return PrimalRuination;

--- a/WrathCombo/Combos/PvE/WAR/WAR_Helper.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR_Helper.cs
@@ -372,7 +372,7 @@ internal partial class WAR : Tank
 
                 if (flags.HasFlag(Combo.AoE) && LevelChecked(Decimate))
                 {
-                    actionID = Decimate;
+                    actionID = OriginalHook(Decimate);
                     return true;
                 }
             }

--- a/WrathCombo/Combos/PvE/WAR/WAR_Helper.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR_Helper.cs
@@ -24,7 +24,6 @@ internal partial class WAR : Tank
     internal static bool HasSurgingTempest => !LevelChecked(StormsEye) || HasStatusEffect(Buffs.SurgingTempest);
     internal static bool HasNascentChaos => HasStatusEffect(Buffs.NascentChaos);
     internal static bool HasWrathful => HasStatusEffect(Buffs.Wrathful);
-    internal static bool Minimal => InCombat() && HasBattleTarget();
     #endregion
 
     #region Openers

--- a/WrathCombo/Combos/PvP/MNKPVP.cs
+++ b/WrathCombo/Combos/PvP/MNKPVP.cs
@@ -75,16 +75,17 @@ internal static class MNKPvP
                 if (IsEnabled(Preset.MNKPvP_Smite) && PvPMelee.CanSmite() && InActionRange(PvPMelee.Smite) && HasTarget() &&
                     GetTargetHPPercent() <= MNKPvP_SmiteThreshold)
                     return PvPMelee.Smite;
+                
+                if (HasStatusEffect(Buffs.FireResonance) && ComboAction is PouncingCoeurl)
+                    return actionID;
 
-                if (IsEnabled(Preset.MNKPvP_Burst_RisingPhoenix) && NumberOfEnemiesInRange(RisingPhoenix) >= 1)
-                {
-                    if (!HasStatusEffect(Buffs.FireResonance) && GetRemainingCharges(RisingPhoenix) > 1 || WasLastWeaponskill(PouncingCoeurl) && GetRemainingCharges(RisingPhoenix) > 0)
-                        return OriginalHook(RisingPhoenix);
-                    if (HasStatusEffect(Buffs.FireResonance) && WasLastWeaponskill(PouncingCoeurl))
-                        return actionID;
-                }
+                if (IsEnabled(Preset.MNKPvP_Burst_RisingPhoenix) && HasBattleTarget() && InActionRange(DragonKick) &&
+                    (!HasStatusEffect(Buffs.FireResonance) && GetRemainingCharges(RisingPhoenix) > 1 || // capped on charges
+                     ComboAction is PouncingCoeurl && GetRemainingCharges(RisingPhoenix) > 0)) // use last charge to buff phantom rush
+                    return OriginalHook(RisingPhoenix);
 
-                if (IsEnabled(Preset.MNKPvP_Burst_RiddleOfEarth) && IsOffCooldown(RiddleOfEarth) && PlayerHealthPercentageHp() <= 95)
+                if (IsEnabled(Preset.MNKPvP_Burst_RiddleOfEarth) && !HasStatusEffect(Buffs.EarthResonance) && IsOffCooldown(RiddleOfEarth) && PlayerHealthPercentageHp() <= 95 || //Pop Riddle of earth
+                    HasStatusEffect(Buffs.EarthResonance) && GetStatusEffectRemainingTime(Buffs.EarthResonance) <= 2) //Fire earths reply before it expires
                     return OriginalHook(RiddleOfEarth);
 
                 if (IsEnabled(Preset.MNKPvP_Burst_Thunderclap) && GetRemainingCharges(Thunderclap) > 0 && !InMeleeRange())
@@ -93,14 +94,7 @@ internal static class MNKPvP
                 if (IsEnabled(Preset.MNKPvP_Burst_WindsReply) && InActionRange(WindsReply) && IsOffCooldown(WindsReply))
                     return WindsReply;
 
-                if (CanWeave())
-                {
-                    if (IsEnabled(Preset.MNKPvP_Burst_RiddleOfEarth) && HasStatusEffect(Buffs.EarthResonance) && GetStatusEffectRemainingTime(Buffs.EarthResonance) < 6)
-                        return OriginalHook(EarthsReply);
-                }
-
-                if (IsEnabled(Preset.MNKPvP_Burst_FiresReply) && GetRemainingCharges(FiresReply) > 0 &&
-                    (!WasLastAction(LeapingOpo) || !WasLastAction(RisingRaptor) || !WasLastAction(PouncingCoeurl)))
+                if (IsEnabled(Preset.MNKPvP_Burst_FiresReply) && GetRemainingCharges(FiresReply) > 0 && ComboAction is not (PouncingCoeurl or LeapingOpo or RisingRaptor))
                     return OriginalHook(FiresReply);
 
             }


### PR DESCRIPTION
Fixed primal rend bug with fell cleave, decoded the parenthesis spaghetti. 
Closes #1186 

Fixed Chaotic Cyclone showing Decimate icon. (missing OH) 

Fixed Monk pvp Rising Phoenix not firing in real pvp. Enemiesinrange apparently not working on players but does on dummies. 