### PR TITLE
[RPR] Fixes

### DIFF
--- a/WrathCombo/Combos/PvE/RPR/RPR.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR.cs
@@ -1,4 +1,3 @@
-using Dalamud.Bindings.ImPlot;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Native;
 using static WrathCombo.Combos.PvE.RPR.Config;
@@ -582,8 +581,7 @@ internal partial class RPR : Melee
             if (actionID is not ArcaneCircle)
                 return actionID;
 
-            return HasStatusEffect(Buffs.ImmortalSacrifice) &&
-                   LevelChecked(PlentifulHarvest)
+            return HasImmortalSacrificeStacks && LevelChecked(PlentifulHarvest)
                 ? PlentifulHarvest
                 : actionID;
         }

--- a/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
@@ -205,7 +205,7 @@ internal partial class RPR
         !ShouldDeferSoulOverflowWeave &&
         InNormalRotation &&
         !IsComboExpiring(3);
-    
+
     private static bool ShouldSpendSoulOvercapST(bool gluttonyEnabled)
     {
         if (!LevelChecked(Gluttony))
@@ -285,48 +285,17 @@ internal partial class RPR
 
     #region GCD Burst
 
-    private const float PerfectioFlexAfterHarvest = 58f;
-
-    private const float PerfectioFlexAfterArcaneCircle = 88f;
-
     private static bool WithinGcd(uint actionId) =>
         LevelChecked(actionId) && (HasCharges(actionId) || GetCooldownRemainingTime(actionId) <= GCDTotal);
 
     private static bool HasPerfectioReady =>
         HasStatusEffect(Buffs.PerfectioParata) && LevelChecked(Perfectio);
 
-    private static float PerfectioRemaining =>
-        GetStatusEffectRemainingTime(Buffs.PerfectioParata);
-
     private static uint PerfectioAction =>
         WithinGcd(Perfectio) ? Perfectio : OriginalHook(Communio);
 
-    private static bool InPerfectioFlexWindow =>
-        HasPerfectioReady && PerfectioRemaining > GCDTotal * 2 &&
-        (JustUsed(PlentifulHarvest, PerfectioFlexAfterHarvest) ||
-         IsOnCooldown(ArcaneCircle) && GetCooldownElapsed(ArcaneCircle) < PerfectioFlexAfterArcaneCircle ||
-         JustUsed(Communio, 30f));
-
-    private static bool ShouldHoldPerfectioInMelee =>
-        HasPerfectioReady && InMeleeRange() && UsesBurstAlignment &&
-        JustUsed(Communio, 30f) && InPerfectioFlexWindow &&
-        PerfectioRemaining > GCDTotal * 5 && AcCD > 15f;
-
-    private static bool ShouldHoldPerfectioForUptime =>
-        HasPerfectioReady && !InMeleeRange() && HasBattleTarget() &&
-        InPerfectioFlexWindow && PerfectioRemaining > GCDTotal * 3 && AcCD > 10f;
-
-    private static bool ShouldSpendPerfectioNow()
-    {
-        if (!HasPerfectioReady)
-            return false;
-
-        // Failsafe: use before falloff regardless of burst alignment.
-        if (PerfectioRemaining <= GCDTotal * 4 || AcCD <= 10f)
-            return true;
-
-        return !ShouldHoldPerfectioInMelee && !ShouldHoldPerfectioForUptime;
-    }
+    private static bool ShouldSpendPerfectioNow() =>
+        HasPerfectioReady;
 
     private static bool CanPerfectioGCD() =>
         HasPerfectioReady && ShouldSpendPerfectioNow() && InActionRange(PerfectioAction);
@@ -362,6 +331,10 @@ internal partial class RPR
         if (!InPostBurstSequence)
             return 0;
 
+        if (HasStatusEffect(Buffs.SoulReaver) || HasStatusEffect(Buffs.Executioner) ||
+            HasStatusEffect(Buffs.ImmortalSacrifice))
+            return 0;
+
         if (ContinueBasicCombo(onAoE) is var combo and not 0)
             return combo;
 
@@ -371,9 +344,12 @@ internal partial class RPR
         return 0;
     }
 
+    private static bool HasImmortalSacrificeStacks =>
+        HasStatusEffect(Buffs.ImmortalSacrifice) && GetStatusEffectStacks(Buffs.ImmortalSacrifice) > 0;
+
     private static bool CanPlentifulHarvest() =>
         !HasStatusEffect(Buffs.Enshrouded) && !HasStatusEffect(Buffs.SoulReaver) &&
-        !HasStatusEffect(Buffs.Executioner) && HasStatusEffect(Buffs.ImmortalSacrifice) &&
+        !HasStatusEffect(Buffs.Executioner) && HasImmortalSacrificeStacks &&
         (GetStatusEffectRemainingTime(Buffs.BloodsownCircle) <= 1 || JustUsed(Communio));
 
     private static bool CanWhorlOfDeath(int refreshThreshold = 6, int hpThreshold = 0) =>

--- a/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
@@ -31,12 +31,12 @@ internal partial class RPR
                 //Balance burst prep: SoD near 60s / 30s on Arcane Circle
                 if (LevelChecked(PlentifulHarvest) && !HasStatusEffect(Buffs.Enshrouded) &&
                     UsesBurstAlignment && (AcCD.InRange(58f, 62f) || AcCD.InRange(28f, 32f)) &&
-                    GetStatusEffectRemainingTime(Debuffs.DeathsDesign, CurrentTarget) < 32)
+                    GetStatusEffectRemainingTime(Debuffs.DeathsDesign, CurrentTarget) <= dotRefresh)
                     return true;
 
                 //Double enshroud
                 if (LevelChecked(PlentifulHarvest) && HasStatusEffect(Buffs.Enshrouded) &&
-                    AcCD <= GCDTotal && GetStatusEffectRemainingTime(Debuffs.DeathsDesign, CurrentTarget) < 32 &&
+                    AcCD <= GCDTotal && GetStatusEffectRemainingTime(Debuffs.DeathsDesign, CurrentTarget) <= dotRefresh &&
                     (JustUsed(VoidReaping, 2f) || JustUsed(CrossReaping, 2f)))
                     return true;
 
@@ -348,12 +348,13 @@ internal partial class RPR
         InPostBurstSequence &&
         !HasBurstComboContinue(onAoE) &&
         !JustUsed(onAoE ? SoulScythe : SoulSlice, GCDTotal) &&
-        (Soul < 50 || !ActionReady(Gluttony)) &&
+        Soul <= 50 &&
         (onAoE
             ? ActionReady(SoulScythe) && InActionRange(SoulScythe)
             : ActionReady(SoulSlice) && InActionRange(SoulSlice) && !IsComboExpiring(2));
 
     private static bool ShouldDeferSoulOverflowWeave =>
+        Soul < 100 &&
         InPostBurstSequence && !JustUsed(Gluttony, GCDTotal * 8);
 
     private static uint PostBurstGCD(bool onAoE, bool soulSliceEnabled = true)


### PR DESCRIPTION
- Prevents filler from skipping `Executioner`, `SoulReaver` and `Plentiful Harvest` after using `Gluttony`.
- Fixes Soul overcap.
- Stops early `Death's Design` refreshes.
- Requires actual `Immortal Sacrifice` stacks before `Plentiful Harvest`.
- Spends `Perfectio` after `Communio` instead of holding it based on `Arcane Circle` cooldown.