### PR TITLE
Abacus Simulator 2026

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -1183,7 +1183,7 @@ internal unsafe class AutoRotationController
                             GetTargetDistance(x.BattleChara) <= QueryRange &&
                             !TargetHasImmortality(x.BattleChara) &&
                             !x.BattleChara.StatusList.Any(x => StatusCache.DoNotHealStatuses.Contains(x.StatusId)) &&
-                            GetTargetHPPercent(x.BattleChara, cfg.HealerSettings.IncludeShields) <=
+                            GetTargetHPPercent(x.BattleChara, cfg.HealerSettings.IncludeShields, true) <=
                             (TargetHasExcog(x.BattleChara) ? cfg.HealerSettings.SingleTargetExcogHPP :
                                 TargetHasRegen(x.BattleChara) ? cfg.HealerSettings.SingleTargetRegenHPP :
                                 cfg.HealerSettings.SingleTargetHPP) &&
@@ -1206,7 +1206,7 @@ internal unsafe class AutoRotationController
                                 (outAct == 0
                                     ? GetTargetDistance(x.BattleChara) <= 20f
                                     : InActionRange(outAct, x.BattleChara)) &&
-                                GetTargetHPPercent(x.BattleChara, cfg.HealerSettings.IncludeShields) <= cfg.HealerSettings.AoETargetHPP);
+                                GetTargetHPPercent(x.BattleChara, cfg.HealerSettings.IncludeShields, true) <= cfg.HealerSettings.AoETargetHPP);
                 memberCount = members.Count();
             }
             catch { memberCount = 0; }

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -1171,7 +1171,7 @@ internal unsafe class AutoRotationController
                             GetTargetDistance(x.BattleChara) <= QueryRange &&
                             !TargetHasImmortality(x.BattleChara) &&
                             !x.BattleChara.StatusList.Any(x => StatusCache.DoNotHealStatuses.Contains(x.StatusId)) &&
-                            GetTargetHPPercent(x.BattleChara, cfg.HealerSettings.IncludeShields, true) <=
+                            GetTargetHPPercent(x.BattleChara, cfg.HealerSettings.IncludeShields) <=
                             (TargetHasExcog(x.BattleChara) ? cfg.HealerSettings.SingleTargetExcogHPP :
                                 TargetHasRegen(x.BattleChara) ? cfg.HealerSettings.SingleTargetRegenHPP :
                                 cfg.HealerSettings.SingleTargetHPP) &&
@@ -1194,7 +1194,7 @@ internal unsafe class AutoRotationController
                                 (outAct == 0
                                     ? GetTargetDistance(x.BattleChara) <= 20f
                                     : InActionRange(outAct, x.BattleChara)) &&
-                                GetTargetHPPercent(x.BattleChara, cfg.HealerSettings.IncludeShields, true) <= cfg.HealerSettings.AoETargetHPP);
+                                GetTargetHPPercent(x.BattleChara, cfg.HealerSettings.IncludeShields) <= cfg.HealerSettings.AoETargetHPP);
                 memberCount = members.Count();
             }
             catch { memberCount = 0; }

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -1046,6 +1046,7 @@ internal unsafe class AutoRotationController
         private static bool Query(IGameObject x) =>
             x is IBattleChara chara &&
             !chara.IsDead &&
+            GetTargetCurrentHP(chara, true) > 0 &&
             chara.IsTargetable &&
             chara.IsHostile() &&
             IsInRange(chara, InBossEncounter() && cfg.DPSSettings.IgnoreRangeInBoss ? 50f : cfg.DPSSettings.MaxDistance) &&

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -1,4 +1,5 @@
 using Dalamud.Game.ClientState.Objects.Types;
+using ECommons.DalamudServices;
 using ECommons.GameFunctions;
 using System.Linq;
 using WrathCombo.AutoRotation;
@@ -319,6 +320,8 @@ internal partial class SCH : Healer
                 if (IsEnabled(Preset.SCH_ST_ADV_DPS_BanefulImpact) && HasStatusEffect(Buffs.ImpactImminent) && !JustUsed(ChainStratagem))
                     return BanefulImpaction;
 
+
+                Svc.Log.Debug($"{IsEnabled(Preset.SCH_ST_ADV_DPS_ChainStrat)} {ActionWatching.NumberOfGcdsUsed > 3} {CanChainStrategem} {GetTargetHPPercent()} {chainThreshold}");
                 if (IsEnabled(Preset.SCH_ST_ADV_DPS_ChainStrat) && ActionWatching.NumberOfGcdsUsed > 3 && CanChainStrategem &&
                     GetTargetHPPercent() > chainThreshold)
                     return ChainStratagem;

--- a/WrathCombo/Core/Configuration.cs
+++ b/WrathCombo/Core/Configuration.cs
@@ -19,6 +19,8 @@ using Setting = WrathCombo.Attributes.Setting;
 using Space = WrathCombo.Attributes.SettingUI_Space;
 using Or = WrathCombo.Attributes.SettingUI_Or;
 using Retarget = WrathCombo.Attributes.SettingUI_RetargetIcon;
+using System.Reflection.Emit;
+using static WrathCombo.Data.ActionWatching;
 
 #endregion
 
@@ -481,6 +483,8 @@ public partial class Configuration : IPluginConfiguration
     #endregion
 
     public HashSet<(ushort Status, uint BaseId)> StatusBlacklist = [];
+
+    public OpCodeConfig OpCodes = new();
 
     #endregion
 }

--- a/WrathCombo/Core/Configuration.cs
+++ b/WrathCombo/Core/Configuration.cs
@@ -282,6 +282,10 @@ public partial class Configuration : IPluginConfiguration
         maxInt: 3)]
     public int MaximumWeavesPerWindow = 2;
 
+    [SettingCategory(Rotation_Behavior_Options)]
+    [Setting(type: Setting.Type.Toggle)]
+    public bool UseExperimentalHP = false;
+
     #endregion
 
     #region Target Settings

--- a/WrathCombo/Core/Configuration.cs
+++ b/WrathCombo/Core/Configuration.cs
@@ -486,5 +486,7 @@ public partial class Configuration : IPluginConfiguration
 
     public OpCodeConfig OpCodes = new();
 
+    public List<FFXIVOPCodes> OpCodesBackup = [];
+
     #endregion
 }

--- a/WrathCombo/Core/OpCodeConfig.cs
+++ b/WrathCombo/Core/OpCodeConfig.cs
@@ -82,9 +82,8 @@ namespace WrathCombo.Core
 
     public class OpCodeConfig
     {
-        public string Version;
-        public int UpdateHpMpTp;
-        public int EffectResultBasic;
+        public string GameVersion;
+        public string RetailVersion;
     }
 
     public class VersionToRetail
@@ -105,7 +104,7 @@ namespace WrathCombo.Core
             try
             {
                 var gameVer = Framework.Instance()->GameVersionString;
-                if (Service.Configuration.OpCodes.Version == gameVer)
+                if (Service.Configuration.OpCodes.GameVersion == gameVer)
                     return;
 
                 var file = P.HTTPClient.GetStringAsync("https://cdn.jsdelivr.net/gh/karashiiro/FFXIVOpcodes@latest/opcodes.json").Result;
@@ -114,17 +113,17 @@ namespace WrathCombo.Core
                 if (config == null)
                     return;
 
+                Service.Configuration.OpCodesBackup = config;
+
                 var versionEndpoint = P.HTTPClient.GetStringAsync("https://raw.githubusercontent.com/xivdev/opcodediff/refs/heads/main/automation/ffxiv_versions_global.json").Result;
                 var versions = JsonConvert.DeserializeObject<List<VersionToRetail>>(versionEndpoint);
 
                 if (versions?.TryGetFirst(x => x.VersionString == gameVer, out var ver) == true)
                 {
                     var codes = config.First(x => x.Version == ver.RetailVersion);
-                    Service.Configuration.OpCodes.Version = gameVer;
-                    Service.Configuration.OpCodes.UpdateHpMpTp = codes.Lists.ServerZoneIpcType.First(x => x.Name == "UpdateHpMpTp").Opcode;
-                    Service.Configuration.OpCodes.EffectResultBasic = codes.Lists.ServerZoneIpcType.First(x => x.Name == "EffectResultBasic").Opcode;
+                    Service.Configuration.OpCodes.GameVersion = gameVer;
+                    Service.Configuration.OpCodes.RetailVersion = ver.RetailVersion;
 
-                    Svc.Log.Debug($"[OpCodeConfig] {Service.Configuration.OpCodes.EffectResultBasic} {Service.Configuration.OpCodes.UpdateHpMpTp}");
                     Service.Configuration.Save();
                 }
             }

