### PR TITLE
[Jobs] Fixes

### DIFF
--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -245,18 +245,19 @@ internal partial class BLM : Caster
                     return LeyLines;
             }
 
-            if ((EndOfFirePhase || EndOfIcePhaseAoE) &&
+            if ((EndOfFirePhase || EndOfIcePhaseAoE || IcePhase && JustUsedFreezeOrBlizzard) &&
                 HasPolyglotStacks() && ActionReady(Foul))
                 return Foul;
 
             if (LevelChecked(OriginalHook(Thunder2)) && HasStatusEffect(Buffs.Thunderhead) &&
                 CanApplyStatus(CurrentTarget, ThunderList[OriginalHook(Thunder2)]) &&
+                (!IcePhase || JustUsedFreezeOrBlizzard || EndOfIcePhaseAoE || !ActionReady(Freeze)) &&
                 (ThunderDebuffAoE is null && ThunderDebuffST is null ||
                  ThunderDebuffAoE?.RemainingTime <= 3 ||
                  ThunderDebuffST?.RemainingTime <= 3))
                 return OriginalHook(Thunder2);
 
-            if (ActiveParadox && EndOfIcePhaseAoE)
+            if (ActiveParadox && (EndOfIcePhaseAoE || IcePhase && JustUsedFreezeOrBlizzard))
                 return OriginalHook(Blizzard);
 
             if (FirePhase)
@@ -572,7 +573,7 @@ internal partial class BLM : Caster
             }
 
             if (IsEnabled(Preset.BLM_AoE_UsePolyglot) &&
-                (EndOfFirePhase || EndOfIcePhaseAoE) &&
+                (EndOfFirePhase || EndOfIcePhaseAoE || IcePhase && JustUsedFreezeOrBlizzard) &&
                 HasPolyglotStacks() && ActionReady(Foul))
                 return Foul;
 
@@ -580,13 +581,14 @@ internal partial class BLM : Caster
                 ActionReady(OriginalHook(Thunder2)) && HasStatusEffect(Buffs.Thunderhead) &&
                 CanApplyStatus(CurrentTarget, ThunderList[OriginalHook(Thunder2)]) &&
                 GetTargetHPPercent() > BLM_AoE_ThunderHP &&
+                (!IcePhase || JustUsedFreezeOrBlizzard || EndOfIcePhaseAoE || !ActionReady(Freeze)) &&
                 (ThunderDebuffAoE is null && ThunderDebuffST is null ||
                  ThunderDebuffAoE?.RemainingTime <= 3 ||
                  ThunderDebuffST?.RemainingTime <= 3))
                 return OriginalHook(Thunder2);
 
             if (IsEnabled(Preset.BLM_AoE_ParadoxFiller) &&
-                ActiveParadox && EndOfIcePhaseAoE)
+                ActiveParadox && (EndOfIcePhaseAoE || IcePhase && JustUsedFreezeOrBlizzard))
                 return OriginalHook(Blizzard);
 
             if (FirePhase)

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -322,8 +322,8 @@ internal partial class BLM : Caster
 
             if (IsEnabled(Preset.BLM_ST_Manaward) && !LocalPlayer!.HasShield() &&
                 ((BLM_ST_ManawardTrigger == 0 && PlayerHealthPercentageHp() <= BLM_ST_ManawardHPThreshold && GroupDamageIncoming()) ||
-                ((BLM_ST_ManawardTrigger == 1 || (BLM_ST_ManawardTrigger == 0 && BLM_ST_ManawardSolo && !IsInParty())) && PlayerHealthPercentageHp() <= BLM_ST_ManawardHPThreshold) ||
-                (BLM_ST_ManawardTrigger == 2 && GroupDamageIncoming())))
+                 ((BLM_ST_ManawardTrigger == 1 || (BLM_ST_ManawardTrigger == 0 && BLM_ST_ManawardSolo && !IsInParty())) && PlayerHealthPercentageHp() <= BLM_ST_ManawardHPThreshold) ||
+                 (BLM_ST_ManawardTrigger == 2 && GroupDamageIncoming())))
                 return Manaward;
 
             if (CanWeave())

--- a/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
@@ -71,6 +71,9 @@ internal partial class BLM
     private static bool EndOfIcePhaseAoE =>
         IcePhase && HasMaxUmbralHeartStacks && TraitLevelChecked(Traits.EnhancedAstralFire);
 
+    private static bool JustUsedFreezeOrBlizzard =>
+        JustUsed(Freeze, GCD) || JustUsed(Blizzard4, GCD);
+
     #endregion
 
     #region Thunder

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -528,8 +528,8 @@ internal partial class MCH : PhysicalRanged
                     GetTargetHPPercent() > MCH_AoE_FlamethrowerHPOption)
                     return Flamethrower;
 
