### PR TITLE
[UI] Update DTR even when hidden

### DIFF
--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -350,29 +350,25 @@ public sealed partial class WrathCombo : IDalamudPlugin
 
             #endregion
 
-            // Skip the IPC checking if hidden
-            if (!DtrBarEntry.UserHidden)
-            {
-                #region DTR Bar Updating
+            #region DTR Bar Updating
 
-                var autoOn = IPC.GetAutoRotationState();
-                var icon = new IconPayload(autoOn
-                    ? BitmapFontIcon.SwordUnsheathed
-                    : BitmapFontIcon.SwordSheathed);
+            var autoOn = IPC.GetAutoRotationState();
+            var icon = new IconPayload(autoOn
+                ? BitmapFontIcon.SwordUnsheathed
+                : BitmapFontIcon.SwordSheathed);
 
-                var text = autoOn ? ": On" : ": Off";
-                if (!Service.Configuration.ShortDTRText && autoOn)
-                    text += $" ({P.IPCSearch.ActiveJobPresets} active)";
-                var ipcControlledText =
-                    P.UIHelper.AutoRotationStateControlled() is not null
-                        ? " (Locked)"
-                        : "";
+            var text = autoOn ? ": On" : ": Off";
+            if (!Service.Configuration.ShortDTRText && autoOn)
+                text += $" ({P.IPCSearch.ActiveJobPresets} active)";
+            var ipcControlledText =
+                P.UIHelper.AutoRotationStateControlled() is not null
+                    ? " (Locked)"
+                    : "";
 
-                var payloadText = new TextPayload(text + ipcControlledText);
-                DtrBarEntry.Text = new SeString(icon, payloadText);
+            var payloadText = new TextPayload(text + ipcControlledText);
+            DtrBarEntry.Text = new SeString(icon, payloadText);
 
-                #endregion
-            }
+            #endregion
 
             if (Service.Configuration.ShowOpenerDtr)
             {


### PR DESCRIPTION
- [X] Updates the main DTR entry even when hidden in dalamud settings, so it can work on Umbra in that situation

This will be a performance hit of some level, it should get an option like the Opener one has to help mitigate that