### PR TITLE
[ALL] Custom Action fixes. Retargetting fixes. 

### DIFF
--- a/WrathCombo/Combos/PvE/AST/AST.cs
+++ b/WrathCombo/Combos/PvE/AST/AST.cs
@@ -192,7 +192,6 @@ internal partial class AST : Healer
         {
             #region Button Selection
 
-            bool alternateMode = AST_ST_DPS_AltMode == 1;
             var replacedActions = (int)AST_ST_DPS_AltMode switch
             {
                 1 => CombustList.Keys.ToArray(),
@@ -351,10 +350,6 @@ internal partial class AST : Healer
                 if (target is not null && ActionReady(dotAction) && CanApplyStatus(target, dotDebuffID) && !JustUsedOn(dotAction, target) && AST_ST_DPS_CombustUptime_TwoTarget)
                     return dotAction.Retarget(replacedActions, target);
             }
-
-            //Alternate Mode (idles as Malefic)
-            if (alternateMode)
-                return OriginalHook(Combust);
             #endregion
 
             return OriginalHook(Malefic);

--- a/WrathCombo/Combos/PvE/AST/AST.cs
+++ b/WrathCombo/Combos/PvE/AST/AST.cs
@@ -192,7 +192,7 @@ internal partial class AST : Healer
         {
             #region Button Selection
 
-            bool alternateMode = AST_ST_DPS_AltMode > 0;
+            bool alternateMode = AST_ST_DPS_AltMode == 1;
             var replacedActions = (int)AST_ST_DPS_AltMode switch
             {
                 1 => CombustList.Keys.ToArray(),
@@ -354,10 +354,10 @@ internal partial class AST : Healer
 
             //Alternate Mode (idles as Malefic)
             if (alternateMode)
-                return OriginalHook(Malefic);
+                return OriginalHook(Combust);
             #endregion
 
-            return OriginalHook(replacedActions.First());
+            return OriginalHook(Malefic);
         }
     }
     internal class AST_AOE_DPS : CustomCombo

--- a/WrathCombo/Combos/PvE/AST/AST.cs
+++ b/WrathCombo/Combos/PvE/AST/AST.cs
@@ -498,16 +498,16 @@ internal partial class AST : Healer
             if (ActionReady(Role.Esuna) &&
                 GetTargetHPPercent(healTarget) >= 40 &&
                 cleansableTarget)
-                return Role.Esuna.RetargetIfEnabled(Benefic);
+                return Role.Esuna.RetargetIfEnabled(actionID);
 
             if (CanWeave() && Role.CanLucidDream(6500))
                 return Role.LucidDreaming;
 
             if (ActionReady(EssentialDignity) && GetTargetHPPercent(healTarget) <= 30)
-                return EssentialDignity.RetargetIfEnabled(Benefic);
+                return EssentialDignity.RetargetIfEnabled(actionID);
 
             if (ActionReady(Exaltation) && (healTarget.IsInParty() && healTarget.Role is CombatRole.Tank || !IsInParty()))
-                return Exaltation.RetargetIfEnabled(Benefic);
+                return Exaltation.RetargetIfEnabled(actionID);
 
             if (!InBossEncounter())
             {
@@ -527,24 +527,24 @@ internal partial class AST : Healer
             if (ActionReady(AspectedBenefic) &&
                 (!HasStatusEffect(Buffs.AspectedBenefic, healTarget) ||
                  !HasStatusEffect(Buffs.NeutralSectShield, healTarget) && HasStatusEffect(Buffs.NeutralSect)))
-                return OriginalHook(AspectedBenefic).RetargetIfEnabled(Benefic);
+                return OriginalHook(AspectedBenefic).RetargetIfEnabled(actionID);
 
             if ((HasArrow || HasBole) &&
                 (healTarget.IsInParty() && healTarget.Role is CombatRole.Tank || !IsInParty()))
-                return OriginalHook(Play2).RetargetIfEnabled(Benefic);
+                return OriginalHook(Play2).RetargetIfEnabled(actionID);
 
             if (HasEwer || HasSpire)
-                return OriginalHook(Play3).RetargetIfEnabled(Benefic);
+                return OriginalHook(Play3).RetargetIfEnabled(actionID);
 
             if (ActionReady(CelestialIntersection) && !HasStatusEffect(Buffs.Intersection) && GetRemainingCharges(EssentialDignity) <= GetRemainingCharges(CelestialIntersection))
-                return CelestialIntersection.RetargetIfEnabled(Benefic);
+                return CelestialIntersection.RetargetIfEnabled(actionID);
 
             if (ActionReady(EssentialDignity))
-                return EssentialDignity.RetargetIfEnabled(Benefic);
+                return EssentialDignity.RetargetIfEnabled(actionID);
 
             return !LevelChecked(Benefic2)
-                ? Benefic.RetargetIfEnabled()
-                : Benefic2.RetargetIfEnabled(Benefic);
+                ? Benefic.RetargetIfEnabled(actionID)
+                : Benefic2.RetargetIfEnabled(actionID);
         }
     }
 