--- a/WrathCombo/Core/OpCodeConfig.cs
+++ b/WrathCombo/Core/OpCodeConfig.cs
@@ -2,6 +2,7 @@
 using ECommons.DalamudServices;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -9,6 +10,7 @@ using WrathCombo.Services;
 
 namespace WrathCombo.Core
 {
+#nullable disable
     public class ClientLobbyIpcType
     {
         [JsonProperty("name")]
@@ -94,29 +96,41 @@ namespace WrathCombo.Core
         public string VersionString;
     }
 
+#nullable enable
+
     public static class OpCodeConfigHelper
     {
         public unsafe static void UpdateOpCodes()
         {
-            var file = P.HTTPClient.GetStringAsync("https://cdn.jsdelivr.net/gh/karashiiro/FFXIVOpcodes@latest/opcodes.json").Result;
-            var config = JsonConvert.DeserializeObject<List<FFXIVOPCodes>>(file);
-
-            if (config == null)
-                return;
-
-            var versionEndpoint = P.HTTPClient.GetStringAsync("https://raw.githubusercontent.com/xivdev/opcodediff/refs/heads/main/automation/ffxiv_versions_global.json").Result;
-            var versions = JsonConvert.DeserializeObject<List<VersionToRetail>>(versionEndpoint);
-            var gameVer = Framework.Instance()->GameVersionString;
-
-            if (versions?.TryGetFirst(x => x.VersionString == gameVer, out var ver) == true)
+            try
             {
-                var codes = config.First(x => x.Version == ver.RetailVersion);
-                Service.Configuration.OpCodes.Version = gameVer;
-                Service.Configuration.OpCodes.UpdateHpMpTp = codes.Lists.ServerZoneIpcType.First(x => x.Name == "UpdateHpMpTp").Opcode;
-                Service.Configuration.OpCodes.EffectResultBasic = codes.Lists.ServerZoneIpcType.First(x => x.Name == "EffectResultBasic").Opcode;
+                var gameVer = Framework.Instance()->GameVersionString;
+                if (Service.Configuration.OpCodes.Version == gameVer)
+                    return;
 
-                Svc.Log.Debug($"[OpCodeConfig] {Service.Configuration.OpCodes.EffectResultBasic} {Service.Configuration.OpCodes.UpdateHpMpTp}");
-                Service.Configuration.Save();
+                var file = P.HTTPClient.GetStringAsync("https://cdn.jsdelivr.net/gh/karashiiro/FFXIVOpcodes@latest/opcodes.json").Result;
+                var config = JsonConvert.DeserializeObject<List<FFXIVOPCodes>>(file);
+
+                if (config == null)
+                    return;
+
+                var versionEndpoint = P.HTTPClient.GetStringAsync("https://raw.githubusercontent.com/xivdev/opcodediff/refs/heads/main/automation/ffxiv_versions_global.json").Result;
+                var versions = JsonConvert.DeserializeObject<List<VersionToRetail>>(versionEndpoint);
+
+                if (versions?.TryGetFirst(x => x.VersionString == gameVer, out var ver) == true)
+                {
+                    var codes = config.First(x => x.Version == ver.RetailVersion);
+                    Service.Configuration.OpCodes.Version = gameVer;
+                    Service.Configuration.OpCodes.UpdateHpMpTp = codes.Lists.ServerZoneIpcType.First(x => x.Name == "UpdateHpMpTp").Opcode;
+                    Service.Configuration.OpCodes.EffectResultBasic = codes.Lists.ServerZoneIpcType.First(x => x.Name == "EffectResultBasic").Opcode;
+
+                    Svc.Log.Debug($"[OpCodeConfig] {Service.Configuration.OpCodes.EffectResultBasic} {Service.Configuration.OpCodes.UpdateHpMpTp}");
+                    Service.Configuration.Save();
+                }
+            }
+            catch(Exception ex)
+            {
+                ex.Log("Issue updating OP Codes");
             }
         }
     }

--- a/WrathCombo/Core/OpCodeConfig.cs
+++ b/WrathCombo/Core/OpCodeConfig.cs
@@ -1,0 +1,123 @@
+﻿using ECommons;
+using ECommons.DalamudServices;
+using FFXIVClientStructs.FFXIV.Client.System.Framework;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using WrathCombo.Services;
+
+namespace WrathCombo.Core
+{
+    public class ClientLobbyIpcType
+    {
+        [JsonProperty("name")]
+        public string Name;
+
+        [JsonProperty("opcode")]
+        public int Opcode;
+    }
+
+    public class ClientZoneIpcType
+    {
+        [JsonProperty("name")]
+        public string Name;
+
+        [JsonProperty("opcode")]
+        public int Opcode;
+    }
+
+    public class Lists
+    {
+        [JsonProperty("ServerZoneIpcType")]
+        public List<ServerZoneIpcType> ServerZoneIpcType;
+
+        [JsonProperty("ClientZoneIpcType")]
+        public List<ClientZoneIpcType> ClientZoneIpcType;
+
+        [JsonProperty("ServerLobbyIpcType")]
+        public List<ServerLobbyIpcType> ServerLobbyIpcType;
+
+        [JsonProperty("ClientLobbyIpcType")]
+        public List<ClientLobbyIpcType> ClientLobbyIpcType;
+
+        [JsonProperty("ServerChatIpcType")]
+        public List<object> ServerChatIpcType;
+
+        [JsonProperty("ClientChatIpcType")]
+        public List<object> ClientChatIpcType;
+    }
+
+    public class FFXIVOPCodes
+    {
+        [JsonProperty("version")]
+        public string Version;
+
+        [JsonProperty("region")]
+        public string Region;
+
+        [JsonProperty("lists")]
+        public Lists Lists;
+    }
+
+    public class ServerLobbyIpcType
+    {
+        [JsonProperty("name")]
+        public string Name;
+
+        [JsonProperty("opcode")]
+        public int Opcode;
+    }
+
+    public class ServerZoneIpcType
+    {
+        [JsonProperty("name")]
+        public string Name;
+
+        [JsonProperty("opcode")]
+        public int Opcode;
+    }
+
+    public class OpCodeConfig
+    {
+        public string Version;
+        public int UpdateHpMpTp;
+        public int EffectResultBasic;
+    }
+
+    public class VersionToRetail
+    {
+        [JsonProperty("retail_version")]
+        public string RetailVersion;
+
+        [JsonProperty("version_string")]
+        public string VersionString;
+    }
+
+    public static class OpCodeConfigHelper
+    {
+        public unsafe static void UpdateOpCodes()
+        {
+            var file = P.HTTPClient.GetStringAsync("https://cdn.jsdelivr.net/gh/karashiiro/FFXIVOpcodes@latest/opcodes.json").Result;
+            var config = JsonConvert.DeserializeObject<List<FFXIVOPCodes>>(file);
+
+            if (config == null)
+                return;
+
+            var versionEndpoint = P.HTTPClient.GetStringAsync("https://raw.githubusercontent.com/xivdev/opcodediff/refs/heads/main/automation/ffxiv_versions_global.json").Result;
+            var versions = JsonConvert.DeserializeObject<List<VersionToRetail>>(versionEndpoint);
+            var gameVer = Framework.Instance()->GameVersionString;
+
+            if (versions?.TryGetFirst(x => x.VersionString == gameVer, out var ver) == true)
+            {
+                var codes = config.First(x => x.Version == ver.RetailVersion);
+                Service.Configuration.OpCodes.Version = gameVer;
+                Service.Configuration.OpCodes.UpdateHpMpTp = codes.Lists.ServerZoneIpcType.First(x => x.Name == "UpdateHpMpTp").Opcode;
+                Service.Configuration.OpCodes.EffectResultBasic = codes.Lists.ServerZoneIpcType.First(x => x.Name == "EffectResultBasic").Opcode;
+
+                Svc.Log.Debug($"[OpCodeConfig] {Service.Configuration.OpCodes.EffectResultBasic} {Service.Configuration.OpCodes.UpdateHpMpTp}");
+                Service.Configuration.Save();
+            }
+        }
+    }
+}

--- a/WrathCombo/CustomCombo/Functions/Target.cs
+++ b/WrathCombo/CustomCombo/Functions/Target.cs
@@ -241,13 +241,13 @@ internal abstract partial class CustomComboFunctions
     public static float PlayerHealthPercentageHp() => LocalPlayer is { } player ? player.CurrentHp * 100f / player.MaxHp : 0f;
 
     /// <summary> Gets an object's current HP as a percentage. Defaults to CurrentTarget unless specified. </summary>
-    public static float GetTargetHPPercent(IGameObject? optionalTarget = null, bool includeShield = false, bool usePendingHp = true)
+    public static float GetTargetHPPercent(IGameObject? optionalTarget = null, bool includeShield = false, bool forceUsePending = false)
     {
         if ((optionalTarget ?? CurrentTarget) is not IBattleChara chara)
             return 0f;
 
         uint currentHp = chara.CurrentHp;
-        if (usePendingHp && SimpleTargetState.TargetStates.TryGetFirst(x => x.GameObjectID == chara.GameObjectId, out var p))
+        if ((Service.Configuration.UseExperimentalHP || forceUsePending) && SimpleTargetState.TargetStates.TryGetFirst(x => x.GameObjectID == chara.GameObjectId, out var p))
             currentHp = p.CurrentHP;
 
         float charaHPPercent = currentHp * 100f / chara.MaxHp;
@@ -261,12 +261,12 @@ internal abstract partial class CustomComboFunctions
     public static uint GetTargetMaxHP(IGameObject? optionalTarget = null) => (optionalTarget ?? CurrentTarget) is IBattleChara chara ? chara.MaxHp : 0;
 
     /// <summary> Gets an object's current HP. Defaults to CurrentTarget unless specified. </summary>
-    public static uint GetTargetCurrentHP(IGameObject? optionalTarget = null, bool usePendingHP = true)
+    public static uint GetTargetCurrentHP(IGameObject? optionalTarget = null, bool forceUsePending = true)
     {
         optionalTarget ??= CurrentTarget;
         if (optionalTarget is IBattleChara chara) 
         {
-            if (usePendingHP && SimpleTargetState.TargetStates.TryGetFirst(x => x.GameObjectID == chara.GameObjectId, out var p))
+            if ((Service.Configuration.UseExperimentalHP || forceUsePending) && SimpleTargetState.TargetStates.TryGetFirst(x => x.GameObjectID == chara.GameObjectId, out var p))
                 return p.CurrentHP;
             else
                 return chara.CurrentHp;

--- a/WrathCombo/CustomCombo/Functions/Target.cs
+++ b/WrathCombo/CustomCombo/Functions/Target.cs
@@ -1,4 +1,5 @@
 ﻿using Dalamud.Game.ClientState.Objects.Types;
+using ECommons;
 using ECommons.DalamudServices;
 using ECommons.GameFunctions;
 using ECommons.Throttlers;
@@ -232,12 +233,16 @@ internal abstract partial class CustomComboFunctions
     public static float PlayerHealthPercentageHp() => LocalPlayer is { } player ? player.CurrentHp * 100f / player.MaxHp : 0f;
 
     /// <summary> Gets an object's current HP as a percentage. Defaults to CurrentTarget unless specified. </summary>
-    public static float GetTargetHPPercent(IGameObject? optionalTarget = null, bool includeShield = false)
+    public static float GetTargetHPPercent(IGameObject? optionalTarget = null, bool includeShield = false, bool usePendingHp = true)
     {
         if ((optionalTarget ?? CurrentTarget) is not IBattleChara chara)
             return 0f;
 
-        float charaHPPercent = chara.CurrentHp * 100f / chara.MaxHp;
+        uint currentHp = chara.CurrentHp;
+        if (usePendingHp && SimpleTargetState.TargetStates.TryGetFirst(x => x.GameObjectID == chara.GameObjectId, out var p))
+            currentHp = p.CurrentHP;
+
+        float charaHPPercent = currentHp * 100f / chara.MaxHp;
 
         return includeShield
             ? Math.Clamp(charaHPPercent + chara.ShieldPercentage, 0f, 100f)
@@ -248,7 +253,19 @@ internal abstract partial class CustomComboFunctions
     public static uint GetTargetMaxHP(IGameObject? optionalTarget = null) => (optionalTarget ?? CurrentTarget) is IBattleChara chara ? chara.MaxHp : 0;
 
     /// <summary> Gets an object's current HP. Defaults to CurrentTarget unless specified. </summary>
-    public static uint GetTargetCurrentHP(IGameObject? optionalTarget = null) => (optionalTarget ?? CurrentTarget) is IBattleChara chara ? chara.CurrentHp : 0;
+    public static uint GetTargetCurrentHP(IGameObject? optionalTarget = null, bool usePendingHP = true)
+    {
+        optionalTarget ??= CurrentTarget;
+        if (optionalTarget is IBattleChara chara) 
+        {
+            if (usePendingHP && SimpleTargetState.TargetStates.TryGetFirst(x => x.GameObjectID == chara.GameObjectId, out var p))
+                return p.CurrentHP;
+            else
+                return chara.CurrentHp;
+        }
+
+        return 0;
+    }
 
     /// <summary> Gets the average HP percentage of all enemies within a specified range. </summary>
     public static float GetAvgEnemyHPPercentInRange(float range)

--- a/WrathCombo/CustomCombo/Functions/Target.cs
+++ b/WrathCombo/CustomCombo/Functions/Target.cs
@@ -261,7 +261,7 @@ internal abstract partial class CustomComboFunctions
     public static uint GetTargetMaxHP(IGameObject? optionalTarget = null) => (optionalTarget ?? CurrentTarget) is IBattleChara chara ? chara.MaxHp : 0;
 
     /// <summary> Gets an object's current HP. Defaults to CurrentTarget unless specified. </summary>
-    public static uint GetTargetCurrentHP(IGameObject? optionalTarget = null, bool forceUsePending = true)
+    public static uint GetTargetCurrentHP(IGameObject? optionalTarget = null, bool forceUsePending = false)
     {
         optionalTarget ??= CurrentTarget;
         if (optionalTarget is IBattleChara chara) 

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -51,6 +51,7 @@ public static class ActionWatching
     internal readonly static List<uint> WeaveActions = [];
     internal readonly static List<uint> CombatActions = [];
     internal readonly static HashSet<uint> BossesBaseIds = [.. Svc.Data.GetExcelSheet<BNpcBase>().Where(charaSheet => charaSheet.Rank is 2 or 6).Select(charaSheet => charaSheet.RowId)];
+    internal readonly static List<PendingHPChange> PendingHPChanges = [];
 
     // Delegates
     public delegate void LastActionChangeDelegate();
@@ -86,10 +87,10 @@ public static class ActionWatching
 
     private static unsafe bool UseActionLocationDetour(ActionManager* thisPtr, ActionType actionType, uint actionId, ulong targetId, Vector3* location, uint extraParam, byte a7)
     {
-        if (actionType == ActionType.Action && !_tainted)
+        if (actionType == ActionType.Action && !_tainted && (location->X != 0 || location->Y != 0 || location->Z != 0))
         {
             var obj = targetId.GetObject();
-            if (!obj.CanUseOn(actionId))
+            if (!obj.CanUseOn(actionId) && !Svc.Data.GetExcelSheet<Action>().GetRow(actionId).CanTargetSelf)
             {
                 _tainted = true;
                 if (CurrentTarget?.CanUseOn(actionId) == true)
@@ -199,6 +200,8 @@ public static class ActionWatching
                             member.HPUpdatePending = true;
                             Svc.Framework.RunOnTick(() => member.HPUpdatePending = false, TimeSpan.FromSeconds(1.5));
                         }
+
+                        PendingHPChanges.Add(new PendingHPChange(targetId, effValue, effType == ActionEffectType.Heal));
                     }
 
                     // Event: MP Gain or MP Loss
@@ -646,4 +649,6 @@ public static class ActionWatching
         Weaponskill = 3,
         Ability = 4,
     }
+
+    public record struct PendingHPChange(ulong gameObjectId, int value, bool positiveChange);
 }

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -95,11 +95,34 @@ public static class ActionWatching
     {
         OnRecievePacketHook.Original(thisPtr, targetId, packet);
         var opCode = *(ushort*)(packet + 2);
+        var tar = ((ulong)targetId).GetObject();
+
+        for (int i = 16; i <= 256; i++)
+        {
+            var val = *(uint*)(packet + i);
+            if (PendingHPChanges.Any(x => x.globalSequence == val))
+            {
+                Svc.Log.Verbose($"Found GS packet {val} {i} and {opCode} {tar?.Name}");
+                PendingHPChanges.RemoveAll(x => x.globalSequence <= val && x.gameObjectId == targetId);
+            }
+        }
+
         if (opCode == 916)
         {
             var newHealth = *(uint*)(packet + 16);
-            var tar = ((ulong)targetId).GetObject();
+            var globalSequence = *(uint*)(packet + 20);
+            PendingHPChanges.RemoveAll(x => x.globalSequence <= globalSequence && targetId == x.gameObjectId);
             Svc.Log.Verbose($"[OpCode] Natty Regen on {tar?.Name} with new health {newHealth}");
+            SimpleTargetState.UpdateNaturalRegenTick(targetId, newHealth);
+        }
+
+        if (opCode == 120)
+        {
+            var newHealth = *(uint*)(packet + 28);
+            var globalSequence = *(uint*)(packet + 20);
+            var val = *(uint*)(packet + 16);
+            Svc.Log.Verbose($"[OpCode]] Global Seq: {globalSequence}.");
+            PendingHPChanges.RemoveAll(x => x.globalSequence <= globalSequence);
             SimpleTargetState.UpdateNaturalRegenTick(targetId, newHealth);
         }
     }
@@ -109,11 +132,11 @@ public static class ActionWatching
         Svc.Log.Verbose($"[ActorControl] {entityId} {category} {arg1} {arg2} {arg3} {arg4} {arg5} {arg6} {arg7} {arg8} {targetId.Id} {isRecorded}");
         ActorControlPacketHook.Original(entityId, category, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, targetId, isRecorded);
 
-        if (category == 1541)
-            SimpleTargetState.UpdateDotDamage(entityId, arg2);
+        if (category == 1541) // Dots
+            SimpleTargetState.UpdatePeriodicHealthChange(entityId, arg2, true);
 
-        if (category == 1540)
-            SimpleTargetState.UpdateHotHeal(entityId, arg2);
+        if (category == 1540) // Hots
+            SimpleTargetState.UpdatePeriodicHealthChange(entityId, arg2, false);
 
         if (category == 4 && arg1 == 0)
             SimpleTargetState.RemoveDueToDroppedCombat(entityId);
@@ -225,7 +248,8 @@ public static class ActionWatching
                         $"Damage HealValue: {eff.DamageHealValue} | " +
                         $"Action: {debugActionName} (ID: {actionId}) → " +
                         $"Target: {debugTargetName} ({targetId}) | " +
-                        $"Flags: [AtSource: {eff.AtSource}, FromTarget: {eff.FromTarget}]"
+                        $"[AtSource: {eff.AtSource}, FromTarget: {eff.FromTarget}] | " +
+                        $"Flags: {header->Flags}"
                     );
 #endif
 
@@ -242,7 +266,7 @@ public static class ActionWatching
                             Svc.Framework.RunOnTick(() => member.HPUpdatePending = false, TimeSpan.FromSeconds(1.5));
                         }
 
-                        PendingHPChanges.Add(new PendingHPChange(effObjectId, eff.DamageHealValue, effType == ActionEffectType.Heal, false, header->GlobalSequence));
+                        PendingHPChanges.Add(new PendingHPChange(effObjectId, eff.DamageHealValue, effType == ActionEffectType.Heal, header->GlobalSequence));
                     }
 
                     // Event: MP Gain or MP Loss
@@ -693,5 +717,5 @@ public static class ActionWatching
         Ability = 4,
     }
 
-    public record struct PendingHPChange(ulong gameObjectId, int value, bool positiveChange, bool processed = false, uint globalSequence = 0);
+    public record struct PendingHPChange(ulong gameObjectId, int value, bool positiveChange, uint globalSequence = 0);
 }

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -10,6 +10,7 @@ using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using FFXIVClientStructs.FFXIV.Client.Network;
+using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using Lumina.Excel.Sheets;
 using System;
 using System.Collections.Frozen;