-                if ((!IsEnabled(Preset.MCH_AoE_Adv_Tools) ||
-                     GetTargetHPPercent() >= MCH_AoE_ToolsHPThreshold) &&
+                if (IsEnabled(Preset.MCH_AoE_Adv_Tools) &&
+                    GetTargetHPPercent() >= MCH_AoE_ToolsHPThreshold &&
                     CanUseAoETools(ref actionID, MCH_AoE_AirAnchor))
                     return actionID;
             }

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -15,7 +15,7 @@ internal partial class MCH : PhysicalRanged
                 return actionID;
 
             //Reassemble to start before combat/after downtime
-            if (CanReassemble() && !IsOverheated && !HasWeaved())
+            if (CanReassembleST() && !IsOverheated && !HasWeaved())
                 return Reassemble;
 
             if (!IsOverheated &&
@@ -59,7 +59,7 @@ internal partial class MCH : PhysicalRanged
                 if (!IsOverheated)
                 {
                     // Reassemble
-                    if (CanReassemble())
+                    if (CanReassembleST())
                         return Reassemble;
 
                     // BarrelStabilizer
@@ -120,9 +120,8 @@ internal partial class MCH : PhysicalRanged
                 if (ComboAction is SplitShot && ActionReady(OriginalHook(SlugShot)))
                     return OriginalHook(SlugShot);
 
-                if (ComboAction is SlugShot && !LevelChecked(Drill) &&
-                    LevelChecked(CleanShot) && !HasStatusEffect(Buffs.Reassembled) &&
-                    ActionReady(Reassemble))
+                if (ComboAction is SlugShot && ActionReady(OriginalHook(CleanShot)) &&
+                    CanReassembleST())
                     return Reassemble;
 
                 if (ComboAction is SlugShot && ActionReady(OriginalHook(CleanShot)))
@@ -174,9 +173,7 @@ internal partial class MCH : PhysicalRanged
 
                 if (!IsOverheated)
                 {
-                    if (ActionReady(Reassemble) &&
-                        !HasStatusEffect(Buffs.Reassembled) &&
-                        CanUseReassembleAoE())
+                    if (CanReassembleAoE())
                         return Reassemble;
 
                     // BarrelStabilizer
@@ -250,8 +247,7 @@ internal partial class MCH : PhysicalRanged
 
             //Reassemble to start before combat/after downtime
             if (IsEnabled(Preset.MCH_ST_Adv_Reassemble) &&
-                CanReassemble() && !IsOverheated && !HasWeaved() &&
-                GetRemainingCharges(Reassemble) > MCH_ST_ReassemblePool)
+                CanReassembleST() && !IsOverheated && !HasWeaved())
                 return Reassemble;
 
             if (!IsOverheated &&
@@ -286,7 +282,6 @@ internal partial class MCH : PhysicalRanged
 
                 // Hypercharge
                 if (IsEnabled(Preset.MCH_ST_Adv_Hypercharge) &&
-                    GetTargetHPPercent() > HPThresholdHypercharge &&
                     CanHypercharge())
                     return Hypercharge;
 
@@ -314,9 +309,7 @@ internal partial class MCH : PhysicalRanged
                 {
                     // Reassemble
                     if (IsEnabled(Preset.MCH_ST_Adv_Reassemble) &&
-                        GetRemainingCharges(Reassemble) > MCH_ST_ReassemblePool &&
-                        GetTargetHPPercent() > HPThresholdReassemble &&
-                        CanReassemble())
+                        CanReassembleST())
                         return Reassemble;
 
                     // BarrelStabilizer
@@ -410,8 +403,8 @@ internal partial class MCH : PhysicalRanged
                     return OriginalHook(SlugShot);
 
                 if (IsEnabled(Preset.MCH_ST_Adv_Reassemble) &&
-                    ComboAction is SlugShot && !LevelChecked(Drill) && ActionReady(CleanShot) &&
-                    !HasStatusEffect(Buffs.Reassembled) && ActionReady(Reassemble))
+                    ComboAction is SlugShot && ActionReady(OriginalHook(CleanShot)) &&
+                    CanReassembleST())
                     return Reassemble;
 
                 if (ComboAction is SlugShot && ActionReady(OriginalHook(CleanShot)))
@@ -455,7 +448,6 @@ internal partial class MCH : PhysicalRanged
 
                 // Hypercharge
                 if (IsEnabled(Preset.MCH_AoE_Adv_Hypercharge) &&
-                    GetTargetHPPercent() > MCH_AoE_HyperchargeHPThreshold &&
                     CanHypercharge(true))
                     return Hypercharge;
 
@@ -474,10 +466,7 @@ internal partial class MCH : PhysicalRanged
                 if (!IsOverheated)
                 {
                     if (IsEnabled(Preset.MCH_AoE_Adv_Reassemble) &&
-                        GetTargetHPPercent() > MCH_AoE_ReassembleHPThreshold &&
-                        ActionReady(Reassemble) && !HasStatusEffect(Buffs.Reassembled) &&
-                        GetRemainingCharges(Reassemble) > MCH_AoE_ReassemblePool &&
-                        CanUseReassembleAoE())
+                        CanReassembleAoE())
                         return Reassemble;
 
                     // BarrelStabilizer

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -415,17 +415,17 @@ internal partial class MCH
             return true;
         }
 
-        if (ActionReady(Drill))
-        {
-            actionID = Drill;
-            return true;
-        }
-
-        if (LevelChecked(BioBlaster) && ActionReady(BioBlaster) &&
+        if (ActionReady(BioBlaster) &&
             !HasStatusEffect(Debuffs.Bioblaster, CurrentTarget) &&
             CanApplyStatus(CurrentTarget, Debuffs.Bioblaster))
         {
             actionID = BioBlaster;
+            return true;
+        }
+
+        if (ActionReady(Drill))
+        {
+            actionID = Drill;
             return true;
         }
 

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -58,29 +58,36 @@ internal partial class MCH
     {
         switch (onAoE)
         {
-            case false when
-                (ActionReady(Hypercharge) || HasStatusEffect(Buffs.Hypercharged)) &&
-                (!IsComboExpiring(6) || ShouldSkipHyperchargeHold()) &&
-                !IsOverheated &&
-                LevelChecked(Heatblast) &&
-                IsDrillCD(CustomCooldownForHyperHold) && IsAirAnchorCD(CustomCooldownForHyperHold) &&
-                (IsChainSawCD(CustomCooldownForHyperHold) || ShouldSkipHyperchargeHold()) &&
-                (!HasStatusEffect(Buffs.ExcavatorReady) || ShouldSkipExcavatorHold()) &&
-                !HasStatusEffect(Buffs.FullMetalMachinist) &&
-                (ActionReady(Wildfire) ||
-                 JustUsed(FullMetalField, GCD / 2) ||
-                 (MCH_ST_WildfireBossOption == 1 && !TargetIsBoss()) ||
-                 GetCooldownRemainingTime(Wildfire) > GCD * 15 ||
-                 (Heat is 100 && GetCooldownRemainingTime(Wildfire) > 10) ||
-                 !LevelChecked(Wildfire)):
+            case true when GetTargetHPPercent() <= HyperchargeHPThresholdAoE:
 
-            case true when
-                (ActionReady(Hypercharge) || HasStatusEffect(Buffs.Hypercharged)) &&
-                !IsOverheated && LevelChecked(Heatblast):
-                return true;
+            case false when GetTargetHPPercent() <= HyperchargeHPThresholdST:
+                return false;
+
+            default:
+                switch (onAoE)
+                {
+                    case false when
+                        (ActionReady(Hypercharge) || HasStatusEffect(Buffs.Hypercharged)) &&
+                        (!IsComboExpiring(6) || ShouldSkipHyperchargeHold()) && !IsOverheated &&
+                        IsDrillCD(CustomCooldownForHyperHold) && IsAirAnchorCD(CustomCooldownForHyperHold) &&
+                        (IsChainSawCD(CustomCooldownForHyperHold) || ShouldSkipHyperchargeHold()) &&
+                        (!HasStatusEffect(Buffs.ExcavatorReady) || ShouldSkipExcavatorHold()) &&
+                        !HasStatusEffect(Buffs.FullMetalMachinist) &&
+                        (ActionReady(Wildfire) ||
+                         JustUsed(FullMetalField, GCD / 2) ||
+                         (MCH_ST_WildfireBossOption == 1 && !TargetIsBoss()) ||
+                         GetCooldownRemainingTime(Wildfire) > GCD * 15 ||
+                         (Heat is 100 && GetCooldownRemainingTime(Wildfire) > 10) ||
+                         !LevelChecked(Wildfire)):
+
+                    case true when
+                        (ActionReady(Hypercharge) || HasStatusEffect(Buffs.Hypercharged)) &&
+                        !IsOverheated:
+                        return true;
+                }
+
+                return false;
         }
-
-        return false;
     }
 
     public static bool IsWildfireAboutToBeUsed() =>
@@ -122,10 +129,6 @@ internal partial class MCH
          GetCooldownRemainingTime(Wildfire) > 90 ||
          GetCooldownRemainingTime(Wildfire) <= GCD ||
          GetStatusEffectRemainingTime(Buffs.FullMetalMachinist) <= 6);
-
-    private static int HPThresholdQueen =>
-        MCH_ST_QueenBossOption == 1 ||
-        !InBossEncounter() ? MCH_ST_QueenHPOption : 0;
 
     private static float CustomCooldownForHyperHold =>
         IsWildfireAboutToBeUsed() ? MCH_ST_WildfireHyperchargeCutoffThreshold : 9f;
@@ -192,16 +195,35 @@ internal partial class MCH
         if (ActionReady(OriginalHook(AirAnchor)))
             numberOfReadyTools++;
 
+        if (!LevelChecked(Drill) && ComboTimer > 0 && ComboAction is SlugShot &&
+            LevelChecked(CleanShot))
+            numberOfReadyTools++;
+
         return numberOfReadyTools;
     }
 