@@ -628,7 +628,7 @@ internal partial class AST : Healer
                 ActionReady(Role.Esuna) &&
                 GetTargetHPPercent(healTarget, AST_ST_SimpleHeals_IncludeShields) >= AST_ST_SimpleHeals_Esuna &&
                 cleansableTarget)
-                return Role.Esuna.RetargetIfEnabled(Benefic);
+                return Role.Esuna.RetargetIfEnabled(actionID);
 
             //Priority List
             for (int i = 0; i < AST_ST_SimpleHeals_Priority.Count; i++)
@@ -640,12 +640,12 @@ internal partial class AST : Healer
                 {
                     if (GetTargetHPPercent(healTarget, AST_ST_SimpleHeals_IncludeShields) <= config &&
                         ActionReady(spell))
-                        return spell.RetargetIfEnabled(Benefic);
+                        return spell.RetargetIfEnabled(actionID);
                 }
             }
             return !LevelChecked(Benefic2) ?
-                Benefic.RetargetIfEnabled(Benefic) :
-                Benefic2.RetargetIfEnabled(Benefic);
+                Benefic.RetargetIfEnabled(actionID) :
+                Benefic2.RetargetIfEnabled(actionID);
         }
     }
 

--- a/WrathCombo/Combos/PvE/BRD/BRD.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD.cs
@@ -82,8 +82,8 @@ internal partial class BRD : PhysicalRanged
             if (TryGCDAttacks(comboFlags, ref actionID) && ActionReady(actionID))
                 return actionID;
 
-        return OriginalHook(QuickNock);
-    }
+            return OriginalHook(QuickNock);
+        }
     }
 
     internal class BRD_ST_AdvMode : CustomCombo
@@ -124,8 +124,8 @@ internal partial class BRD : PhysicalRanged
             if (TryGCDAttacks(comboFlags, ref actionID) && ActionReady(actionID))
                 return actionID;
 
-        return OriginalHook(HeavyShot);
-    }
+            return OriginalHook(HeavyShot);
+        }
     }
     #endregion
 

--- a/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
@@ -522,15 +522,9 @@ internal partial class BRD
                 return true;
             }
             
-            if (flags.HasFlag(Combo.ST) && autoWardenST && WardenResolver() is not null)
+            if (autoWardenST && WardenResolver() is not null)
             {
                 actionID = TheWardensPaeon.Retarget(actionID, WardenResolver);
-                return true;
-            }
-
-            if (flags.HasFlag(Combo.AoE) && autoWardenST && WardenResolver() is not null)
-            {
-                actionID = TheWardensPaeon.Retarget([Ladonsbite, QuickNock], WardenResolver);
                 return true;
             }
         }
@@ -766,50 +760,25 @@ internal partial class BRD
             var blueTarget = SimpleTarget.DottableEnemy(blueDotAction, blueDotDebuffID, ComputeMultidotHpThreshold, computeMultidotRefresh);
             var purpleTarget = SimpleTarget.DottableEnemy(purpleDotAction, purpleDotDebuffID, ComputeMultidotHpThreshold, computeMultidotRefresh);
             #endregion
