### PR TITLE
[Auto-Rotation] Pause When No Targets

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationConfig.cs
+++ b/WrathCombo/AutoRotation/AutoRotationConfig.cs
@@ -19,6 +19,7 @@ public class AutoRotationConfig
     public int Throttler = 50;
     public bool OrbwalkerIntegration;
     public float QueueWindow = 0.3f;
+    public bool PauseWhenNoTarget;
 }
 
 public class DPSSettings

--- a/WrathCombo/AutoRotation/AutoRotationConfigIPCWrapper.cs
+++ b/WrathCombo/AutoRotation/AutoRotationConfigIPCWrapper.cs
@@ -101,6 +101,8 @@ public class AutoRotationConfigIPCWrapper(AutoRotationConfig? config)
 
     public float QueueWindow => config.QueueWindow;
 
+    public bool PauseWhenNoTarget => config.PauseWhenNoTarget;
+
     #endregion
 }
 

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -803,7 +803,7 @@ internal unsafe class AutoRotationController
             var target = !cfg.DPSSettings.AoEIgnoreManual && cfg.DPSRotationMode == DPSRotationMode.Manual ?
     Svc.Targets.Target : DPSTargeting.BaseSelection.MaxBy(x => NumberOfEnemiesInRange(OriginalHook(gameAct), x, true));
 
-            if (target == null && cfg.PauseWhenNoTarget) return true;
+            if (target is null && cfg.PauseWhenNoTarget) return true;
 
             if (attributes.AutoAction!.IsHeal)
             {
@@ -927,7 +927,7 @@ internal unsafe class AutoRotationController
 
             var target = GetSingleTarget(mode);
 
-            if (target == null && cfg.PauseWhenNoTarget) return true;
+            if (target is null && cfg.PauseWhenNoTarget) return true;
 
             OverrideTarget = target ?? OverrideTarget;
             var outAct = OriginalHook(InvokeCombo(preset, attributes, ref gameAct, target));

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -800,6 +800,11 @@ internal unsafe class AutoRotationController
             if (LocalPlayer is not { } player)
                 return false;
 
+            var target = !cfg.DPSSettings.AoEIgnoreManual && cfg.DPSRotationMode == DPSRotationMode.Manual ?
+    Svc.Targets.Target : DPSTargeting.BaseSelection.MaxBy(x => NumberOfEnemiesInRange(OriginalHook(gameAct), x, true));
+
+            if (target == null && cfg.PauseWhenNoTarget) return true;
+
             if (attributes.AutoAction!.IsHeal)
             {
                 LockedAoE = false;
@@ -831,9 +836,6 @@ internal unsafe class AutoRotationController
             }
             else
             {
-                var target = !cfg.DPSSettings.AoEIgnoreManual && cfg.DPSRotationMode == DPSRotationMode.Manual ?
-                    Svc.Targets.Target : DPSTargeting.BaseSelection.MaxBy(x => NumberOfEnemiesInRange(OriginalHook(gameAct), x, true));
-
                 if (!NIN.InMudra)
                 {
                     var st = GetSingleTarget(mode);
@@ -854,6 +856,7 @@ internal unsafe class AutoRotationController
                         LockedST = false;
                     }
                 }
+
                 OverrideTarget = target ?? OverrideTarget;
                 uint outAct = OriginalHook(InvokeCombo(preset, attributes, ref gameAct, OverrideTarget));
                 if (outAct is All.SavageBlade) return true;
@@ -923,6 +926,9 @@ internal unsafe class AutoRotationController
                 return false;
 
             var target = GetSingleTarget(mode);
+
+            if (target == null && cfg.PauseWhenNoTarget) return true;
+
             OverrideTarget = target ?? OverrideTarget;
             var outAct = OriginalHook(InvokeCombo(preset, attributes, ref gameAct, target));
             if (!ActionReady(outAct))

--- a/WrathCombo/Window/Tabs/AutoRotationTab.cs
+++ b/WrathCombo/Window/Tabs/AutoRotationTab.cs
@@ -87,6 +87,11 @@ internal class AutoRotationTab : ConfigWindow
 
         ImGuiComponents.HelpMarker(AutoRotationUI.HelpText_UnTargetAndDisableForPenalty);
 
+        changed |= P.UIHelper.ShowIPCControlledCheckboxIfNeeded(
+            "Pause Actions from Combos When No Target Selected", ref cfg.PauseWhenNoTarget);
+
+        ImGuiComponents.HelpMarker($"Pauses all actions that would come from combos if there is no target selected with the selected targeting mode. Ideal for blocking self-use actions if no target is available.");
+
         ImGuiEx.TextUnderlined("Automatic Activation Settings");
 
         changed |= ImGui.Checkbox(AutoRotationUI.Checkbox_EnableInstancedEnter, ref cfg.EnableInInstance);


### PR DESCRIPTION
Based on @Limiana's use case, a setting added to auto-rotation to pause all combo outputs whenever no target is selected, either via the automatic targeting mode or manually. Primarily to block early uses of self-use actions when combat may have started but no target is available (or set in the case of manual targeting).