@@ -27,6 +28,7 @@ using WrathCombo.Services;
 using static FFXIVClientStructs.FFXIV.Client.Game.Character.ActionEffectHandler;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 using Action = Lumina.Excel.Sheets.Action;
+using Task = System.Threading.Tasks.Task;
 namespace WrathCombo.Data;
 
 public static class ActionWatching
@@ -107,23 +109,25 @@ public static class ActionWatching
             }
         }
 
-        if (opCode == 916)
+        if (Service.Configuration.OpCodes is { } codes && codes.Version == Framework.Instance()->GameVersionString)
         {
-            var newHealth = *(uint*)(packet + 16);
-            var globalSequence = *(uint*)(packet + 20);
-            PendingHPChanges.RemoveAll(x => x.globalSequence <= globalSequence && targetId == x.gameObjectId);
-            Svc.Log.Verbose($"[OpCode] Natty Regen on {tar?.Name} with new health {newHealth}");
-            SimpleTargetState.UpdateNaturalRegenTick(targetId, newHealth);
-        }
+            if (opCode == codes.UpdateHpMpTp)
+            {
+                var newHealth = *(uint*)(packet + 16);
+                var newMp = *(ushort*)(packet + 20);
+                Svc.Log.Verbose($"[OpCode] Natty Regen on {tar?.Name} with new health {newHealth} and MP {newMp}");
+                SimpleTargetState.UpdateNaturalRegenTick(targetId, newHealth);
+            }
 
-        if (opCode == 120)
-        {
-            var newHealth = *(uint*)(packet + 28);
-            var globalSequence = *(uint*)(packet + 20);
-            var val = *(uint*)(packet + 16);
-            Svc.Log.Verbose($"[OpCode]] Global Seq: {globalSequence}.");
-            PendingHPChanges.RemoveAll(x => x.globalSequence <= globalSequence);
-            SimpleTargetState.UpdateNaturalRegenTick(targetId, newHealth);
+            if (opCode == codes.EffectResultBasic)
+            {
+                var newHealth = *(uint*)(packet + 28);
+                var globalSequence = *(uint*)(packet + 20);
+                var val = *(uint*)(packet + 16);
+                Svc.Log.Verbose($"[OpCode] Effect Resolved on {tar?.Name} with GS {globalSequence}.");
+                PendingHPChanges.RemoveAll(x => x.globalSequence <= globalSequence);
+                SimpleTargetState.UpdateNaturalRegenTick(targetId, newHealth);
+            }
         }
     }
 

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Threading;
-using System.Threading.Tasks;
 using WrathCombo.AutoRotation;
 using WrathCombo.Combos.PvE;
 using WrathCombo.CustomComboNS;
@@ -99,19 +98,19 @@ public static class ActionWatching
         var opCode = *(ushort*)(packet + 2);
         var tar = ((ulong)targetId).GetObject();
 
-        for (int i = 16; i <= 256; i++)
+        if (Service.Configuration.OpCodes is { } codes && codes.GameVersion == Framework.Instance()->GameVersionString)
         {
-            var val = *(uint*)(packet + i);
-            if (PendingHPChanges.Any(x => x.globalSequence == val))
+            var opCodeName = "";
+            try
             {
-                Svc.Log.Verbose($"Found GS packet {val} {i} and {opCode} {tar?.Name}");
-                PendingHPChanges.RemoveAll(x => x.globalSequence <= val && x.gameObjectId == targetId);
+                opCodeName = Service.Configuration.OpCodesBackup.First(x => x.Version == codes.RetailVersion).Lists.ServerZoneIpcType.First(x => x.Opcode == opCode).Name;
             }
-        }
+            catch { }
 
-        if (Service.Configuration.OpCodes is { } codes && codes.Version == Framework.Instance()->GameVersionString)
-        {
-            if (opCode == codes.UpdateHpMpTp)
+            if (!string.IsNullOrEmpty(opCodeName))
+                Svc.Log.Verbose($"[OpCodeVerboseAf] Found {opCodeName} on {tar?.Name}");
+
+            if (opCodeName == "UpdateHpMpTp")
             {
                 var newHealth = *(uint*)(packet + 16);
                 var newMp = *(ushort*)(packet + 20);
@@ -119,14 +118,22 @@ public static class ActionWatching
                 SimpleTargetState.UpdateNaturalRegenTick(targetId, newHealth);
             }
 
-            if (opCode == codes.EffectResultBasic)
+            if (opCodeName is "EffectResult" or "EffectResultBasic")
             {
                 var newHealth = *(uint*)(packet + 28);
                 var globalSequence = *(uint*)(packet + 20);
                 var val = *(uint*)(packet + 16);
                 Svc.Log.Verbose($"[OpCode] Effect Resolved on {tar?.Name} with GS {globalSequence}.");
-                PendingHPChanges.RemoveAll(x => x.globalSequence <= globalSequence);
+                PendingHPChanges.RemoveAll(x => x.globalSequence == globalSequence);
                 SimpleTargetState.UpdateNaturalRegenTick(targetId, newHealth);
+            }
+
+            if (opCodeName is "Effect")
+            {
+                //This is an interesting one, for heals you get this right away but if the heal does not actually change HP it
+                //doesn't get resolved above so maybe worth just timing these out after 1.5s if not resolved
+                var globalSequence = *(uint*)(packet + 28);
+                Svc.Framework.RunOnTick(() => PendingHPChanges.RemoveAll(x => x.globalSequence == globalSequence), TimeSpan.FromSeconds(1.5f));
             }
         }
     }

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -93,6 +93,7 @@ public static class ActionWatching
 
     private static unsafe void OnReceivePacketDetour(PacketDispatcher* thisPtr, uint targetId, nint packet)
     {
+        OnRecievePacketHook.Original(thisPtr, targetId, packet);
         var opCode = *(ushort*)(packet + 2);
         if (opCode == 916)
         {
@@ -101,8 +102,6 @@ public static class ActionWatching
             Svc.Log.Verbose($"[OpCode] Natty Regen on {tar?.Name} with new health {newHealth}");
             SimpleTargetState.UpdateNaturalRegenTick(targetId, newHealth);
         }
-
-        OnRecievePacketHook.Original(thisPtr, targetId, packet);
     }
 
     private static void ActorControlDetour(uint entityId, uint category, uint arg1, uint arg2, uint arg3, uint arg4, uint arg5, uint arg6, uint arg7, uint arg8, GameObjectId targetId, bool isRecorded)

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -224,7 +224,7 @@ public static class ActionWatching
                         $"Params: [{eff.Param0}, {eff.Param1}, {eff.Param2}, {eff.Param3}, {eff.Param4}] | " +
                         $"Damage HealValue: {eff.DamageHealValue} | " +
                         $"Action: {debugActionName} (ID: {actionId}) → " +
-                        $"Target: {debugTargetName} | " +
+                        $"Target: {debugTargetName} ({targetId}) | " +
                         $"Flags: [AtSource: {eff.AtSource}, FromTarget: {eff.FromTarget}]"
                     );
 #endif

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -107,7 +107,7 @@ public static class ActionWatching
 
     private static void ActorControlDetour(uint entityId, uint category, uint arg1, uint arg2, uint arg3, uint arg4, uint arg5, uint arg6, uint arg7, uint arg8, GameObjectId targetId, bool isRecorded)
     {
-        Svc.Log.Debug($"[ActorControl] {entityId} {category} {arg1} {arg2} {arg3} {arg4} {arg5} {arg6} {arg7} {arg8} {targetId.Id} {isRecorded}");
+        Svc.Log.Verbose($"[ActorControl] {entityId} {category} {arg1} {arg2} {arg3} {arg4} {arg5} {arg6} {arg7} {arg8} {targetId.Id} {isRecorded}");
         ActorControlPacketHook.Original(entityId, category, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, targetId, isRecorded);
 
         if (category == 1541)
@@ -243,7 +243,7 @@ public static class ActionWatching
                             Svc.Framework.RunOnTick(() => member.HPUpdatePending = false, TimeSpan.FromSeconds(1.5));
                         }
 
-                        PendingHPChanges.Add(new PendingHPChange(effObjectId, eff.DamageHealValue, effType == ActionEffectType.Heal));
+                        PendingHPChanges.Add(new PendingHPChange(effObjectId, eff.DamageHealValue, effType == ActionEffectType.Heal, false, header->GlobalSequence));
                     }
 
                     // Event: MP Gain or MP Loss
@@ -694,5 +694,5 @@ public static class ActionWatching
         Ability = 4,
     }
 
-    public record struct PendingHPChange(ulong gameObjectId, int value, bool positiveChange, bool processed = false);
+    public record struct PendingHPChange(ulong gameObjectId, int value, bool positiveChange, bool processed = false, uint globalSequence = 0);
 }

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -9,6 +9,7 @@ using ECommons.Logging;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
+using FFXIVClientStructs.FFXIV.Client.Network;
 using Lumina.Excel.Sheets;
 using System;
 using System.Collections.Frozen;
@@ -67,6 +68,7 @@ public static class ActionWatching
     private delegate void SendActionDelegate(ulong targetObjectId, byte actionType, uint actionId, ushort sequence, long a5, long a6, long a7, long a8, long a9);
     private static readonly Hook<SendActionDelegate>? SendActionHook;
     public static readonly Hook<ActionManager.Delegates.IsActionOffCooldown> CanQueueAction;