-            
-            if (flags.HasFlag(Combo.ST))
+           
+            if (ironTarget is not null && LevelChecked(IronJaws))
             {
-                if (ironTarget is not null && LevelChecked(IronJaws))
-                {
-                    actionID = IronJaws.Retarget(actionID, ironTarget);
-                    return true;
-                }
-
-                if (blueTarget is not null && LevelChecked(Windbite))
-                {
-                    actionID = blueDotAction.Retarget(actionID, blueTarget);
-                    return true;
-                }
-
-                if (purpleTarget is not null && LevelChecked(VenomousBite))
-                {
-                    actionID = purpleDotAction.Retarget(actionID, purpleTarget);
-                    return true;
-                }
+                actionID = IronJaws.Retarget(actionID, ironTarget);
+                return true;
             }
-            if (flags.HasFlag(Combo.AoE))
+
+            if (blueTarget is not null && LevelChecked(Windbite))
             {
-                if (ironTarget is not null && LevelChecked(IronJaws))
-                {
-                    actionID = IronJaws.Retarget(actionID, ironTarget);
-                    return true;
-                }
-
-                if (blueTarget is not null && LevelChecked(Windbite))
-                {
-                    actionID = blueDotAction.Retarget(actionID, blueTarget);
-                    return true;
-                }
-
-                if (purpleTarget is not null && LevelChecked(VenomousBite))
-                {
-                    actionID = purpleDotAction.Retarget(actionID, purpleTarget);
-                    return true;
-                }
+                actionID = blueDotAction.Retarget(actionID, blueTarget);
+                return true;
             }
-            
+
+            if (purpleTarget is not null && LevelChecked(VenomousBite))
+            {
+                actionID = purpleDotAction.Retarget(actionID, purpleTarget);
+                return true;
+            }
         }
-        
         #endregion
 
         return false;

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -308,7 +308,7 @@ internal partial class DNC : PhysicalRanged
                     ActionReady(Improvisation) &&
                     !HasStatusEffect(Buffs.TechnicalFinish) &&
                     InCombat() &&
-                    EnemyIn8Yalms)
+                    AlliesIn8Yalms)
                     return Improvisation;
             }
 

--- a/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC_Helper.cs
@@ -60,7 +60,7 @@ internal partial class DNC
     /// <remarks>
     ///     This is used for <see cref="Improvisation" />.
     /// </remarks>
-    private static bool EnemyIn8Yalms => NumberOfEnemiesInRange(Improvisation) > 0;
+    private static bool AlliesIn8Yalms => NumberOfAlliesInRange(Improvisation) > 2;
 
     /// <summary>
     ///     Logic to pick different openers.

--- a/WrathCombo/Combos/PvE/DRG/DRG_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRG/DRG_Helper.cs
@@ -50,7 +50,7 @@ internal partial class DRG
             if (includeDisembowel && !HasStatusEffect(Buffs.PowerSurge) && !LevelChecked(SonicThrust))
                 return OriginalHook(TrueThrust);
 
-            return actionId;
+            return OriginalHook(DoomSpike);
         }
 
         if (ComboTimer > 0)

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -205,7 +205,7 @@ internal partial class SCH : Healer
                     ? OriginalHook(EmergencyTactics)
                     : OriginalHook(Adloquium).RetargetIfEnabled(actionID);
             
-            return Physick.RetargetIfEnabled();
+            return Physick.RetargetIfEnabled(actionID);
         }
     }
     
@@ -506,7 +506,7 @@ internal partial class SCH : Healer
                         return spell.RetargetIfEnabled(actionID);
                 }
             }
-            return Physick.RetargetIfEnabled();
+            return Physick.RetargetIfEnabled(actionID);
         }
     }
     

--- a/WrathCombo/Combos/PvE/SCH/SCH.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH.cs
@@ -273,7 +273,6 @@ internal partial class SCH : Healer
 
         protected override uint Invoke(uint actionID)
         {
-            bool alternateMode = SCH_ST_DPS_Adv_Actions > 0;
             var replacedActions = (int)SCH_ST_DPS_Adv_Actions switch
             {
                 1 => BioList.Keys.ToArray(),
@@ -356,11 +355,8 @@ internal partial class SCH : Healer
             //Ruin 2 Movement
             if (IsEnabled(Preset.SCH_ST_ADV_DPS_Ruin2Movement) && ActionReady(Ruin2) && IsMoving() && InCombat())
                 return OriginalHook(Ruin2);
-            
-            if (alternateMode)
-                return OriginalHook(Ruin);
 
-            return OriginalHook(replacedActions.First());
+            return OriginalHook(Ruin);
         }
     }
     