-    private static bool CanUseReassembleAoE() =>
+    private static bool HasAoEReassembleTarget() =>
         LevelChecked(Drill) && GetCooldownRemainingTime(Drill) < GCD ||
         LevelChecked(AirAnchor) && GetCooldownRemainingTime(AirAnchor) < GCD ||
         LevelChecked(Chainsaw) && GetCooldownRemainingTime(Chainsaw) < GCD ||
         LevelChecked(Excavator) && HasStatusEffect(Buffs.ExcavatorReady) ||
         LevelChecked(Scattergun) && ActionReady(Scattergun) ||
         ActionReady(OriginalHook(SpreadShot));
+
+    private static bool CanReassembleAoE()
+    {
+        uint remainingCharges = GetRemainingCharges(Reassemble);
+
+        if (!ActionReady(Reassemble) || HasStatusEffect(Buffs.Reassembled) ||
+            !HasBattleTarget() || GetTargetHPPercent() <= AoEReassembleHPThreshold ||
+            !InReassembleRange() || JustUsed(Reassemble, 2f))
+            return false;
+
+        if (remainingCharges == 0 || remainingCharges <= AoEReassembleChargePool)
+            return false;
+
+        return HasAoEReassembleTarget();
+    }
 
     private static bool InReassembleRange() =>
         LevelChecked(Drill) && InActionRange(Drill) ||