+    public static readonly Hook<PacketDispatcher.Delegates.HandleActorControlPacket> ActorControlPacketHook;
 
     private static Task UpdateActionTask = null!;
     private static CancellationTokenSource source = new CancellationTokenSource();
@@ -82,30 +84,49 @@ public static class ActionWatching
         UseActionHook ??= Svc.Hook.HookFromAddress<ActionManager.Delegates.UseAction>(ActionManager.Addresses.UseAction.Value, UseActionDetour);
         UseActionLocHook ??= Svc.Hook.HookFromAddress<ActionManager.Delegates.UseActionLocation>(ActionManager.Addresses.UseActionLocation.Value, UseActionLocationDetour);
         CanQueueAction ??= Svc.Hook.HookFromAddress<ActionManager.Delegates.IsActionOffCooldown>(ActionManager.Addresses.IsActionOffCooldown.Value, CanQueueActionDetour);
+        ActorControlPacketHook ??= Svc.Hook.HookFromAddress<PacketDispatcher.Delegates.HandleActorControlPacket>(PacketDispatcher.Addresses.HandleActorControlPacket.Value, ActorControlDetour);
         OnCastInterrupted += CancelPendingLastActionUpdate;
+
+    }
+
+    private static void ActorControlDetour(uint entityId, uint category, uint arg1, uint arg2, uint arg3, uint arg4, uint arg5, uint arg6, uint arg7, uint arg8, GameObjectId targetId, bool isRecorded)
+    {
+        Svc.Log.Debug($"[ActorControl] {entityId} {category} {arg1} {arg2} {arg3} {arg4} {arg5} {arg6} {arg7} {arg8} {targetId.Id} {isRecorded}");
+        ActorControlPacketHook.Original(entityId, category, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, targetId, isRecorded);
+
+        if (category == 1541)
+            SimpleTargetState.UpdateDotDamage(entityId, arg2);
+
+        if (category == 1540)
+            SimpleTargetState.UpdateHotHeal(entityId, arg2);
+
+        if (category == 4 && arg1 == 0)
+            SimpleTargetState.RemoveDueToDroppedCombat(entityId);
+        
     }
 
     private static unsafe bool UseActionLocationDetour(ActionManager* thisPtr, ActionType actionType, uint actionId, ulong targetId, Vector3* location, uint extraParam, byte a7)
     {
-        if (actionType == ActionType.Action && !_tainted && (location->X != 0 || location->Y != 0 || location->Z != 0))
-        {
-            var obj = targetId.GetObject();
-            if (!obj.CanUseOn(actionId) && !Svc.Data.GetExcelSheet<Action>().GetRow(actionId).CanTargetSelf)
-            {
-                _tainted = true;
-                if (CurrentTarget?.CanUseOn(actionId) == true)
-                    targetId = CurrentTarget.ObjectId;
-                else if (Player.Object?.CanUseOn(actionId) == true)
-                    targetId = Player.Object.ObjectId;
+        // TODO Revisit maybe
+        //if (actionType == ActionType.Action && !_tainted && !(location->X != 0 || location->Y != 0 || location->Z != 0))
+        //{
+        //    var obj = targetId.GetObject();
+        //    if (!obj.CanUseOn(actionId) && !Svc.Data.GetExcelSheet<Action>().GetRow(actionId).CanTargetSelf)
+        //    {
+        //        _tainted = true;
+        //        if (CurrentTarget?.CanUseOn(actionId) == true)
+        //            targetId = CurrentTarget.ObjectId;
+        //        else if (Player.Object?.CanUseOn(actionId) == true)
+        //            targetId = Player.Object.ObjectId;
 
-                if (targetId.GetObject() is { } validObj)
-                    DuoLog.Error($"{actionId.ActionName()} has been attempted to be used on an invalid target, likely due to using another rotation plugin. We have updated the target to {validObj.Name} which it can be used on. Please ensure you are only using one rotation plugin for correct behaviour.");
-                else
-                    DuoLog.Error($"{actionId.ActionName()} has been attempted to be used on an invalid target, likely due to using another rotation plugin. We are unable to redirect this to a valid target. Please ensure you are only using one rotation plugin for correct behaviour.");
+        //        if (targetId.GetObject() is { } validObj)
+        //            DuoLog.Error($"{actionId.ActionName()} has been attempted to be used on an invalid target, likely due to using another rotation plugin. We have updated the target to {validObj.Name} which it can be used on. Please ensure you are only using one rotation plugin for correct behaviour.");
+        //        else
+        //            DuoLog.Error($"{actionId.ActionName()} has been attempted to be used on an invalid target, likely due to using another rotation plugin. We are unable to redirect this to a valid target. Please ensure you are only using one rotation plugin for correct behaviour.");
 
-                Svc.Framework.RunOnTick(() => _tainted = false, TimeSpan.FromSeconds(2));
-            }
-        }
+        //        Svc.Framework.RunOnTick(() => _tainted = false, TimeSpan.FromSeconds(2));
+        //    }
+        //}
         return UseActionLocHook.Original(thisPtr, actionType, actionId, targetId, location, extraParam, a7);
     }
 
@@ -116,6 +137,7 @@ public static class ActionWatching
         UseActionHook?.Enable();
         UseActionLocHook?.Enable();
         CanQueueAction?.Enable();
+        ActorControlPacketHook?.Enable();
         Svc.Condition.ConditionChange += ResetActions;
     }
 
@@ -128,6 +150,7 @@ public static class ActionWatching
         UseActionHook?.Dispose();
         UseActionLocHook?.Dispose();
         CanQueueAction?.Dispose();
+        ActorControlPacketHook?.Dispose();
         OnCastInterrupted -= CancelPendingLastActionUpdate;
     }
 
@@ -182,6 +205,7 @@ public static class ActionWatching
                         $"Type: {effType} | " +
                         $"Value: {effValue} | " +
                         $"Params: [{eff.Param0}, {eff.Param1}, {eff.Param2}, {eff.Param3}, {eff.Param4}] | " +
+                        $"Damage HealValue: {eff.DamageHealValue} | " +
                         $"Action: {debugActionName} (ID: {actionId}) → " +
                         $"Target: {debugTargetName} | " +
                         $"Flags: [AtSource: {eff.AtSource}, FromTarget: {eff.FromTarget}]"
@@ -193,15 +217,15 @@ public static class ActionWatching
                     {
                         if (partyMembers.TryGetValue(targetId, out var member))
                         {
-                            member.CurrentHP = effType == ActionEffectType.Damage
-                                ? Math.Min(member.BattleChara.MaxHp, member.CurrentHP - effValue)
-                                : Math.Min(member.BattleChara.MaxHp, member.CurrentHP + effValue);
+                            member.CurrentHP = (uint)(effType == ActionEffectType.Damage
+                                ? Math.Min(member.BattleChara.MaxHp, member.CurrentHP - eff.DamageHealValue)
+                                : Math.Min(member.BattleChara.MaxHp, member.CurrentHP + eff.DamageHealValue));
 
                             member.HPUpdatePending = true;
                             Svc.Framework.RunOnTick(() => member.HPUpdatePending = false, TimeSpan.FromSeconds(1.5));
                         }
 
-                        PendingHPChanges.Add(new PendingHPChange(targetId, effValue, effType == ActionEffectType.Heal));
+                        PendingHPChanges.Add(new PendingHPChange(effObjectId, eff.DamageHealValue, effType == ActionEffectType.Heal));
                     }
 
                     // Event: MP Gain or MP Loss
@@ -613,6 +637,7 @@ public static class ActionWatching
         UseActionHook?.Disable();
         UseActionLocHook?.Disable();
         CanQueueAction?.Disable();
+        ActorControlPacketHook?.Disable();
         Svc.Condition.ConditionChange -= ResetActions;
     }
 
@@ -650,5 +675,5 @@ public static class ActionWatching
         Ability = 4,
     }
 
-    public record struct PendingHPChange(ulong gameObjectId, int value, bool positiveChange);
+    public record struct PendingHPChange(ulong gameObjectId, int value, bool positiveChange, bool processed = false);
 }

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -69,6 +69,7 @@ public static class ActionWatching
     private static readonly Hook<SendActionDelegate>? SendActionHook;
     public static readonly Hook<ActionManager.Delegates.IsActionOffCooldown> CanQueueAction;
     public static readonly Hook<PacketDispatcher.Delegates.HandleActorControlPacket> ActorControlPacketHook;
+    public static readonly Hook<PacketDispatcher.Delegates.OnReceivePacket> OnRecievePacketHook;
 
     private static Task UpdateActionTask = null!;
     private static CancellationTokenSource source = new CancellationTokenSource();
@@ -85,8 +86,23 @@ public static class ActionWatching
         UseActionLocHook ??= Svc.Hook.HookFromAddress<ActionManager.Delegates.UseActionLocation>(ActionManager.Addresses.UseActionLocation.Value, UseActionLocationDetour);
         CanQueueAction ??= Svc.Hook.HookFromAddress<ActionManager.Delegates.IsActionOffCooldown>(ActionManager.Addresses.IsActionOffCooldown.Value, CanQueueActionDetour);
         ActorControlPacketHook ??= Svc.Hook.HookFromAddress<PacketDispatcher.Delegates.HandleActorControlPacket>(PacketDispatcher.Addresses.HandleActorControlPacket.Value, ActorControlDetour);
+        OnRecievePacketHook ??= Svc.Hook.HookFromAddress<PacketDispatcher.Delegates.OnReceivePacket>((nint)PacketDispatcher.StaticVirtualTablePointer->OnReceivePacket, OnReceivePacketDetour);
         OnCastInterrupted += CancelPendingLastActionUpdate;
 
+    }
+
+    private static unsafe void OnReceivePacketDetour(PacketDispatcher* thisPtr, uint targetId, nint packet)
+    {
+        var opCode = *(ushort*)(packet + 2);
+        if (opCode == 916)
+        {
+            var newHealth = *(uint*)(packet + 16);
+            var tar = ((ulong)targetId).GetObject();
+            Svc.Log.Verbose($"[OpCode] Natty Regen on {tar?.Name} with new health {newHealth}");
+            SimpleTargetState.UpdateNaturalRegenTick(targetId, newHealth);
+        }
+
+        OnRecievePacketHook.Original(thisPtr, targetId, packet);
     }
 
     private static void ActorControlDetour(uint entityId, uint category, uint arg1, uint arg2, uint arg3, uint arg4, uint arg5, uint arg6, uint arg7, uint arg8, GameObjectId targetId, bool isRecorded)
@@ -102,7 +118,7 @@ public static class ActionWatching
 
         if (category == 4 && arg1 == 0)
             SimpleTargetState.RemoveDueToDroppedCombat(entityId);
-        
+
     }
 
     private static unsafe bool UseActionLocationDetour(ActionManager* thisPtr, ActionType actionType, uint actionId, ulong targetId, Vector3* location, uint extraParam, byte a7)
@@ -138,6 +154,7 @@ public static class ActionWatching
         UseActionLocHook?.Enable();
         CanQueueAction?.Enable();
         ActorControlPacketHook?.Enable();
+        OnRecievePacketHook?.Enable();
         Svc.Condition.ConditionChange += ResetActions;
     }
 
@@ -151,6 +168,7 @@ public static class ActionWatching
         UseActionLocHook?.Dispose();
         CanQueueAction?.Dispose();
         ActorControlPacketHook?.Dispose();
+        OnRecievePacketHook?.Dispose();
         OnCastInterrupted -= CancelPendingLastActionUpdate;
     }
 
@@ -638,6 +656,7 @@ public static class ActionWatching
         UseActionLocHook?.Disable();
         CanQueueAction?.Disable();
         ActorControlPacketHook?.Disable();
+        OnRecievePacketHook?.Disable();
         Svc.Condition.ConditionChange -= ResetActions;
     }
 

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -59,31 +59,53 @@ public static class ActionWatching
     public delegate void ActionSendDelegate();
     public static event ActionSendDelegate? OnActionSend;
 
-    private unsafe delegate void ReceiveActionEffectDelegate(uint casterEntityId, Character* casterPtr, Vector3* targetPos, Header* header, TargetEffects* effects, GameObjectId* targetEntityIds);
-    private readonly static Hook<ReceiveActionEffectDelegate>? ReceiveActionEffectHook;
-
-    private unsafe delegate bool UseActionDelegate(ActionManager* actionManager, ActionType actionType, uint actionId, ulong targetId, uint extraParam, ActionManager.UseActionMode mode, uint comboRouteId, bool* outOptAreaTargeted);
-    private readonly static Hook<UseActionDelegate>? UseActionHook;
+    private readonly static Hook<Delegates.Receive>? ReceiveActionEffectHook;
+    private readonly static Hook<ActionManager.Delegates.UseAction>? UseActionHook;
+    private readonly static Hook<ActionManager.Delegates.UseActionLocation>? UseActionLocHook;
 
     private delegate void SendActionDelegate(ulong targetObjectId, byte actionType, uint actionId, ushort sequence, long a5, long a6, long a7, long a8, long a9);
     private static readonly Hook<SendActionDelegate>? SendActionHook;