--- a/WrathCombo/Combos/PvE/SGE/SGE.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE.cs
@@ -126,7 +126,7 @@ internal partial class SGE : Healer
                 // Addersgall Protection
                 if (ActionReady(Druochole) && Addersgall >= 3)
                     return Druochole
-                        .RetargetIfEnabled(OriginalHook(actionID));
+                        .RetargetIfEnabled(actionID);
 
                 // Psyche
                 if (ActionReady(Psyche) && HasBattleTarget() &&
@@ -352,7 +352,7 @@ internal partial class SGE : Healer
                 if (IsEnabled(Preset.SGE_AoE_DPS_AddersgallProtect) &&
                     ActionReady(Druochole) && Addersgall >= SGE_AoE_DPS_AddersgallProtect)
                     return Druochole
-                        .RetargetIfEnabled(OriginalHook(actionID));
+                        .RetargetIfEnabled(actionID);
 
                 // Psyche
                 if (IsEnabled(Preset.SGE_AoE_DPS_Psyche))
@@ -460,7 +460,7 @@ internal partial class SGE : Healer
                 if (ActionReady(Krasis))
                     return Krasis.RetargetIfEnabled(actionID);
                 if (ActionReady(Taurochole) && HasAddersgall())
-                    return Taurochole.RetargetIfEnabled(Diagnosis);
+                    return Taurochole.RetargetIfEnabled(actionID);
                 if (ActionReady(Haima) && !HasStatusEffect(Buffs.Panhaima, healTarget))
                     return Haima.RetargetIfEnabled(actionID);
             }
@@ -486,7 +486,7 @@ internal partial class SGE : Healer
                     ? EukrasianDiagnosis
                     : Eukrasia;
 
-            return Diagnosis.RetargetIfEnabled();
+            return Diagnosis.RetargetIfEnabled(actionID);
         }
     }
 
@@ -616,7 +616,7 @@ internal partial class SGE : Healer
                             .RetargetIfEnabled(actionID);
             }
 
-            return Diagnosis.RetargetIfEnabled();
+            return Diagnosis.RetargetIfEnabled(actionID);
         }
     }
 

--- a/WrathCombo/Combos/PvE/SMN/SMN.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN.cs
@@ -31,13 +31,7 @@ internal partial class SMN : Caster
             #endregion
 
             if (TryOGCDSpells(comboFlags, ref actionID))
-                return actionID == Rekindle && IsEnabled(Preset.SMN_ST_Advanced_Combo_DemiSummons_Rekindle)
-                    ? OriginalHook(AstralFlow).Retarget([Ruin, Ruin2, Ruin3], 
-                        SimpleTarget.TargetsTarget.IfInParty() ??
-                        SimpleTarget.AnyTank.IfMissingHP() ??
-                        SimpleTarget.LowestHPPAlly.IfMissingHP() ??
-                        SimpleTarget.Self)
-                    : actionID;
+                return actionID;
             
             if (TryMitigation(comboFlags, ref actionID))
                 return actionID;
@@ -83,13 +77,7 @@ internal partial class SMN : Caster
             #endregion
 
             if (TryOGCDSpells(comboFlags, ref actionID))
-                return actionID == Rekindle && IsEnabled(Preset.SMN_ST_Advanced_Combo_DemiSummons_Rekindle)
-                    ? OriginalHook(AstralFlow).Retarget([Outburst, Tridisaster], 
-                        SimpleTarget.TargetsTarget.IfInParty() ??
-                        SimpleTarget.AnyTank.IfMissingHP() ??
-                        SimpleTarget.LowestHPPAlly.IfMissingHP() ??
-                        SimpleTarget.Self)
-                    : actionID;
+                return actionID;
             
             if (TryMitigation(comboFlags, ref actionID))
                 return actionID;
