### PR TITLE
Stop attacking TEA Jagd Dolls below the 25% feed threshold

### DIFF
--- a/WrathCombo/Combos/PvE/Content/ContentSpecificActions.cs
+++ b/WrathCombo/Combos/PvE/Content/ContentSpecificActions.cs
@@ -35,6 +35,9 @@ public static class ContentSpecificActions
         // Skip checking for Combat Actions if this is a Healing Combo
         if (healing) return false;
 
+        if (EncounterSafety.TryGetTEADollBlock(ref actionID))
+            return true;
+
         if (OccultCrescent.TryGetPhantomAction(ref actionID))
             return true;
 

--- a/WrathCombo/Combos/PvE/Content/EncounterSafety.cs
+++ b/WrathCombo/Combos/PvE/Content/EncounterSafety.cs
@@ -1,0 +1,42 @@
+#region
+
+using Dalamud.Game.ClientState.Objects.Types;
+using WrathCombo.CustomComboNS;
+using WrathCombo.Extensions;
+using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
+using ContentInfo = ECommons.GameHelpers.Content;
+
+#endregion
+
+namespace WrathCombo.Combos.PvE.Content;
+
+/// <summary>
+///     Encounter-specific safety blocks, for enemies that must not be attacked
+///     under certain conditions.
+/// </summary>
+public static class EncounterSafety
+{
+    /// <summary>Jagd Doll's BNpcName ID.</summary>
+    private const uint JagdDoll = 3759;
+
+    private static IGameObject? Target => SimpleTarget.HardTarget;
+
+    /// <summary>
+    ///     Blocks combat actions against The Epic of Alexander (Ultimate)'s
+    ///     Jagd Dolls once they are below the 25% HP feed threshold, as any
+    ///     further damage risks killing them and wiping the raid.
+    /// </summary>
+    /// <param name="actionID">
+    ///     The action; left as the blocked action.
+    /// </param>
+    /// <returns>Whether the action should be blocked.</returns>
+    public static bool TryGetTEADollBlock(ref uint actionID)
+    {
+        if (ContentInfo.TerritoryID != 887) // The Epic of Alexander (Ultimate)
+            return false;
+
+        return Target is not null &&
+               Target.GetNameId() is JagdDoll &&
+               GetTargetHPPercent(Target) < 25;
+    }
+}

--- a/WrathCombo/CustomCombo/Functions/Status.cs
+++ b/WrathCombo/CustomCombo/Functions/Status.cs
@@ -351,6 +351,14 @@ internal abstract partial class CustomComboFunctions
                     return true; //Unfooled means you can attack the Lyre
                 return false;
 
+            case 887: // The Epic of Alexander (Ultimate)
+                // Jagd Doll = NameId 3759
+                // Technically not invincible, but killing one wipes the raid;
+                // ignore them once below the 25% HP feed threshold
+                if (tar.GetNameId() is 3759)
+                    return GetTargetHPPercent(tar) < 25;
+                return StatusCache.CompareLists(StatusCache.InvincibleStatuses, targetStatuses);
+
             case 917: //Puppet's Bunker, Flight Mechs
                 // 724P Alpha = 11792 (A)
                 // 767P Beta  = 11793 (B)


### PR DESCRIPTION
Jagd Dolls in The Epic of Alexander (Ultimate) must be brought below 25% HP to be fed to Liquid Rage, but killing one wipes the raid.

- TargetIsInvincible: ignore dolls under 25% so Auto-Rotation targeting, AoE enemy counting, and retargeting skip them
- EncounterSafety.TryGetTEADollBlock: block combo buttons (via Savage Blade replacement) while the hard target is a doll under 25%

This was tested in A4N since it's hard to find a group for TEA right now but can once more players are doing other content than UMAD. I have some screenshots when I was testing it and even used the debug tool in the addon. Feel free to DM me on discord.
Discord: loop_0x539