-
-    public unsafe delegate bool CanQueueActionDelegate(ActionManager* actionManager, uint actionType, uint actionID);
-    public static readonly Hook<CanQueueActionDelegate> CanQueueAction;
+    public static readonly Hook<ActionManager.Delegates.IsActionOffCooldown> CanQueueAction;
 
     private static Task UpdateActionTask = null!;
     private static CancellationTokenSource source = new CancellationTokenSource();
     private static CancellationToken token;
 
     public static bool UpdatingActions;
+    private static bool _tainted;
 
     static unsafe ActionWatching()
     {
-        ReceiveActionEffectHook ??= Svc.Hook.HookFromAddress<ReceiveActionEffectDelegate>(Addresses.Receive.Value, ReceiveActionEffectDetour);
+        ReceiveActionEffectHook ??= Svc.Hook.HookFromAddress<Delegates.Receive>(Addresses.Receive.Value, ReceiveActionEffectDetour);
         SendActionHook ??= Svc.Hook.HookFromSignature<SendActionDelegate>("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 24 ?? ?? ?? ?? 48 8B E9 41 0F B7 D9", SendActionDetour);
-        UseActionHook ??= Svc.Hook.HookFromAddress<UseActionDelegate>(ActionManager.Addresses.UseAction.Value, UseActionDetour);
+        UseActionHook ??= Svc.Hook.HookFromAddress<ActionManager.Delegates.UseAction>(ActionManager.Addresses.UseAction.Value, UseActionDetour);
+        UseActionLocHook ??= Svc.Hook.HookFromAddress<ActionManager.Delegates.UseActionLocation>(ActionManager.Addresses.UseActionLocation.Value, UseActionLocationDetour);
+        CanQueueAction ??= Svc.Hook.HookFromAddress<ActionManager.Delegates.IsActionOffCooldown>(ActionManager.Addresses.IsActionOffCooldown.Value, CanQueueActionDetour);
         OnCastInterrupted += CancelPendingLastActionUpdate;
-        CanQueueAction ??= Svc.Hook.HookFromAddress<CanQueueActionDelegate>(ActionManager.Addresses.IsActionOffCooldown.Value, CanQueueActionDetour);
+    }
+
+    private static unsafe bool UseActionLocationDetour(ActionManager* thisPtr, ActionType actionType, uint actionId, ulong targetId, Vector3* location, uint extraParam, byte a7)
+    {
+        if (actionType == ActionType.Action && !_tainted)
+        {
+            var obj = targetId.GetObject();
+            if (!obj.CanUseOn(actionId))
+            {
+                _tainted = true;
+                if (CurrentTarget?.CanUseOn(actionId) == true)
+                    targetId = CurrentTarget.ObjectId;
+                else if (Player.Object?.CanUseOn(actionId) == true)
+                    targetId = Player.Object.ObjectId;
+
+                if (targetId.GetObject() is { } validObj)
+                    DuoLog.Error($"{actionId.ActionName()} has been attempted to be used on an invalid target, likely due to using another rotation plugin. We have updated the target to {validObj.Name} which it can be used on. Please ensure you are only using one rotation plugin for correct behaviour.");
+                else
+                    DuoLog.Error($"{actionId.ActionName()} has been attempted to be used on an invalid target, likely due to using another rotation plugin. We are unable to redirect this to a valid target. Please ensure you are only using one rotation plugin for correct behaviour.");
+
+                Svc.Framework.RunOnTick(() => _tainted = false, TimeSpan.FromSeconds(2));
+            }
+        }
+        return UseActionLocHook.Original(thisPtr, actionType, actionId, targetId, location, extraParam, a7);
     }
 
     public static void Enable()
@@ -91,8 +113,9 @@ public static class ActionWatching
         ReceiveActionEffectHook?.Enable();
         SendActionHook?.Enable();
         UseActionHook?.Enable();
-        Svc.Condition.ConditionChange += ResetActions;
+        UseActionLocHook?.Enable();
         CanQueueAction?.Enable();
+        Svc.Condition.ConditionChange += ResetActions;
     }
 
 
@@ -102,8 +125,9 @@ public static class ActionWatching
         ReceiveActionEffectHook?.Dispose();
         SendActionHook?.Dispose();
         UseActionHook?.Dispose();
-        OnCastInterrupted -= CancelPendingLastActionUpdate;
+        UseActionLocHook?.Dispose();
         CanQueueAction?.Dispose();
+        OnCastInterrupted -= CancelPendingLastActionUpdate;
     }
 
     /// <summary> Handles logic when an action causes an effect. </summary>
@@ -366,25 +390,25 @@ public static class ActionWatching
         }
     }
 
-    public unsafe static bool CanQueueCS(uint actionId) => CanQueueActionDetour(ActionManager.Instance(), 1, actionId);
+    public unsafe static bool CanQueueCS(uint actionId) => CanQueueActionDetour(ActionManager.Instance(), ActionType.Action, actionId);
 
-    private static unsafe bool CanQueueActionDetour(ActionManager* actionManager, uint actionType, uint actionID)
+    private static unsafe bool CanQueueActionDetour(ActionManager* actionManager, ActionType actionType, uint actionID)
     {
         float threshold = Service.Configuration.QueueAdjust ? Service.Configuration.QueueAdjustThreshold : 0.5f;
 
         return GetRemainingActionRecast(actionManager, actionType, actionID) is { } remaining && remaining <= threshold;
 
-        unsafe float? GetRemainingActionRecast(ActionManager* actionManager, uint actionType, uint actionID)
+        unsafe float? GetRemainingActionRecast(ActionManager* actionManager, ActionType actionType, uint actionID)
         {
             var recastGroupDetail = actionManager->GetRecastGroupDetail(actionManager->GetRecastGroup((int)actionType, actionID));
             if (recastGroupDetail == null) return null;
 
-            var additionalRecastGroupDetail = actionManager->GetRecastGroupDetail(actionManager->GetAdditionalRecastGroup((ActionType)actionType, actionID));
+            var additionalRecastGroupDetail = actionManager->GetRecastGroupDetail(actionManager->GetAdditionalRecastGroup(actionType, actionID));
             var additionalRecastRemaining = additionalRecastGroupDetail != null && additionalRecastGroupDetail->IsActive ? additionalRecastGroupDetail->Total - additionalRecastGroupDetail->Elapsed : 0;
 
             if (!recastGroupDetail->IsActive) return additionalRecastRemaining;
 
-            var charges = actionType == 1 ? ActionManager.GetMaxCharges(actionID, Player.MaxLevel) : 1;
+            var charges = actionType == ActionType.Action ? ActionManager.GetMaxCharges(actionID, Player.MaxLevel) : 1;
             var recastRemaining = recastGroupDetail->Total / charges - recastGroupDetail->Elapsed;
             return recastRemaining > additionalRecastRemaining ? recastRemaining : additionalRecastRemaining;
         }
@@ -584,8 +608,9 @@ public static class ActionWatching
         ReceiveActionEffectHook.Disable();
         SendActionHook?.Disable();
         UseActionHook?.Disable();
-        Svc.Condition.ConditionChange -= ResetActions;
+        UseActionLocHook?.Disable();
         CanQueueAction?.Disable();
+        Svc.Condition.ConditionChange -= ResetActions;
     }
 
     [Obsolete("Use CustomComboFunctions.GetActionName instead. This method will be removed in a future update.")]

--- a/WrathCombo/Data/SimpleTargetState.cs
+++ b/WrathCombo/Data/SimpleTargetState.cs
@@ -1,14 +1,12 @@
 ﻿using Dalamud.Game.ClientState.Objects.Types;
+using ECommons;
 using ECommons.DalamudServices;
 using ECommons.GameFunctions;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Channels;
 using WrathCombo.Extensions;
-using static FFXIVClientStructs.FFXIV.Client.UI.AddonJobHudMNK1.ChakraGauge;
 
 namespace WrathCombo.Data
 {
@@ -34,31 +32,88 @@ namespace WrathCombo.Data
                 if (!o.Struct()->InCombat)
                 {
                     TargetStates.RemoveAll(x => x.GameObjectID == o.GameObjectId);
+                    continue;
                 }
 
                 if (TargetStates.Any(x => x.GameObjectID == o.GameObjectId))
                     continue;
 
                 SimpleTargetState target = new(o.CurrentHp, o.MaxHp, o.GameObjectId);
-
                 TargetStates.Add(target);
+
+                UpdateNaturalRegenTick(o.GameObjectId);
             }
 
             UpdatePendingHP();
         }
 
-        public unsafe static void UpdatePendingHP() 
-        { 
+        private static void UpdateNaturalRegenTick(ulong gameObjectId)
+        {
+            if (TargetStates.TryGetFirst(x => x.GameObjectID == gameObjectId, out var p))
+            {
+                var onePercent = p.MaxHP / 100;
+                if (gameObjectId.GetObject() is { } t && !t.IsHostile() && (t.IsAPlayer() || t.IsInParty()))
+                    p.CurrentHP = Math.Min(p.CurrentHP + onePercent, p.MaxHP);
+
+                Svc.Framework.RunOnTick(() => UpdateNaturalRegenTick(gameObjectId), TimeSpan.FromSeconds(3));
+            }
+
+        }
+
+        public unsafe static void UpdatePendingHP()
+        {
             foreach (var o in TargetStates)
             {
-                BattleChara* b = (BattleChara*)o.GameObjectID.GetObject().Address;
-                if (!b->InCombat)
-                    continue;
-                foreach (var p in ActionWatching.PendingHPChanges.Where(x => x.gameObjectId == o.GameObjectID))
+                if (o.GameObjectID.GetObject() is { } t)
                 {
-                    o.CurrentHP = (uint)Math.Clamp(o.CurrentHP + (p.positiveChange ? p.value : -p.value), 0, o.MaxHP);
+                    var b = (BattleChara*)t.Address;
+                    if (!b->InCombat)
+                        continue;
                 }
-                ActionWatching.PendingHPChanges.RemoveAll(x => x.gameObjectId == o.GameObjectID);
+
+                var copy = ActionWatching.PendingHPChanges;
+                for (int i = 0; i < ActionWatching.PendingHPChanges.Count; i++)
+                {
+                    var p = ActionWatching.PendingHPChanges[i];
+                    if (p.gameObjectId != o.GameObjectID)
+                        continue;
+
+                    o.CurrentHP = (uint)Math.Clamp(o.CurrentHP + (p.positiveChange ? p.value : -p.value), 0, o.MaxHP);
+                    p.processed = true;
+                    ActionWatching.PendingHPChanges[i] = p;
+                }
+            }
+            ActionWatching.PendingHPChanges.RemoveAll(x => x.processed);
+        }
+
+        internal static void UpdateDotDamage(uint entityId, uint diff)
+        {
+            if (TargetStates.TryGetFirst(x => x.GameObjectID == entityId, out var p))
+            {
+                if (Svc.Objects.Where(x => x.EntityId == entityId).Cast<IBattleChara>().First() is { } t)
+                {
+                    p.CurrentHP = Math.Min(p.CurrentHP - diff, 0);
+                }
+            }
+        }
+
+        internal static void RemoveDueToDroppedCombat(uint entityId)
+        {
+            Svc.Framework.RunOnTick(() =>
+            {
+                TargetStates.ForEach(x => { if (x.GameObjectID == entityId) x.CurrentHP = x.MaxHP; });
+                ActionWatching.PendingHPChanges.RemoveAll(x => x.gameObjectId == entityId);
+            }, TimeSpan.FromTicks(100));
+        }
+
+        internal static void UpdateHotHeal(uint entityId, uint diff)
+        {
+            if (TargetStates.TryGetFirst(x => x.GameObjectID == entityId, out var p))
+            {
+                if (Svc.Objects.Where(x => x.EntityId == entityId).Cast<IBattleChara>().First() is { } t)
+                {
+                    p.CurrentHP = Math.Min(p.CurrentHP + diff, p.MaxHP);
+                }
             }
         }
     }

--- a/WrathCombo/Data/SimpleTargetState.cs
+++ b/WrathCombo/Data/SimpleTargetState.cs
@@ -1,8 +1,6 @@
 ﻿using Dalamud.Game.ClientState.Objects.Types;
 using ECommons;
 using ECommons.DalamudServices;
