### PR TITLE
Updated Blacklist to catch some more edge cases

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -22,6 +22,7 @@ using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
 using WrathCombo.Extensions;
 using WrathCombo.Services;
+using WrathCombo.Services.ActionRequestIPC;
 using WrathCombo.Services.IPC_Subscriber;
 using WrathCombo.Window.Functions;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
@@ -661,6 +662,8 @@ internal unsafe class AutoRotationController
     {
         if (HasStatusEffect(418) || LocalPlayer is not { } || !EzThrottler.Throttle("CleanseThrottle", 50)) return;
 
+        if (ActionRequestIPCProvider.GetArtificialCooldown(ActionType.Action, Healer.Role.Esuna) > 0) return;
+
         if (SimpleTarget.Stack.AllyToEsuna is IBattleChara memberBC)
         {
             var res = ActionManager.GetActionInRangeOrLoS(Healer.Role.Esuna, LocalPlayer.GameObject(), memberBC.GameObject());
@@ -678,6 +681,7 @@ internal unsafe class AutoRotationController
     {
         if (HasStatusEffect(418)) return;
         if (!LevelChecked(SGE.Kardia)) return;
+        if (ActionRequestIPCProvider.GetArtificialCooldown(ActionType.Action, SGE.Kardia) > 0) return;
         if (CombatEngageDuration().TotalSeconds < 3) return;
 
         foreach (var member in GetPartyMembers().Where(x => !x.BattleChara.IsDead).OrderByDescending(x => x.BattleChara?.GetRole() is CombatRole.Tank))
@@ -1023,6 +1027,9 @@ internal unsafe class AutoRotationController
                     }
                 }
             }
+
+            if (ActionRequestIPCProvider.GetArtificialCooldown(ActionType.Action, outAct) > 0)
+                return All.SavageBlade;
 
             return outAct;
         }

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -22,7 +22,6 @@ using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
 using WrathCombo.Extensions;
 using WrathCombo.Services;
-using WrathCombo.Services.ActionRequestIPC;
 using WrathCombo.Services.IPC_Subscriber;
 using WrathCombo.Window.Functions;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