@@ -122,17 +110,16 @@ internal partial class SMN : Caster
         protected internal override Preset Preset => Preset.SMN_ST_Advanced_Combo;
         protected override uint Invoke(uint actionID)
         {
+            const Combo comboFlags = Combo.ST | Combo.Adv;
+            
             bool allRuins = SMN_ST_Advanced_Combo_AltMode == 0;
+            
+            var replacedActions = allRuins ? AllRuinsList.ToArray() : NotRuin3List.ToArray();
 
-            if (!CustomActionHelper.OneButtonRotationChecker(actionID, CustomActionType.SingleTargetDPS, allRuins ? AllRuinsList.ToArray() : NotRuin3List.ToArray())) return actionID;
+            if (!CustomActionHelper.OneButtonRotationChecker(actionID, CustomActionType.SingleTargetDPS, replacedActions.ToArray())) return actionID;
 
             if (NeedToSummon)
                 return SummonCarbuncle;
-
-            #region Variables
-            const Combo comboFlags = Combo.ST | Combo.Adv;
-            var replacedActions = allRuins ? AllRuinsList.ToArray() : NotRuin3List.ToArray();
-            #endregion
 
             #region Opener
             if (IsEnabled(Preset.SMN_ST_Advanced_Combo_Balance_Opener) &&
@@ -146,13 +133,7 @@ internal partial class SMN : Caster
             #endregion
             
             if (TryOGCDSpells(comboFlags, ref actionID))
-                return actionID == Rekindle && IsEnabled(Preset.SMN_ST_Advanced_Combo_DemiSummons_Rekindle)
-                    ? OriginalHook(AstralFlow).Retarget(replacedActions, 
-                         SimpleTarget.TargetsTarget.IfInParty() ??
-                         SimpleTarget.AnyTank.IfMissingHP() ??
-                         SimpleTarget.LowestHPPAlly.IfMissingHP() ??
-                         SimpleTarget.Self)
-                    : actionID;
+                return actionID;
             
             if (TryMitigation(comboFlags, ref actionID))
                 return actionID;
@@ -198,13 +179,7 @@ internal partial class SMN : Caster
             #endregion
 
             if (TryOGCDSpells(comboFlags, ref actionID))
-                return actionID == Rekindle && IsEnabled(Preset.SMN_ST_Advanced_Combo_DemiSummons_Rekindle)
-                    ? OriginalHook(AstralFlow).Retarget([Outburst, Tridisaster], 
-                        SimpleTarget.TargetsTarget.IfInParty() ??
-                        SimpleTarget.AnyTank.IfMissingHP() ??
-                        SimpleTarget.LowestHPPAlly.IfMissingHP() ??
-                        SimpleTarget.Self)
-                    : actionID;
+                return actionID;
             
             if (TryMitigation(comboFlags, ref actionID))
                 return actionID;

--- a/WrathCombo/Combos/PvE/SMN/SMN_Helper.cs
+++ b/WrathCombo/Combos/PvE/SMN/SMN_Helper.cs
@@ -4,8 +4,10 @@ using Dalamud.Game.ClientState.Objects.Types;
 using FFXIVClientStructs.FFXIV.Client.Game.Gauge;
 using System;
 using System.Collections.Generic;
+using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
+using WrathCombo.Extensions;
 using static WrathCombo.Combos.PvE.SMN.Config;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 using AetherFlags = Dalamud.Game.ClientState.JobGauge.Enums.AetherFlags;
@@ -345,6 +347,11 @@ internal partial class SMN
             IsSTEnabled(flags, Preset.SMN_ST_Advanced_Combo_DemiSummons_Rekindle) ||
             IsAoEEnabled(flags, Preset.SMN_AoE_Advanced_Combo_DemiSummons_Rekindle);
         
+        bool rekindleRetargetEnabled =
+            flags.HasFlag(Combo.Simple) ||
+            IsSTEnabled(flags, Preset.SMN_ST_Advanced_Combo_DemiSummons_Rekindle_Retarget) ||
+            IsAoEEnabled(flags, Preset.SMN_AoE_Advanced_Combo_DemiSummons_Rekindle_Retarget);
+        
         bool searingFlashEnabled =
             flags.HasFlag(Combo.Simple) ||
             IsSTEnabled(flags, Preset.SMN_ST_Advanced_Combo_SearingFlash) ||
@@ -442,11 +449,22 @@ internal partial class SMN
                     actionID = OriginalHook(AstralFlow);
                     return true;
                 }
-                
+
                 if (rekindleEnabled && ActionReady(OriginalHook(AstralFlow)) && DemiPheonix)
                 {
-                    actionID = Rekindle;
-                    return true;
+                    if (rekindleRetargetEnabled)
+                    {
+                        actionID = Rekindle.Retarget(actionID,
+                            SimpleTarget.TargetsTarget.IfInParty() ??
+                            SimpleTarget.AnyTank.IfMissingHP() ??
+                            SimpleTarget.LowestHPPAlly.IfMissingHP() ??
+                            SimpleTarget.Self);
+                        return true;
+                    }
+                    {
+                        actionID = Rekindle;
+                        return true;
+                    }
                 }
             }
             #endregion

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -432,7 +432,7 @@ internal partial class WHM : Healer
             
             return LevelChecked(Cure2)
                 ? Cure2.RetargetIfEnabled(actionID)