-using ECommons.GameFunctions;
-using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -60,12 +58,10 @@ namespace WrathCombo.Data
         {
             foreach (var o in TargetStates)
             {
-                //if (o.GameObjectID.GetObject() is { } t)
-                //{
-                //    var b = (BattleChara*)t.Address;
-                //    if (!b->InCombat)
-                //        continue;
-                //}
+                if (o.GameObjectID.GetObject() is { } t && o.CurrentHP == 0 && t.GetNameId() == 541)
+                {
+                    o.CurrentHP = o.MaxHP;
+                }
 
                 var copy = ActionWatching.PendingHPChanges;
                 for (int i = 0; i < ActionWatching.PendingHPChanges.Count; i++)
@@ -89,7 +85,10 @@ namespace WrathCombo.Data
             {
                 if (Svc.Objects.Where(x => x.EntityId == entityId).Cast<IBattleChara>().First() is { } t)
                 {
-                    p.CurrentHP = Math.Max(p.CurrentHP - diff, 0);
+                    if (diff > p.CurrentHP)
+                        p.CurrentHP = 0;
+                    else
+                        p.CurrentHP = p.CurrentHP - diff;
                 }
             }
         }

--- a/WrathCombo/Data/SimpleTargetState.cs
+++ b/WrathCombo/Data/SimpleTargetState.cs
@@ -1,0 +1,65 @@
+﻿using Dalamud.Game.ClientState.Objects.Types;
+using ECommons.DalamudServices;
+using ECommons.GameFunctions;
+using FFXIVClientStructs.FFXIV.Client.Game.Character;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Channels;
+using WrathCombo.Extensions;
+using static FFXIVClientStructs.FFXIV.Client.UI.AddonJobHudMNK1.ChakraGauge;
+
+namespace WrathCombo.Data
+{
+    public class SimpleTargetState
+    {
+        public uint CurrentHP;
+        public uint MaxHP;
+        public ulong GameObjectID;
+
+        public SimpleTargetState(uint currentHP, uint maxHP, ulong gameObjectID)
+        {
+            CurrentHP = currentHP;
+            MaxHP = maxHP;
+            GameObjectID = gameObjectID;
+        }
+
+        public static List<SimpleTargetState> TargetStates = [];
+
+        public unsafe static void ManageStateList()
+        {
+            foreach (var o in Svc.Objects.Where(x => x is IBattleChara).Cast<IBattleChara>())
+            {
+                if (!o.Struct()->InCombat)
+                {
+                    TargetStates.RemoveAll(x => x.GameObjectID == o.GameObjectId);
+                }
+
+                if (TargetStates.Any(x => x.GameObjectID == o.GameObjectId))
+                    continue;
+
+                SimpleTargetState target = new(o.CurrentHp, o.MaxHp, o.GameObjectId);
+
+                TargetStates.Add(target);
+            }
+
+            UpdatePendingHP();
+        }
+
+        public unsafe static void UpdatePendingHP() 
+        { 
+            foreach (var o in TargetStates)
+            {
+                BattleChara* b = (BattleChara*)o.GameObjectID.GetObject().Address;
+                if (!b->InCombat)
+                    continue;
+                foreach (var p in ActionWatching.PendingHPChanges.Where(x => x.gameObjectId == o.GameObjectID))
+                {
+                    o.CurrentHP = (uint)Math.Clamp(o.CurrentHP + (p.positiveChange ? p.value : -p.value), 0, o.MaxHP);
+                }
+                ActionWatching.PendingHPChanges.RemoveAll(x => x.gameObjectId == o.GameObjectID);
+            }
+        }
+    }
+}

--- a/WrathCombo/Data/SimpleTargetState.cs
+++ b/WrathCombo/Data/SimpleTargetState.cs
@@ -40,22 +40,16 @@ namespace WrathCombo.Data
 
                 SimpleTargetState target = new(o.CurrentHp, o.MaxHp, o.GameObjectId);
                 TargetStates.Add(target);
-
-                UpdateNaturalRegenTick(o.GameObjectId);
             }
 
             UpdatePendingHP();
         }
 
-        private static void UpdateNaturalRegenTick(ulong gameObjectId)
+        public static void UpdateNaturalRegenTick(ulong gameObjectId, uint newHealth)
         {
             if (TargetStates.TryGetFirst(x => x.GameObjectID == gameObjectId, out var p))
             {
-                var onePercent = p.MaxHP / 100;
-                if (gameObjectId.GetObject() is { } t && !t.IsHostile() && (t.IsAPlayer() || t.IsInParty()))
-                    p.CurrentHP = Math.Min(p.CurrentHP + onePercent, p.MaxHP);
-
-                Svc.Framework.RunOnTick(() => UpdateNaturalRegenTick(gameObjectId), TimeSpan.FromSeconds(3));
+                p.CurrentHP = newHealth;
             }
 
         }

--- a/WrathCombo/Data/SimpleTargetState.cs
+++ b/WrathCombo/Data/SimpleTargetState.cs
@@ -1,6 +1,7 @@
 ﻿using Dalamud.Game.ClientState.Objects.Types;
 using ECommons;
 using ECommons.DalamudServices;
+using ECommons.GameFunctions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -27,12 +28,6 @@ namespace WrathCombo.Data
         {
             foreach (var o in Svc.Objects.Where(x => x is IBattleChara).Cast<IBattleChara>())
             {
-                //if (!o.Struct()->InCombat)
-                //{
-                //    TargetStates.RemoveAll(x => x.GameObjectID == o.GameObjectId);
-                //    continue;
-                //}
-
                 TargetStates.RemoveAll(x => o.IsDead && o.GameObjectId == x.GameObjectID);
 
                 if (TargetStates.Any(x => x.GameObjectID == o.GameObjectId) || !o.IsTargetable)
@@ -58,37 +53,10 @@ namespace WrathCombo.Data
         {
             foreach (var o in TargetStates)
             {
-                if (o.GameObjectID.GetObject() is { } t && o.CurrentHP == 0 && t.GetNameId() == 541)
+                if (o.GameObjectID.GetObject() is IBattleChara t)
                 {
-                    o.CurrentHP = o.MaxHP;
-                }
-
-                var copy = ActionWatching.PendingHPChanges;
-                for (int i = 0; i < ActionWatching.PendingHPChanges.Count; i++)
-                {
-                    var p = ActionWatching.PendingHPChanges[i];
-                    if (p.gameObjectId != o.GameObjectID)
-                        continue;
-
-                    Svc.Log.Verbose($"Processing GS {p.globalSequence}");
-                    o.CurrentHP = (uint)Math.Clamp(o.CurrentHP + (p.positiveChange ? p.value : -p.value), 0, o.MaxHP);
-                    p.processed = true;
-                    ActionWatching.PendingHPChanges[i] = p;
-                }
-            }
-            ActionWatching.PendingHPChanges.RemoveAll(x => x.processed);
-        }
-
-        internal static void UpdateDotDamage(uint entityId, uint diff)
-        {
-            if (TargetStates.TryGetFirst(x => x.GameObjectID == entityId, out var p))
-            {
-                if (Svc.Objects.Where(x => x.EntityId == entityId).Cast<IBattleChara>().First() is { } t)
-                {
-                    if (diff > p.CurrentHP)
-                        p.CurrentHP = 0;
-                    else
-                        p.CurrentHP = p.CurrentHP - diff;
+                    var totalDiff = ActionWatching.PendingHPChanges.Where(x => x.gameObjectId == o.GameObjectID).Sum(x => x.positiveChange ? x.value : -x.value);
+                    o.CurrentHP = Math.Clamp((uint)(t.CurrentHp + totalDiff), 0, t.MaxHp);
                 }
             }
         }
@@ -102,13 +70,13 @@ namespace WrathCombo.Data
             }, TimeSpan.FromTicks(100));
         }
 
-        internal static void UpdateHotHeal(uint entityId, uint diff)
+        internal static void UpdatePeriodicHealthChange(uint entityId, uint diff, bool damage)
         {
             if (TargetStates.TryGetFirst(x => x.GameObjectID == entityId, out var p))
             {
                 if (Svc.Objects.Where(x => x.EntityId == entityId).Cast<IBattleChara>().First() is { } t)
                 {
-                    p.CurrentHP = Math.Min(p.CurrentHP + diff, p.MaxHP);
+                    p.CurrentHP = (uint)Math.Clamp(p.CurrentHP + (damage ? -diff : diff), 0, p.MaxHP);
                 }
             }
         }

--- a/WrathCombo/Data/SimpleTargetState.cs
+++ b/WrathCombo/Data/SimpleTargetState.cs
@@ -29,11 +29,13 @@ namespace WrathCombo.Data
         {
             foreach (var o in Svc.Objects.Where(x => x is IBattleChara).Cast<IBattleChara>())
             {
-                if (!o.Struct()->InCombat)
-                {
-                    TargetStates.RemoveAll(x => x.GameObjectID == o.GameObjectId);
-                    continue;
-                }
+                //if (!o.Struct()->InCombat)
+                //{
+                //    TargetStates.RemoveAll(x => x.GameObjectID == o.GameObjectId);
+                //    continue;
+                //}
+
+                TargetStates.RemoveAll(x => o.IsDead && o.GameObjectId == x.GameObjectID);
 
                 if (TargetStates.Any(x => x.GameObjectID == o.GameObjectId))
                     continue;
@@ -41,7 +43,7 @@ namespace WrathCombo.Data
                 SimpleTargetState target = new(o.CurrentHp, o.MaxHp, o.GameObjectId);
                 TargetStates.Add(target);
             }
-
+            TargetStates.RemoveAll(x => !Svc.Objects.Any(y => y.GameObjectId == x.GameObjectID));
             UpdatePendingHP();
         }
 
@@ -58,12 +60,12 @@ namespace WrathCombo.Data
         {
             foreach (var o in TargetStates)
             {
-                if (o.GameObjectID.GetObject() is { } t)
-                {
-                    var b = (BattleChara*)t.Address;
-                    if (!b->InCombat)
-                        continue;
-                }
+                //if (o.GameObjectID.GetObject() is { } t)
+                //{
+                //    var b = (BattleChara*)t.Address;
+                //    if (!b->InCombat)
+                //        continue;
+                //}
 
                 var copy = ActionWatching.PendingHPChanges;
                 for (int i = 0; i < ActionWatching.PendingHPChanges.Count; i++)
@@ -72,6 +74,7 @@ namespace WrathCombo.Data
                     if (p.gameObjectId != o.GameObjectID)
                         continue;
 
+                    Svc.Log.Verbose($"Processing GS {p.globalSequence}");
                     o.CurrentHP = (uint)Math.Clamp(o.CurrentHP + (p.positiveChange ? p.value : -p.value), 0, o.MaxHP);
                     p.processed = true;
                     ActionWatching.PendingHPChanges[i] = p;
@@ -86,7 +89,7 @@ namespace WrathCombo.Data
             {
                 if (Svc.Objects.Where(x => x.EntityId == entityId).Cast<IBattleChara>().First() is { } t)
                 {
-                    p.CurrentHP = Math.Min(p.CurrentHP - diff, 0);
+                    p.CurrentHP = Math.Max(p.CurrentHP - diff, 0);
                 }
             }
         }

--- a/WrathCombo/Data/SimpleTargetState.cs
+++ b/WrathCombo/Data/SimpleTargetState.cs
@@ -1,7 +1,6 @@
 ﻿using Dalamud.Game.ClientState.Objects.Types;
 using ECommons;
 using ECommons.DalamudServices;
-using ECommons.GameFunctions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -76,7 +75,11 @@ namespace WrathCombo.Data
             {
                 if (Svc.Objects.Where(x => x.EntityId == entityId).Cast<IBattleChara>().First() is { } t)
                 {
-                    p.CurrentHP = (uint)Math.Clamp(p.CurrentHP + (damage ? -diff : diff), 0, p.MaxHP);
+                    var val = damage ? -diff : diff;
+                    if (p.CurrentHP + val < 0)
+                        p.CurrentHP = 0;
+                    else
+                        p.CurrentHP = (uint)Math.Clamp(p.CurrentHP + val, 0, p.MaxHP);
                 }
             }
         }

--- a/WrathCombo/Data/SimpleTargetState.cs
+++ b/WrathCombo/Data/SimpleTargetState.cs
@@ -37,7 +37,7 @@ namespace WrathCombo.Data
 
                 TargetStates.RemoveAll(x => o.IsDead && o.GameObjectId == x.GameObjectID);
 
-                if (TargetStates.Any(x => x.GameObjectID == o.GameObjectId))
+                if (TargetStates.Any(x => x.GameObjectID == o.GameObjectId) || !o.IsTargetable)
                     continue;
 
                 SimpleTargetState target = new(o.CurrentHp, o.MaxHp, o.GameObjectId);

--- a/WrathCombo/OpCodeConfig.json
+++ b/WrathCombo/OpCodeConfig.json
@@ -1,4 +1,0 @@
-{
-  "RegenCode": 342,
-  "DamageTick": 120
-}