@@ -662,8 +661,6 @@ internal unsafe class AutoRotationController
     {
         if (HasStatusEffect(418) || LocalPlayer is not { } || !EzThrottler.Throttle("CleanseThrottle", 50)) return;
 
-        if (ActionRequestIPCProvider.GetArtificialCooldown(ActionType.Action, Healer.Role.Esuna) > 0) return;
-
         if (SimpleTarget.Stack.AllyToEsuna is IBattleChara memberBC)
         {
             var res = ActionManager.GetActionInRangeOrLoS(Healer.Role.Esuna, LocalPlayer.GameObject(), memberBC.GameObject());
@@ -681,7 +678,6 @@ internal unsafe class AutoRotationController
     {
         if (HasStatusEffect(418)) return;
         if (!LevelChecked(SGE.Kardia)) return;
-        if (ActionRequestIPCProvider.GetArtificialCooldown(ActionType.Action, SGE.Kardia) > 0) return;
         if (CombatEngageDuration().TotalSeconds < 3) return;
 
         foreach (var member in GetPartyMembers().Where(x => !x.BattleChara.IsDead).OrderByDescending(x => x.BattleChara?.GetRole() is CombatRole.Tank))
@@ -1028,7 +1024,7 @@ internal unsafe class AutoRotationController
                 }
             }
 
-            if (ActionRequestIPCProvider.GetArtificialCooldown(ActionType.Action, outAct) > 0)
+            if (!CustomComboFunctions.ActionReady(outAct)) 
                 return All.SavageBlade;
 
             return outAct;

--- a/WrathCombo/Core/ActionReplacer.cs
+++ b/WrathCombo/Core/ActionReplacer.cs
@@ -19,7 +19,6 @@ using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
 using WrathCombo.Extensions;
 using WrathCombo.Services;
-using WrathCombo.Services.ActionRequestIPC;
 using static WrathCombo.CustomComboNS.Functions.Jobs;
 
 #endregion
@@ -153,7 +152,7 @@ internal sealed class ActionReplacer : IDisposable
             {
                 if (combo.TryInvoke(actionID, out uint newActionID))
                 {
-                    if (ActionRequestIPCProvider.GetArtificialCooldown(ActionType.Action, newActionID) > 0)
+                    if (!CustomComboFunctions.ActionReady(newActionID))
                         continue;
 
                     if (Service.Configuration.BlockSpellOnMove &&
@@ -168,7 +167,7 @@ internal sealed class ActionReplacer : IDisposable
             }
 
             var original = OriginalHook(actionID);
-            if (ActionRequestIPCProvider.GetArtificialCooldown(ActionType.Action, original) > 0)
+            if (!CustomComboFunctions.ActionReady(original))
                 return actionID;
             return original;
         }

--- a/WrathCombo/Core/ActionReplacer.cs
+++ b/WrathCombo/Core/ActionReplacer.cs
@@ -19,6 +19,7 @@ using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
 using WrathCombo.Extensions;
 using WrathCombo.Services;
+using WrathCombo.Services.ActionRequestIPC;
 using static WrathCombo.CustomComboNS.Functions.Jobs;
 
 #endregion
@@ -152,6 +153,9 @@ internal sealed class ActionReplacer : IDisposable
             {
                 if (combo.TryInvoke(actionID, out uint newActionID))
                 {
+                    if (ActionRequestIPCProvider.GetArtificialCooldown(ActionType.Action, newActionID) > 0)
+                        continue;
+
                     if (Service.Configuration.BlockSpellOnMove &&
                         ActionManager.GetAdjustedCastTime(ActionType.Action, newActionID) > 0 &&
                         CustomComboFunctions.TimeMoving.Ticks > 0)
@@ -163,7 +167,10 @@ internal sealed class ActionReplacer : IDisposable
                 }
             }
 
-            return OriginalHook(actionID);
+            var original = OriginalHook(actionID);
+            if (ActionRequestIPCProvider.GetArtificialCooldown(ActionType.Action, original) > 0)
+                return actionID;
+            return original;
         }
 
         catch (Exception ex)

--- a/WrathCombo/CustomCombo/CustomCombo.cs
+++ b/WrathCombo/CustomCombo/CustomCombo.cs
@@ -7,6 +7,7 @@ using WrathCombo.Combos.PvE;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Services.ActionRequestIPC;
+using ActionType = FFXIVClientStructs.FFXIV.Client.Game.ActionType;
 using ECommonsJob = ECommons.ExcelServices.Job;
 
 namespace WrathCombo.CustomComboNS;
@@ -83,6 +84,9 @@ internal abstract partial class CustomCombo : CustomComboFunctions
         }
 
         uint resultingActionID = Invoke(actionID);
+
+        if (ActionRequestIPCProvider.GetArtificialCooldown(ActionType.Action, resultingActionID) > 0)
+            return false;
 
         var presetException = _presetsAllowedToReturnUnchanged
             .TryGetValue(Preset, out var actionException);

--- a/WrathCombo/CustomCombo/CustomCombo.cs
+++ b/WrathCombo/CustomCombo/CustomCombo.cs
@@ -7,7 +7,6 @@ using WrathCombo.Combos.PvE;
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Services.ActionRequestIPC;
-using ActionType = FFXIVClientStructs.FFXIV.Client.Game.ActionType;
 using ECommonsJob = ECommons.ExcelServices.Job;
 
 namespace WrathCombo.CustomComboNS;
@@ -85,7 +84,7 @@ internal abstract partial class CustomCombo : CustomComboFunctions
 
         uint resultingActionID = Invoke(actionID);
 
-        if (ActionRequestIPCProvider.GetArtificialCooldown(ActionType.Action, resultingActionID) > 0)
+        if (!ActionReady(resultingActionID))
             return false;
 
         var presetException = _presetsAllowedToReturnUnchanged


### PR DESCRIPTION
Current blacklist implementation appeared to not catch some cases, such as gauge based abilities (e.g. Apex Arrow)
Added explicit blacklist rules for Esuna, Kardia, should the user want them blacklisted.
Added a safeguard for when a blacklisted action is returned it'll instead return SavageBlade. 

Only caveat is blacklisted actions icons may revert to a lower level one, e.g. Refulgent Arrow shows as Straight Shot when blacklisted, some actions may not be visible at all, e.g. White Mage's Glare IV does not show instead of Presence of Mind, when it is blacklisted.