-                : Cure.RetargetIfEnabled();
+                : Cure.RetargetIfEnabled(actionID);
         }
     }
     
@@ -578,7 +578,7 @@ internal partial class WHM : Healer
                     ? ThinAir
                     : Cure2.RetargetIfEnabled(actionID);
 
-            return Cure.RetargetIfEnabled();
+            return Cure.RetargetIfEnabled(actionID);
         }
     }
 

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -234,7 +234,7 @@ internal partial class WHM : Healer
                 
                 //2 target Dotting System to maintain dots on 2 enemies. Works with the same sliders and one target
                 if (target is not null && ActionReady(dotAction) && CanApplyStatus(target, dotDebuffID) && !JustUsedOn(dotAction, target) && WHM_ST_MainCombo_DoT_TwoTarget)
-                    return dotAction.Retarget(actionID, target);
+                    return dotAction.Retarget(replacedActions, target);
             }
             
             // Blood Lily Spend

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -173,16 +173,15 @@ internal partial class WHM : Healer
 
             #region Opener
 
-            if (IsEnabled(Preset.WHM_ST_MainCombo_Opener))
-                if (Opener().FullOpener(ref actionID))
-                    return actionID;
+            if (IsEnabled(Preset.WHM_ST_MainCombo_Opener) && Opener().FullOpener(ref actionID))
+                return actionID;
 
             #endregion
 
             if (ContentSpecificActions.TryGet(out var contentAction))
                 return contentAction;
 
-            if (!PartyInCombat()) return actionID;
+            if (!PartyInCombat()) return OriginalHook(Stone1);
 
             #region Special Feature Raidwide
 


### PR DESCRIPTION
- RDM PCT BLM MCH PLD WAR DRK GNB NIN MNK RPR VPR SAM Good so far as i can see for custom icons
- BRD Should have? fixed wardens paeon. Removed doubled up sections not needed due to actionid retargetting. so hard to test debuff cleansing.
- SGE Fixed the healer retargetting that was missed
- WHM fixed the out of combat bailout. it was still actionid, needed to be OH stone
- WHM Fixed st multidot retargetting
- WHM Fixed the healer retargetting that was missed
- AST Removes the need for alt mode code entirely since it isnt running actionID at the end. 
- AST Fixed the healer retargetting that was missed
- SCH Same fix as AST. no more need for alternate mode in code. 
- SCH Fixed the healer retargetting that was missed
- SMN Fixed retarget rekindle. it wasnt playing nice as it was coded(my early attempt at retarget with flags). moved the rekindle retargetting to the help just like bard. this one works so wardens paeon should too. 
- DNC Fixed Improv st issue. Found no custom button errors though
- DRG Replaced te action id with OH doom spike for the dobasic combo aoe to fix that one. 