--- a/WrathCombo/OpCodeConfig.json
+++ b/WrathCombo/OpCodeConfig.json
@@ -1,4 +1,4 @@
 {
-  "RegenCode": 916,
+  "RegenCode": 342,
   "DamageTick": 120
 }

--- a/WrathCombo/OpCodeConfig.json
+++ b/WrathCombo/OpCodeConfig.json
@@ -1,0 +1,4 @@
+{
+  "RegenCode": 916,
+  "DamageTick": 120
+}

--- a/WrathCombo/Resources/Localization/UI/Settings/SettingsCfgUI.Designer.cs
+++ b/WrathCombo/Resources/Localization/UI/Settings/SettingsCfgUI.Designer.cs
@@ -1654,6 +1654,55 @@ namespace WrathCombo.Resources.Localization.UI.Settings {
         /// <summary>
         ///   Looks up a localized string similar to Off.
         /// </summary>
+        internal static string UseExperimentalHP_defaultValue {
+            get {
+                return ResourceManager.GetString("UseExperimentalHP_defaultValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This is a new way of evaluating current HP values, using pre-emptively obtained values to update health values internally before it is reflected in-game properly.
+        ///
+        ///As such, you may see things happen earlier than what may be expected, as values for damage and healing are generated much earlier than shown in game. For example, as soon as you hit the slidecast window the value of the spell is already known.
+        ///
+        ///Used currently when evaluating HP% checks in features and auto-rotation..
+        /// </summary>
+        internal static string UseExperimentalHP_helpMark {
+            get {
+                return ResourceManager.GetString("UseExperimentalHP_helpMark", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Experimental HP Check Feature.
+        /// </summary>
+        internal static string UseExperimentalHP_Name {
+            get {
+                return ResourceManager.GetString("UseExperimentalHP_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Preference.
+        /// </summary>
+        internal static string UseExperimentalHP_recommendedValue {
+            get {
+                return ResourceManager.GetString("UseExperimentalHP_recommendedValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This is highly experimental, and may have undesired behaviours. Please be vigilant and report this..
+        /// </summary>
+        internal static string UseExperimentalHP_warningMark {
+            get {
+                return ResourceManager.GetString("UseExperimentalHP_warningMark", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Off.
+        /// </summary>
         internal static string UseFieldMouseoverOverridesInDefaultHealStack_defaultValue {
             get {
                 return ResourceManager.GetString("UseFieldMouseoverOverridesInDefaultHealStack_defaultValue", resourceCulture);

--- a/WrathCombo/Resources/Localization/UI/Settings/SettingsCfgUI.Designer.cs
+++ b/WrathCombo/Resources/Localization/UI/Settings/SettingsCfgUI.Designer.cs
@@ -1665,7 +1665,7 @@ namespace WrathCombo.Resources.Localization.UI.Settings {
         ///
         ///As such, you may see things happen earlier than what may be expected, as values for damage and healing are generated much earlier than shown in game. For example, as soon as you hit the slidecast window the value of the spell is already known.
         ///
-        ///Used currently when evaluating HP% checks in features and auto-rotation..
+        ///This is actually best recommended for healers using auto-rotation to mitigate the amount of double  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string UseExperimentalHP_helpMark {
             get {

--- a/WrathCombo/Resources/Localization/UI/Settings/SettingsCfgUI.resx
+++ b/WrathCombo/Resources/Localization/UI/Settings/SettingsCfgUI.resx
@@ -746,6 +746,8 @@ It is recommended to enable this if you are a keyboard+mouse user and enable Ret
 
 As such, you may see things happen earlier than what may be expected, as values for damage and healing are generated much earlier than shown in game. For example, as soon as you hit the slidecast window the value of the spell is already known.
 
+This is actually best recommended for healers using auto-rotation to mitigate the amount of double casted heals. For DPS, this will switch targets with auto-rotation the moment a killing blow goes out, rather than waiting until the target is officially recognized as dead.
+
 Used currently when evaluating HP% checks in features and auto-rotation.</value>
   </data>
   <data name="UseExperimentalHP_recommendedValue" xml:space="preserve">

--- a/WrathCombo/Resources/Localization/UI/Settings/SettingsCfgUI.resx
+++ b/WrathCombo/Resources/Localization/UI/Settings/SettingsCfgUI.resx
@@ -738,4 +738,23 @@ It is recommended to enable this if you are a keyboard+mouse user and enable Ret
   <data name="AoEDamageToast_defaultValue" xml:space="preserve">
     <value>Off</value>
   </data>
+  <data name="UseExperimentalHP_Name" xml:space="preserve">
+    <value>Experimental HP Check Feature</value>
+  </data>
+  <data name="UseExperimentalHP_helpMark" xml:space="preserve">
+    <value>This is a new way of evaluating current HP values, using pre-emptively obtained values to update health values internally before it is reflected in-game properly.
+
+As such, you may see things happen earlier than what may be expected, as values for damage and healing are generated much earlier than shown in game. For example, as soon as you hit the slidecast window the value of the spell is already known.
+
+Used currently when evaluating HP% checks in features and auto-rotation.</value>
+  </data>
+  <data name="UseExperimentalHP_recommendedValue" xml:space="preserve">
+    <value>Preference</value>
+  </data>
+  <data name="UseExperimentalHP_defaultValue" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="UseExperimentalHP_warningMark" xml:space="preserve">
+    <value>This is highly experimental, and may have undesired behaviours. Please be vigilant and report this.</value>
+  </data>
 </root>

--- a/WrathCombo/Window/Functions/UserConfig.cs
+++ b/WrathCombo/Window/Functions/UserConfig.cs
@@ -3,6 +3,7 @@ using Dalamud.Interface.Colors;
 using Dalamud.Interface.Components;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Utility;
+using ECommons.DalamudServices;
 using ECommons.ImGuiMethods;
 using System;
 using System.Linq;
@@ -34,7 +35,10 @@ public static class UserConfig
         ImGui.Indent();
         int output = Configuration.GetCustomIntValue(config, minValue);
         if (output < minValue)
-            output = Configuration.SetCustomIntValue(config, output);
+        {
+            Svc.Log.Debug($"{config} has {output} less than {minValue}");
+            output = Configuration.SetCustomIntValue(config, minValue);
+        }
 
         float contentRegionMin = ImGui.GetItemRectMax().Y - ImGui.GetItemRectMin().Y;
         float wrapPos = ImGui.GetContentRegionMax().X - 35f;

--- a/WrathCombo/Window/Functions/UserConfig.cs
+++ b/WrathCombo/Window/Functions/UserConfig.cs
@@ -36,7 +36,7 @@ public static class UserConfig
         int output = Configuration.GetCustomIntValue(config, minValue);
         if (output < minValue)
         {
-            Svc.Log.Debug($"{config} has {output} less than {minValue}");
+            Svc.Log.Warning($"{config} has a value {output} less than {minValue}");
             output = Configuration.SetCustomIntValue(config, minValue);
         }
 
@@ -155,7 +155,10 @@ public static class UserConfig
     {
         float output = Configuration.GetCustomFloatValue(config, minValue);
         if (output < minValue)
-            output = Configuration.SetCustomFloatValue(config, output);
+        {
+            Svc.Log.Warning($"{config} has a value {output} less than {minValue}");
+            output = Configuration.SetCustomFloatValue(config, minValue);
+        }
 
         float contentRegionMin = ImGui.GetItemRectMax().Y - ImGui.GetItemRectMin().Y;
         float wrapPos = ImGui.GetContentRegionMax().X - 35f;

--- a/WrathCombo/Window/Tabs/Debug.cs
+++ b/WrathCombo/Window/Tabs/Debug.cs
@@ -10,11 +10,13 @@ using ECommons.DalamudServices;
 using ECommons.ExcelServices;
 using ECommons.GameFunctions;
 using ECommons.GameHelpers;
+using ECommons.Hooks.ActionEffectTypes;
 using ECommons.ImGuiMethods;
 using ECommons.Logging;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using FFXIVClientStructs.FFXIV.Common.Lua;
 using Lumina.Excel.Sheets;
 using Newtonsoft.Json;
 using System;
@@ -430,6 +432,8 @@ internal class Debug : ConfigWindow, IDisposable
                     Util.ShowStruct(&JobGaugeManager.Instance()->Pictomancer);
                     break;
             }
+
+            Util.ShowObject(player.Struct()->CastInfo);
 
             ImGuiEx.Spacing(new Vector2(0f, SpacingSmall));
 
@@ -1241,8 +1245,32 @@ internal class Debug : ConfigWindow, IDisposable
                         CustomStyleText($"ID", $"{p.GameObjectID}");
                         CustomStyleText($"HP", $"{p.CurrentHP} ({GetTargetHPPercent(t):N0}%)");
                         CustomStyleText($"Object HP", $"{t.CurrentHp} ({GetTargetHPPercent(t, usePendingHp: false):N0}%)");
+
+                        if (ImGui.CollapsingHeader($"Action Efftcts###af{t.GameObjectId}"))
+                        {
+                            foreach (var eff in t.Struct()->ActionEffectHandler.IncomingEffects)
+                            {
+                                ImGui.Separator();
+                                CustomStyleText($"GS:", $"{eff.GlobalSequence}");
+                                CustomStyleText($"Action:", $"{eff.ActionId.ActionName()}");
+                                CustomStyleText($"Target Confirmed:", $"{eff.TargetConfirmed}");
+                                CustomStyleText($"Source Confirmed:", $"{eff.SourceConfirmed}");
+                                foreach (var ef in eff.Effects.Effects)
+                                {
+                                    if (ef.Type == 0)
+                                        continue;
+
+                                    CustomStyleText($"{(Data.ActionEffectType)ef.Type}", $"{ef.Value + ((ef.Param4 & 0x40) != 0 ? ef.Param3 * 0x10000 : 0)}");
+                                }
+                            }
+                        }
                     }
                 }
+            }
+
+            foreach (var pending in ActionWatching.PendingHPChanges)
+            {
+                ImGui.Text($"{pending.gameObjectId.GetObject()?.Name} {pending.gameObjectId} {pending.globalSequence}");
             }
             ImGui.Unindent();
         }
@@ -1330,6 +1358,8 @@ internal class Debug : ConfigWindow, IDisposable
                     CustomStyleText("Action Range:", $"{GetActionRange(charaSpell?.RowId ?? 0)}y");
                     CustomStyleText("Effect Range:", $"{charaSpell?.EffectRange ?? 0}y");
                     CustomStyleText("Interruptible:", $"{castChara.IsCastInterruptible}");
+
+                    Util.ShowObject(castChara.Struct()->CastInfo);
                 }
                 else CustomStyleText("No valid target.", "");
 

--- a/WrathCombo/Window/Tabs/Debug.cs
+++ b/WrathCombo/Window/Tabs/Debug.cs
@@ -1274,7 +1274,8 @@ internal class Debug : ConfigWindow, IDisposable
             CustomStyleText("Name:", target?.Name);
             CustomStyleText("Nameplate:", target?.GetNameplateKind().ToString());
             CustomStyleText("Rank:", $"{battleNPCRow?.Rank.ToString() ?? "null"} (found sheet: {(foundSheet is true ? "yes" : "no")})");
-            CustomStyleText("Health:", $"{GetTargetCurrentHP():N0} / {GetTargetMaxHP():N0} ({MathF.Round(GetTargetHPPercent(), 2)}%)");
+            CustomStyleText("Health:", $"{GetTargetCurrentHP(usePendingHP: false):N0} / {GetTargetMaxHP():N0} ({MathF.Round(GetTargetHPPercent(usePendingHp: false), 2)}%)");
+            CustomStyleText("Health (with pending):", $"{GetTargetCurrentHP(usePendingHP: true):N0} / {GetTargetMaxHP():N0} ({MathF.Round(GetTargetHPPercent(usePendingHp: true), 2)}%)");
             CustomStyleText("Distance:", $"{MathF.Round(GetTargetDistance(), 2)}y");
             CustomStyleText("Hitbox Radius:", target?.HitboxRadius);
             CustomStyleText("In Melee Range:", InMeleeRange());

--- a/WrathCombo/Window/Tabs/Debug.cs
+++ b/WrathCombo/Window/Tabs/Debug.cs
@@ -507,6 +507,7 @@ internal class Debug : ConfigWindow, IDisposable
                 if (ImGui.TreeNode($"{member?.BattleChara?.Name}###{member.GameObjectId}"))
                 {
                     CustomStyleText("Health:", $"{GetTargetCurrentHP(member.BattleChara):N0} / {member.BattleChara.MaxHp:N0} ({GetTargetHPPercent(member.BattleChara)}%)");
+                    CustomStyleText("Regen Tick:", $"{member.BattleChara.MaxHp / 100}");
                     CustomStyleText("MP:", $"{member.CurrentMP:N0} / {member.BattleChara.MaxMp:N0}");
                     CustomStyleText("Job:", $"{member.RealJob?.NameEnglish} (ID: {member.RealJob?.RowId})");
                     CustomStyleText("Dead Timer:", TimeSpentDead(member.BattleChara.GameObjectId));

--- a/WrathCombo/Window/Tabs/Debug.cs
+++ b/WrathCombo/Window/Tabs/Debug.cs
@@ -506,7 +506,7 @@ internal class Debug : ConfigWindow, IDisposable
             {
                 if (ImGui.TreeNode($"{member?.BattleChara?.Name}###{member.GameObjectId}"))
                 {
-                    CustomStyleText("Health:", $"{member.CurrentHP:N0} / {member.BattleChara.MaxHp:N0} ({MathF.Round(member.CurrentHP * 100f / member.BattleChara.MaxHp, 2)}%)");
+                    CustomStyleText("Health:", $"{GetTargetCurrentHP(member.BattleChara):N0} / {member.BattleChara.MaxHp:N0} ({GetTargetHPPercent(member.BattleChara)}%)");
                     CustomStyleText("MP:", $"{member.CurrentMP:N0} / {member.BattleChara.MaxMp:N0}");
                     CustomStyleText("Job:", $"{member.RealJob?.NameEnglish} (ID: {member.RealJob?.RowId})");
                     CustomStyleText("Dead Timer:", TimeSpentDead(member.BattleChara.GameObjectId));

--- a/WrathCombo/Window/Tabs/Debug.cs
+++ b/WrathCombo/Window/Tabs/Debug.cs
@@ -1060,8 +1060,8 @@ internal class Debug : ConfigWindow, IDisposable
                     if (ImGui.CollapsingHeader($"{t?.Name}###SimpleTarget{p.GameObjectID}"))
                     {
                         CustomStyleText($"ID", $"{p.GameObjectID}");
-                        CustomStyleText($"HP", $"{p.CurrentHP} ({GetTargetHPPercent(t):N0}%)");
-                        CustomStyleText($"Object HP", $"{t.CurrentHp} ({GetTargetHPPercent(t, usePendingHp: false):N0}%)");
+                        CustomStyleText($"HP", $"{p.CurrentHP} ({GetTargetHPPercent(t, forceUsePending: true):N0}%)");
+                        CustomStyleText($"Object HP", $"{t.CurrentHp} ({GetTargetHPPercent(t, forceUsePending: false):N0}%)");
 
                         if (ImGui.CollapsingHeader($"Action Efftcts###af{t.GameObjectId}"))
                         {
@@ -1322,8 +1322,8 @@ internal class Debug : ConfigWindow, IDisposable
             CustomStyleText("Name:", target?.Name);
             CustomStyleText("Nameplate:", target?.GetNameplateKind().ToString());
             CustomStyleText("Rank:", $"{battleNPCRow?.Rank.ToString() ?? "null"} (found sheet: {(foundSheet is true ? "yes" : "no")})");
-            CustomStyleText("Health:", $"{GetTargetCurrentHP(usePendingHP: false):N0} / {GetTargetMaxHP():N0} ({MathF.Round(GetTargetHPPercent(usePendingHp: false), 2)}%)");
-            CustomStyleText("Health (with pending):", $"{GetTargetCurrentHP(usePendingHP: true):N0} / {GetTargetMaxHP():N0} ({MathF.Round(GetTargetHPPercent(usePendingHp: true), 2)}%)");
+            CustomStyleText("Health:", $"{GetTargetCurrentHP(forceUsePending: false):N0} / {GetTargetMaxHP():N0} ({MathF.Round(GetTargetHPPercent(forceUsePending: false), 2)}%)");
+            CustomStyleText("Health (with pending):", $"{GetTargetCurrentHP(forceUsePending: true):N0} / {GetTargetMaxHP():N0} ({MathF.Round(GetTargetHPPercent(forceUsePending: true), 2)}%)");
             CustomStyleText("Distance:", $"{MathF.Round(GetTargetDistance(), 2)}y");
             CustomStyleText("Hitbox Radius:", target?.HitboxRadius);
             CustomStyleText("In Melee Range:", InMeleeRange());

--- a/WrathCombo/Window/Tabs/Debug.cs
+++ b/WrathCombo/Window/Tabs/Debug.cs
@@ -1239,8 +1239,8 @@ internal class Debug : ConfigWindow, IDisposable
                     if (ImGui.CollapsingHeader($"{t?.Name}###SimpleTarget{p.GameObjectID}"))
                     {
                         CustomStyleText($"ID", $"{p.GameObjectID}");
-                        CustomStyleText($"HP", $"{p.CurrentHP}");
-                        CustomStyleText($"Object HP", $"{t.CurrentHp}");
+                        CustomStyleText($"HP", $"{p.CurrentHP} ({GetTargetHPPercent(t):N0}%)");
+                        CustomStyleText($"Object HP", $"{t.CurrentHp} ({GetTargetHPPercent(t, usePendingHp: false):N0}%)");
                     }
                 }
             }

--- a/WrathCombo/Window/Tabs/Debug.cs
+++ b/WrathCombo/Window/Tabs/Debug.cs
@@ -1230,6 +1230,23 @@ internal class Debug : ConfigWindow, IDisposable
             ImGui.Unindent();
         }
 
+        if (ImGui.CollapsingHeader("Pending HP"))
+        {
+            ImGui.Indent();
+            foreach (var p in SimpleTargetState.TargetStates)
+            {
+                if (p.GameObjectID.GetObject() is IBattleChara t) {
+                    if (ImGui.CollapsingHeader($"{t?.Name}###SimpleTarget{p.GameObjectID}"))
+                    {
+                        CustomStyleText($"ID", $"{p.GameObjectID}");
+                        CustomStyleText($"HP", $"{p.CurrentHP}");
+                        CustomStyleText($"Object HP", $"{t.CurrentHp}");
+                    }
+                }
+            }
+            ImGui.Unindent();
+        }
+
         #endregion
 
         ImGuiEx.Spacing(new Vector2(0, SpacingMedium));

--- a/WrathCombo/Window/Tabs/Debug.cs
+++ b/WrathCombo/Window/Tabs/Debug.cs
@@ -1050,6 +1050,49 @@ internal class Debug : ConfigWindow, IDisposable
             ImGui.Unindent();
         }
 
+        if (ImGui.CollapsingHeader("Pending HP"))
+        {
+            ImGui.Indent();
+            foreach (var p in SimpleTargetState.TargetStates)
+            {
+                if (p.GameObjectID.GetObject() is IBattleChara t)
+                {
+                    if (ImGui.CollapsingHeader($"{t?.Name}###SimpleTarget{p.GameObjectID}"))
+                    {
+                        CustomStyleText($"ID", $"{p.GameObjectID}");
+                        CustomStyleText($"HP", $"{p.CurrentHP} ({GetTargetHPPercent(t):N0}%)");
+                        CustomStyleText($"Object HP", $"{t.CurrentHp} ({GetTargetHPPercent(t, usePendingHp: false):N0}%)");
+
+                        if (ImGui.CollapsingHeader($"Action Efftcts###af{t.GameObjectId}"))
+                        {
+                            foreach (var eff in t.Struct()->ActionEffectHandler.IncomingEffects)
+                            {
+                                ImGui.Separator();
+                                CustomStyleText($"GS:", $"{eff.GlobalSequence}");
+                                CustomStyleText($"Action:", $"{eff.ActionId.ActionName()}");
+                                CustomStyleText($"Target Confirmed:", $"{eff.TargetConfirmed}");
+                                CustomStyleText($"Source Confirmed:", $"{eff.SourceConfirmed}");
+                                foreach (var ef in eff.Effects.Effects)
+                                {
+                                    if (ef.Type == 0)
+                                        continue;
+
+                                    CustomStyleText($"{(Data.ActionEffectType)ef.Type}", $"{ef.Value + ((ef.Param4 & 0x40) != 0 ? ef.Param3 * 0x10000 : 0)}");
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            foreach (var pending in ActionWatching.PendingHPChanges)
+            {
+                ImGui.Text($"{pending.gameObjectId.GetObject()?.Name} {pending.gameObjectId} {pending.globalSequence}");
+            }
+            ImGui.Unindent();
+        }
+
+
         #endregion
 
         ImGuiEx.Spacing(new Vector2(0f, SpacingSmall));
@@ -1231,47 +1274,6 @@ internal class Debug : ConfigWindow, IDisposable
         {
             ImGui.Indent();
             ActionRequestDebugUI.Draw();
-            ImGui.Unindent();
-        }
-
-        if (ImGui.CollapsingHeader("Pending HP"))
-        {
-            ImGui.Indent();
-            foreach (var p in SimpleTargetState.TargetStates)
-            {
-                if (p.GameObjectID.GetObject() is IBattleChara t) {
-                    if (ImGui.CollapsingHeader($"{t?.Name}###SimpleTarget{p.GameObjectID}"))
-                    {
-                        CustomStyleText($"ID", $"{p.GameObjectID}");
-                        CustomStyleText($"HP", $"{p.CurrentHP} ({GetTargetHPPercent(t):N0}%)");
-                        CustomStyleText($"Object HP", $"{t.CurrentHp} ({GetTargetHPPercent(t, usePendingHp: false):N0}%)");
-
-                        if (ImGui.CollapsingHeader($"Action Efftcts###af{t.GameObjectId}"))
-                        {
-                            foreach (var eff in t.Struct()->ActionEffectHandler.IncomingEffects)
-                            {
-                                ImGui.Separator();
-                                CustomStyleText($"GS:", $"{eff.GlobalSequence}");
-                                CustomStyleText($"Action:", $"{eff.ActionId.ActionName()}");
-                                CustomStyleText($"Target Confirmed:", $"{eff.TargetConfirmed}");
-                                CustomStyleText($"Source Confirmed:", $"{eff.SourceConfirmed}");
-                                foreach (var ef in eff.Effects.Effects)
-                                {
-                                    if (ef.Type == 0)
-                                        continue;
-
-                                    CustomStyleText($"{(Data.ActionEffectType)ef.Type}", $"{ef.Value + ((ef.Param4 & 0x40) != 0 ? ef.Param3 * 0x10000 : 0)}");
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            foreach (var pending in ActionWatching.PendingHPChanges)
-            {
-                ImGui.Text($"{pending.gameObjectId.GetObject()?.Name} {pending.gameObjectId} {pending.globalSequence}");
-            }
             ImGui.Unindent();
         }
 

--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -56,7 +56,7 @@ public sealed partial class WrathCombo : IDalamudPlugin
         AutomaticDecompression = DecompressionMethods.All,
         ConnectCallback = new HappyEyeballsCallback().ConnectCallback,
     };
-    private readonly HttpClient httpClient = new(httpHandler) { Timeout = TimeSpan.FromSeconds(5) };
+    internal readonly HttpClient HTTPClient = new(httpHandler) { Timeout = TimeSpan.FromSeconds(5) };
     private readonly IDtrBarEntry DtrBarEntry;
     public readonly IDtrBarEntry OpenerDtr;
     internal Provider IPC;
@@ -187,6 +187,7 @@ public sealed partial class WrathCombo : IDalamudPlugin
         Service.Address.Setup(Svc.SigScanner);
         MoveHook = new();
         PresetStorage.RemoveRedundantPresets();
+        OpCodeConfigHelper.UpdateOpCodes();
 
         Service.ComboCache = new CustomComboCache();
         Service.ActionReplacer = new ActionReplacer();
@@ -438,7 +439,7 @@ public sealed partial class WrathCombo : IDalamudPlugin
             var basicMessage = $"Welcome to WrathCombo v{GetType().Assembly
                 .GetName().Version}!";
             using var motd =
-                httpClient.GetAsync("https://raw.githubusercontent.com/PunishXIV/WrathCombo/main/res/motd.txt").Result;
+                HTTPClient.GetAsync("https://raw.githubusercontent.com/PunishXIV/WrathCombo/main/res/motd.txt").Result;
             motd.EnsureSuccessStatusCode();
             var data = motd.Content.ReadAsStringAsync().Result;
             List<Payload> payloads =

--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -398,6 +398,8 @@ public sealed partial class WrathCombo : IDalamudPlugin
 
             if (Service.Configuration.AoEDamageTTS || Service.Configuration.AoEDamageToast)
                 CustomComboFunctions.PlayGroupwideAlert();
+
+            SimpleTargetState.ManageStateList();
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
- Leverages the values of action effects to simulate "real-time" HP values on objects.
- `GetTargetHPPercent` and `GetTargetCurrentHP` have been modified to leverage this, default is on but can be disabled if need be.
- Auto-rotation has also been set so that it will switch targets once a target has hit 0 HP, which means snappier responses.

The HP values in testing can be a bit wonky, but will always resync soon enough, as much as it's capturing global sequences from the packets they don't seem to match up with what's been processed.