@@ -210,26 +232,27 @@ internal partial class MCH
         LevelChecked(Scattergun) && InActionRange(OriginalHook(SpreadShot)) ||
         !LevelChecked(Drill) && InActionRange(OriginalHook(SpreadShot));
 
-    private static bool CanReassemble()
+    private static bool CanReassembleST()
     {
         UpdateReassembleChargeTracking();
 
         uint remainingCharges = GetRemainingCharges(Reassemble);
 
-        if (HasStatusEffect(Buffs.Reassembled) || IsWildfireActive || !HasBattleTarget() ||
+        if (!ActionReady(Reassemble) || HasStatusEffect(Buffs.Reassembled) || IsWildfireActive || !HasBattleTarget() ||
+            GetTargetHPPercent() <= ReassembleHPThreshold ||
             !InReassembleRange() || JustUsed(Reassemble, 2f))
             return false;
 
-        if (remainingCharges == 0 || !ShouldReassemble())
+        if (remainingCharges == 0 || remainingCharges <= ReassembleChargePool || !ShouldReassemble())
             return false;
 
-        if (MCH_ST_Adv_ReassembleChoice == 0)
+        if (!IsEnabled(Preset.MCH_ST_SimpleMode) && MCH_ST_Adv_ReassembleChoice == 0)
         {
             int numberOfReadyTools = ReadyTools();
             return numberOfReadyTools >= remainingCharges;
         }
 
-        if (MCH_ST_Adv_ReassembleChoice == 1)
+        if (IsEnabled(Preset.MCH_ST_SimpleMode) || MCH_ST_Adv_ReassembleChoice == 1)
         {
             if (ActionReady(Excavator) && HasStatusEffect(Buffs.ExcavatorReady))
                 return true;
@@ -241,6 +264,9 @@ internal partial class MCH
                 return true;
 
             if (ActionReady(Drill) && (!LevelChecked(AirAnchor) || GetCooldownRemainingTime(AirAnchor) > GCD * 2))
+                return true;
+
+            if (!LevelChecked(Drill) && ComboTimer > 0 && ComboAction is SlugShot && LevelChecked(CleanShot))
                 return true;
         }
 
@@ -273,6 +299,28 @@ internal partial class MCH
     #endregion
 
     #region HP Treshold
+
+    private static int ReassembleHPThreshold =>
+        IsEnabled(Preset.MCH_ST_SimpleMode) ? 25 : HPThresholdReassemble;
+
+    private static int ReassembleChargePool =>
+        IsEnabled(Preset.MCH_ST_SimpleMode) ? 0 : MCH_ST_ReassemblePool;
+
+    private static int AoEReassembleHPThreshold =>
+        IsEnabled(Preset.MCH_AoE_SimpleMode) ? 25 : MCH_AoE_ReassembleHPThreshold;
+
+    private static int AoEReassembleChargePool =>
+        IsEnabled(Preset.MCH_AoE_SimpleMode) ? 0 : MCH_AoE_ReassemblePool;
+
+    private static int HyperchargeHPThresholdST =>
+        IsEnabled(Preset.MCH_ST_SimpleMode) ? 25 : HPThresholdHypercharge;
+
+    private static int HyperchargeHPThresholdAoE =>
+        IsEnabled(Preset.MCH_AoE_SimpleMode) ? 25 : MCH_AoE_HyperchargeHPThreshold;
+
+    private static int HPThresholdQueen =>
+        MCH_ST_QueenBossOption == 1 ||
+        !InBossEncounter() ? MCH_ST_QueenHPOption : 0;
 
     private static int HPThresholdHypercharge =>
         MCH_ST_HyperchargeBossOption == 1 ||

--- a/WrathCombo/Combos/PvE/SAM/SAM.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM.cs
@@ -182,15 +182,16 @@ internal partial class SAM : Melee
             if (ComboTimer > 0 && ComboAction is Fuko or Fuga ||
                 HasStatusEffect(Buffs.MeikyoShisui))
             {
-                if (LevelChecked(Mangetsu) &&
-                    (!HasGetsu ||
-                     !HasStatusEffect(Buffs.Fugetsu)))
-                    return Mangetsu;
-
                 if (LevelChecked(Oka) &&
                     (!HasKa ||
                      !HasStatusEffect(Buffs.Fuka)))
                     return Oka;
+
+                if (LevelChecked(Mangetsu) &&
+                    (!HasGetsu ||
+                     !HasStatusEffect(Buffs.Fugetsu) ||
+                     !LevelChecked(Oka)))
+                    return Mangetsu;
             }
 
             return actionID;
@@ -445,17 +446,18 @@ internal partial class SAM : Melee
             if (ComboTimer > 0 && ComboAction is Fuko or Fuga ||
                 HasStatusEffect(Buffs.MeikyoShisui))
             {
-                if (LevelChecked(Mangetsu) &&
-                    (!HasGetsu ||
-                     IsNotEnabled(Preset.SAM_AoE_Oka) ||
-                     !HasStatusEffect(Buffs.Fugetsu)))
-                    return Mangetsu;
-
                 if (IsEnabled(Preset.SAM_AoE_Oka) &&
                     LevelChecked(Oka) &&
                     (!HasKa ||
                      !HasStatusEffect(Buffs.Fuka)))
                     return Oka;
+
+                if (LevelChecked(Mangetsu) &&
+                    (!HasGetsu ||
+                     !HasStatusEffect(Buffs.Fugetsu) ||
+                     !LevelChecked(Oka) ||
+                     IsNotEnabled(Preset.SAM_AoE_Oka)))
+                    return Mangetsu;
             }
 
             return actionID;
@@ -510,7 +512,8 @@ internal partial class SAM : Melee
 
                     if (SAM_Yukaze_Gekko &&
                         LevelChecked(Jinpu) &&
-                        ((OnTargetsRear() || OnTargetsFront()) && !HasGetsu && LevelChecked(Gekko) ||
+                        (!LevelChecked(Kasha) && LevelChecked(Gekko) ||
+                         (OnTargetsRear() || OnTargetsFront()) && !HasGetsu && LevelChecked(Gekko) ||
                          HasKa && !HasGetsu && LevelChecked(Gekko) ||
                          SAM_ST_YukikazeCombo_Prio == 1 && !HasStatusEffect(Buffs.Fugetsu) ||
                          SenCount is 3 && RefreshFugetsu))
@@ -635,19 +638,20 @@ internal partial class SAM : Melee
             if (ComboTimer > 0 && ComboAction is Fuko or Fuga ||
                 HasStatusEffect(Buffs.MeikyoShisui))
             {
-                if (LevelChecked(Mangetsu) &&
-                    (!HasGetsu ||
-                     !SAM_Mangetsu_Oka ||
-                     !HasStatusEffect(Buffs.Fugetsu) ||
-                     SenCount is 2 or 3 && RefreshFugetsu))
-                    return Mangetsu;
-
                 if (SAM_Mangetsu_Oka &&
                     LevelChecked(Oka) &&
                     (!HasKa ||
                      !HasStatusEffect(Buffs.Fuka) ||
                      SenCount is 2 or 3 && RefreshFuka))
                     return Oka;
+
+                if (LevelChecked(Mangetsu) &&
+                    (!HasGetsu ||
+                     !SAM_Mangetsu_Oka ||
+                     !HasStatusEffect(Buffs.Fugetsu) ||
+                     !LevelChecked(Oka) ||
+                     SenCount is 2 or 3 && RefreshFugetsu))
+                    return Mangetsu;
             }
 
             return OriginalHook(Fuko);

--- a/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
@@ -25,8 +25,8 @@ internal partial class SAM
             {
                 if ((simpleMode || IsEnabled(Preset.SAM_ST_Yukikaze)) &&
                     !HasSetsu && LevelChecked(Yukikaze) &&
-                    (GetStatusEffectRemainingTime(Buffs.Fugetsu) > 7 || IsNotEnabled(Preset.SAM_ST_Gekko)) &&
-                    (GetStatusEffectRemainingTime(Buffs.Fuka) > 7 || IsNotEnabled(Preset.SAM_ST_Kasha)))
+                    (GetStatusEffectRemainingTime(Buffs.Fugetsu) > 7 || IsNotEnabled(Preset.SAM_ST_Gekko) || !LevelChecked(Kasha)) &&
+                    (GetStatusEffectRemainingTime(Buffs.Fuka) > 7 || IsNotEnabled(Preset.SAM_ST_Kasha) || !LevelChecked(Kasha)))
                     return Yukikaze;
 
                 if ((simpleMode || IsEnabled(Preset.SAM_ST_Kasha)) &&
@@ -39,7 +39,8 @@ internal partial class SAM
 
                 if ((simpleMode || IsEnabled(Preset.SAM_ST_Gekko)) &&
                     LevelChecked(Jinpu) &&
-                    ((OnTargetsRear() || OnTargetsFront()) && !HasGetsu && LevelChecked(Gekko) ||
+                    (!LevelChecked(Kasha) && LevelChecked(Gekko) ||
+                     (OnTargetsRear() || OnTargetsFront()) && !HasGetsu && LevelChecked(Gekko) ||
                      OnTargetsFlank() && HasKa && LevelChecked(Gekko) ||
                      !HasStatusEffect(Buffs.Fugetsu) ||
                      SenCount is 3 && RefreshFugetsu))
@@ -221,7 +222,8 @@ internal partial class SAM
 
         if ((simpleMode || IsEnabled(Preset.SAM_ST_Gekko)) &&
             LevelChecked(Gekko) &&
-            (!HasStatusEffect(Buffs.Fugetsu) ||
+            (!LevelChecked(Kasha) ||
+             !HasStatusEffect(Buffs.Fugetsu) ||
              (OnTargetsRear() || OnTargetsFront()) && !HasGetsu ||
              OnTargetsFlank() && HasKa))
             return !OnTargetsRear() &&

--- a/WrathCombo/Combos/PvE/VPR/VPR_Config.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR_Config.cs
@@ -17,18 +17,16 @@ internal partial class VPR
                 #region ST
 
                 case Preset.VPR_ST_Opener:
-                    DrawBossOnlyChoice(VPR_Balance_Content);
-                    ImGui.NewLine();
-
                     DrawRadioButton(VPR_OpenerSelection, Generics.StandardOpener,
                         Generics.StandardOpener, 0, descriptionAsTooltip: true);
                     DrawRadioButton(VPR_OpenerSelection, VPR_Config.EarlyBuffOpener,
                         VPR_Config.UseEarlyBuffOpener, 1, descriptionAsTooltip: true);
-                    ImGui.NewLine();
-
+                    
                     DrawAdditionalBoolChoice(VPR_Opener_ExcludeUF,
                         FormatAndCache(Generics.Exclude0, UncoiledFury.ActionName()),
                         "");
+
+                    DrawBossOnlyChoice(VPR_Balance_Content);
                     break;
 
                 case Preset.VPR_ST_SerpentsIre:

--- a/WrathCombo/Combos/PvE/VPR/VPR_Config.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR_Config.cs
@@ -18,6 +18,13 @@ internal partial class VPR
 
                 case Preset.VPR_ST_Opener:
                     DrawBossOnlyChoice(VPR_Balance_Content);
+                    ImGui.NewLine();
+
+                    DrawRadioButton(VPR_OpenerSelection, Generics.StandardOpener,
+                        Generics.StandardOpener, 0, descriptionAsTooltip: true);
+                    DrawRadioButton(VPR_OpenerSelection, VPR_Config.EarlyBuffOpener,
+                        VPR_Config.UseEarlyBuffOpener, 1, descriptionAsTooltip: true);
+                    ImGui.NewLine();
 
                     DrawAdditionalBoolChoice(VPR_Opener_ExcludeUF,
                         FormatAndCache(Generics.Exclude0, UncoiledFury.ActionName()),
@@ -181,6 +188,7 @@ internal partial class VPR
 
             //ST
             VPR_Balance_Content = new("VPR_Balance_Content", 1),
+            VPR_OpenerSelection = new("VPR_OpenerSelection"),
             VPR_ST_UncoiledFuryHoldCharges = new("VPR_ST_UncoiledFuryHoldCharges", 1),
             VPR_ST_UncoiledFuryAlwaysUse = new("VPR_ST_UncoiledFuryAlwaysUse", 5),
             VPR_ST_ReawakenBossOption = new("VPR_ST_ReawakenBossOption"),

--- a/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
@@ -379,13 +379,18 @@ internal partial class VPR
 
     internal static WrathOpener Opener()
     {
-        if (StandardOpener.LevelChecked)
+        if (StandardOpener.LevelChecked && VPR_OpenerSelection == 0)
             return StandardOpener;
+
+        if (EarlyBuffOpener.LevelChecked && VPR_OpenerSelection == 1)
+            return EarlyBuffOpener;
+
 
         return WrathOpener.Dummy;
     }
 
     internal static VPRStandardOpener StandardOpener = new();
+    internal static VPREarlyBuffOpener EarlyBuffOpener = new();
 
     internal class VPRStandardOpener : WrathOpener
     {
@@ -447,6 +452,73 @@ internal partial class VPR
             ([21, 22, 23, 24, 25, 26], () => VPR_Opener_ExcludeUF || !HasCharges(RattlingCoil)),
             ([27], () => ComboAction is not SwiftskinsSting),
             ([28], () => !DeathRattleWeave && !JustUsed(HindstingStrike))
+        ];
+
+        internal override UserData ContentCheckConfig => VPR_Balance_Content;
+        public override Preset Preset => Preset.VPR_ST_Opener;
+        public override bool HasCooldowns() =>
+            IsOriginal(ReavingFangs) &&
+            GetRemainingCharges(Vicewinder) is 2 &&
+            IsOffCooldown(SerpentsIre);
+    }
+
+    internal class VPREarlyBuffOpener : WrathOpener
+    {
+        public override int MinOpenerLevel => 100;
+
+        public override int MaxOpenerLevel => 109;
+
+        public override List<uint> OpenerActions { get; set; } =
+        [
+            Vicewinder,
+            SerpentsIre,
+            HuntersCoil,
+            TwinfangBite,
+            TwinbloodBite,
+            SwiftskinsCoil,
+            TwinbloodBite,
+            TwinfangBite,
+            Reawaken,
+            FirstGeneration,
+            FirstLegacy,
+            SecondGeneration,
+            SecondLegacy,
+            ThirdGeneration,
+            ThirdLegacy,
+            FourthGeneration,
+            FourthLegacy,
+            Ouroboros,
+            UncoiledFury, //19
+            UncoiledTwinfang, //20
+            UncoiledTwinblood, //21
+            Vicewinder,
+            HuntersCoil, //23
+            TwinfangBite, //24
+            TwinbloodBite, //25
+            SwiftskinsCoil, //26
+            TwinbloodBite, //27
+            TwinfangBite, //28
+            UncoiledFury, //29
+            UncoiledTwinfang, //30
+            UncoiledTwinblood, //31
+            UncoiledFury, //32
+            UncoiledTwinfang, //33
+            UncoiledTwinblood //34
+        ];
+
+        public override List<(int[], uint, Func<bool>)> SubstitutionSteps { get; set; } =
+        [
+            ([23], SwiftskinsCoil, OnTargetsRear),
+            ([24], TwinbloodBite, () => HasStatusEffect(Buffs.SwiftskinsVenom)),
+            ([25], TwinfangBite, () => HasStatusEffect(Buffs.HuntersVenom)),
+            ([26], HuntersCoil, () => UsedSwiftskinsCoil),
+            ([27], TwinfangBite, () => HasStatusEffect(Buffs.HuntersVenom)),
+            ([28], TwinbloodBite, () => HasStatusEffect(Buffs.SwiftskinsVenom))
+        ];
+
+        public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
+        [
+            ([19, 20, 21, 29, 30, 31, 32, 33, 34], () => VPR_Opener_ExcludeUF || !HasCharges(RattlingCoil))
         ];
 
         internal override UserData ContentCheckConfig => VPR_Balance_Content;

--- a/WrathCombo/Resources/Localization/JobConfigs/VPR_Config.Designer.cs
+++ b/WrathCombo/Resources/Localization/JobConfigs/VPR_Config.Designer.cs
@@ -106,6 +106,15 @@ namespace WrathCombo.Resources.Localization.JobConfigs {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Early Buff opener..
+        /// </summary>
+        internal static string EarlyBuffOpener {
+            get {
+                return ResourceManager.GetString("EarlyBuffOpener", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Forces {0} or {1} if buff needs to be reapplied..
         /// </summary>
         internal static string Forces0Or1ForBuffs {
@@ -129,6 +138,15 @@ namespace WrathCombo.Resources.Localization.JobConfigs {
         internal static string Replace0WithFullCombo {
             get {
                 return ResourceManager.GetString("Replace0WithFullCombo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Uses 1st GCD Buffs opener..
+        /// </summary>
+        internal static string UseEarlyBuffOpener {
+            get {
+                return ResourceManager.GetString("UseEarlyBuffOpener", resourceCulture);
             }
         }
         

--- a/WrathCombo/Resources/Localization/JobConfigs/VPR_Config.Designer.cs
+++ b/WrathCombo/Resources/Localization/JobConfigs/VPR_Config.Designer.cs
@@ -106,7 +106,7 @@ namespace WrathCombo.Resources.Localization.JobConfigs {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Early Buff opener..
+        ///   Looks up a localized string similar to Early buff opener..
         /// </summary>
         internal static string EarlyBuffOpener {
             get {
@@ -142,7 +142,7 @@ namespace WrathCombo.Resources.Localization.JobConfigs {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Uses 1st GCD Buffs opener..
+        ///   Looks up a localized string similar to Uses 1st GCD buffs opener..
         /// </summary>
         internal static string UseEarlyBuffOpener {
             get {

--- a/WrathCombo/Resources/Localization/JobConfigs/VPR_Config.resx
+++ b/WrathCombo/Resources/Localization/JobConfigs/VPR_Config.resx
@@ -137,7 +137,7 @@
     <value>Disables the range check for {0} and {1}, so it will be used even without a target selected.</value>
   </data>
   <data name="EarlyBuffOpener" xml:space="preserve">
-    <value>Early Buff opener.</value>
+    <value>Early buff opener.</value>
   </data>
   <data name="Forces0Or1ForBuffs" xml:space="preserve">
     <value>Forces {0} or {1} if buff needs to be reapplied.</value>
@@ -149,7 +149,7 @@
     <value>Replaces {0} with Full Generation - Legacy combo.</value>
   </data>
   <data name="UseEarlyBuffOpener" xml:space="preserve">
-    <value>Uses 1st GCD Buffs opener.</value>
+    <value>Uses 1st GCD buffs opener.</value>
   </data>
   <data name="WillHoldLastChargeOf0For1" xml:space="preserve">
     <value>Will hold the last charge of {0} for use with {1}, even when out of position for normal GCD.

--- a/WrathCombo/Resources/Localization/JobConfigs/VPR_Config.resx
+++ b/WrathCombo/Resources/Localization/JobConfigs/VPR_Config.resx
@@ -136,6 +136,9 @@
   <data name="DisableRangeCheckFor0And1" xml:space="preserve">
     <value>Disables the range check for {0} and {1}, so it will be used even without a target selected.</value>
   </data>
+  <data name="EarlyBuffOpener" xml:space="preserve">
+    <value>Early Buff opener.</value>
+  </data>
   <data name="Forces0Or1ForBuffs" xml:space="preserve">
     <value>Forces {0} or {1} if buff needs to be reapplied.</value>
   </data>
@@ -144,6 +147,9 @@
   </data>
   <data name="Replace0WithFullCombo" xml:space="preserve">
     <value>Replaces {0} with Full Generation - Legacy combo.</value>
+  </data>
+  <data name="UseEarlyBuffOpener" xml:space="preserve">
+    <value>Uses 1st GCD Buffs opener.</value>
   </data>
   <data name="WillHoldLastChargeOf0For1" xml:space="preserve">
     <value>Will hold the last charge of {0} for use with {1}, even when out of position for normal GCD.


### PR DESCRIPTION
#### MCH
 - Fix Aoe using `Tools` when it is not enabled.
 - Make `Reassemble` on low lvl in parity with the rest, so it respects charges and sliders.
 - Fix `Hypercharge` not being used below lvl 35.
 - Rewrite part of `Reassemble` and `Hypercharge` to behave better on all lvls.
#### VPR
 - Add `1st GCD Buffs` opener.
#### BLM
 - Fix `Freeze` and `Blizzard` being used twice in `Ice Phase`
#### SAM
 - Fix `Mangetsu` not being used
 - Fix `ST only using `Hakaze` on low lvl