### PR TITLE
[JOBS] Fixes for MNK, VPR, MCH, SAM, cleanup of all

### DIFF
--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -54,14 +54,14 @@ internal partial class BLM : Caster
             if (TryStMovementGcd() is var movementGcd and not 0)
                 return movementGcd;
 
-            if (FirePhase)
+            if (IsInFirePhase)
             {
                 uint gcd = UseFirePhaseGcd();
                 if (gcd != 0)
                     return gcd;
             }
 
-            if (IcePhase)
+            if (IsInIcePhase)
             {
                 uint gcd = UseIcePhaseGcd();
                 if (gcd != 0)
@@ -120,10 +120,10 @@ internal partial class BLM : Caster
             if (TryAoEParadoxFiller() is var paradox and not 0)
                 return paradox;
 
-            if (FirePhase && UseAoEFirePhaseGcd() is var fireGcd and not 0)
+            if (IsInFirePhase && UseAoEFirePhaseGcd() is var fireGcd and not 0)
                 return fireGcd;
 
-            if (IcePhase && UseAoEIcePhaseGcd() is var iceGcd and not 0)
+            if (IsInIcePhase && UseAoEIcePhaseGcd() is var iceGcd and not 0)
                 return iceGcd;
 
             return OriginalHook(Blizzard2);
@@ -209,7 +209,7 @@ internal partial class BLM : Caster
                 TryStMovementGcd(useConfiguredPriority: true) is var movementGcd and not 0)
                 return movementGcd;
 
-            if (FirePhase)
+            if (IsInFirePhase)
             {
                 uint gcd = UseFirePhaseGcd(
                     IsEnabled(Preset.BLM_ST_FlareStar),
@@ -224,7 +224,7 @@ internal partial class BLM : Caster
                     return gcd;
             }
 
-            if (IcePhase)
+            if (IsInIcePhase)
             {
                 uint gcd = UseIcePhaseGcd(useTranspose: IsEnabled(Preset.BLM_ST_Transpose));
                 if (gcd != 0)
@@ -285,7 +285,7 @@ internal partial class BLM : Caster
             if (TryAoEParadoxFiller(IsEnabled(Preset.BLM_AoE_ParadoxFiller)) is var paradox and not 0)
                 return paradox;
 
-            if (FirePhase &&
+            if (IsInFirePhase &&
                 UseAoEFirePhaseGcd(
                     IsEnabled(Preset.BLM_AoE_Triplecast),
                     BLM_AoE_TriplecastHoldCharges,
@@ -293,7 +293,7 @@ internal partial class BLM : Caster
                     IsNotEnabled(Preset.BLM_AoE_Transpose)) is var fireGcd and not 0)
                 return fireGcd;
 
-            if (IcePhase &&
+            if (IsInIcePhase &&
                 UseAoEIcePhaseGcd(
                     IsEnabled(Preset.BLM_AoE_Transpose),
                     IsNotEnabled(Preset.BLM_AoE_Transpose),
@@ -346,18 +346,18 @@ internal partial class BLM : Caster
 
             return actionID switch
             {
-                Fire when BLM_F1to3 == 0 && BLM_Fire1_Despair && FirePhase && MP.Cur < 2400 && LevelChecked(Despair) => Despair,
+                Fire when BLM_F1to3 == 0 && BLM_Fire1_Despair && IsInFirePhase && MP.Cur < 2400 && LevelChecked(Despair) => Despair,
 
                 Fire when BLM_F1to3 == 0 && LevelChecked(Fire3) &&
                           (AstralFireStacks is 1 or 2 && HasStatusEffect(Buffs.Firestarter) ||
-                           LevelChecked(Paradox) && !ActiveParadox ||
+                           LevelChecked(Paradox) && !IsParadoxActive ||
                            !InCombat() && LevelChecked(Fire4) ||
-                           IcePhase && !ActiveParadox ||
+                           IsInIcePhase && !IsParadoxActive ||
                            !LevelChecked(Fire4) &&
                            HasStatusEffect(Buffs.Firestarter)) && !JustUsed(Fire3) => Fire3,
 
-                Fire3 when BLM_F1to3 == 1 && LevelChecked(Fire3) && FirePhase &&
-                           (LevelChecked(Paradox) && ActiveParadox && AstralFireStacks is 3 ||
+                Fire3 when BLM_F1to3 == 1 && LevelChecked(Fire3) && IsInFirePhase &&
+                           (LevelChecked(Paradox) && IsParadoxActive && AstralFireStacks is 3 ||
                             !LevelChecked(Fire4) && !HasStatusEffect(Buffs.Firestarter)) &&
                            !JustUsed(OriginalHook(Fire)) => OriginalHook(Fire),
 
@@ -374,7 +374,7 @@ internal partial class BLM : Caster
             if (actionID is not Fire)
                 return actionID;
 
-            return ActiveParadox && IcePhase
+            return IsParadoxActive && IsInIcePhase
                 ? OriginalHook(Blizzard)
                 : ActionReady(Fire4)
                     ? Fire4
@@ -399,7 +399,7 @@ internal partial class BLM : Caster
                     : actionID;
             }
 
-            return IcePhase switch
+            return IsInIcePhase switch
             {
                 false when BLM_Fire4_FlareStar && CanFlareStar() && LevelChecked(FlareStar) => FlareStar,
                 false when BLM_Fire4_Fire3 && AstralFireStacks < 3 => LevelChecked(Fire3) ? Fire3 : Fire,
@@ -424,9 +424,9 @@ internal partial class BLM : Caster
 
             return actionID switch
             {
-                Flare when BLM_Flare_FlareStar && FirePhase && CanFlareStar() => FlareStar,
-                Flare when FirePhase && LevelChecked(Flare) => Flare,
-                Flare when IcePhase && ActionReady(Freeze) => Freeze,
+                Flare when BLM_Flare_FlareStar && IsInFirePhase && CanFlareStar() => FlareStar,
+                Flare when IsInFirePhase && LevelChecked(Flare) => Flare,
+                Flare when IsInIcePhase && ActionReady(Freeze) => Freeze,
                 var _ => actionID
             };
         }
@@ -444,12 +444,12 @@ internal partial class BLM : Caster
             return actionID switch
             {
                 Blizzard when BLM_B1to3 == 0 && LevelChecked(Blizzard3) &&
-                              (FirePhase ||
+                              (IsInFirePhase ||
                                UmbralIceStacks is 1 ||
                                UmbralIceStacks is 2) => Blizzard3,
 
-                Blizzard3 when BLM_B1to3 == 1 && LevelChecked(Blizzard3) && IcePhase && UmbralIceStacks is 3 => OriginalHook(Blizzard),
-                Blizzard3 when BLM_Blizzard3_Despair && FirePhase && LevelChecked(Despair) && MP.Cur >= 800 => Despair,
+                Blizzard3 when BLM_B1to3 == 1 && LevelChecked(Blizzard3) && IsInIcePhase && UmbralIceStacks is 3 => OriginalHook(Blizzard),
+                Blizzard3 when BLM_Blizzard3_Despair && IsInFirePhase && LevelChecked(Despair) && MP.Cur >= 800 => Despair,
 
                 var _ => actionID
             };
@@ -464,7 +464,7 @@ internal partial class BLM : Caster
             if (actionID is not Blizzard)
                 return actionID;
 
-            return ActiveParadox && FirePhase
+            return IsParadoxActive && IsInFirePhase
                 ? OriginalHook(Fire)
                 : ActionReady(Blizzard4)
                     ? Blizzard4
@@ -480,7 +480,7 @@ internal partial class BLM : Caster
             if (actionID is not Blizzard4)
                 return actionID;
 
-            return FirePhase && LevelChecked(Despair) && MP.Cur >= 800
+            return IsInFirePhase && LevelChecked(Despair) && MP.Cur >= 800
                 ? Despair
                 : actionID;
         }
@@ -496,7 +496,7 @@ internal partial class BLM : Caster
 
             return actionID switch
             {
-                Freeze when HasMaxUmbralHeartStacks && LevelChecked(Paradox) && ActiveParadox && IcePhase => OriginalHook(Blizzard),
+                Freeze when IsUmbralHeartCapped && LevelChecked(Paradox) && IsParadoxActive && IsInIcePhase => OriginalHook(Blizzard),
                 Freeze when !LevelChecked(Freeze) => Blizzard2,
                 var _ => actionID
             };
@@ -511,7 +511,7 @@ internal partial class BLM : Caster
             if (actionID is not FlareStar)
                 return actionID;
 
-            return FirePhase && LevelChecked(FlareStar) && ActiveParadox && AstralSoulStacks < 6
+            return IsInFirePhase && LevelChecked(FlareStar) && IsParadoxActive && AstralSoulStacks < 6
                 ? OriginalHook(Fire)
                 : actionID;
         }
@@ -525,7 +525,7 @@ internal partial class BLM : Caster
             if (actionID is not Amplifier)
                 return actionID;
 
-            return BLM_AmplifierXenoCD && IsOnCooldown(Amplifier) && HasPolyglot || HasMaxPolyglotStacks
+            return BLM_AmplifierXenoCD && IsOnCooldown(Amplifier) && HasPolyglot || IsPolyglotCapped
                 ? Xenoglossy
                 : actionID;
         }
@@ -570,7 +570,7 @@ internal partial class BLM : Caster
             if (actionID is not Transpose)
                 return actionID;
 
-            return IcePhase && LevelChecked(UmbralSoul)
+            return IsInIcePhase && LevelChecked(UmbralSoul)
                 ? UmbralSoul
                 : actionID;
         }

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -1,6 +1,5 @@
 using WrathCombo.Core;
 using WrathCombo.CustomComboNS;
-using WrathCombo.Extensions;
 using WrathCombo.Native;
 using static WrathCombo.Combos.PvE.BLM.Config;
 namespace WrathCombo.Combos.PvE;

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -217,7 +217,6 @@ internal partial class BLM : Caster
                     IsEnabled(Preset.BLM_ST_Transpose),
                     IsEnabled(Preset.BLM_ST_UsePolyglot),
                     false,
-                    BLM_ST_MovementOption[MovementSwiftcast],
                     BLM_ST_PolyglotMovement,
                     BLM_ST_PolyglotSaveUsage);
                 if (gcd != 0)

--- a/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Statuses;
 using ECommons.GameHelpers;
 using System;
@@ -898,3 +898,4 @@ internal partial class BLM
 
     #endregion
 }
+

--- a/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
@@ -76,12 +76,12 @@ internal partial class BLM
 
     private static bool CanFire3 =>
         LevelChecked(Fire3) && HasStatusEffect(Buffs.Firestarter) &&
-        (AstralFireStacks < 3 || !LevelChecked(Fire4) && TimeSinceFirestarterBuff >= GCDTotal * 3);
+        (AstralFireStacks < 3 || !LevelChecked(Fire4) && TimeSinceFirestarterBuff >= GCD * 3);
 
     private static bool CanFireParadox =>
         IsParadoxActive && MP.Cur >= MP.FireParadox &&
         (!HasStatusEffect(Buffs.Firestarter) && AstralFireStacks < 3 ||
-         JustUsed(FlareStar, GCDTotal * 4) ||
+         JustUsed(FlareStar, GCD * 4) ||
          !LevelChecked(FlareStar) && ActionReady(Despair));
 
     private static bool IsEndOfFirePhase =>
@@ -103,7 +103,7 @@ internal partial class BLM
         IsInIcePhase && IsUmbralHeartCapped && TraitLevelChecked(Traits.EnhancedAstralFire);
 
     private static bool JustUsedFreezeOrBlizzard =>
-        JustUsed(Freeze, GCDTotal) || JustUsed(Blizzard4, GCDTotal);
+        JustUsed(Freeze, GCD) || JustUsed(Blizzard4, GCD);
 
     #endregion
 
@@ -270,7 +270,7 @@ internal partial class BLM
 
         if (useSwiftcast &&
             ActionReady(Role.Swiftcast) && JustUsed(Despair) &&
-            GetCooldownRemainingTime(Manafont) > GCDTotal &&
+            GetCooldownRemainingTime(Manafont) > GCD &&
             !HasStatusEffect(Buffs.Triplecast) &&
             InActionRange(Fire) && HasBattleTarget())
             return Role.Swiftcast;
@@ -494,7 +494,7 @@ internal partial class BLM
             !HasStatusEffect(Buffs.Triplecast) && ActionReady(Triplecast) &&
             HasBattleTarget() && InActionRange(Fire2) && !JustUsed(Triplecast) &&
             GetRemainingCharges(Triplecast) > triplecastHoldCharges &&
-            IsUmbralHeartCapped && GetCooldownRemainingTime(Manafont) > GCDTotal * 3)
+            IsUmbralHeartCapped && GetCooldownRemainingTime(Manafont) > GCD * 3)
             return Triplecast;
 
         if (ActionReady(Flare))
@@ -819,6 +819,8 @@ internal partial class BLM
         { HighThunder, Debuffs.HighThunder },
         { HighThunder2, Debuffs.HighThunder2 }
     }.ToFrozenDictionary();
+
+    private static float GCD => GetCooldown(OriginalHook(Fire)).CooldownTotal;
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
@@ -660,7 +660,7 @@ internal partial class BLM
     {
         public override int MinOpenerLevel => 100;
 
-        public override int MaxOpenerLevel => 109;
+        public override int MaxOpenerLevel => 100;
 
         public override List<uint> OpenerActions { get; set; } =
         [
@@ -669,7 +669,7 @@ internal partial class BLM
             Role.Swiftcast,
             Amplifier,
             Fire4,
-            LeyLines,
+            LeyLines, //6
             Fire4,
             Fire4,
             Fire4,
@@ -697,11 +697,16 @@ internal partial class BLM
             Fire3
         ];
 
+        public override Preset Preset => Preset.BLM_ST_Opener;
+
         internal override UserData ContentCheckConfig => BLM_Balance_Content;
 
-        public override List<int> DelayedWeaveSteps { get; set; } = [6];
+        public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
+        [
+            ([6], () => HasStatusEffect(Buffs.LeyLines))
+        ];
 
-        public override Preset Preset => Preset.BLM_ST_Opener;
+        public override List<int> DelayedWeaveSteps { get; set; } = [6];
 
         public override bool HasCooldowns() =>
             MP.Full &&
@@ -716,7 +721,7 @@ internal partial class BLM
     {
         public override int MinOpenerLevel => 100;
 
-        public override int MaxOpenerLevel => 109;
+        public override int MaxOpenerLevel => 100;
 
         public override List<uint> OpenerActions { get; set; } =
         [
@@ -752,11 +757,16 @@ internal partial class BLM
             Fire3
         ];
 
+        public override Preset Preset => Preset.BLM_ST_Opener;
+
         internal override UserData ContentCheckConfig => BLM_Balance_Content;
 
-        public override List<int> DelayedWeaveSteps { get; set; } = [6];
+        public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
+        [
+            ([6], () => HasStatusEffect(Buffs.LeyLines))
+        ];
 
-        public override Preset Preset => Preset.BLM_ST_Opener;
+        public override List<int> DelayedWeaveSteps { get; set; } = [6];
 
         public override bool HasCooldowns() =>
             MP.Full &&

--- a/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
@@ -898,4 +898,3 @@ internal partial class BLM
 
     #endregion
 }
-

--- a/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
@@ -39,7 +39,7 @@ internal partial class BLM
     private static uint PolyglotSpell =>
         LevelChecked(Xenoglossy) ? Xenoglossy : Foul;
 
-    private static bool PolyglotOvercapProtection() =>
+    private static bool OvercapPolyglotProtection() =>
         HasMaxPolyglotStacks && PolyglotTimer <= 5;
 
     private static bool ShouldSpendPolyglotInFire(
@@ -360,7 +360,7 @@ internal partial class BLM
         useScathe && IsMoving() && !LevelChecked(Triplecast) && ActionReady(Scathe);
 
     private static uint TryStPolyglotOvercap(bool usePolyglot = true) =>
-        usePolyglot && PolyglotOvercapProtection()
+        usePolyglot && OvercapPolyglotProtection()
             ? PolyglotSpell
             : 0;
 
@@ -462,7 +462,7 @@ internal partial class BLM
     #region AoE GCDs
 
     private static uint TryAoEPolyglotOvercap(bool usePolyglot = true) =>
-        usePolyglot && PolyglotOvercapProtection() && ActionReady(Foul)
+        usePolyglot && OvercapPolyglotProtection() && ActionReady(Foul)
             ? Foul
             : 0;
 

--- a/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
@@ -20,7 +20,7 @@ internal partial class BLM
         TraitLevelChecked(Traits.EnhancedPolyglotII) ? 3 :
         TraitLevelChecked(Traits.EnhancedPolyglot) ? 2 : 1;
 
-    private static bool HasMaxPolyglotStacks =>
+    private static bool IsPolyglotCapped =>
         PolyglotStacks == MaxPolyglot;
 
     private static int BossHpThreshold(int hpBossOption, int hpOption, bool isBoss) =>
@@ -39,8 +39,8 @@ internal partial class BLM
     private static uint PolyglotSpell =>
         LevelChecked(Xenoglossy) ? Xenoglossy : Foul;
 
-    private static bool OvercapPolyglotProtection() =>
-        HasMaxPolyglotStacks && PolyglotTimer <= 5;
+    private static bool OvercapPolyglotProtection =>
+        IsPolyglotCapped && PolyglotTimer <= 5;
 
     private static bool ShouldSpendPolyglotInFire(
         bool alwaysSpend = true,
@@ -83,13 +83,13 @@ internal partial class BLM
         (AstralFireStacks < 3 || !LevelChecked(Fire4) && TimeSinceFirestarterBuff >= GCDTotal * 3);
 
     private static bool CanFireParadox =>
-        ActiveParadox && MP.Cur >= MP.FireParadox &&
+        IsParadoxActive && MP.Cur >= MP.FireParadox &&
         (!HasStatusEffect(Buffs.Firestarter) && AstralFireStacks < 3 ||
          JustUsed(FlareStar, GCDTotal * 4) ||
          !LevelChecked(FlareStar) && ActionReady(Despair));
 
-    private static bool EndOfFirePhase =>
-        FirePhase && !ActionReady(Despair) && !ActionReady(FireSpam) && !ActionReady(FlareStar);
+    private static bool IsEndOfFirePhase =>
+        IsInFirePhase && !ActionReady(Despair) && !ActionReady(FireSpam) && !ActionReady(FlareStar);
 
     #endregion
 
@@ -100,11 +100,11 @@ internal partial class BLM
             ? Blizzard4
             : Blizzard;
 
-    private static bool HasMaxUmbralHeartStacks =>
+    private static bool IsUmbralHeartCapped =>
         UmbralHearts is 3;
 
-    private static bool EndOfIcePhaseAoE =>
-        IcePhase && HasMaxUmbralHeartStacks && TraitLevelChecked(Traits.EnhancedAstralFire);
+    private static bool IsEndOfIcePhaseAoE =>
+        IsInIcePhase && IsUmbralHeartCapped && TraitLevelChecked(Traits.EnhancedAstralFire);
 
     private static bool JustUsedFreezeOrBlizzard =>
         JustUsed(Freeze, GCDTotal) || JustUsed(Blizzard4, GCDTotal);
@@ -145,7 +145,7 @@ internal partial class BLM
         LevelChecked(OriginalHook(Thunder2)) && HasStatusEffect(Buffs.Thunderhead) &&
         CanApplyStatus(CurrentTarget, ThunderList[OriginalHook(Thunder2)]) &&
         GetTargetHPPercent() > hpThreshold &&
-        (!IcePhase || JustUsedFreezeOrBlizzard || EndOfIcePhaseAoE || !ActionReady(Freeze)) &&
+        (!IsInIcePhase || JustUsedFreezeOrBlizzard || IsEndOfIcePhaseAoE || !ActionReady(Freeze)) &&
         (ThunderDebuffAoE is null && ThunderDebuffST is null ||
          ThunderDebuffAoE?.RemainingTime <= dotRefresh ||
          ThunderDebuffST?.RemainingTime <= dotRefresh);
@@ -188,7 +188,7 @@ internal partial class BLM
         if (useDespair && ActionReady(Despair))
             return Despair;
 
-        if (ActionReady(Blizzard3) && EndOfFirePhase)
+        if (ActionReady(Blizzard3) && IsEndOfFirePhase)
             return Blizzard3;
 
         if (useTranspose && ActionReady(Transpose) &&
@@ -200,7 +200,7 @@ internal partial class BLM
 
     private static uint UseIcePhaseGcd(bool useTranspose = true)
     {
-        if (UmbralHearts is 3 && UmbralIceStacks is 3 && ActiveParadox)
+        if (UmbralHearts is 3 && UmbralIceStacks is 3 && IsParadoxActive)
             return OriginalHook(Blizzard);
 
         if (MP.Full || JustUsed(Blizzard4))
@@ -243,7 +243,7 @@ internal partial class BLM
     #region ST Weaves
 
     private static bool CanStAmplifierWeave(bool useAmplifier = true) =>
-        useAmplifier && ActionReady(Amplifier) && !HasMaxPolyglotStacks;
+        useAmplifier && ActionReady(Amplifier) && !IsPolyglotCapped;
 
     private static bool CanStLeyLinesWeave(
         bool useLeyLines = true,
@@ -268,7 +268,7 @@ internal partial class BLM
         bool transposeIncludeLowMp = false,
         uint fallbackWhenNoTranspose = 0)
     {
-        if (!EndOfFirePhase)
+        if (!IsEndOfFirePhase)
             return 0;
 
         if (useManafont && ActionReady(Manafont))
@@ -309,7 +309,7 @@ internal partial class BLM
         bool triplecastIgnoreLeyLines = true,
         bool triplecastRequireChargeReserve = false)
     {
-        if (!IcePhase)
+        if (!IsInIcePhase)
             return 0;
 
         if (useTranspose && MP.Full && JustUsed(Paradox) && ActionReady(Transpose))
@@ -360,7 +360,7 @@ internal partial class BLM
         useScathe && IsMoving() && !LevelChecked(Triplecast) && ActionReady(Scathe);
 
     private static uint TryStPolyglotOvercap(bool usePolyglot = true) =>
-        usePolyglot && OvercapPolyglotProtection()
+        usePolyglot && OvercapPolyglotProtection
             ? PolyglotSpell
             : 0;
 
@@ -373,7 +373,7 @@ internal partial class BLM
         useAmplifier && usePolyglot &&
         LevelChecked(Amplifier) &&
         GetCooldownRemainingTime(Amplifier) < 5 &&
-        HasMaxPolyglotStacks
+        IsPolyglotCapped
             ? Xenoglossy
             : 0;
 
@@ -402,7 +402,7 @@ internal partial class BLM
             return Triplecast;
 
         if (LevelChecked(Paradox) &&
-            FirePhase && ActiveParadox &&
+            IsInFirePhase && IsParadoxActive &&
             MP.Cur >= MP.FireParadox &&
             !HasStatusEffect(Buffs.Firestarter) &&
             !HasStatusEffect(Buffs.Triplecast) &&
@@ -436,10 +436,10 @@ internal partial class BLM
             : 0;
 
     private static bool CanAoEManafontWeave(bool useManafont = true) =>
-        useManafont && ActionReady(Manafont) && EndOfFirePhase;
+        useManafont && ActionReady(Manafont) && IsEndOfFirePhase;
 
     private static bool CanAoETransposeWeave(bool useTranspose = true) =>
-        useTranspose && ActionReady(Transpose) && (EndOfFirePhase || EndOfIcePhaseAoE);
+        useTranspose && ActionReady(Transpose) && (IsEndOfFirePhase || IsEndOfIcePhaseAoE);
 
     private static bool CanAoEAmplifierWeave(bool useAmplifier = true, int polyglotTimerThreshold = 20) =>
         useAmplifier && ActionReady(Amplifier) && PolyglotTimer >= polyglotTimerThreshold;
@@ -462,13 +462,13 @@ internal partial class BLM
     #region AoE GCDs
 
     private static uint TryAoEPolyglotOvercap(bool usePolyglot = true) =>
-        usePolyglot && OvercapPolyglotProtection() && ActionReady(Foul)
+        usePolyglot && OvercapPolyglotProtection && ActionReady(Foul)
             ? Foul
             : 0;
 
     private static uint TryAoEPolyglot(bool usePolyglot = true) =>
         usePolyglot &&
-        (EndOfFirePhase || EndOfIcePhaseAoE || IcePhase && JustUsedFreezeOrBlizzard) &&
+        (IsEndOfFirePhase || IsEndOfIcePhaseAoE || IsInIcePhase && JustUsedFreezeOrBlizzard) &&
         HasPolyglot && ActionReady(Foul)
             ? Foul
             : 0;
@@ -480,7 +480,7 @@ internal partial class BLM
 
     private static uint TryAoEParadoxFiller(bool useParadox = true) =>
         useParadox &&
-        ActiveParadox && (EndOfIcePhaseAoE || IcePhase && JustUsedFreezeOrBlizzard)
+        IsParadoxActive && (IsEndOfIcePhaseAoE || IsInIcePhase && JustUsedFreezeOrBlizzard)
             ? OriginalHook(Blizzard)
             : 0;
 
@@ -500,7 +500,7 @@ internal partial class BLM
             !HasStatusEffect(Buffs.Triplecast) && ActionReady(Triplecast) &&
             HasBattleTarget() && InActionRange(Fire2) && !JustUsed(Triplecast) &&
             GetRemainingCharges(Triplecast) > triplecastHoldCharges &&
-            HasMaxUmbralHeartStacks && GetCooldownRemainingTime(Manafont) > GCDTotal * 3)
+            IsUmbralHeartCapped && GetCooldownRemainingTime(Manafont) > GCDTotal * 3)
             return Triplecast;
 
         if (ActionReady(Flare))
@@ -524,7 +524,7 @@ internal partial class BLM
         bool useBlizzard4Sub = true,
         bool flareTransposeRequiresNoUmbralHeart = false)
     {
-        if (HasMaxUmbralHeartStacks ||
+        if (IsUmbralHeartCapped ||
             MP.Cur >= 5000 && LevelChecked(Flare) &&
             (!flareTransposeRequiresNoUmbralHeart || !TraitLevelChecked(Traits.UmbralHeart)) ||
             MP.Full && !LevelChecked(Flare))
@@ -575,7 +575,7 @@ internal partial class BLM
             () => BLM_ST_MovementOption[MovementDespair] &&
                   ActionReady(Despair) &&
                   TraitLevelChecked(Traits.EnhancedAstralFire) &&
-                  FirePhase && MP.Cur is >= 800 and < 1500 &&
+                  IsInFirePhase && MP.Cur is >= 800 and < 1500 &&
                   !HasStatusEffect(Buffs.Triplecast) &&
                   !HasStatusEffect(Role.Buffs.Swiftcast)),
 
@@ -592,7 +592,7 @@ internal partial class BLM
         (OriginalHook(Fire), Preset.BLM_ST_Movement,
             () => BLM_ST_MovementOption[MovementParadox] &&
                   ActionReady(OriginalHook(Paradox)) &&
-                  FirePhase && ActiveParadox &&
+                  IsInFirePhase && IsParadoxActive &&
                   MP.Cur >= MP.FireParadox &&
                   !HasStatusEffect(Buffs.Firestarter) &&
                   !HasStatusEffect(Buffs.Triplecast) &&
@@ -616,7 +616,7 @@ internal partial class BLM
         (Fire3, Preset.BLM_ST_Movement,
             () => BLM_ST_MovementOption[MovementFire3] &&
                   ActionReady(Fire3) &&
-                  FirePhase &&
+                  IsInFirePhase &&
                   HasStatusEffect(Buffs.Firestarter) &&
                   !HasStatusEffect(Buffs.Triplecast) &&
                   !HasStatusEffect(Role.Buffs.Swiftcast)),
@@ -773,17 +773,17 @@ internal partial class BLM
 
     private static BLMGauge Gauge => GetJobGauge<BLMGauge>();
 
-    private static bool FirePhase => Gauge.InAstralFire;
+    private static bool IsInFirePhase => Gauge.InAstralFire;
 
     private static byte AstralFireStacks => Gauge.AstralFireStacks;
 
-    private static bool IcePhase => Gauge.InUmbralIce;
+    private static bool IsInIcePhase => Gauge.InUmbralIce;
 
     private static byte UmbralIceStacks => Gauge.UmbralIceStacks;
 
     private static byte UmbralHearts => Gauge.UmbralHearts;
 
-    private static bool ActiveParadox => Gauge.IsParadoxActive;
+    private static bool IsParadoxActive => Gauge.IsParadoxActive;
 
     private static int AstralSoulStacks => Gauge.AstralSoulStacks;
 

--- a/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM_Helper.cs
@@ -44,7 +44,6 @@ internal partial class BLM
 
     private static bool ShouldSpendPolyglotInFire(
         bool alwaysSpend = true,
-        bool useMovementSwiftcastPolyglot = false,
         int polyglotMovementThreshold = 0,
         int polyglotSaveUsage = 0)
     {
@@ -54,12 +53,9 @@ internal partial class BLM
         if (alwaysSpend)
             return true;
 
-        if (useMovementSwiftcastPolyglot &&
-            PolyglotStacks > polyglotMovementThreshold &&
-            PolyglotStacks > polyglotSaveUsage)
-            return true;
-
-        return !useMovementSwiftcastPolyglot &&
+        // Retain manual + movement pools (config enforces sum <= MaxPolyglot).
+        // Spend in rotation only when above both thresholds.
+        return PolyglotStacks > polyglotMovementThreshold &&
                PolyglotStacks > polyglotSaveUsage;
     }
 
@@ -160,13 +156,11 @@ internal partial class BLM
         bool useTranspose = true,
         bool usePolyglot = true,
         bool alwaysSpendPolyglot = true,
-        bool useMovementSwiftcastPolyglot = false,
         int polyglotMovementThreshold = 0,
         int polyglotSaveUsage = 0)
     {
         if (usePolyglot &&
-            ShouldSpendPolyglotInFire(alwaysSpendPolyglot, useMovementSwiftcastPolyglot, polyglotMovementThreshold,
-                polyglotSaveUsage))
+            ShouldSpendPolyglotInFire(alwaysSpendPolyglot, polyglotMovementThreshold, polyglotSaveUsage))
             return PolyglotSpell;
 
         if (CanFireParadox)

--- a/WrathCombo/Combos/PvE/DRG/DRG.cs
+++ b/WrathCombo/Combos/PvE/DRG/DRG.cs
@@ -12,7 +12,7 @@ internal partial class DRG : Melee
         protected override uint Invoke(uint actionID)
         {
             if (!CustomActionHelper.OneButtonRotationChecker(actionID, CustomActionType.SingleTargetDPS, TrueThrust))
-            return actionID;
+                return actionID;
 
             if (ContentSpecificActions.TryGet(out uint contentAction))
                 return contentAction;
@@ -76,7 +76,7 @@ internal partial class DRG : Melee
 
             return !InMeleeRange() && HasBattleTarget()
                 ? OutsideOfMelee(actionID, OutsideOfMeleeOptions.SimpleSt)
-                : DoBasicCombo(actionID, true);
+                : DoBasicCombo(useTrueNorth: true);
         }
     }
 
@@ -108,7 +108,7 @@ internal partial class DRG : Melee
                     if (CanMirageDive(true, true))
                         return MirageDive;
 
-                    if (CanUseGeirskogul(true))
+                    if (CanUseGeirskogul())
                         return Geirskogul;
 
                     if (CanUseWyrmwind())
@@ -148,7 +148,7 @@ internal partial class DRG : Melee
 
             return !InActionRange(DoomSpike) && HasBattleTarget()
                 ? OutsideOfMelee(actionID, OutsideOfMeleeOptions.SimpleAoE)
-                : DoBasicCombo(actionID, onAoE: true, includeDisembowel: true);
+                : DoBasicCombo(onAoE: true, includeDisembowel: true);
         }
     }
 
@@ -271,7 +271,7 @@ internal partial class DRG : Melee
 
             return !InMeleeRange() && HasBattleTarget()
                 ? OutsideOfMelee(actionID, stRanged)
-                : DoBasicCombo(actionID, IsEnabled(Preset.DRG_TrueNorthDynamic), trueNorthCharges: DRG_ManualTN);
+                : DoBasicCombo(IsEnabled(Preset.DRG_TrueNorthDynamic), trueNorthCharges: DRG_ManualTN);
         }
     }
 
@@ -313,7 +313,7 @@ internal partial class DRG : Melee
                             return MirageDive;
 
                         if (IsEnabled(Preset.DRG_AoE_Geirskogul) &&
-                            CanUseGeirskogul(true, DRG_AoE_GeirskogulHPThreshold))
+                            CanUseGeirskogul(DRG_AoE_GeirskogulHPThreshold))
                             return Geirskogul;
 
                         if (IsEnabled(Preset.DRG_AoE_Wyrmwind) &&
@@ -384,7 +384,7 @@ internal partial class DRG : Melee
 
             return !InActionRange(DoomSpike) && HasBattleTarget()
                 ? OutsideOfMelee(actionID, aoeRanged)
-                : DoBasicCombo(actionID, onAoE: true, includeDisembowel: IsEnabled(Preset.DRG_AoE_Disembowel));
+                : DoBasicCombo(onAoE: true, includeDisembowel: IsEnabled(Preset.DRG_AoE_Disembowel));
         }
     }
 

--- a/WrathCombo/Combos/PvE/DRG/DRG_Config.cs
+++ b/WrathCombo/Combos/PvE/DRG/DRG_Config.cs
@@ -22,6 +22,10 @@ internal partial class DRG
                         FormatAndCache(Generics.Action_Opener, PiercingTalon.ActionName()),
                         FormatAndCache(Generics.Use_0_Opener, PiercingTalon.ActionName()), 1);
 
+                    DrawHorizontalRadioButton(DRG_SelectedOpener,
+                        DRG_Config.EarlyBuffOpener,
+                        FormatAndCache(DRG_Config.UseEarlyBuffOpener), 2);
+
                     DrawBossOnlyChoice(DRG_BalanceContent);
                     break;
 

--- a/WrathCombo/Combos/PvE/DRG/DRG_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRG/DRG_Helper.cs
@@ -19,7 +19,6 @@ internal partial class DRG
     #region Basic Combo
 
     private static uint DoBasicCombo(
-        uint actionId,
         bool useTrueNorth = false,
         bool onAoE = false,
         bool includeDisembowel = false,
@@ -123,7 +122,7 @@ internal partial class DRG
 
             return JustUsed(DoomSpike);
         }
-    
+
 
         if (!InActionRange(TrueThrust))
             return false;
@@ -145,7 +144,6 @@ internal partial class DRG
 
         return false;
     }
-    
 
     #endregion
 
@@ -210,7 +208,7 @@ internal partial class DRG
         return diveExpiring || !DRG_ST_DoubleMirage;
     }
 
-    private static bool CanUseGeirskogul(bool onAoE = false, int hpThreshold = 0) =>
+    private static bool CanUseGeirskogul(int hpThreshold = 0) =>
         ActionReady(Geirskogul) &&
         InActionRange(Geirskogul) &&
         HasBattleTarget() &&
@@ -218,9 +216,9 @@ internal partial class DRG
         GetTargetHPPercent() > hpThreshold;
 
     private static int GeirskogulHPThreshold() =>
-        InBossEncounter() ? TargetIsBoss() 
+        InBossEncounter() ? TargetIsBoss()
                 ? DRG_ST_GeirskogulBossHPOption
-                : DRG_ST_GeirskogulBossAddsHPOption 
+                : DRG_ST_GeirskogulBossAddsHPOption
             : DRG_ST_GeirskogulTrashHPOption;
 
     private static bool CanStarcross() =>
@@ -327,7 +325,7 @@ internal partial class DRG
                 return RiseOfTheDragon;
 
             if (options.UseGeirskogul &&
-                CanUseGeirskogul(true, options.GeirskogulHpThreshold) && InCombat())
+                CanUseGeirskogul(options.GeirskogulHpThreshold) && InCombat())
                 return Geirskogul;
 
             if (options.UseNastrond &&
@@ -338,7 +336,7 @@ internal partial class DRG
                 ActionReady(PiercingTalon) && !CanDRGWeave())
                 return PiercingTalon;
 
-            return DoBasicCombo(actionId, onAoE: true, includeDisembowel: options.IncludeDisembowel);
+            return DoBasicCombo(onAoE: true, includeDisembowel: options.IncludeDisembowel);
         }
 
         if (options.UseMirage &&
@@ -369,7 +367,7 @@ internal partial class DRG
             ActionReady(PiercingTalon))
             return PiercingTalon;
 
-        return DoBasicCombo(actionId, options.UseTrueNorth, trueNorthCharges: options.TrueNorthCharges);
+        return DoBasicCombo(options.UseTrueNorth, trueNorthCharges: options.TrueNorthCharges);
     }
 
     #endregion

--- a/WrathCombo/Combos/PvE/DRG/DRG_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRG/DRG_Helper.cs
@@ -492,6 +492,7 @@ internal partial class DRG
         ];
 
         public override Preset Preset => Preset.DRG_ST_Opener;
+
         internal override UserData ContentCheckConfig => DRG_BalanceContent;
 
         public override bool HasCooldowns() =>

--- a/WrathCombo/Combos/PvE/DRG/DRG_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRG/DRG_Helper.cs
@@ -586,4 +586,3 @@ internal partial class DRG
 
     #endregion
 }
-

--- a/WrathCombo/Combos/PvE/DRG/DRG_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRG/DRG_Helper.cs
@@ -114,7 +114,7 @@ internal partial class DRG
 
                 return HasStatusEffect(Buffs.LanceCharge) ||
                        HasStatusEffect(Buffs.BattleLitany) ||
-                       LoTDActive;
+                       IsLoTDActive;
             }
 
             if (LevelChecked(SonicThrust) && JustUsed(DoomSpike))
@@ -127,7 +127,7 @@ internal partial class DRG
         if (!InActionRange(TrueThrust))
             return false;
 
-        if (LevelChecked(Drakesbane) && LoTDActive &&
+        if (LevelChecked(Drakesbane) && IsLoTDActive &&
             (HasStatusEffect(Buffs.LanceCharge) || HasStatusEffect(Buffs.BattleLitany)) &&
             (JustUsed(WheelingThrust) ||
              JustUsed(FangAndClaw) ||
@@ -188,7 +188,7 @@ internal partial class DRG
         ActionReady(WyrmwindThrust) &&
         FirstmindsFocus is 2 &&
         InActionRange(WyrmwindThrust) &&
-        (LoTDActive ||
+        (IsLoTDActive ||
          HasStatusEffect(Buffs.DraconianFire) ||
          HasStatusEffect(Buffs.RaidenThrustReady) ||
          NumberOfEnemiesInRange(WyrmwindThrust, CurrentTarget) >= 2);
@@ -199,7 +199,7 @@ internal partial class DRG
             OriginalHook(Jump) is not MirageDive || !InActionRange(MirageDive))
             return false;
 
-        if (onAoE || ignoreDoubleMirageHold || LoTDActive)
+        if (onAoE || ignoreDoubleMirageHold || IsLoTDActive)
             return true;
 
         bool diveExpiring = GetStatusEffectRemainingTime(Buffs.DiveReady) <= 1.2f &&
@@ -212,7 +212,7 @@ internal partial class DRG
         ActionReady(Geirskogul) &&
         InActionRange(Geirskogul) &&
         HasBattleTarget() &&
-        !LoTDTimerActive &&
+        !IsLoTDTimerActive &&
         GetTargetHPPercent() > hpThreshold;
 
     private static int GeirskogulHPThreshold() =>
@@ -228,7 +228,7 @@ internal partial class DRG
         ActionReady(RiseOfTheDragon) && HasStatusEffect(Buffs.DragonsFlight) && InActionRange(RiseOfTheDragon);
 
     private static bool CanNastrond() =>
-        ActionReady(Nastrond) && HasStatusEffect(Buffs.NastrondReady) && LoTDActive && InActionRange(Nastrond);
+        ActionReady(Nastrond) && HasStatusEffect(Buffs.NastrondReady) && IsLoTDActive && InActionRange(Nastrond);
 
     private static bool CanHighJump(
         bool onAoE = false,
@@ -240,7 +240,7 @@ internal partial class DRG
             : !LevelChecked(HighJump) && IsOriginal(Jump) ||
               LevelChecked(HighJump) && IsOriginal(HighJump) &&
               (allowDoubleMirageHold || !DRG_ST_DoubleMirage ||
-               DRG_ST_DoubleMirage && (GetCooldownRemainingTime(Geirskogul) < 13 || LoTDTimerActive)));
+               DRG_ST_DoubleMirage && (GetCooldownRemainingTime(Geirskogul) < 13 || IsLoTDTimerActive)));
 
     private static bool CanDragonfireDive(
         UserBoolArray? holdOptions = null,
@@ -248,10 +248,10 @@ internal partial class DRG
         ActionReady(DragonfireDive) && !HasStatusEffect(Buffs.DragonsFlight) &&
         GetTargetHPPercent() > hpThreshold &&
         CanUseWithHoldOptions(holdOptions) &&
-        (LoTDTimerActive || !LevelChecked(Geirskogul));
+        (IsLoTDTimerActive || !LevelChecked(Geirskogul));
 
     private static bool CanStardiver(UserBoolArray? holdOptions = null) =>
-        ActionReady(Stardiver) && LoTDActive && !HasStatusEffect(Buffs.StarcrossReady) &&
+        ActionReady(Stardiver) && IsLoTDActive && !HasStatusEffect(Buffs.StarcrossReady) &&
         CanUseWithHoldOptions(holdOptions);
 
     private readonly struct OutsideOfMeleeOptions
@@ -556,13 +556,13 @@ internal partial class DRG
 
     private static DRGGauge Gauge => GetJobGauge<DRGGauge>();
 
-    private static bool LoTDActive => Gauge.IsLOTDActive;
+    private static bool IsLoTDActive => Gauge.IsLOTDActive;
 
     private static short LoTDTimer => Gauge.LOTDTimer;
 
     private static byte FirstmindsFocus => Gauge.FirstmindsFocusCount;
 
-    private static bool LoTDTimerActive => LoTDTimer > 0;
+    private static bool IsLoTDTimerActive => LoTDTimer > 0;
 
     private static readonly FrozenDictionary<uint, ushort> ChaoticList = new Dictionary<uint, ushort>
     {

--- a/WrathCombo/Combos/PvE/DRG/DRG_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRG/DRG_Helper.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Statuses;
 using System.Collections.Frozen;
 using System.Collections.Generic;
@@ -586,3 +586,4 @@ internal partial class DRG
 
     #endregion
 }
+

--- a/WrathCombo/Combos/PvE/DRG/DRG_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRG/DRG_Helper.cs
@@ -400,17 +400,22 @@ internal partial class DRG
             DRG_SelectedOpener == 1)
             return PiercingTalonOpener;
 
+        if (EarlyBuffOpener.LevelChecked &&
+            DRG_SelectedOpener == 2)
+            return EarlyBuffOpener;
+
         return WrathOpener.Dummy;
     }
 
     internal static DRGStandardOpener StandardOpener = new();
     internal static DRGPiercingTalonOpener PiercingTalonOpener = new();
+    internal static DRGEarlyBuffOpener EarlyBuffOpener = new();
 
     internal class DRGStandardOpener : WrathOpener
     {
         public override int MinOpenerLevel => 100;
 
-        public override int MaxOpenerLevel => 109;
+        public override int MaxOpenerLevel => 100;
 
         public override List<uint> OpenerActions { get; set; } =
         [
@@ -455,7 +460,7 @@ internal partial class DRG
     {
         public override int MinOpenerLevel => 100;
 
-        public override int MaxOpenerLevel => 109;
+        public override int MaxOpenerLevel => 100;
 
         public override List<uint> OpenerActions { get; set; } =
         [
@@ -494,6 +499,55 @@ internal partial class DRG
             IsOffCooldown(BattleLitany) &&
             IsOffCooldown(DragonfireDive) &&
             IsOffCooldown(LanceCharge);
+    }
+
+    internal class DRGEarlyBuffOpener : WrathOpener
+    {
+        public override int MinOpenerLevel => 100;
+
+        public override int MaxOpenerLevel => 100;
+
+        public override List<uint> OpenerActions { get; set; } =
+        [
+            LanceCharge,
+            BattleLitany,
+            TrueThrust,
+            DragonfireDive,
+            VorpalThrust,
+            LifeSurge,
+            Geirskogul,
+            HeavensThrust,
+            LifeSurge,
+            WyrmwindThrust,
+            Drakesbane,
+            HighJump,
+            MirageDive,
+            ChaoticSpring,
+            Nastrond,
+            RiseOfTheDragon,
+            WheelingThrust,
+            Nastrond,
+            FangAndClaw,
+            Stardiver,
+            Nastrond,
+            RaidenThrust,
+            Nastrond,
+            VorpalThrust,
+            HighJump,
+            HeavensThrust,
+            MirageDive
+        ];
+
+        public override Preset Preset => Preset.DRG_ST_Opener;
+
+        internal override UserData ContentCheckConfig => DRG_BalanceContent;
+
+        public override bool HasCooldowns() =>
+            GetRemainingCharges(LifeSurge) is 2 &&
+            IsOffCooldown(BattleLitany) &&
+            IsOffCooldown(DragonfireDive) &&
+            IsOffCooldown(LanceCharge) &&
+            CountdownRemaining is >= 1.5f and <= 3f;
     }
 
     #endregion

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -16,7 +16,7 @@ internal partial class MCH : PhysicalRanged
                 return actionID;
 
             //Reassemble to start before combat/after downtime
-            if (CanReassemble(false) && !IsOverheated && !HasWeaved())
+            if (CanReassemble(false, forPrepull: true) && !IsOverheated && !HasWeaved())
                 return Reassemble;
 
             if (!IsOverheated &&
@@ -176,7 +176,7 @@ internal partial class MCH : PhysicalRanged
 
             //Reassemble to start before combat/after downtime
             if (IsEnabled(Preset.MCH_ST_Adv_Reassemble) &&
-                CanReassemble(false, MCH_ST_Adv_ReassembleChoice, MCH_ST_ReassemblePool, ReassembleHPThreshold) &&
+                CanReassemble(false, MCH_ST_Adv_ReassembleChoice, MCH_ST_ReassemblePool, ReassembleHPThreshold, forPrepull: true) &&
                 !IsOverheated && !HasWeaved())
                 return Reassemble;
 

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -176,7 +176,7 @@ internal partial class MCH : PhysicalRanged
 
             //Reassemble to start before combat/after downtime
             if (IsEnabled(Preset.MCH_ST_Adv_Reassemble) &&
-                CanReassemble(false, MCH_ST_Adv_ReassembleChoice, MCH_ST_ReassemblePool, ReassembleHPThreshold, forPrepull: true) &&
+                CanReassemble(false, MCH_ST_Adv_ReassembleChoice, MCH_ST_ReassemblePool, ReassembleHPThreshold, true) &&
                 !IsOverheated && !HasWeaved())
                 return Reassemble;
 

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -155,7 +155,7 @@ internal partial class MCH : PhysicalRanged
             if (ActionReady(OriginalHook(Heatblast)) && IsOverheated)
                 return OverheatGCD(onAoE: true);
 
-            return OriginalHook(SpreadShot);
+            return DoBasicCombo(onAoE: true);
         }
     }
 
@@ -297,8 +297,11 @@ internal partial class MCH : PhysicalRanged
                 ActionReady(OriginalHook(Heatblast)) && IsOverheated)
                 return OverheatGCD(onAoE: false);
 
-            return DoBasicCombo(IsEnabled(Preset.MCH_ST_Adv_Reassemble),
-                MCH_ST_Adv_ReassembleChoice, MCH_ST_ReassemblePool, ReassembleHPThreshold);
+            return DoBasicCombo(
+                allowReassembleOnClean: IsEnabled(Preset.MCH_ST_Adv_Reassemble),
+                reassembleChoice: MCH_ST_Adv_ReassembleChoice,
+                chargePool: MCH_ST_ReassemblePool,
+                hpThreshold: ReassembleHPThreshold);
         }
     }
 
@@ -391,7 +394,7 @@ internal partial class MCH : PhysicalRanged
             if (ActionReady(OriginalHook(Heatblast)) && IsOverheated)
                 return OverheatGCD(true, IsEnabled(Preset.MCH_AoE_Adv_GaussRicochet));
 
-            return OriginalHook(SpreadShot);
+            return DoBasicCombo(onAoE: true);
         }
     }
 

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -29,7 +29,7 @@ internal partial class MCH : PhysicalRanged
                 if (OvercapGaussRicochetProtection(out uint gaussRico))
                     return gaussRico;
 
-                if (RobotActive && ActionReady(OriginalHook(RookOverdrive)) &&
+                if (IsRobotActive && ActionReady(OriginalHook(RookOverdrive)) &&
                     GetTargetHPPercent() <= 1)
                     return OriginalHook(RookOverdrive);
 
@@ -193,7 +193,7 @@ internal partial class MCH : PhysicalRanged
                     return gaussRico;
 
                 if (IsEnabled(Preset.MCH_ST_Adv_QueenOverdrive) &&
-                    RobotActive && ActionReady(OriginalHook(RookOverdrive)) &&
+                    IsRobotActive && ActionReady(OriginalHook(RookOverdrive)) &&
                     GetTargetHPPercent() <= MCH_ST_QueenOverDriveHPThreshold)
                     return OriginalHook(RookOverdrive);
 
@@ -328,7 +328,7 @@ internal partial class MCH : PhysicalRanged
                     return gaussRico;
 
                 if (IsEnabled(Preset.MCH_AoE_Adv_QueenOverdrive) &&
-                    RobotActive && ActionReady(OriginalHook(RookOverdrive)) &&
+                    IsRobotActive && ActionReady(OriginalHook(RookOverdrive)) &&
                     GetTargetHPPercent() <= MCH_AoE_QueenOverDriveHPThreshold)
                     return OriginalHook(RookOverdrive);
 
@@ -517,7 +517,7 @@ internal partial class MCH : PhysicalRanged
             if (actionID is not (AutomatonQueen or RookAutoturret))
                 return actionID;
 
-            return RobotActive
+            return IsRobotActive
                 ? OriginalHook(QueenOverdrive)
                 : actionID;
         }

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -84,7 +84,7 @@ internal partial class MCH : PhysicalRanged
             if (IsOverheated && ActionReady(OriginalHook(Heatblast)))
                 return OverheatGCD(onAoE: false);
 
-            return DoBasicCombo(actionID, true);
+            return DoBasicCombo(allowReassembleOnClean: true);
         }
     }
 
@@ -297,7 +297,7 @@ internal partial class MCH : PhysicalRanged
                 ActionReady(OriginalHook(Heatblast)) && IsOverheated)
                 return OverheatGCD(onAoE: false);
 
-            return DoBasicCombo(actionID, IsEnabled(Preset.MCH_ST_Adv_Reassemble),
+            return DoBasicCombo(IsEnabled(Preset.MCH_ST_Adv_Reassemble),
                 MCH_ST_Adv_ReassembleChoice, MCH_ST_ReassemblePool, ReassembleHPThreshold);
         }
     }
@@ -404,7 +404,7 @@ internal partial class MCH : PhysicalRanged
             if (actionID is not (CleanShot or HeatedCleanShot))
                 return actionID;
 
-            return DoBasicCombo(OriginalHook(SplitShot));
+            return DoBasicCombo();
         }
     }
 

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -97,7 +97,7 @@ internal partial class MCH : PhysicalRanged
             if (!CustomActionHelper.OneButtonRotationChecker(actionID, CustomActionType.AoEDPS, SpreadShot, Scattergun))
                 return actionID;
 
-            if (HasStatusEffect(Buffs.Flamethrower) || JustUsed(Flamethrower, GCDTotal))
+            if (HasStatusEffect(Buffs.Flamethrower) || JustUsed(Flamethrower, GCD))
                 return All.SavageBlade;
 
             if (ContentSpecificActions.TryGet(out uint contentAction))
@@ -314,7 +314,7 @@ internal partial class MCH : PhysicalRanged
             if (!CustomActionHelper.OneButtonRotationChecker(actionID, CustomActionType.AoEDPS, SpreadShot, Scattergun))
                 return actionID;
 
-            if (HasStatusEffect(Buffs.Flamethrower) || JustUsed(Flamethrower, GCDTotal))
+            if (HasStatusEffect(Buffs.Flamethrower) || JustUsed(Flamethrower, GCD))
                 return All.SavageBlade;
 
             if (ContentSpecificActions.TryGet(out uint contentAction))

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -293,7 +293,7 @@ internal partial class MCH
         return numberOfReadyTools;
     }
 
-    private static bool CanReassembleAoE(int chargePool = 0, int hpThreshold = 25)
+    private static bool CanReassembleAoE(int chargePool = 0, int hpThreshold = 25, bool forPrepull = false)
     {
         uint remainingCharges = GetRemainingCharges(Reassemble);
 
@@ -305,17 +305,17 @@ internal partial class MCH
         if (remainingCharges == 0 || remainingCharges <= chargePool)
             return false;
 
-        if (ToolReadyForReassembleWeave(Excavator) && HasStatusEffect(Buffs.ExcavatorReady))
+        if (ToolReadyForReassemble(Excavator, forPrepull) && HasStatusEffect(Buffs.ExcavatorReady))
             return true;
 
-        if (ToolReadyForReassembleWeave(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady))
+        if (ToolReadyForReassemble(Chainsaw, forPrepull) && !HasStatusEffect(Buffs.ExcavatorReady))
             return true;
 
-        if (ToolReadyForReassembleWeave(AirAnchor) &&
+        if (ToolReadyForReassemble(AirAnchor, forPrepull) &&
             (!LevelChecked(Chainsaw) || GetCooldownRemainingTime(Chainsaw) > GCDTotal * 2))
             return true;
 
-        if (CanUseDrill(true) && ToolReadyForReassembleWeave(Drill))
+        if (CanUseDrill(true) && ToolReadyForReassemble(Drill, forPrepull))
             return true;
 
         if (LevelChecked(Scattergun) && ActionReady(Scattergun))
@@ -331,10 +331,10 @@ internal partial class MCH
         LevelChecked(Scattergun) && InActionRange(OriginalHook(SpreadShot)) ||
         !LevelChecked(Drill) && InActionRange(OriginalHook(SpreadShot));
 
-    private static bool CanReassemble(bool onAoE, int reassembleChoice = 1, int chargePool = 0, int hpThreshold = 25) =>
-        onAoE ? CanReassembleAoE(chargePool, hpThreshold) : CanReassembleST(reassembleChoice, chargePool, hpThreshold);
+    private static bool CanReassemble(bool onAoE, int reassembleChoice = 1, int chargePool = 0, int hpThreshold = 25, bool forPrepull = false) =>
+        onAoE ? CanReassembleAoE(chargePool, hpThreshold, forPrepull) : CanReassembleST(reassembleChoice, chargePool, hpThreshold, forPrepull);
 
-    private static bool CanReassembleST(int reassembleChoice = 1, int chargePool = 0, int hpThreshold = 25)
+    private static bool CanReassembleST(int reassembleChoice = 1, int chargePool = 0, int hpThreshold = 25, bool forPrepull = false)
     {
         UpdateReassembleChargeTracking();
 
@@ -359,12 +359,12 @@ internal partial class MCH
                 return numberOfReadyTools >= remainingCharges;
             }
 
-            case 1 when ToolReadyForReassembleWeave(Excavator) && HasStatusEffect(Buffs.ExcavatorReady):
-            case 1 when ToolReadyForReassembleWeave(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady):
-            case 1 when ToolReadyForReassembleWeave(AirAnchor) && (!LevelChecked(Chainsaw) || GetCooldownRemainingTime(Chainsaw) > GCDTotal * 2):
-            case 1 when ToolReadyForReassembleWeave(Drill) && (!LevelChecked(AirAnchor) || GetCooldownRemainingTime(AirAnchor) > GCDTotal * 2):
+            case 1 when ToolReadyForReassemble(Excavator, forPrepull) && HasStatusEffect(Buffs.ExcavatorReady):
+            case 1 when ToolReadyForReassemble(Chainsaw, forPrepull) && !HasStatusEffect(Buffs.ExcavatorReady):
+            case 1 when ToolReadyForReassemble(AirAnchor, forPrepull) && (!LevelChecked(Chainsaw) || GetCooldownRemainingTime(Chainsaw) > GCDTotal * 2):
+            case 1 when ToolReadyForReassemble(Drill, forPrepull) && (!LevelChecked(AirAnchor) || GetCooldownRemainingTime(AirAnchor) > GCDTotal * 2):
             case 1 when !LevelChecked(Drill) && ComboTimer > 0 && ComboAction is SlugShot && LevelChecked(CleanShot):
-            case 1 when !LevelChecked(CleanShot) && ToolReadyForReassembleWeave(HotShot):
+            case 1 when !LevelChecked(CleanShot) && ToolReadyForReassemble(HotShot, forPrepull):
                 return true;
 
             default:
@@ -499,10 +499,14 @@ internal partial class MCH
 
     private static bool ToolReadyForReassembleWeave(uint actionId) =>
         LevelChecked(actionId) &&
-        !ActionReady(actionId) &&
-        (HasCharges(actionId)
-            ? GetCooldownChargeRemainingTime(actionId) <= GCDTotal * 0.5f
-            : GetCooldownRemainingTime(actionId) <= GCDTotal * 0.5f);
+        (HasCharges(actionId) && GetRemainingCharges(actionId) > 0 ||
+         IsOnCooldown(actionId) && (HasCharges(actionId)
+             ? GetCooldownChargeRemainingTime(actionId) <= GCDTotal * 0.5f
+             : GetCooldownRemainingTime(actionId) <= GCDTotal * 0.5f) ||
+         !IsOnCooldown(actionId) && GetCooldownRemainingTime(actionId) <= GCDTotal * 0.5f);
+
+    private static bool ToolReadyForReassemble(uint actionId, bool forPrepull) =>
+        forPrepull ? ToolsReady(actionId) : ToolReadyForReassembleWeave(actionId);
 
     private static bool CanUseDrill(bool onAoE) =>
         !onAoE || !LevelChecked(BioBlaster);

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using Dalamud.Game.ClientState.JobGauge.Types;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using System;
 using System.Collections.Generic;
@@ -139,7 +139,6 @@ internal partial class MCH
         if (!IsHyperchargeReady())
             return false;
 
-        // Pre-Bio Blaster: spend Drill. After: spend Bio Blaster (DoT counts as spent).
         if (LevelChecked(BioBlaster))
         {
             if (!UsedBioBlaster(toolHoldThreshold))
@@ -498,7 +497,6 @@ internal partial class MCH
     private static bool ToolsReady(uint actionId) =>
         LevelChecked(actionId) && (HasCharges(actionId) || GetCooldownRemainingTime(actionId) <= GCDTotal);
 
-    // Reassemble weave window — tool not castable yet, but lands within half a GCD after this oGCD.
     private static bool ToolReadyForReassembleWeave(uint actionId) =>
         LevelChecked(actionId) &&
         !ActionReady(actionId) &&
@@ -599,8 +597,16 @@ internal partial class MCH
         return ActionManager.Instance()->Combo.Timer != 0 && ActionManager.Instance()->Combo.Timer < gcd;
     }
 
-    private static uint DoBasicCombo(bool allowReassembleOnClean = false, int reassembleChoice = 1, int chargePool = 0, int hpThreshold = 25)
+    private static uint ContinueBasicCombo(
+        bool onAoE = false,
+        bool allowReassembleOnClean = false,
+        int reassembleChoice = 1,
+        int chargePool = 0,
+        int hpThreshold = 25)
     {
+        if (onAoE)
+            return OriginalHook(SpreadShot);
+
         if (ComboTimer > 0)
         {
             if (ComboAction is SplitShot && ActionReady(OriginalHook(SlugShot)))
@@ -617,6 +623,14 @@ internal partial class MCH
 
         return OriginalHook(SplitShot);
     }
+
+    private static uint DoBasicCombo(
+        bool onAoE = false,
+        bool allowReassembleOnClean = false,
+        int reassembleChoice = 1,
+        int chargePool = 0,
+        int hpThreshold = 25) =>
+        ContinueBasicCombo(onAoE, allowReassembleOnClean, reassembleChoice, chargePool, hpThreshold);
 
     #endregion
 
@@ -908,3 +922,4 @@ internal partial class MCH
 
     #endregion
 }
+

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -922,4 +922,3 @@ internal partial class MCH
 
     #endregion
 }
-

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -272,7 +272,7 @@ internal partial class MCH
         if (ToolsReady(Drill))
             numberOfReadyTools += (int)GetRemainingCharges(Drill);
 
-        if (ToolsReady(Chainsaw))
+        if (ToolReadyForReassembleWeave(Chainsaw))
         {
             numberOfReadyTools++;
             if (LevelChecked(Excavator))
@@ -284,7 +284,7 @@ internal partial class MCH
             numberOfReadyTools++;
         }
 
-        if (ToolsReady(OriginalHook(AirAnchor)))
+        if (ToolReadyForReassembleWeave(AirAnchor))
             numberOfReadyTools++;
 
         if (!LevelChecked(Drill) && ComboTimer > 0 && ComboAction is SlugShot &&
@@ -306,17 +306,17 @@ internal partial class MCH
         if (remainingCharges == 0 || remainingCharges <= chargePool)
             return false;
 
-        if (ToolsReady(Excavator) && HasStatusEffect(Buffs.ExcavatorReady))
+        if (ToolReadyForReassembleWeave(Excavator) && HasStatusEffect(Buffs.ExcavatorReady))
             return true;
 
-        if (ToolsReady(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady))
+        if (ToolReadyForReassembleWeave(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady))
             return true;
 
-        if (ToolsReady(AirAnchor) &&
+        if (ToolReadyForReassembleWeave(AirAnchor) &&
             (!LevelChecked(Chainsaw) || GetCooldownRemainingTime(Chainsaw) > GCDTotal * 2))
             return true;
 
-        if (CanUseDrill(true) && ToolsReady(Drill))
+        if (CanUseDrill(true) && ToolReadyForReassembleWeave(Drill))
             return true;
 
         if (LevelChecked(Scattergun) && ActionReady(Scattergun))
@@ -360,12 +360,12 @@ internal partial class MCH
                 return numberOfReadyTools >= remainingCharges;
             }
 
-            case 1 when ToolsReady(Excavator) && HasStatusEffect(Buffs.ExcavatorReady):
-            case 1 when ToolsReady(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady):
-            case 1 when ToolsReady(AirAnchor) && (!LevelChecked(Chainsaw) || GetCooldownRemainingTime(Chainsaw) > GCDTotal * 2):
-            case 1 when ToolsReady(Drill) && (!LevelChecked(AirAnchor) || GetCooldownRemainingTime(AirAnchor) > GCDTotal * 2):
+            case 1 when ToolReadyForReassembleWeave(Excavator) && HasStatusEffect(Buffs.ExcavatorReady):
+            case 1 when ToolReadyForReassembleWeave(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady):
+            case 1 when ToolReadyForReassembleWeave(AirAnchor) && (!LevelChecked(Chainsaw) || GetCooldownRemainingTime(Chainsaw) > GCDTotal * 2):
+            case 1 when ToolReadyForReassembleWeave(Drill) && (!LevelChecked(AirAnchor) || GetCooldownRemainingTime(AirAnchor) > GCDTotal * 2):
             case 1 when !LevelChecked(Drill) && ComboTimer > 0 && ComboAction is SlugShot && LevelChecked(CleanShot):
-            case 1 when !LevelChecked(CleanShot) && ToolsReady(HotShot):
+            case 1 when !LevelChecked(CleanShot) && ToolReadyForReassembleWeave(HotShot):
                 return true;
 
             default:
@@ -497,6 +497,14 @@ internal partial class MCH
 
     private static bool ToolsReady(uint actionId) =>
         LevelChecked(actionId) && (HasCharges(actionId) || GetCooldownRemainingTime(actionId) <= GCDTotal);
+
+    // Reassemble weave window — tool not castable yet, but lands within half a GCD after this oGCD.
+    private static bool ToolReadyForReassembleWeave(uint actionId) =>
+        LevelChecked(actionId) &&
+        !ActionReady(actionId) &&
+        (HasCharges(actionId)
+            ? GetCooldownChargeRemainingTime(actionId) <= GCDTotal * 0.5f
+            : GetCooldownRemainingTime(actionId) <= GCDTotal * 0.5f);
 
     private static bool CanUseDrill(bool onAoE) =>
         !onAoE || !LevelChecked(BioBlaster);

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -47,7 +47,7 @@ internal partial class MCH
 
         if (!HasStatusEffect(Buffs.Wildfire) &&
             ActionReady(OriginalHook(RookAutoturret)) &&
-            !RobotActive &&
+            !IsRobotActive &&
             GetTargetHPPercent() > hpThreshold)
         {
             if (LevelChecked(Wildfire))
@@ -863,7 +863,7 @@ internal partial class MCH
 
     private static bool IsOverheated => Gauge.IsOverheated;
 
-    private static bool RobotActive => Gauge.IsRobotActive;
+    private static bool IsRobotActive => Gauge.IsRobotActive;
 
     private static byte Heat => Gauge.Heat;
 

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -494,16 +494,23 @@ internal partial class MCH
 
     #region Tools
 
+    private static bool IsBelowMaxCharges(uint actionId) =>
+        GetMaxCharges(actionId) > 1 && GetRemainingCharges(actionId) < GetMaxCharges(actionId);
+
+    private static float GetToolCDRemaining(uint actionId) =>
+        IsBelowMaxCharges(actionId)
+            ? GetCooldownChargeRemainingTime(actionId)
+            : GetCooldownRemainingTime(actionId);
+
+    private static bool ToolsReady(uint actionId, float window) =>
+        LevelChecked(actionId) &&
+        (HasCharges(actionId) || GetToolCDRemaining(actionId) <= window);
+
     private static bool ToolsReady(uint actionId) =>
-        LevelChecked(actionId) && (HasCharges(actionId) || GetCooldownRemainingTime(actionId) <= GCDTotal);
+        ToolsReady(actionId, GCDTotal);
 
     private static bool ToolReadyForReassembleWeave(uint actionId) =>
-        LevelChecked(actionId) &&
-        (HasCharges(actionId) && GetRemainingCharges(actionId) > 0 ||
-         IsOnCooldown(actionId) && (HasCharges(actionId)
-             ? GetCooldownChargeRemainingTime(actionId) <= GCDTotal * 0.5f
-             : GetCooldownRemainingTime(actionId) <= GCDTotal * 0.5f) ||
-         !IsOnCooldown(actionId) && GetCooldownRemainingTime(actionId) <= GCDTotal * 0.5f);
+        ToolsReady(actionId, GCDTotal * 0.5f);
 
     private static bool ToolReadyForReassemble(uint actionId, bool forPrepull) =>
         forPrepull ? ToolsReady(actionId) : ToolReadyForReassembleWeave(actionId);
@@ -511,15 +518,20 @@ internal partial class MCH
     private static bool CanUseDrill(bool onAoE) =>
         !onAoE || !LevelChecked(BioBlaster);
 
-    private static bool IsDrillCD(float time = 9f) =>
-        !LevelChecked(Drill) ||
-        !TraitLevelChecked(Traits.EnhancedMultiWeapon) && GetCooldownRemainingTime(Drill) >= time ||
-        TraitLevelChecked(Traits.EnhancedMultiWeapon) && GetRemainingCharges(Drill) < GetMaxCharges(Drill) && GetCooldownChargeRemainingTime(Drill) >= time;
+    private static bool IsChargedToolCD(uint actionId, float time = 9f)
+    {
+        if (!LevelChecked(actionId))
+            return true;
 
-    private static bool IsBioBlasterCD(float time = 9f) =>
-        !LevelChecked(BioBlaster) ||
-        !TraitLevelChecked(Traits.EnhancedMultiWeapon) && GetCooldownRemainingTime(BioBlaster) >= time ||
-        TraitLevelChecked(Traits.EnhancedMultiWeapon) && GetRemainingCharges(BioBlaster) < GetMaxCharges(BioBlaster) && GetCooldownChargeRemainingTime(BioBlaster) >= time;
+        if (HasCharges(actionId) && !IsBelowMaxCharges(actionId))
+            return false;
+
+        return GetToolCDRemaining(actionId) >= time;
+    }
+
+    private static bool IsDrillCD(float time = 9f) => IsChargedToolCD(Drill, time);
+
+    private static bool IsBioBlasterCD(float time = 9f) => IsChargedToolCD(BioBlaster, time);
 
     private static bool IsAirAnchorCD(float time = 9f) =>
         !LevelChecked(OriginalHook(HotShot)) ||

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -591,7 +591,7 @@ internal partial class MCH
         return ActionManager.Instance()->Combo.Timer != 0 && ActionManager.Instance()->Combo.Timer < gcd;
     }
 
-    private static uint DoBasicCombo(uint actionId, bool allowReassembleOnClean = false, int reassembleChoice = 1, int chargePool = 0, int hpThreshold = 25)
+    private static uint DoBasicCombo(bool allowReassembleOnClean = false, int reassembleChoice = 1, int chargePool = 0, int hpThreshold = 25)
     {
         if (ComboTimer > 0)
         {

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -715,14 +715,14 @@ internal partial class MCH
             HeatedCleanShot
         ];
 
+        public override Preset Preset => Preset.MCH_ST_Adv_Opener;
+
         internal override UserData ContentCheckConfig => MCH_Balance_Content;
 
         public override List<(int[] Steps, Func<int> HoldDelay)> PrepullDelays { get; set; } =
         [
             ([2], () => 4)
         ];
-
-        public override Preset Preset => Preset.MCH_ST_Adv_Opener;
 
         public override bool HasCooldowns() =>
             GetRemainingCharges(Reassemble) is 2 &&
@@ -778,13 +778,15 @@ internal partial class MCH
             HeatedCleanShot
         ];
 
+        public override Preset Preset => Preset.MCH_ST_Adv_Opener;
+
         internal override UserData ContentCheckConfig => MCH_Balance_Content;
 
         public override List<(int[] Steps, Func<int> HoldDelay)> PrepullDelays { get; set; } =
         [
             ([2], () => 4)
         ];
-        public override Preset Preset => Preset.MCH_ST_Adv_Opener;
+
         public override bool HasCooldowns() =>
             GetRemainingCharges(Reassemble) is 2 &&
             GetRemainingCharges(OriginalHook(GaussRound)) is 3 &&
@@ -834,6 +836,8 @@ internal partial class MCH
             Drill
         ];
 
+        public override Preset Preset => Preset.MCH_ST_Adv_Opener;
+
         internal override UserData ContentCheckConfig => MCH_Balance_Content;
 
         public override List<(int[] Steps, Func<int> HoldDelay)> PrepullDelays { get; set; } =
@@ -845,7 +849,7 @@ internal partial class MCH
         [
             14
         ];
-        public override Preset Preset => Preset.MCH_ST_Adv_Opener;
+
         public override bool HasCooldowns() =>
             GetRemainingCharges(Reassemble) is 2 &&
             GetRemainingCharges(OriginalHook(GaussRound)) is 3 &&

--- a/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH_Helper.cs
@@ -100,9 +100,9 @@ internal partial class MCH
 
     private static bool ShouldUseHyperchargeST(int wildfireBossOnlyOption) =>
         ActionReady(Wildfire) ||
-        JustUsed(FullMetalField, GCDTotal / 2) ||
+        JustUsed(FullMetalField, GCD / 2) ||
         wildfireBossOnlyOption == 1 && !TargetIsBoss() ||
-        GetCooldownRemainingTime(Wildfire) > GCDTotal * 15 ||
+        GetCooldownRemainingTime(Wildfire) > GCD * 15 ||
         Heat is 100 && GetCooldownRemainingTime(Wildfire) > 10 ||
         !LevelChecked(Wildfire);
 
@@ -167,7 +167,7 @@ internal partial class MCH
         !IsOverheated &&
         (ActionReady(Wildfire) ||
          GetCooldownRemainingTime(Wildfire) > 90 ||
-         GetCooldownRemainingTime(Wildfire) <= GCDTotal ||
+         GetCooldownRemainingTime(Wildfire) <= GCD ||
          GetStatusEffectRemainingTime(Buffs.FullMetalMachinist) <= 6);
 
     private static bool JustUsedOverheatGCD(float window, bool onAoE) =>
@@ -212,7 +212,7 @@ internal partial class MCH
         float? hyperchargeWindow = null) =>
         CanApplyStatus(CurrentTarget, Debuffs.Wildfire) &&
         ActionReady(Wildfire) &&
-        JustUsed(Hypercharge, hyperchargeWindow ?? GCDTotal + 0.9f) &&
+        JustUsed(Hypercharge, hyperchargeWindow ?? GCD + 0.9f) &&
         !HasStatusEffect(Buffs.Wildfire) &&
         (requireBoss
             ? TargetIsBoss()
@@ -268,7 +268,7 @@ internal partial class MCH
     {
         int numberOfReadyTools = 0;
 
-        if (ToolsReady(Drill))
+        if (ActionReady(Drill))
             numberOfReadyTools += (int)GetRemainingCharges(Drill);
 
         if (ToolReadyForReassembleWeave(Chainsaw))
@@ -312,7 +312,7 @@ internal partial class MCH
             return true;
 
         if (ToolReadyForReassemble(AirAnchor, forPrepull) &&
-            (!LevelChecked(Chainsaw) || GetCooldownRemainingTime(Chainsaw) > GCDTotal * 2))
+            (!LevelChecked(Chainsaw) || GetCooldownRemainingTime(Chainsaw) > GCD * 2))
             return true;
 
         if (CanUseDrill(true) && ToolReadyForReassemble(Drill, forPrepull))
@@ -361,8 +361,8 @@ internal partial class MCH
 
             case 1 when ToolReadyForReassemble(Excavator, forPrepull) && HasStatusEffect(Buffs.ExcavatorReady):
             case 1 when ToolReadyForReassemble(Chainsaw, forPrepull) && !HasStatusEffect(Buffs.ExcavatorReady):
-            case 1 when ToolReadyForReassemble(AirAnchor, forPrepull) && (!LevelChecked(Chainsaw) || GetCooldownRemainingTime(Chainsaw) > GCDTotal * 2):
-            case 1 when ToolReadyForReassemble(Drill, forPrepull) && (!LevelChecked(AirAnchor) || GetCooldownRemainingTime(AirAnchor) > GCDTotal * 2):
+            case 1 when ToolReadyForReassemble(AirAnchor, forPrepull) && (!LevelChecked(Chainsaw) || GetCooldownRemainingTime(Chainsaw) > GCD * 2):
+            case 1 when ToolReadyForReassemble(Drill, forPrepull) && (!LevelChecked(AirAnchor) || GetCooldownRemainingTime(AirAnchor) > GCD * 2):
             case 1 when !LevelChecked(Drill) && ComboTimer > 0 && ComboAction is SlugShot && LevelChecked(CleanShot):
             case 1 when !LevelChecked(CleanShot) && ToolReadyForReassemble(HotShot, forPrepull):
                 return true;
@@ -502,18 +502,12 @@ internal partial class MCH
             ? GetCooldownChargeRemainingTime(actionId)
             : GetCooldownRemainingTime(actionId);
 
-    private static bool ToolsReady(uint actionId, float window) =>
-        LevelChecked(actionId) &&
-        (HasCharges(actionId) || GetToolCDRemaining(actionId) <= window);
-
-    private static bool ToolsReady(uint actionId) =>
-        ToolsReady(actionId, GCDTotal);
-
     private static bool ToolReadyForReassembleWeave(uint actionId) =>
-        ToolsReady(actionId, GCDTotal * 0.5f);
+        LevelChecked(actionId) &&
+        (HasCharges(actionId) || GetToolCDRemaining(actionId) <= GCD * 0.5f);
 
     private static bool ToolReadyForReassemble(uint actionId, bool forPrepull) =>
-        forPrepull ? ToolsReady(actionId) : ToolReadyForReassembleWeave(actionId);
+        forPrepull ? ActionReady(actionId) : ToolReadyForReassembleWeave(actionId);
 
     private static bool CanUseDrill(bool onAoE) =>
         !onAoE || !LevelChecked(BioBlaster);
@@ -549,28 +543,28 @@ internal partial class MCH
 
     private static bool CanUseTools(ref uint actionID, bool onAoE, bool useAirAnchor = true, bool holdExcavatorForWildfire = false)
     {
-        if (ToolsReady(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady))
+        if (ActionReady(Chainsaw) && !HasStatusEffect(Buffs.ExcavatorReady))
         {
             actionID = Chainsaw;
             return true;
         }
 
-        if (ToolsReady(Excavator) && HasStatusEffect(Buffs.ExcavatorReady) &&
+        if (ActionReady(Excavator) && HasStatusEffect(Buffs.ExcavatorReady) &&
             (onAoE || !holdExcavatorForWildfire ||
-             GetStatusEffectRemainingTime(Buffs.ExcavatorReady) <= GCDTotal * 3))
+             GetStatusEffectRemainingTime(Buffs.ExcavatorReady) <= GCD * 3))
         {
             actionID = Excavator;
             return true;
         }
 
-        if ((!onAoE || useAirAnchor) && ToolsReady(AirAnchor))
+        if ((!onAoE || useAirAnchor) && ActionReady(AirAnchor))
         {
             actionID = AirAnchor;
             return true;
         }
 
         if (onAoE &&
-            ToolsReady(BioBlaster) &&
+            ActionReady(BioBlaster) &&
             !HasStatusEffect(Debuffs.Bioblaster, CurrentTarget) &&
             CanApplyStatus(CurrentTarget, Debuffs.Bioblaster))
         {
@@ -578,7 +572,7 @@ internal partial class MCH
             return true;
         }
 
-        if (CanUseDrill(onAoE) && ToolsReady(Drill))
+        if (CanUseDrill(onAoE) && ActionReady(Drill))
         {
             actionID = Drill;
             return true;
@@ -586,14 +580,14 @@ internal partial class MCH
 
         if (onAoE &&
             HasStatusEffect(Buffs.Reassembled) &&
-            ToolsReady(OriginalHook(SpreadShot)))
+            ActionReady(OriginalHook(SpreadShot)))
         {
             actionID = OriginalHook(SpreadShot);
             return true;
         }
 
-        if (!onAoE && !LevelChecked(AirAnchor) && ToolsReady(HotShot) &&
-            (!LevelChecked(CleanShot) || !HasStatusEffect(Buffs.Reassembled) && ActionReady(HotShot)))
+        if (!onAoE && !LevelChecked(AirAnchor) && ActionReady(HotShot) &&
+            (!LevelChecked(CleanShot) || !HasStatusEffect(Buffs.Reassembled)))
         {
             actionID = HotShot;
             return true;
@@ -606,9 +600,11 @@ internal partial class MCH
 
     #region Combos
 
+    private static float GCD => GetCooldown(OriginalHook(SplitShot)).CooldownTotal;
+
     private static unsafe bool IsComboExpiring(float times)
     {
-        float gcd = GCDTotal * times;
+        float gcd = GCD * times;
 
         return ActionManager.Instance()->Combo.Timer != 0 && ActionManager.Instance()->Combo.Timer < gcd;
     }

--- a/WrathCombo/Combos/PvE/MNK/MNK.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK.cs
@@ -73,7 +73,7 @@ internal partial class MNK : Melee
             // Perfect Balance or Standard Beast Chakra's
             return DoPerfectBalanceCombo(ref actionID)
                 ? actionID
-                : DoBasicCombo(actionID);
+                : DoBasicCombo();
         }
     }
 
@@ -141,7 +141,7 @@ internal partial class MNK : Melee
                 return actionID;
 
             // Monk Rotation
-            return DoBasicCombo(actionID, onAoE: true);
+            return DoBasicCombo(onAoE: true);
         }
     }
 
@@ -257,7 +257,7 @@ internal partial class MNK : Melee
             // Perfect Balance or Standard Beast Chakra's
             return DoPerfectBalanceCombo(ref actionID)
                 ? actionID
-                : DoBasicCombo(actionID, IsEnabled(Preset.MNK_STUseTrueNorth), trueNorthCharges: MNK_ManualTN);
+                : DoBasicCombo(IsEnabled(Preset.MNK_STUseTrueNorth), trueNorthCharges: MNK_ManualTN);
         }
     }
 
@@ -355,7 +355,7 @@ internal partial class MNK : Melee
                 return actionID;
 
             // Monk Rotation
-            return DoBasicCombo(actionID, onAoE: true);
+            return DoBasicCombo(onAoE: true);
         }
     }
 

--- a/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
@@ -215,7 +215,7 @@ internal partial class MNK
         JustUsed(CelestialRevolution, window);
 
     private static bool HasElapsedSinceBlitz(float minGcds) =>
-        HasUsedBlitzRecently(GCDTotal * 12) && !HasUsedBlitzRecently(GCDTotal * minGcds);
+        HasUsedBlitzRecently(GCD * 12) && !HasUsedBlitzRecently(GCD * minGcds);
 
     private static uint ForcedOpoGCD(bool onAoE)
     {
@@ -241,17 +241,17 @@ internal partial class MNK
         if (!IsOriginal(MasterfulBlitz) || GetRemainingCharges(PerfectBalance) >= GetMaxCharges(PerfectBalance))
             return false;
 
-        if (!HasUsedBlitzRecently(GCDTotal * 12))
+        if (!HasUsedBlitzRecently(GCD * 12))
             return false;
 
         if (HasStatusEffect(Buffs.FiresRumination) ||
-            JustUsed(FiresReply, GCDTotal * 12))
+            JustUsed(FiresReply, GCD * 12))
             return false;
 
         if (!HasElapsedSinceBlitz(1f) || HasElapsedSinceBlitz(4f))
             return false;
 
-        if (JustUsedOpoGCD(GCDTotal, onAoE) && HasElapsedSinceBlitz(2f))
+        if (JustUsedOpoGCD(GCD, onAoE) && HasElapsedSinceBlitz(2f))
             return false;
 
         return true;
@@ -268,11 +268,11 @@ internal partial class MNK
         if (GetRemainingCharges(PerfectBalance) >= GetMaxCharges(PerfectBalance))
             return false;
 
-        if (!HasUsedBlitzRecently(GCDTotal * 12))
+        if (!HasUsedBlitzRecently(GCD * 12))
             return false;
 
         if (useFiresReply && LevelChecked(FiresReply))
-            return JustUsed(FiresReply, GCDTotal * 6) && !HasStatusEffect(Buffs.FiresRumination);
+            return JustUsed(FiresReply, GCD * 6) && !HasStatusEffect(Buffs.FiresRumination);
 
         return HasElapsedSinceBlitz(2.5f);
     }
@@ -282,13 +282,13 @@ internal partial class MNK
         if (!IsBurstHoldReleaseReady())
             return false;
 
-        if (!HasBattleTarget() || !JustUsedOpoGCD(GCDTotal, onAoE))
+        if (!HasBattleTarget() || !JustUsedOpoGCD(GCD, onAoE))
             return false;
 
         if (onAoE && perfectBalanceHpThreshold > 0 && GetTargetHPPercent() < perfectBalanceHpThreshold)
             return false;
 
-        if (JustUsed(PerfectBalance, 20 + GCDTotal * 5))
+        if (JustUsed(PerfectBalance, 20 + GCD * 5))
             return false;
 
         return true;
@@ -324,13 +324,13 @@ internal partial class MNK
 
         if (!ActionReady(PerfectBalance) || HasStatusEffect(Buffs.PerfectBalance) ||
             HasStatusEffect(Buffs.FormlessFist) || !IsOriginal(MasterfulBlitz) ||
-            !HasBattleTarget() || JustUsed(PerfectBalance) || !JustUsedOpoGCD(GCDTotal, onAoE))
+            !HasBattleTarget() || JustUsed(PerfectBalance) || !JustUsedOpoGCD(GCD, onAoE))
             return false;
 
         if (onAoE && perfectBalanceHpThreshold > 0 && GetTargetHPPercent() < perfectBalanceHpThreshold)
             return false;
 
-        if (!JustUsed(PerfectBalance, 20 + GCDTotal * 5))
+        if (!JustUsed(PerfectBalance, 20 + GCD * 5))
         {
             if (onAoE)
             {
@@ -352,7 +352,7 @@ internal partial class MNK
 
         if (!LevelChecked(RiddleOfFire) ||
             HasStatusEffect(Buffs.RiddleOfFire) && !LevelChecked(Brotherhood))
-            return JustUsedOpoGCD(GCDTotal * 3, onAoE);
+            return JustUsedOpoGCD(GCD * 3, onAoE);
 
         return onAoE && CanPerfectBalanceMaxChargeAoE();
     }
@@ -374,6 +374,9 @@ internal partial class MNK
     #endregion
 
     #region Misc
+
+    private static float GCD =>
+        GetCooldown(OriginalHook(Bootshine)).CooldownTotal;
 
     private static int BossHpThreshold(int hpBossOption, int hpOption, bool isBoss) =>
         hpBossOption == 1 || !isBoss ? hpOption : 0;
@@ -409,7 +412,7 @@ internal partial class MNK
 
     private static bool ShouldSpendMasterfulBlitz(bool onAoE)
     {
-        if (BlitzTimer <= GCDTotal * 3)
+        if (BlitzTimer <= GCD * 3)
             return true;
 
         if (IsBurstHoldReleaseReady())
@@ -474,7 +477,7 @@ internal partial class MNK
 
         if (!HasStatusEffect(Buffs.Brotherhood) &&
             ActionReady(RiddleOfFire) && LevelChecked(Brotherhood) &&
-            GetCooldownRemainingTime(Brotherhood) <= GCDTotal)
+            GetCooldownRemainingTime(Brotherhood) <= GCD)
             return false;
 
         uint meditation = onAoE ? InspiritedMeditation : SteeledMeditation;
@@ -496,7 +499,7 @@ internal partial class MNK
         !HasStatusEffect(Buffs.FiresRumination) &&
         !HasStatusEffect(Buffs.RiddleOfFire) &&
         (!LevelChecked(Brotherhood) ||
-         JustUsed(Brotherhood, GCDTotal * 5) ||
+         JustUsed(Brotherhood, GCD * 5) ||
          HasStatusEffect(Buffs.Brotherhood) ||
          GetCooldownRemainingTime(Brotherhood) is > 50 and < 65 ||
          !LevelChecked(Brotherhood));
@@ -507,10 +510,10 @@ internal partial class MNK
         !HasStatusEffect(Buffs.FormlessFist) &&
         IsOriginal(MasterfulBlitz) &&
         InActionRange(FiresReply) &&
-        !JustUsed(RiddleOfFire, GCDTotal) &&
+        !JustUsed(RiddleOfFire, GCD) &&
         !HasStatusEffect(Buffs.PerfectBalance) &&
-        (JustUsedOpoGCD(GCDTotal * 1.5f, onAoE) ||
-         GetStatusEffectRemainingTime(Buffs.FiresRumination) < GCDTotal * 2 ||
+        (JustUsedOpoGCD(GCD * 1.5f, onAoE) ||
+         GetStatusEffectRemainingTime(Buffs.FiresRumination) < GCD * 2 ||
          !InMeleeRange());
 
     private static bool CanBrotherhood() =>
@@ -531,7 +534,7 @@ internal partial class MNK
          !HasStatusEffect(Buffs.FiresRumination) &&
          (GetCooldownRemainingTime(RiddleOfFire) > 10 ||
           HasStatusEffect(Buffs.RiddleOfFire) ||
-          GetStatusEffectRemainingTime(Buffs.WindsRumination) < GCDTotal * 2 ||
+          GetStatusEffectRemainingTime(Buffs.WindsRumination) < GCD * 2 ||
           !InMeleeRange()));
 
     #endregion

--- a/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
@@ -105,7 +105,7 @@ internal partial class MNK
             ? Demolish
             : OriginalHook(SnapPunch);
 
-    private static uint DoBasicCombo(uint actionId, bool useTrueNorth = true, bool onAoE = false, int trueNorthCharges = 0)
+    private static uint DoBasicCombo(bool useTrueNorth = true, bool onAoE = false, int trueNorthCharges = 0)
     {
         if (onAoE)
         {

--- a/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
@@ -538,11 +538,12 @@ internal partial class MNK
     private static bool CanWindsReply() =>
         HasStatusEffect(Buffs.WindsRumination) &&
         InActionRange(WindsReply) &&
-        !HasStatusEffect(Buffs.FiresRumination) &&
-        (GetCooldownRemainingTime(RiddleOfFire) > 10 ||
-         HasStatusEffect(Buffs.RiddleOfFire) ||
-         GetStatusEffectRemainingTime(Buffs.WindsRumination) < GCDTotal * 2 ||
-         !InMeleeRange());
+        (GetStatusEffectRemainingTime(Buffs.WindsRumination) <= 3f ||
+         !HasStatusEffect(Buffs.FiresRumination) &&
+         (GetCooldownRemainingTime(RiddleOfFire) > 10 ||
+          HasStatusEffect(Buffs.RiddleOfFire) ||
+          GetStatusEffectRemainingTime(Buffs.WindsRumination) < GCDTotal * 2 ||
+          !InMeleeRange()));
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
@@ -598,14 +598,16 @@ internal partial class MNK
             DragonKick
         ];
 
+        public override Preset Preset => Preset.MNK_STUseOpener;
+
+        internal override UserData ContentCheckConfig => MNK_Balance_Content;
+
         public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
         [
             ([1], () => Chakra >= 5),
             ([2], () => JustUsed(FormShift, 30f))
         ];
 
-        internal override UserData ContentCheckConfig => MNK_Balance_Content;
-        public override Preset Preset => Preset.MNK_STUseOpener;
         public override bool HasCooldowns() =>
             GetRemainingCharges(PerfectBalance) is 2 &&
             IsOffCooldown(Brotherhood) &&
@@ -645,14 +647,16 @@ internal partial class MNK
             DragonKick
         ];
 
+        public override Preset Preset => Preset.MNK_STUseOpener;
+
+        internal override UserData ContentCheckConfig => MNK_Balance_Content;
+
         public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
         [
             ([1], () => Chakra >= 5),
             ([2], () => JustUsed(FormShift, 30f))
         ];
 
-        internal override UserData ContentCheckConfig => MNK_Balance_Content;
-        public override Preset Preset => Preset.MNK_STUseOpener;
         public override bool HasCooldowns() =>
             GetRemainingCharges(PerfectBalance) is 2 &&
             IsOffCooldown(Brotherhood) &&
@@ -697,14 +701,16 @@ internal partial class MNK
             LeapingOpo
         ];
 
+        public override Preset Preset => Preset.MNK_STUseOpener;
+
+        internal override UserData ContentCheckConfig => MNK_Balance_Content;
+
         public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
         [
             ([1], () => Chakra >= 5),
             ([2], () => JustUsed(FormShift, 30f))
         ];
 
-        internal override UserData ContentCheckConfig => MNK_Balance_Content;
-        public override Preset Preset => Preset.MNK_STUseOpener;
         public override bool HasCooldowns() =>
             GetRemainingCharges(PerfectBalance) is 2 &&
             IsOffCooldown(Brotherhood) &&
@@ -749,14 +755,16 @@ internal partial class MNK
             LeapingOpo
         ];
 
+        public override Preset Preset => Preset.MNK_STUseOpener;
+
+        internal override UserData ContentCheckConfig => MNK_Balance_Content;
+
         public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
         [
             ([1], () => Chakra >= 5),
             ([2], () => JustUsed(FormShift, 30f))
         ];
 
-        internal override UserData ContentCheckConfig => MNK_Balance_Content;
-        public override Preset Preset => Preset.MNK_STUseOpener;
         public override bool HasCooldowns() =>
             GetRemainingCharges(PerfectBalance) is 2 &&
             IsOffCooldown(Brotherhood) &&
@@ -800,14 +808,16 @@ internal partial class MNK
             DragonKick
         ];
 
+        public override Preset Preset => Preset.MNK_STUseOpener;
+
+        internal override UserData ContentCheckConfig => MNK_Balance_Content;
+
         public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
         [
             ([1], () => Chakra >= 5),
             ([2], () => JustUsed(FormShift, 30f))
         ];
 
-        internal override UserData ContentCheckConfig => MNK_Balance_Content;
-        public override Preset Preset => Preset.MNK_STUseOpener;
         public override bool HasCooldowns() =>
             GetRemainingCharges(PerfectBalance) is 2 &&
             IsOffCooldown(Brotherhood) &&

--- a/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
@@ -432,7 +432,7 @@ internal partial class MNK
         if (onAoE)
             return true;
 
-        if (HasStatusEffect(Buffs.RiddleOfFire) || HasStatusEffect(Buffs.Brotherhood))
+        if (HasStatusEffect(Buffs.RiddleOfFire))
             return true;
 
         return !LevelChecked(RiddleOfFire);
@@ -484,6 +484,11 @@ internal partial class MNK
     private static bool CanUseChakra(bool onAoE = false)
     {
         if (CanBrotherhood() || CanRoF())
+            return false;
+
+        if (!HasStatusEffect(Buffs.Brotherhood) &&
+            ActionReady(RiddleOfFire) && LevelChecked(Brotherhood) &&
+            GetCooldownRemainingTime(Brotherhood) <= GCDTotal)
             return false;
 
         uint meditation = onAoE ? InspiritedMeditation : SteeledMeditation;

--- a/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game.ClientState.JobGauge.Enums;
+using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
 using System;
 using System.Collections.Generic;
@@ -191,19 +191,15 @@ internal partial class MNK
         if (!IsRoFCDInPerfectBalanceWindow())
             return false;
 
-        // Even window first PB — RoF and BH both 2-7s on Opo GCD
         if (IsEvenWindowApproaching())
             return true;
 
-        // Double Lunar odd minutes use post-RoF PB instead of pre-RoF
         if (IsDoubleLunarOpener(useOpenerBalance) && GetCooldownRemainingTime(Brotherhood) > 7)
             return false;
 
-        // Solar odd — RoF 2-7s only
         return true;
     }
 
-    // Simple ST, Advanced ST without opener, and AoE — RoF 2-7s pre-burst PB.
     private static bool ShouldUsePreRoFPerfectBalanceDefault() =>
         IsRoFCDInPerfectBalanceWindow();
 
@@ -233,7 +229,7 @@ internal partial class MNK
 
     private static bool ForceSecondOpo(bool onAoE, bool useFiresReply = true)
     {
-        if (useFiresReply)
+        if (useFiresReply && LevelChecked(FiresReply))
             return false;
 
         if (!HasStatusEffect(Buffs.Brotherhood) || !HasStatusEffect(Buffs.RiddleOfFire))
@@ -251,12 +247,10 @@ internal partial class MNK
         if (HasStatusEffect(Buffs.FiresRumination) ||
             JustUsed(FiresReply, GCDTotal * 12))
             return false;
-
-        // First post-blitz Opo (Formless) done — insert a second Opo before 2nd PB
+        
         if (!HasElapsedSinceBlitz(1f) || HasElapsedSinceBlitz(4f))
             return false;
-
-        // Second Opo just used — PB weave is next
+        
         if (JustUsedOpoGCD(GCDTotal, onAoE) && HasElapsedSinceBlitz(2f))
             return false;
 
@@ -277,14 +271,9 @@ internal partial class MNK
         if (!HasUsedBlitzRecently(GCDTotal * 12))
             return false;
 
-        // FR spent this burst (combo or manual) — weave 2nd PB after the post-FR Formless Opo.
-        if (JustUsed(FiresReply, GCDTotal * 6) && !HasStatusEffect(Buffs.FiresRumination))
-            return true;
+        if (useFiresReply && LevelChecked(FiresReply))
+            return JustUsed(FiresReply, GCDTotal * 6) && !HasStatusEffect(Buffs.FiresRumination);
 
-        if (useFiresReply)
-            return false;
-
-        // FR intentionally skipped in combo — Blitz → Opo → Opo → PB
         return HasElapsedSinceBlitz(2.5f);
     }
 
@@ -304,8 +293,7 @@ internal partial class MNK
 
         return true;
     }
-
-    // Both burst buffs are ready but PB must weave first (burst-hold release / drift recovery).
+    
     private static bool IsBurstHoldReleaseReady()
     {
         if (!ActionReady(PerfectBalance) || HasStatusEffect(Buffs.PerfectBalance) ||
@@ -318,7 +306,6 @@ internal partial class MNK
         if (HasStatusEffect(Buffs.Brotherhood) || HasStatusEffect(Buffs.RiddleOfFire))
             return false;
 
-        // Pre-RoF PB timing already handles ordering when CDs are in the 2-7s window.
         if (IsRoFCDInPerfectBalanceWindow())
             return false;
 
@@ -370,7 +357,6 @@ internal partial class MNK
         return onAoE && CanPerfectBalanceMaxChargeAoE();
     }
 
-    // Last-resort AoE PB — only at full charges when normal timing does not apply.
     private static bool CanPerfectBalanceMaxChargeAoE()
     {
         if (GetRemainingCharges(PerfectBalance) != GetMaxCharges(PerfectBalance))
@@ -504,7 +490,6 @@ internal partial class MNK
 
     #region Buffs
 
-    //RoF
     private static bool CanRoF() =>
         !IsBurstHoldReleaseReady() &&
         ActionReady(RiddleOfFire) &&
@@ -517,6 +502,7 @@ internal partial class MNK
          !LevelChecked(Brotherhood));
 
     private static bool CanFiresReply(bool onAoE = false) =>
+        LevelChecked(FiresReply) &&
         HasStatusEffect(Buffs.FiresRumination) &&
         !HasStatusEffect(Buffs.FormlessFist) &&
         IsOriginal(MasterfulBlitz) &&
@@ -527,7 +513,6 @@ internal partial class MNK
          GetStatusEffectRemainingTime(Buffs.FiresRumination) < GCDTotal * 2 ||
          !InMeleeRange());
 
-    //Brotherhood
     private static bool CanBrotherhood() =>
         !IsBurstHoldReleaseReady() &&
         ActionReady(Brotherhood) &&
@@ -535,7 +520,6 @@ internal partial class MNK
         !HasStatusEffect(Buffs.Brotherhood) &&
         (InBossEncounter() || TimeStoodStill.Seconds >= 2);
 
-    //RoW
     private static bool CanRoW() =>
         ActionReady(RiddleOfWind) &&
         !HasStatusEffect(Buffs.WindsRumination);
@@ -939,3 +923,4 @@ internal static class MNKExtensions
 {
     public const Nadi None = 0;
 }
+

--- a/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
@@ -247,10 +247,10 @@ internal partial class MNK
         if (HasStatusEffect(Buffs.FiresRumination) ||
             JustUsed(FiresReply, GCDTotal * 12))
             return false;
-        
+
         if (!HasElapsedSinceBlitz(1f) || HasElapsedSinceBlitz(4f))
             return false;
-        
+
         if (JustUsedOpoGCD(GCDTotal, onAoE) && HasElapsedSinceBlitz(2f))
             return false;
 
@@ -293,7 +293,7 @@ internal partial class MNK
 
         return true;
     }
-    
+
     private static bool IsBurstHoldReleaseReady()
     {
         if (!ActionReady(PerfectBalance) || HasStatusEffect(Buffs.PerfectBalance) ||
@@ -923,4 +923,3 @@ internal static class MNKExtensions
 {
     public const Nadi None = 0;
 }
-

--- a/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
+++ b/WrathCombo/Combos/PvE/MNK/MNK_Helper.cs
@@ -170,15 +170,15 @@ internal partial class MNK
             : JustUsed(OriginalHook(Bootshine), window) ||
               JustUsed(DragonKick, window);
 
-    private static bool IsRoFCDInPerfectBalanceWindow() =>
+    private static bool IsRoFInPerfectBalanceWindow() =>
         GetCooldownRemainingTime(RiddleOfFire) is >= 2 and <= 7;
 
-    private static bool IsBrotherhoodCDInPerfectBalanceWindow() =>
+    private static bool IsBrotherhoodInPerfectBalanceWindow() =>
         GetCooldownRemainingTime(Brotherhood) is >= 2 and <= 7;
 
     private static bool IsEvenWindowApproaching() =>
-        IsRoFCDInPerfectBalanceWindow() &&
-        IsBrotherhoodCDInPerfectBalanceWindow();
+        IsRoFInPerfectBalanceWindow() &&
+        IsBrotherhoodInPerfectBalanceWindow();
 
     private static bool IsDoubleLunarOpener(bool useOpenerBalance) =>
         useOpenerBalance && (MNK_SelectedOpener == 0 || MNK_SelectedOpener == 2);
@@ -188,7 +188,7 @@ internal partial class MNK
         if (!useOpenerBalance)
             return ShouldUsePreRoFPerfectBalanceDefault();
 
-        if (!IsRoFCDInPerfectBalanceWindow())
+        if (!IsRoFInPerfectBalanceWindow())
             return false;
 
         if (IsEvenWindowApproaching())
@@ -201,7 +201,7 @@ internal partial class MNK
     }
 
     private static bool ShouldUsePreRoFPerfectBalanceDefault() =>
-        IsRoFCDInPerfectBalanceWindow();
+        IsRoFInPerfectBalanceWindow();
 
     private static bool ShouldUsePostRoFLunarOddPerfectBalance(bool useOpenerBalance) =>
         IsDoubleLunarOpener(useOpenerBalance) &&
@@ -306,7 +306,7 @@ internal partial class MNK
         if (HasStatusEffect(Buffs.Brotherhood) || HasStatusEffect(Buffs.RiddleOfFire))
             return false;
 
-        if (IsRoFCDInPerfectBalanceWindow())
+        if (IsRoFInPerfectBalanceWindow())
             return false;
 
         return true;
@@ -365,7 +365,7 @@ internal partial class MNK
         if (IsBurstHoldReleaseReady())
             return false;
 
-        if (IsRoFCDInPerfectBalanceWindow())
+        if (IsRoFInPerfectBalanceWindow())
             return false;
 
         return true;

--- a/WrathCombo/Combos/PvE/RPR/RPR.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR.cs
@@ -42,7 +42,7 @@ internal partial class RPR : Melee
                 if (CanGluttonyWeave())
                     return Gluttony;
 
-                if (CanBloodstalkOverflow())
+                if (CanBloodstalkWeave())
                     return OriginalHook(BloodStalk);
 
                 if (UseEnshroudWeaves(out uint weave, false))
@@ -123,7 +123,7 @@ internal partial class RPR : Melee
                 if (CanGluttonyWeave())
                     return Gluttony;
 
-                if (CanGrimSwatheOverflow(true))
+                if (CanGrimSwatheWeave(true))
                     return GrimSwathe;
 
                 if (UseEnshroudWeaves(out uint weave, true))
@@ -204,11 +204,13 @@ internal partial class RPR : Melee
                     return Role.TrueNorth;
 
                 if (IsEnabled(Preset.RPR_ST_Gluttony) &&
-                    CanGluttonyWeave())
+                    CanGluttonyWeave(enshroudEnabled: IsEnabled(Preset.RPR_ST_Enshroud)))
                     return Gluttony;
 
                 if (IsEnabled(Preset.RPR_ST_Bloodstalk) &&
-                    CanBloodstalkOverflow(gluttonyEnabled: IsEnabled(Preset.RPR_ST_Gluttony)))
+                    CanBloodstalkWeave(
+                        gluttonyEnabled: IsEnabled(Preset.RPR_ST_Gluttony),
+                        enshroudEnabled: IsEnabled(Preset.RPR_ST_Enshroud)))
                     return OriginalHook(BloodStalk);
 
                 if (UseEnshroudWeaves(out uint weave, false,
@@ -256,7 +258,7 @@ internal partial class RPR : Melee
                 return ShadowOfDeath;
 
             if (IsEnabled(Preset.RPR_ST_GibbetGallows) &&
-                CanGibbetGallowsGCD())
+                CanGibbetGallowsGCD(enshroudEnabled: IsEnabled(Preset.RPR_ST_Enshroud)))
             {
                 uint gg = GibbetGallowsAction(positionalChoice,
                     false,
@@ -319,11 +321,11 @@ internal partial class RPR : Melee
                     return Enshroud;
 
                 if (IsEnabled(Preset.RPR_AoE_Gluttony) &&
-                    CanGluttonyWeave())
+                    CanGluttonyWeave(enshroudEnabled: IsEnabled(Preset.RPR_AoE_Enshroud)))
                     return Gluttony;
 
                 if (IsEnabled(Preset.RPR_AoE_GrimSwathe) &&
-                    CanGrimSwatheOverflow(true))
+                    CanGrimSwatheWeave(true, enshroudEnabled: IsEnabled(Preset.RPR_AoE_Enshroud)))
                     return GrimSwathe;
 
                 if (UseEnshroudWeaves(out uint weave, true,
@@ -363,7 +365,7 @@ internal partial class RPR : Melee
                 return PlentifulHarvest;
 
             if (IsEnabled(Preset.RPR_AoE_Guillotine) &&
-                CanGuillotineGCD())
+                CanGuillotineGCD(enshroudEnabled: IsEnabled(Preset.RPR_AoE_Enshroud)))
                 return OriginalHook(Guillotine);
 
             if (EnshroudComboGCD(true,

--- a/WrathCombo/Combos/PvE/RPR/RPR.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR.cs
@@ -89,7 +89,7 @@ internal partial class RPR : Melee
             return !InMeleeRange() && HasBattleTarget() &&
                    !HasStatusEffect(Buffs.Executioner) && !HasStatusEffect(Buffs.SoulReaver)
                 ? RangedAttack(actionID, true, true)
-                : DoBasicCombo(actionID);
+                : DoBasicCombo();
         }
     }
 
@@ -157,7 +157,7 @@ internal partial class RPR : Melee
             if (CanSoulSliceScythe(true))
                 return SoulScythe;
 
-            return DoBasicCombo(actionID, true);
+            return DoBasicCombo(onAoE: true);
         }
     }
 
@@ -287,7 +287,7 @@ internal partial class RPR : Melee
                     IsEnabled(Preset.RPR_ST_RangedFiller),
                     RPR_ST_EnhancedHarpe,
                     !RPR_ST_EnhancedHarpe)
-                : DoBasicCombo(actionID);
+                : DoBasicCombo();
         }
     }
 
@@ -375,7 +375,7 @@ internal partial class RPR : Melee
                 CanSoulSliceScythe(true))
                 return SoulScythe;
 
-            return DoBasicCombo(actionID, true);
+            return DoBasicCombo(onAoE: true);
         }
     }
 

--- a/WrathCombo/Combos/PvE/RPR/RPR.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR.cs
@@ -209,8 +209,8 @@ internal partial class RPR : Melee
 
                 if (IsEnabled(Preset.RPR_ST_Bloodstalk) &&
                     CanBloodstalkWeave(
-                        gluttonyEnabled: IsEnabled(Preset.RPR_ST_Gluttony),
-                        enshroudEnabled: IsEnabled(Preset.RPR_ST_Enshroud)))
+                        IsEnabled(Preset.RPR_ST_Gluttony),
+                        IsEnabled(Preset.RPR_ST_Enshroud)))
                     return OriginalHook(BloodStalk);
 
                 if (UseEnshroudWeaves(out uint weave, false,
@@ -325,7 +325,7 @@ internal partial class RPR : Melee
                     return Gluttony;
 
                 if (IsEnabled(Preset.RPR_AoE_GrimSwathe) &&
-                    CanGrimSwatheWeave(true, enshroudEnabled: IsEnabled(Preset.RPR_AoE_Enshroud)))
+                    CanGrimSwatheWeave(true, IsEnabled(Preset.RPR_AoE_Enshroud)))
                     return GrimSwathe;
 
                 if (UseEnshroudWeaves(out uint weave, true,

--- a/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
@@ -70,7 +70,7 @@ internal partial class RPR
             ActionReady(HarvestMoon) && HasStatusEffect(Buffs.Soulsow))
             return HarvestMoon;
 
-        if (HasPerfectioReady && InActionRange(PerfectioAction) &&
+        if (IsPerfectioReady && InActionRange(PerfectioAction) &&
             (!InMeleeRange() || ShouldSpendPerfectioNow()))
             return PerfectioAction;
 
@@ -195,7 +195,7 @@ internal partial class RPR
         LevelChecked(Gluttony) && GetCooldownRemainingTime(Gluttony) <= GCDTotal && Role.CanTrueNorth() &&
         (!advanced || GetRemainingCharges(Role.TrueNorth) > tnChargePool);
 
-    private static bool CanUseSoulOverflowWeave() =>
+    private static bool CanSoulOverflowWeave() =>
         !ShouldHoldSoulOverflowWeave &&
         InNormalRotation &&
         !IsComboExpiring(3);
@@ -221,13 +221,13 @@ internal partial class RPR
 
     private static bool CanBloodstalkWeave(bool gluttonyEnabled = true, bool enshroudEnabled = true) =>
         !IsShroudOvercapping(enshroudEnabled) &&
-        CanUseSoulOverflowWeave() &&
+        CanSoulOverflowWeave() &&
         ActionReady(OriginalHook(BloodStalk)) &&
         ShouldSpendSoulOvercapST(gluttonyEnabled);
 
     private static bool CanGrimSwatheWeave(bool onAoE = false, bool enshroudEnabled = true) =>
         !IsShroudOvercapping(enshroudEnabled, onAoE) &&
-        CanUseSoulOverflowWeave() &&
+        CanSoulOverflowWeave() &&
         ActionReady(GrimSwathe) &&
         InActionRange(onAoE ? OriginalHook(GrimSwathe) : GrimSwathe) &&
         ShouldSpendSoulOvercapAoE();
@@ -280,24 +280,24 @@ internal partial class RPR
 
     #region GCD Burst
 
-    private static bool WithinGcd(uint actionId) =>
+    private static bool WithinGCD(uint actionId) =>
         LevelChecked(actionId) && (HasCharges(actionId) || GetCooldownRemainingTime(actionId) <= GCDTotal);
 
-    private static bool HasPerfectioReady =>
+    private static bool IsPerfectioReady =>
         HasStatusEffect(Buffs.PerfectioParata) && LevelChecked(Perfectio);
 
     private static uint PerfectioAction =>
-        WithinGcd(Perfectio) ? Perfectio : OriginalHook(Communio);
+        WithinGCD(Perfectio) ? Perfectio : OriginalHook(Communio);
 
     private static bool ShouldSpendPerfectioNow() =>
-        HasPerfectioReady;
+        IsPerfectioReady;
 
     private static bool CanPerfectioGCD() =>
-        HasPerfectioReady && ShouldSpendPerfectioNow() && InActionRange(PerfectioAction);
+        IsPerfectioReady && ShouldSpendPerfectioNow() && InActionRange(PerfectioAction);
 
     private static bool InPostBurstSequence =>
         JustUsed(Perfectio, GCDTotal * 8) ||
-        JustUsed(OriginalHook(Communio), GCDTotal * 2) && !HasPerfectioReady && !HasStatusEffect(Buffs.Enshrouded);
+        JustUsed(OriginalHook(Communio), GCDTotal * 2) && !IsPerfectioReady && !HasStatusEffect(Buffs.Enshrouded);
 
     private static bool HasBurstComboContinue() =>
         InPostBurstSequence &&

--- a/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
@@ -170,6 +170,12 @@ internal partial class RPR
         return false;
     }
 
+    private static bool IsShroudCapped =>
+        Shroud >= MaxShroud;
+
+    private static bool IsShroudOvercapping(bool enshroudEnabled = true, bool onAoE = false) =>
+        IsShroudCapped && (!enshroudEnabled || !CanEnshroud(onAoE));
+
     #endregion
 
     #region Weaves
@@ -178,8 +184,9 @@ internal partial class RPR
         ActionReady(ArcaneCircle) && GetTargetHPPercent() > hpThreshold &&
         (onAoE || LevelChecked(Enshroud) && JustUsed(ShadowOfDeath) || !LevelChecked(Enshroud));
 
-    private static bool CanGluttonyWeave() =>
-        CanBurstGluttonyWeave() ||
+    private static bool CanGluttonyWeave(bool enshroudEnabled = true) =>
+        CanBurstGluttonyWeave(enshroudEnabled) ||
+        !IsShroudOvercapping(enshroudEnabled) &&
         ActionReady(Gluttony) && InNormalRotation && !IsComboExpiring(3) &&
         !(InPostBurstSequence && Soul < 50);
 
@@ -189,7 +196,7 @@ internal partial class RPR
         (!advanced || GetRemainingCharges(Role.TrueNorth) > tnChargePool);
 
     private static bool CanUseSoulOverflowWeave() =>
-        !ShouldDeferSoulOverflowWeave &&
+        !ShouldHoldSoulOverflowWeave &&
         InNormalRotation &&
         !IsComboExpiring(3);
 
@@ -212,12 +219,14 @@ internal partial class RPR
         Soul is 100 ||
         GetCooldownRemainingTime(Gluttony) > GCDTotal * 5;
 
-    private static bool CanBloodstalkOverflow(bool gluttonyEnabled = true) =>
+    private static bool CanBloodstalkWeave(bool gluttonyEnabled = true, bool enshroudEnabled = true) =>
+        !IsShroudOvercapping(enshroudEnabled) &&
         CanUseSoulOverflowWeave() &&
         ActionReady(OriginalHook(BloodStalk)) &&
         ShouldSpendSoulOvercapST(gluttonyEnabled);
 
-    private static bool CanGrimSwatheOverflow(bool onAoE = false) =>
+    private static bool CanGrimSwatheWeave(bool onAoE = false, bool enshroudEnabled = true) =>
+        !IsShroudOvercapping(enshroudEnabled, onAoE) &&
         CanUseSoulOverflowWeave() &&
         ActionReady(GrimSwathe) &&
         InActionRange(onAoE ? OriginalHook(GrimSwathe) : GrimSwathe) &&
@@ -295,11 +304,12 @@ internal partial class RPR
         !IsComboExpiring(2) &&
         ComboTimer > 0;
 
-    private static bool CanBurstGluttonyWeave() =>
+    private static bool CanBurstGluttonyWeave(bool enshroudEnabled = true) =>
+        !IsShroudOvercapping(enshroudEnabled) &&
         InPostBurstSequence && Soul >= 50 && ActionReady(Gluttony) &&
         !HasBurstComboContinue();
 
-    private static bool SoulSliceOVercapProtection(bool onAoE)
+    private static bool OvercapSoulSliceProtection(bool onAoE)
     {
         if (Soul >= 100)
             return false;
@@ -319,12 +329,12 @@ internal partial class RPR
         InPostBurstSequence &&
         !HasBurstComboContinue() &&
         !JustUsed(onAoE ? SoulScythe : SoulSlice, GCDTotal) &&
-        (Soul <= 50 || SoulSliceOVercapProtection(onAoE)) &&
+        (Soul <= 50 || OvercapSoulSliceProtection(onAoE)) &&
         (onAoE
             ? ActionReady(SoulScythe) && InActionRange(SoulScythe)
             : ActionReady(SoulSlice) && InActionRange(SoulSlice) && !IsComboExpiring(2));
 
-    private static bool ShouldDeferSoulOverflowWeave =>
+    private static bool ShouldHoldSoulOverflowWeave =>
         Soul < 100 &&
         InPostBurstSequence && !JustUsed(Gluttony, GCDTotal * 8);
 
@@ -361,12 +371,14 @@ internal partial class RPR
         !HasStatusEffect(Buffs.SoulReaver) && !HasStatusEffect(Buffs.Executioner) &&
         GetTargetHPPercent() > hpThreshold;
 
-    private static bool CanGuillotineGCD() =>
+    private static bool CanGuillotineGCD(bool enshroudEnabled = true) =>
+        !IsShroudOvercapping(enshroudEnabled, true) &&
         (HasStatusEffect(Buffs.SoulReaver) || HasStatusEffect(Buffs.Executioner)) &&
         !HasStatusEffect(Buffs.Enshrouded) && LevelChecked(Guillotine) &&
         InActionRange(OriginalHook(Guillotine));
 
-    private static bool CanGibbetGallowsGCD() =>
+    private static bool CanGibbetGallowsGCD(bool enshroudEnabled = true) =>
+        !IsShroudOvercapping(enshroudEnabled) &&
         LevelChecked(Gibbet) && !HasStatusEffect(Buffs.Enshrouded) &&
         (HasStatusEffect(Buffs.SoulReaver) || HasStatusEffect(Buffs.Executioner));
 
@@ -500,8 +512,11 @@ internal partial class RPR
         return 0;
     }
 
-    private static uint BloodStalkGrimSwatheSoulReaverGCD(uint actionId)
+    private static uint BloodStalkGrimSwatheSoulReaverGCD(uint actionId, bool enshroudEnabled = true)
     {
+        if (IsShroudOvercapping(enshroudEnabled, actionId is GrimSwathe))
+            return 0;
+
         if (actionId is GrimSwathe &&
             (HasStatusEffect(Buffs.SoulReaver) || HasStatusEffect(Buffs.Executioner)) &&
             LevelChecked(Guillotine))
@@ -524,7 +539,7 @@ internal partial class RPR
     private static bool CanSoulSliceScythe(bool onAoE) =>
         !InPostBurstSequence &&
         InNormalRotation && !IsComboExpiring(3) &&
-        (Soul <= 50 || SoulSliceOVercapProtection(onAoE)) &&
+        (Soul <= 50 || OvercapSoulSliceProtection(onAoE)) &&
         (onAoE
             ? ActionReady(SoulScythe) && InActionRange(SoulScythe)
             : ActionReady(SoulSlice) && InActionRange(SoulSlice));
@@ -780,9 +795,13 @@ internal partial class RPR
 
     #region Gauge
 
+    private const byte MaxShroud = 100;
+
     private static RPRGauge Gauge => GetJobGauge<RPRGauge>();
 
     private static byte Soul => Gauge.Soul;
+
+    private static byte Shroud => Gauge.Shroud;
 
     private static byte Lemure => Gauge.LemureShroud;
 

--- a/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
@@ -28,15 +28,14 @@ internal partial class RPR
 
             if (!trashOnly || InBossEncounter() || !arcaneCircleEnabled)
             {
-                //Balance burst prep: SoD near 60s / 30s on Arcane Circle
                 if (LevelChecked(PlentifulHarvest) && !HasStatusEffect(Buffs.Enshrouded) &&
                     UsesBurstAlignment && (AcCD.InRange(58f, 62f) || AcCD.InRange(28f, 32f)) &&
-                    GetStatusEffectRemainingTime(Debuffs.DeathsDesign, CurrentTarget) <= dotRefresh)
+                    GetStatusEffectRemainingTime(Debuffs.DeathsDesign, CurrentTarget) < 32)
                     return true;
 
                 //Double enshroud
                 if (LevelChecked(PlentifulHarvest) && HasStatusEffect(Buffs.Enshrouded) &&
-                    AcCD <= GCDTotal && GetStatusEffectRemainingTime(Debuffs.DeathsDesign, CurrentTarget) <= dotRefresh &&
+                    AcCD <= GCDTotal && GetStatusEffectRemainingTime(Debuffs.DeathsDesign, CurrentTarget) < 32 &&
                     (JustUsed(VoidReaping, 2f) || JustUsed(CrossReaping, 2f)))
                     return true;
 

--- a/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
@@ -663,10 +663,9 @@ internal partial class RPR
             Slice
         ];
 
-        public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
-        [
-            ([1], () => InMeleeRange())
-        ];
+        public override Preset Preset => Preset.RPR_ST_Opener;
+
+        internal override UserData ContentCheckConfig => RPR_Balance_Content;
 
         public override List<(int[], uint, Func<bool>)> SubstitutionSteps { get; set; } =
         [
@@ -676,8 +675,10 @@ internal partial class RPR
             ([21], Gallows, () => HasStatusEffect(Buffs.EnhancedGallows))
         ];
 
-        public override Preset Preset => Preset.RPR_ST_Opener;
-        internal override UserData ContentCheckConfig => RPR_Balance_Content;
+        public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
+        [
+            ([1], () => InMeleeRange())
+        ];
 
         public override bool HasCooldowns() =>
             GetRemainingCharges(SoulSlice) is 2 &&
@@ -719,6 +720,10 @@ internal partial class RPR
             Slice
         ];
 
+        public override Preset Preset => Preset.RPR_ST_Opener;
+
+        internal override UserData ContentCheckConfig => RPR_Balance_Content;
+
         public override List<(int[], uint, Func<bool>)> SubstitutionSteps { get; set; } =
         [
             ([5], ExecutionersGallows, OnTargetsRear),
@@ -726,9 +731,6 @@ internal partial class RPR
             ([19], UnveiledGallows, () => HasStatusEffect(Buffs.EnhancedGallows)),
             ([20], Gallows, () => HasStatusEffect(Buffs.EnhancedGallows))
         ];
-
-        public override Preset Preset => Preset.RPR_ST_Opener;
-        internal override UserData ContentCheckConfig => RPR_Balance_Content;
 
         public override bool HasCooldowns() =>
             GetRemainingCharges(SoulSlice) is 2 &&
@@ -768,11 +770,10 @@ internal partial class RPR
             Gibbet //19
         ];
 
-        public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
-        [
-            ([1], () => InMeleeRange())
-        ];
         public override Preset Preset => Preset.RPR_ST_Opener;
+
+        internal override UserData ContentCheckConfig => RPR_Balance_Content;
+
         public override List<(int[], uint, Func<bool>)> SubstitutionSteps { get; set; } =
         [
             ([16], Gallows, OnTargetsRear),
@@ -781,7 +782,10 @@ internal partial class RPR
             ([19], Gallows, () => HasStatusEffect(Buffs.EnhancedGallows))
         ];
 
-        internal override UserData ContentCheckConfig => RPR_Balance_Content;
+        public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
+        [
+            ([1], () => InMeleeRange())
+        ];
 
         public override bool HasCooldowns() =>
             GetRemainingCharges(SoulSlice) is 2 &&

--- a/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
@@ -35,14 +35,14 @@ internal partial class RPR
 
                 //Double enshroud
                 if (LevelChecked(PlentifulHarvest) && HasStatusEffect(Buffs.Enshrouded) &&
-                    AcCD <= GCDTotal && GetStatusEffectRemainingTime(Debuffs.DeathsDesign, CurrentTarget) < 32 &&
+                    AcCD <= GCD && GetStatusEffectRemainingTime(Debuffs.DeathsDesign, CurrentTarget) < 32 &&
                     (JustUsed(VoidReaping, 2f) || JustUsed(CrossReaping, 2f)))
                     return true;
 
                 //lvl 88+ general use
                 if (LevelChecked(PlentifulHarvest) && !HasStatusEffect(Buffs.Enshrouded) &&
                     GetStatusEffectRemainingTime(Debuffs.DeathsDesign, CurrentTarget) <= dotRefresh &&
-                    (AcCD > GCDTotal * 8 || IsOffCooldown(ArcaneCircle)))
+                    (AcCD > GCD * 8 || IsOffCooldown(ArcaneCircle)))
                     return true;
 
                 //below lvl 88 use
@@ -151,7 +151,7 @@ internal partial class RPR
                 return true;
 
             if (LevelChecked(PlentifulHarvest) &&
-                AcCD <= GCDTotal + 1.5f)
+                AcCD <= GCD + 1.5f)
                 return true;
 
             if (LevelChecked(PlentifulHarvest) &&
@@ -192,7 +192,7 @@ internal partial class RPR
 
     private static bool CanTrueNorthForGluttony(bool advanced = false, int tnChargePool = 0) =>
         !InPostBurstSequence &&
-        LevelChecked(Gluttony) && GetCooldownRemainingTime(Gluttony) <= GCDTotal && Role.CanTrueNorth() &&
+        LevelChecked(Gluttony) && GetCooldownRemainingTime(Gluttony) <= GCD && Role.CanTrueNorth() &&
         (!advanced || GetRemainingCharges(Role.TrueNorth) > tnChargePool);
 
     private static bool CanSoulOverflowWeave() =>
@@ -211,13 +211,13 @@ internal partial class RPR
         if (!gluttonyEnabled)
             return false;
 
-        return IsOnCooldown(Gluttony) && GetCooldownRemainingTime(Gluttony) > GCDTotal * 4;
+        return IsOnCooldown(Gluttony) && GetCooldownRemainingTime(Gluttony) > GCD * 4;
     }
 
     private static bool ShouldSpendSoulOvercapAoE() =>
         !LevelChecked(Gluttony) ||
         Soul is 100 ||
-        GetCooldownRemainingTime(Gluttony) > GCDTotal * 5;
+        GetCooldownRemainingTime(Gluttony) > GCD * 5;
 
     private static bool CanBloodstalkWeave(bool gluttonyEnabled = true, bool enshroudEnabled = true) =>
         !IsShroudOvercapping(enshroudEnabled) &&
@@ -242,7 +242,7 @@ internal partial class RPR
             ? Lemure is 2 && Void is 1
             : Lemure <= 4) &&
         (!useArcaneCircleBoss || onAoE ||
-         GetCooldownRemainingTime(ArcaneCircle) > GCDTotal * 3 && !JustUsed(ArcaneCircle, 2) &&
+         GetCooldownRemainingTime(ArcaneCircle) > GCD * 3 && !JustUsed(ArcaneCircle, 2) &&
          (arcaneCircleBossOption == 0 ||
           InBossEncounter() ||
           arcaneCircleBossOption == 1 && !InBossEncounter() && IsOffCooldown(ArcaneCircle)) ||
@@ -281,7 +281,7 @@ internal partial class RPR
     #region GCD Burst
 
     private static bool WithinGCD(uint actionId) =>
-        LevelChecked(actionId) && (HasCharges(actionId) || GetCooldownRemainingTime(actionId) <= GCDTotal);
+        LevelChecked(actionId) && (HasCharges(actionId) || GetCooldownRemainingTime(actionId) <= GCD);
 
     private static bool IsPerfectioReady =>
         HasStatusEffect(Buffs.PerfectioParata) && LevelChecked(Perfectio);
@@ -296,8 +296,8 @@ internal partial class RPR
         IsPerfectioReady && ShouldSpendPerfectioNow() && InActionRange(PerfectioAction);
 
     private static bool InPostBurstSequence =>
-        JustUsed(Perfectio, GCDTotal * 8) ||
-        JustUsed(OriginalHook(Communio), GCDTotal * 2) && !IsPerfectioReady && !HasStatusEffect(Buffs.Enshrouded);
+        JustUsed(Perfectio, GCD * 8) ||
+        JustUsed(OriginalHook(Communio), GCD * 2) && !IsPerfectioReady && !HasStatusEffect(Buffs.Enshrouded);
 
     private static bool HasBurstComboContinue() =>
         InPostBurstSequence &&
@@ -322,13 +322,13 @@ internal partial class RPR
             return true;
 
         return GetRemainingCharges(action) >= 1 &&
-               GetCooldownChargeRemainingTime(action) <= GCDTotal * 2;
+               GetCooldownChargeRemainingTime(action) <= GCD * 2;
     }
 
     private static bool CanBurstSoulSliceScythe(bool onAoE = false) =>
         InPostBurstSequence &&
         !HasBurstComboContinue() &&
-        !JustUsed(onAoE ? SoulScythe : SoulSlice, GCDTotal) &&
+        !JustUsed(onAoE ? SoulScythe : SoulSlice, GCD) &&
         (Soul <= 50 || OvercapSoulSliceProtection(onAoE)) &&
         (onAoE
             ? ActionReady(SoulScythe) && InActionRange(SoulScythe)
@@ -336,7 +336,7 @@ internal partial class RPR
 
     private static bool ShouldHoldSoulOverflowWeave =>
         Soul < 100 &&
-        InPostBurstSequence && !JustUsed(Gluttony, GCDTotal * 8);
+        InPostBurstSequence && !JustUsed(Gluttony, GCD * 8);
 
     private static uint PostBurstGCD(bool onAoE, bool soulSliceEnabled = true)
     {
@@ -590,16 +590,18 @@ internal partial class RPR
 
     #region Combos
 
+    private static float GCD => GetCooldown(Slice).CooldownTotal;
+
     private static unsafe bool IsComboExpiring(float times)
     {
-        float gcd = GCDTotal * times;
+        float gcd = GCD * times;
 
         return ActionManager.Instance()->Combo.Timer != 0 && ActionManager.Instance()->Combo.Timer < gcd;
     }
 
     private static bool IsDebuffExpiring(float times)
     {
-        float gcd = GCDTotal * times;
+        float gcd = GCD * times;
 
         return HasStatusEffect(Debuffs.DeathsDesign, CurrentTarget) && GetStatusEffectRemainingTime(Debuffs.DeathsDesign, CurrentTarget) < gcd;
     }

--- a/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
@@ -311,11 +311,27 @@ internal partial class RPR
         InPostBurstSequence && Soul >= 50 && ActionReady(Gluttony) &&
         !HasBurstComboContinue();
 
+    private static bool ShouldSpendSoulSliceChargeOvercap(bool onAoE)
+    {
+        if (Soul >= 100)
+            return false;
+
+        uint action = onAoE ? SoulScythe : SoulSlice;
+        if (!ActionReady(action))
+            return false;
+
+        if (GetRemainingCharges(action) >= GetMaxCharges(action))
+            return true;
+
+        return GetRemainingCharges(action) >= 1 &&
+               GetCooldownChargeRemainingTime(action) <= GCDTotal * 2;
+    }
+
     private static bool CanBurstSoulSliceScythe(bool onAoE = false) =>
         InPostBurstSequence &&
         !HasBurstComboContinue() &&
         !JustUsed(onAoE ? SoulScythe : SoulSlice, GCDTotal) &&
-        Soul <= 50 &&
+        (Soul <= 50 || ShouldSpendSoulSliceChargeOvercap(onAoE)) &&
         (onAoE
             ? ActionReady(SoulScythe) && InActionRange(SoulScythe)
             : ActionReady(SoulSlice) && InActionRange(SoulSlice) && !IsComboExpiring(2));
@@ -333,13 +349,13 @@ internal partial class RPR
             HasStatusEffect(Buffs.ImmortalSacrifice))
             return 0;
 
-        if (ContinueBasicCombo(onAoE) is var combo and not 0)
-            return combo;
+        if (HasBurstComboContinue())
+            return ContinueBasicCombo(onAoE);
 
         if (soulSliceEnabled && CanBurstSoulSliceScythe(onAoE))
             return onAoE ? SoulScythe : SoulSlice;
 
-        return 0;
+        return ContinueBasicCombo(onAoE);
     }
 
     private static bool HasImmortalSacrificeStacks =>
@@ -519,7 +535,8 @@ internal partial class RPR
 
     private static bool CanSoulSliceScythe(bool onAoE) =>
         !InPostBurstSequence &&
-        Soul <= 50 && InNormalRotation && !IsComboExpiring(3) &&
+        InNormalRotation && !IsComboExpiring(3) &&
+        (Soul <= 50 || ShouldSpendSoulSliceChargeOvercap(onAoE)) &&
         (onAoE
             ? ActionReady(SoulScythe) && InActionRange(SoulScythe)
             : ActionReady(SoulSlice) && InActionRange(SoulSlice));

--- a/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
@@ -122,10 +122,8 @@ internal partial class RPR
         return OriginalHook(Slice);
     }
 
-    private static uint DoBasicCombo(uint actionId, bool onAoE = false) =>
-        ContinueBasicCombo(onAoE) is var continued and not 0
-            ? continued
-            : actionId;
+    private static uint DoBasicCombo(bool onAoE = false) =>
+        ContinueBasicCombo(onAoE);
 
     #endregion
 
@@ -304,10 +302,10 @@ internal partial class RPR
         JustUsed(Perfectio, GCDTotal * 8) ||
         JustUsed(OriginalHook(Communio), GCDTotal * 2) && !HasPerfectioReady && !HasStatusEffect(Buffs.Enshrouded);
 
-    private static bool HasBurstComboContinue(bool onAoE = false) =>
+    private static bool HasBurstComboContinue() =>
         InPostBurstSequence &&
         !IsComboExpiring(2) &&
-        ContinueBasicCombo(onAoE) != 0;
+        ComboTimer > 0;
 
     private static bool CanBurstGluttonyWeave() =>
         InPostBurstSequence && Soul >= 50 && ActionReady(Gluttony) &&
@@ -315,7 +313,7 @@ internal partial class RPR
 
     private static bool CanBurstSoulSliceScythe(bool onAoE = false) =>
         InPostBurstSequence &&
-        !HasBurstComboContinue(onAoE) &&
+        !HasBurstComboContinue() &&
         !JustUsed(onAoE ? SoulScythe : SoulSlice, GCDTotal) &&
         Soul <= 50 &&
         (onAoE

--- a/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
@@ -875,4 +875,3 @@ internal partial class RPR
 
     #endregion
 }
-

--- a/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
@@ -310,7 +310,7 @@ internal partial class RPR
         InPostBurstSequence && Soul >= 50 && ActionReady(Gluttony) &&
         !HasBurstComboContinue();
 
-    private static bool ShouldSpendSoulSliceChargeOvercap(bool onAoE)
+    private static bool SoulSliceOVercapProtection(bool onAoE)
     {
         if (Soul >= 100)
             return false;
@@ -330,7 +330,7 @@ internal partial class RPR
         InPostBurstSequence &&
         !HasBurstComboContinue() &&
         !JustUsed(onAoE ? SoulScythe : SoulSlice, GCDTotal) &&
-        (Soul <= 50 || ShouldSpendSoulSliceChargeOvercap(onAoE)) &&
+        (Soul <= 50 || SoulSliceOVercapProtection(onAoE)) &&
         (onAoE
             ? ActionReady(SoulScythe) && InActionRange(SoulScythe)
             : ActionReady(SoulSlice) && InActionRange(SoulSlice) && !IsComboExpiring(2));
@@ -535,7 +535,7 @@ internal partial class RPR
     private static bool CanSoulSliceScythe(bool onAoE) =>
         !InPostBurstSequence &&
         InNormalRotation && !IsComboExpiring(3) &&
-        (Soul <= 50 || ShouldSpendSoulSliceChargeOvercap(onAoE)) &&
+        (Soul <= 50 || SoulSliceOVercapProtection(onAoE)) &&
         (onAoE
             ? ActionReady(SoulScythe) && InActionRange(SoulScythe)
             : ActionReady(SoulSlice) && InActionRange(SoulSlice));

--- a/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/RPR/RPR_Helper.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using Dalamud.Game.ClientState.JobGauge.Types;
 using ECommons.MathHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using System;
@@ -66,21 +66,17 @@ internal partial class RPR
         bool enhancedHarpeOnly = false,
         bool allowHarpeWhileMoving = true)
     {
-        //Harvest Moon
         if (useHarvestMoon &&
             ActionReady(HarvestMoon) && HasStatusEffect(Buffs.Soulsow))
             return HarvestMoon;
 
-        //Perfectio ranged flex — prefer over Harpe when available out of melee
         if (HasPerfectioReady && InActionRange(PerfectioAction) &&
             (!InMeleeRange() || ShouldSpendPerfectioNow()))
             return PerfectioAction;
 
-        //Ranged Attacks
         if (useRangedFiller &&
             ActionReady(OriginalHook(Harpe)))
         {
-            //Communio
             if (HasStatusEffect(Buffs.Enshrouded) && Lemure is 1 &&
                 LevelChecked(Communio))
                 return Communio;
@@ -148,30 +144,24 @@ internal partial class RPR
             !HasStatusEffect(Buffs.SoulReaver) && !HasStatusEffect(Buffs.Executioner) && HasBattleTarget() &&
             !HasStatusEffect(Buffs.PerfectioParata) && !HasStatusEffect(Buffs.Enshrouded))
         {
-            // Before Plentiful Harvest 
             if (!LevelChecked(PlentifulHarvest))
                 return true;
 
-            // Shroud in Arcane Circle 
             if (HasStatusEffect(Buffs.ArcaneCircle))
                 return true;
 
-            // Prep for double Enshroud (~9s AC: two filler GCDs, then Enshroud)
             if (LevelChecked(PlentifulHarvest) &&
                 AcCD <= GCDTotal + 1.5f)
                 return true;
 
-            //2nd part of Double Enshroud
             if (LevelChecked(PlentifulHarvest) &&
                 JustUsed(PlentifulHarvest, 5))
                 return true;
 
-            //Natural Odd Minute Shrouds
             if (!HasStatusEffect(Buffs.ArcaneCircle) && !IsDebuffExpiring(5) &&
                 AcCD.InRange(49, 66))
                 return true;
 
-            // Correction for 2 min windows 
             if (!HasStatusEffect(Buffs.ArcaneCircle) && !IsDebuffExpiring(5) &&
                 Soul >= 90)
                 return true;
@@ -217,7 +207,6 @@ internal partial class RPR
         return IsOnCooldown(Gluttony) && GetCooldownRemainingTime(Gluttony) > GCDTotal * 4;
     }
 
-    // AoE: pool for Gluttony unless at cap or its CD is too far out.
     private static bool ShouldSpendSoulOvercapAoE() =>
         !LevelChecked(Gluttony) ||
         Soul is 100 ||
@@ -571,7 +560,6 @@ internal partial class RPR
 
     #region Misc
 
-    //Auto Arcane Crest
     private static bool CanUseArcaneCrest =>
         ActionReady(ArcaneCrest) && InCombat() &&
         (GroupDamageIncoming(3f) ||
@@ -887,3 +875,4 @@ internal partial class RPR
 
     #endregion
 }
+

--- a/WrathCombo/Combos/PvE/SAM/SAM.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM.cs
@@ -91,7 +91,7 @@ internal partial class SAM : Melee
             if (ActionReady(Enpi) && !InMeleeRange() && HasBattleTarget())
                 return Enpi;
 
-            return DoCombo(onAoE: false, useTrueNorth: true);
+            return DoCombo(false, true);
         }
     }
 
@@ -293,7 +293,7 @@ internal partial class SAM : Melee
             }
 
             return DoCombo(
-                onAoE: false,
+                false,
                 IsEnabled(Preset.SAM_ST_TrueNorth),
                 IsEnabled(Preset.SAM_ST_Yukikaze),
                 IsEnabled(Preset.SAM_ST_Kasha),
@@ -379,7 +379,7 @@ internal partial class SAM : Melee
                     return senAction;
             }
 
-            return DoCombo(onAoE: true, useOka: IsEnabled(Preset.SAM_AoE_Oka));
+            return DoCombo(true, useOka: IsEnabled(Preset.SAM_AoE_Oka));
         }
     }
 

--- a/WrathCombo/Combos/PvE/SAM/SAM.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM.cs
@@ -91,7 +91,7 @@ internal partial class SAM : Melee
             if (ActionReady(Enpi) && !InMeleeRange() && HasBattleTarget())
                 return Enpi;
 
-            return DoStCombo(true);
+            return DoCombo(onAoE: false, useTrueNorth: true);
         }
     }
 
@@ -149,7 +149,7 @@ internal partial class SAM : Melee
 
             return CanAoESenGcd(out uint senAction, onlyWhenStationary: true)
                 ? senAction
-                : DoAoECombo();
+                : DoCombo(onAoE: true);
         }
     }
 
@@ -292,12 +292,13 @@ internal partial class SAM : Melee
                     return Enpi;
             }
 
-            return DoStCombo(
+            return DoCombo(
+                onAoE: false,
                 IsEnabled(Preset.SAM_ST_TrueNorth),
                 IsEnabled(Preset.SAM_ST_Yukikaze),
                 IsEnabled(Preset.SAM_ST_Kasha),
                 IsEnabled(Preset.SAM_ST_Gekko),
-                SAM_ST_ManualTN);
+                trueNorthCharges: SAM_ST_ManualTN);
         }
     }
 
@@ -378,7 +379,7 @@ internal partial class SAM : Melee
                     return senAction;
             }
 
-            return DoAoECombo(IsEnabled(Preset.SAM_AoE_Oka));
+            return DoCombo(onAoE: true, useOka: IsEnabled(Preset.SAM_AoE_Oka));
         }
     }
 
@@ -564,6 +565,7 @@ internal partial class SAM : Melee
                     return Oka;
 
                 if (LevelChecked(Mangetsu) &&
+                    HasStatusEffect(Buffs.Fuka) &&
                     (!HasGetsu ||
                      !SAM_Mangetsu_Oka ||
                      !HasStatusEffect(Buffs.Fugetsu) ||

--- a/WrathCombo/Combos/PvE/SAM/SAM.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM.cs
@@ -91,7 +91,7 @@ internal partial class SAM : Melee
             if (ActionReady(Enpi) && !InMeleeRange() && HasBattleTarget())
                 return Enpi;
 
-            return DoCombo(false, true);
+            return DoCombo(false);
         }
     }
 

--- a/WrathCombo/Combos/PvE/SAM/SAM.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM.cs
@@ -147,7 +147,7 @@ internal partial class SAM : Melee
             if (CanAoEOgiNamikiri(onlyWhenStationary: true))
                 return OriginalHook(OgiNamikiri);
 
-            return CanAoESenGcd(out uint senAction, onlyWhenStationary: true)
+            return CanAoESenGCD(out uint senAction, onlyWhenStationary: true)
                 ? senAction
                 : DoCombo(onAoE: true);
         }
@@ -375,7 +375,7 @@ internal partial class SAM : Melee
                     return OriginalHook(OgiNamikiri);
 
                 if (IsEnabled(Preset.SAM_AoE_TenkaGoken) &&
-                    CanAoESenGcd(out uint senAction, onlyWhenStationary: true))
+                    CanAoESenGCD(out uint senAction, onlyWhenStationary: true))
                     return senAction;
             }
 
@@ -435,7 +435,7 @@ internal partial class SAM : Melee
                          (OnTargetsRear() || OnTargetsFront()) && !HasGetsu && LevelChecked(Gekko) ||
                          HasKa && !HasGetsu && LevelChecked(Gekko) ||
                          SAM_ST_YukikazeCombo_Prio == 1 && !HasStatusEffect(Buffs.Fugetsu) ||
-                         SenCount is 3 && RefreshFugetsu))
+                         SenCount is 3 && ShouldRefreshFugetsu))
                         return Jinpu;
 
                     if (SAM_Yukaze_Kasha &&
@@ -443,7 +443,7 @@ internal partial class SAM : Melee
                         ((OnTargetsFlank() || OnTargetsFront()) && !HasKa && LevelChecked(Kasha) ||
                          HasGetsu && !HasKa && LevelChecked(Kasha) ||
                          SAM_ST_YukikazeCombo_Prio == 1 && !HasStatusEffect(Buffs.Fuka) ||
-                         SenCount is 3 && RefreshFuka))
+                         SenCount is 3 && ShouldRefreshFuka))
                         return Shifu;
                 }
 
@@ -561,7 +561,7 @@ internal partial class SAM : Melee
                     LevelChecked(Oka) &&
                     (!HasKa ||
                      !HasStatusEffect(Buffs.Fuka) ||
-                     SenCount is 2 or 3 && RefreshFuka))
+                     SenCount is 2 or 3 && ShouldRefreshFuka))
                     return Oka;
 
                 if (LevelChecked(Mangetsu) &&
@@ -570,7 +570,7 @@ internal partial class SAM : Melee
                      !SAM_Mangetsu_Oka ||
                      !HasStatusEffect(Buffs.Fugetsu) ||
                      !LevelChecked(Oka) ||
-                     SenCount is 2 or 3 && RefreshFugetsu))
+                     SenCount is 2 or 3 && ShouldRefreshFugetsu))
                     return Mangetsu;
             }
 
@@ -635,7 +635,7 @@ internal partial class SAM : Melee
                 return Shoha;
 
             if (IsEnabled(Preset.SAM_Iaijutsu_OgiNamikiri) &&
-                (ActionReady(OriginalHook(OgiNamikiri)) && HasStatusEffect(Buffs.OgiNamikiriReady) || NamikiriReady))
+                (ActionReady(OriginalHook(OgiNamikiri)) && HasStatusEffect(Buffs.OgiNamikiriReady) || IsNamikiriReady))
                 return OriginalHook(OgiNamikiri);
 
             if (IsEnabled(Preset.SAM_Iaijutsu_TsubameGaeshi) &&
@@ -736,7 +736,7 @@ internal partial class SAM : Melee
 
             if (IsEnabled(Preset.SAM_Ikishoten_Namikiri) &&
                 ActionReady(OriginalHook(OgiNamikiri)) &&
-                (HasStatusEffect(Buffs.OgiNamikiriReady) || NamikiriReady))
+                (HasStatusEffect(Buffs.OgiNamikiriReady) || IsNamikiriReady))
                 return OriginalHook(OgiNamikiri);
 
             return actionID;
@@ -793,7 +793,7 @@ internal partial class SAM : Melee
                 return Shoha;
 
             if (LevelChecked(OgiNamikiri) &&
-                (HasStatusEffect(Buffs.OgiNamikiriReady) || NamikiriReady))
+                (HasStatusEffect(Buffs.OgiNamikiriReady) || IsNamikiriReady))
                 return OriginalHook(OgiNamikiri);
 
             if (LevelChecked(Zanshin) &&

--- a/WrathCombo/Combos/PvE/SAM/SAM.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM.cs
@@ -1,4 +1,3 @@
-using Dalamud.Bindings.ImPlot;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Native;
 using static WrathCombo.Combos.PvE.SAM.Config;
@@ -92,7 +91,7 @@ internal partial class SAM : Melee
             if (ActionReady(Enpi) && !InMeleeRange() && HasBattleTarget())
                 return Enpi;
 
-            return DoStCombo(actionID, true);
+            return DoStCombo(true);
         }
     }
 
@@ -150,7 +149,7 @@ internal partial class SAM : Melee
 
             return CanAoESenGcd(out uint senAction, onlyWhenStationary: true)
                 ? senAction
-                : DoAoECombo(actionID);
+                : DoAoECombo();
         }
     }
 
@@ -293,7 +292,7 @@ internal partial class SAM : Melee
                     return Enpi;
             }
 
-            return DoStCombo(actionID,
+            return DoStCombo(
                 IsEnabled(Preset.SAM_ST_TrueNorth),
                 IsEnabled(Preset.SAM_ST_Yukikaze),
                 IsEnabled(Preset.SAM_ST_Kasha),
@@ -379,7 +378,7 @@ internal partial class SAM : Melee
                     return senAction;
             }
 
-            return DoAoECombo(actionID, IsEnabled(Preset.SAM_AoE_Oka));
+            return DoAoECombo(IsEnabled(Preset.SAM_AoE_Oka));
         }
     }
 

--- a/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game.ClientState.JobGauge.Enums;
+using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
 using System;
 using System.Collections.Generic;
@@ -69,13 +69,13 @@ internal partial class SAM
             {
                 if (useOka && LevelChecked(Oka) &&
                     (!HasKa || !HasStatusEffect(Buffs.Fuka) ||
-                     SenCount is 2 or 3 && RefreshFuka))
+                     SenCount is 2 or 3 && ShouldRefreshFuka))
                     return Oka;
 
                 if (LevelChecked(Mangetsu) &&
                     HasStatusEffect(Buffs.Fuka) &&
                     (!HasGetsu || !HasStatusEffect(Buffs.Fugetsu) || !useOka || !LevelChecked(Oka) ||
-                     SenCount is 2 or 3 && RefreshFugetsu))
+                     SenCount is 2 or 3 && ShouldRefreshFugetsu))
                     return Mangetsu;
             }
 
@@ -97,7 +97,7 @@ internal partial class SAM
                     ((OnTargetsFlank() || OnTargetsFront()) && !HasKa && LevelChecked(Kasha) ||
                      OnTargetsRear() && HasGetsu && LevelChecked(Kasha) ||
                      !HasStatusEffect(Buffs.Fuka) ||
-                     SenCount is 3 && RefreshFuka))
+                     SenCount is 3 && ShouldRefreshFuka))
                     return Shifu;
 
                 if (useGekko &&
@@ -106,7 +106,7 @@ internal partial class SAM
                      (OnTargetsRear() || OnTargetsFront()) && !HasGetsu && LevelChecked(Gekko) ||
                      OnTargetsFlank() && HasKa && LevelChecked(Gekko) ||
                      !HasStatusEffect(Buffs.Fugetsu) ||
-                     SenCount is 3 && RefreshFugetsu))
+                     SenCount is 3 && ShouldRefreshFugetsu))
                     return Jinpu;
             }
 
@@ -152,8 +152,8 @@ internal partial class SAM
                GetTargetHPPercent() > hpThreshold &&
                dotRemaining <= dotRefresh &&
                HasStatusEffect(Buffs.Fuka) && HasStatusEffect(Buffs.Fugetsu) &&
-               (EnhancedSenei && (JustUsed(Senei, 35f) || JustUsed(Ikishoten, 35f) || !HasStatusEffect(Debuffs.Higanbana, CurrentTarget)) ||
-                !EnhancedSenei);
+               (HasEnhancedSenei && (JustUsed(Senei, 35f) || JustUsed(Ikishoten, 35f) || !HasStatusEffect(Debuffs.Higanbana, CurrentTarget)) ||
+                !HasEnhancedSenei);
     }
 
     private static int HiganbanaHPThreshold()
@@ -168,15 +168,15 @@ internal partial class SAM
 
     #region Misc
 
-    private static bool RefreshFugetsu =>
+    private static bool ShouldRefreshFugetsu =>
         GetStatusEffectRemainingTime(Buffs.Fugetsu) <=
         GetStatusEffectRemainingTime(Buffs.Fuka);
 
-    private static bool RefreshFuka =>
+    private static bool ShouldRefreshFuka =>
         GetStatusEffectRemainingTime(Buffs.Fuka) <=
         GetStatusEffectRemainingTime(Buffs.Fugetsu);
 
-    private static bool EnhancedSenei =>
+    private static bool HasEnhancedSenei =>
         TraitLevelChecked(Traits.EnhancedHissatsu);
 
     private static int SenCount =>
@@ -198,8 +198,8 @@ internal partial class SAM
         (SenCount is 3 ||
          SenCount is 1 && GetStatusEffectRemainingTime(Debuffs.Higanbana, CurrentTarget) < higanbanaDotRefresh ||
          HasStatusEffect(Buffs.OgiNamikiriReady) ||
-         EnhancedSenei && JustUsed(Senei, 30f) ||
-         !EnhancedSenei && JustUsed(KaeshiSetsugekka, 20f));
+         HasEnhancedSenei && JustUsed(Senei, 30f) ||
+         !HasEnhancedSenei && JustUsed(KaeshiSetsugekka, 20f));
 
     private static bool CanUseShinten() =>
         ActionReady(Shinten) && InActionRange(Shinten);
@@ -211,7 +211,7 @@ internal partial class SAM
 
     private static bool ShouldUseSenei(int kenkiOvercapAmount)
     {
-        if (!EnhancedSenei || HasStatusEffect(Buffs.ZanshinReady))
+        if (!HasEnhancedSenei || HasStatusEffect(Buffs.ZanshinReady))
             return false;
 
         float gcd = GetCooldown(OriginalHook(Hakaze)).CooldownTotal;
@@ -226,7 +226,7 @@ internal partial class SAM
     }
 
     private static bool ShouldSpendKenkiPreEnhanced(int kenkiOvercapAmount) =>
-        !EnhancedSenei &&
+        !HasEnhancedSenei &&
         (GetCooldownRemainingTime(Ikishoten) > 10 && Kenki >= kenkiOvercapAmount ||
          GetCooldownRemainingTime(Ikishoten) <= 10 && Kenki > 50);
 
@@ -259,7 +259,7 @@ internal partial class SAM
             ? DoMeikyoCombo(onAoE, useTrueNorth, useYukikaze, useKasha, useGekko, useOka, trueNorthCharges)
             : ContinueBasicCombo(onAoE, useTrueNorth, useYukikaze, useKasha, useGekko, useOka, trueNorthCharges);
 
-    private static bool CanAoESenGcd(
+    private static bool CanAoESenGCD(
         out uint action,
         bool allowTsubame = true,
         bool allowIaijutsu = true,
@@ -333,8 +333,8 @@ internal partial class SAM
     private static bool CanAoEOgiNamikiri(bool onlyWhenStationary = false) =>
         ActionReady(OriginalHook(OgiNamikiri)) &&
         (onlyWhenStationary
-            ? !IsMoving() && (HasStatusEffect(Buffs.OgiNamikiriReady) || NamikiriReady)
-            : NamikiriReady || HasStatusEffect(Buffs.OgiNamikiriReady) && !IsMoving());
+            ? !IsMoving() && (HasStatusEffect(Buffs.OgiNamikiriReady) || IsNamikiriReady)
+            : IsNamikiriReady || HasStatusEffect(Buffs.OgiNamikiriReady) && !IsMoving());
 
     #endregion
 
@@ -357,7 +357,7 @@ internal partial class SAM
 
         if (InBossEncounter())
         {
-            if (EnhancedSenei)
+            if (HasEnhancedSenei)
             {
                 if (GetRemainingCharges(MeikyoShisui) >= 1 &&
                     JustUsed(KaeshiNamikiri, 10f) &&
@@ -394,13 +394,13 @@ internal partial class SAM
         {
             if (useOka && LevelChecked(Oka) &&
                 (!HasKa || !HasStatusEffect(Buffs.Fuka) ||
-                 SenCount is 2 or 3 && RefreshFuka))
+                 SenCount is 2 or 3 && ShouldRefreshFuka))
                 return Oka;
 
             if (LevelChecked(Mangetsu) &&
                 HasStatusEffect(Buffs.Fuka) &&
                 (!HasGetsu || !HasStatusEffect(Buffs.Fugetsu) || !useOka || !LevelChecked(Oka) ||
-                 SenCount is 2 or 3 && RefreshFugetsu))
+                 SenCount is 2 or 3 && ShouldRefreshFugetsu))
                 return Mangetsu;
 
             return OriginalHook(Fuga);
@@ -465,7 +465,7 @@ internal partial class SAM
          HasStatusEffect(Buffs.TsubameReady)) &&
         (GetStatusEffectRemainingTime(Buffs.TsubameReady) < 5 ||
          SenCount is 3 ||
-         EnhancedSenei && GetCooldownRemainingTime(Senei) > 33);
+         HasEnhancedSenei && GetCooldownRemainingTime(Senei) > 33);
 
     private static bool CanZanshin() =>
         ActionReady(Zanshin) &&
@@ -480,7 +480,7 @@ internal partial class SAM
         bool useHiganbanaBurstRules = true,
         bool higanbanaBossOnly = false)
     {
-        if (NamikiriReady)
+        if (IsNamikiriReady)
             return true;
 
         if (ActionReady(OriginalHook(OgiNamikiri)) && InActionRange(OriginalHook(OgiNamikiri)) &&
@@ -788,7 +788,7 @@ internal partial class SAM
 
     private static Kaeshi Kaeshi => Gauge.Kaeshi;
 
-    private static bool NamikiriReady => Kaeshi is Kaeshi.Namikiri;
+    private static bool IsNamikiriReady => Kaeshi is Kaeshi.Namikiri;
 
     private static int GetSenCount()
     {

--- a/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
@@ -576,19 +576,19 @@ internal partial class SAM
             Higanbana
         ];
 
-        internal override UserData ContentCheckConfig => SAM_Balance_Content;
+        public override Preset Preset => Preset.SAM_ST_Opener;
 
-        public override List<(int[] Steps, Func<int> HoldDelay)> PrepullDelays { get; set; } =
-        [
-            ([2], () => SAM_Opener_PrePullDelay)
-        ];
+        internal override UserData ContentCheckConfig => SAM_Balance_Content;
 
         public override List<(int[] Steps, uint NewAction, Func<bool> Condition)> SubstitutionSteps { get; set; } =
         [
             ([2], 11, () => !TargetNeedsPositionals())
         ];
 
-        public override Preset Preset => Preset.SAM_ST_Opener;
+        public override List<(int[] Steps, Func<int> HoldDelay)> PrepullDelays { get; set; } =
+        [
+            ([2], () => SAM_Opener_PrePullDelay)
+        ];
 
         public override bool HasCooldowns() =>
             IsOffCooldown(MeikyoShisui) &&
@@ -627,19 +627,19 @@ internal partial class SAM
             KaeshiSetsugekka
         ];
 
-        internal override UserData ContentCheckConfig => SAM_Balance_Content;
+        public override Preset Preset => Preset.SAM_ST_Opener;
 
-        public override List<(int[] Steps, Func<int> HoldDelay)> PrepullDelays { get; set; } =
-        [
-            ([2], () => SAM_Opener_PrePullDelay)
-        ];
+        internal override UserData ContentCheckConfig => SAM_Balance_Content;
 
         public override List<(int[] Steps, uint NewAction, Func<bool> Condition)> SubstitutionSteps { get; set; } =
         [
             ([2], 11, () => !TargetNeedsPositionals())
         ];
 
-        public override Preset Preset => Preset.SAM_ST_Opener;
+        public override List<(int[] Steps, Func<int> HoldDelay)> PrepullDelays { get; set; } =
+        [
+            ([2], () => SAM_Opener_PrePullDelay)
+        ];
 
         public override bool HasCooldowns() =>
             GetRemainingCharges(MeikyoShisui) is 2 &&
@@ -680,19 +680,19 @@ internal partial class SAM
             KaeshiSetsugekka
         ];
 
-        internal override UserData ContentCheckConfig => SAM_Balance_Content;
+        public override Preset Preset => Preset.SAM_ST_Opener;
 
-        public override List<(int[] Steps, Func<int> HoldDelay)> PrepullDelays { get; set; } =
-        [
-            ([2], () => SAM_Opener_PrePullDelay)
-        ];
+        internal override UserData ContentCheckConfig => SAM_Balance_Content;
 
         public override List<(int[] Steps, uint NewAction, Func<bool> Condition)> SubstitutionSteps { get; set; } =
         [
             ([2], 11, () => !TargetNeedsPositionals())
         ];
 
-        public override Preset Preset => Preset.SAM_ST_Opener;
+        public override List<(int[] Steps, Func<int> HoldDelay)> PrepullDelays { get; set; } =
+        [
+            ([2], () => SAM_Opener_PrePullDelay)
+        ];
 
         public override bool HasCooldowns() =>
             GetRemainingCharges(MeikyoShisui) is 2 &&
@@ -738,12 +738,9 @@ internal partial class SAM
             TendoKaeshiSetsugekka //26
         ];
 
-        internal override UserData ContentCheckConfig => SAM_Balance_Content;
+        public override Preset Preset => Preset.SAM_ST_Opener;
 
-        public override List<(int[] Steps, Func<int> HoldDelay)> PrepullDelays { get; set; } =
-        [
-            ([2], () => SAM_Opener_PrePullDelay)
-        ];
+        internal override UserData ContentCheckConfig => SAM_Balance_Content;
 
         public override List<(int[] Steps, uint NewAction, Func<bool> Condition)> SubstitutionSteps { get; set; } =
         [
@@ -760,7 +757,10 @@ internal partial class SAM
             ([13], () => SenCount is not 1 && !(SenCount is 2 && JustUsed(Gekko)))
         ];
 
-        public override Preset Preset => Preset.SAM_ST_Opener;
+        public override List<(int[] Steps, Func<int> HoldDelay)> PrepullDelays { get; set; } =
+        [
+            ([2], () => SAM_Opener_PrePullDelay)
+        ];
 
         public override bool HasCooldowns() =>
             GetRemainingCharges(MeikyoShisui) is 2 &&

--- a/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
@@ -11,6 +11,44 @@ namespace WrathCombo.Combos.PvE;
 
 internal partial class SAM
 {
+    #region Iaijutsu
+
+    private static bool CanIaijutsu(
+        bool useHiganbana,
+        bool useTenkaGoken,
+        bool useMidare,
+        int higanbanaHpThreshold = 0,
+        double higanbanaDotRefresh = 15)
+    {
+        if (LevelChecked(Iaijutsu) && InActionRange(OriginalHook(Iaijutsu)))
+        {
+            //Higanbana
+            if (useHiganbana &&
+                SenCount is 1 &&
+                CanHiganbana(higanbanaHpThreshold, higanbanaDotRefresh))
+                return true;
+
+            //Tenka Goken
+            if (useTenkaGoken &&
+                SenCount is 2 &&
+                !LevelChecked(MidareSetsugekka))
+                return true;
+
+            if (useMidare &&
+                OriginalHook(Iaijutsu) is MidareSetsugekka or TendoSetsugekka &&
+                LevelChecked(MidareSetsugekka) && !HasStatusEffect(Buffs.TsubameReady))
+                return true;
+
+            //Midare Setsugekka
+            if (useMidare &&
+                SenCount is 3 &&
+                LevelChecked(MidareSetsugekka) && !HasStatusEffect(Buffs.TsubameReady))
+                return true;
+        }
+        return false;
+    }
+
+    #endregion
     #region Basic Combo
 
     private static uint ContinueBasicCombo(
@@ -99,45 +137,6 @@ internal partial class SAM
         bool useGekko = true,
         int trueNorthCharges = 0) =>
         ContinueBasicCombo(false, useTrueNorth, useYukikaze, useKasha, useGekko, trueNorthCharges: trueNorthCharges);
-
-    #endregion
-
-    #region Iaijutsu
-
-    private static bool CanIaijutsu(
-        bool useHiganbana,
-        bool useTenkaGoken,
-        bool useMidare,
-        int higanbanaHpThreshold = 0,
-        double higanbanaDotRefresh = 15)
-    {
-        if (LevelChecked(Iaijutsu) && InActionRange(OriginalHook(Iaijutsu)))
-        {
-            //Higanbana
-            if (useHiganbana &&
-                SenCount is 1 &&
-                CanHiganbana(higanbanaHpThreshold, higanbanaDotRefresh))
-                return true;
-
-            //Tenka Goken
-            if (useTenkaGoken &&
-                SenCount is 2 &&
-                !LevelChecked(MidareSetsugekka))
-                return true;
-
-            if (useMidare &&
-                OriginalHook(Iaijutsu) is MidareSetsugekka or TendoSetsugekka &&
-                LevelChecked(MidareSetsugekka) && !HasStatusEffect(Buffs.TsubameReady))
-                return true;
-
-            //Midare Setsugekka
-            if (useMidare &&
-                SenCount is 3 &&
-                LevelChecked(MidareSetsugekka) && !HasStatusEffect(Buffs.TsubameReady))
-                return true;
-        }
-        return false;
-    }
 
     #endregion
 
@@ -887,4 +886,3 @@ internal partial class SAM
 
     #endregion
 }
-

--- a/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
@@ -14,7 +14,6 @@ internal partial class SAM
     #region Basic Combo
 
     private static uint DoBasicCombo(
-        uint actionId,
         bool useTrueNorth = true,
         bool useYukikaze = true,
         bool useKasha = true,
@@ -221,17 +220,16 @@ internal partial class SAM
     #region Combo Resolution
 
     private static uint DoStCombo(
-        uint actionId,
         bool useTrueNorth,
         bool useYukikaze = true,
         bool useKasha = true,
         bool useGekko = true,
         int trueNorthCharges = 0) =>
         HasStatusEffect(Buffs.MeikyoShisui)
-            ? DoMeikyoCombo(actionId, useTrueNorth, useYukikaze, useKasha, useGekko, trueNorthCharges)
-            : DoBasicCombo(actionId, useTrueNorth, useYukikaze, useKasha, useGekko, trueNorthCharges);
+            ? DoMeikyoCombo(useTrueNorth, useYukikaze, useKasha, useGekko, trueNorthCharges)
+            : DoBasicCombo(useTrueNorth, useYukikaze, useKasha, useGekko, trueNorthCharges);
 
-    private static uint DoAoECombo(uint actionId, bool useOka = true)
+    private static uint DoAoECombo(bool useOka = true)
     {
         if (ComboTimer is 0 && !HasStatusEffect(Buffs.MeikyoShisui))
             return OriginalHook(Fuga);
@@ -370,7 +368,6 @@ internal partial class SAM
     }
 
     private static uint DoMeikyoCombo(
-        uint actionId,
         bool useTrueNorth = true,
         bool useYukikaze = true,
         bool useKasha = true,

--- a/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
@@ -214,7 +214,7 @@ internal partial class SAM
         if (!HasEnhancedSenei || HasStatusEffect(Buffs.ZanshinReady))
             return false;
 
-        float gcd = GetCooldown(OriginalHook(Hakaze)).CooldownTotal;
+        float gcd = GCD;
 
         return GetCooldownRemainingTime(Senei) < gcd * 2 && Kenki >= 90 ||
                JustUsed(Senei, 20f) && !JustUsed(Ikishoten) ||
@@ -242,6 +242,9 @@ internal partial class SAM
                ShouldUseSenei(kenkiOvercapAmount) ||
                ShouldSpendKenkiPreEnhanced(kenkiOvercapAmount);
     }
+
+    private static float GCD =>
+        GetCooldown(OriginalHook(Hakaze)).CooldownTotal;
 
     #endregion
 
@@ -371,7 +374,7 @@ internal partial class SAM
                     SenCount is 3 && GetCooldownRemainingTime(Senei) <= 5)
                     return true;
             }
-            else if (GetCooldownRemainingTime(Senei) <= GCDTotal ||
+            else if (GetCooldownRemainingTime(Senei) <= GCD ||
                      GetCooldownRemainingTime(Senei) is > 50 and < 65)
                 return true;
         }
@@ -519,7 +522,7 @@ internal partial class SAM
 
         if (useShinten &&
             ActionReady(Shinten) && InActionRange(Shinten) &&
-            GetCooldownRemainingTime(Senei) >= GCDTotal * 5 &&
+            GetCooldownRemainingTime(Senei) >= GCD * 5 &&
             !JustUsed(Ikishoten))
             return Shinten;
 

--- a/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
+++ b/WrathCombo/Combos/PvE/SAM/SAM_Helper.cs
@@ -13,13 +13,37 @@ internal partial class SAM
 {
     #region Basic Combo
 
-    private static uint DoBasicCombo(
+    private static uint ContinueBasicCombo(
+        bool onAoE = false,
         bool useTrueNorth = true,
         bool useYukikaze = true,
         bool useKasha = true,
         bool useGekko = true,
+        bool useOka = true,
         int trueNorthCharges = 0)
     {
+        if (onAoE)
+        {
+            if (ComboTimer is 0)
+                return OriginalHook(Fuga);
+
+            if (ComboAction is Fuko or Fuga)
+            {
+                if (useOka && LevelChecked(Oka) &&
+                    (!HasKa || !HasStatusEffect(Buffs.Fuka) ||
+                     SenCount is 2 or 3 && RefreshFuka))
+                    return Oka;
+
+                if (LevelChecked(Mangetsu) &&
+                    HasStatusEffect(Buffs.Fuka) &&
+                    (!HasGetsu || !HasStatusEffect(Buffs.Fugetsu) || !useOka || !LevelChecked(Oka) ||
+                     SenCount is 2 or 3 && RefreshFugetsu))
+                    return Mangetsu;
+            }
+
+            return OriginalHook(Fuga);
+        }
+
         if (ComboTimer > 0)
         {
             if (ComboAction is Hakaze or Gyofu)
@@ -68,6 +92,14 @@ internal partial class SAM
         return OriginalHook(Hakaze);
     }
 
+    private static uint DoBasicCombo(
+        bool useTrueNorth = true,
+        bool useYukikaze = true,
+        bool useKasha = true,
+        bool useGekko = true,
+        int trueNorthCharges = 0) =>
+        ContinueBasicCombo(false, useTrueNorth, useYukikaze, useKasha, useGekko, trueNorthCharges: trueNorthCharges);
+
     #endregion
 
     #region Iaijutsu
@@ -93,7 +125,6 @@ internal partial class SAM
                 !LevelChecked(MidareSetsugekka))
                 return true;
 
-            // Spend as soon as iaijutsu is replaced on the hotbar (Meikyo/Tendo).
             if (useMidare &&
                 OriginalHook(Iaijutsu) is MidareSetsugekka or TendoSetsugekka &&
                 LevelChecked(MidareSetsugekka) && !HasStatusEffect(Buffs.TsubameReady))
@@ -174,7 +205,6 @@ internal partial class SAM
     private static bool CanUseShinten() =>
         ActionReady(Shinten) && InActionRange(Shinten);
 
-    // Execute, hard overcap, or post-iai dump windows.
     private static bool ShouldSpendKenkiUrgent() =>
         Kenki is 100 && ComboAction == OriginalHook(Gyofu) ||
         Kenki >= 95 && (ComboAction is Jinpu or Shifu || SenCount is 3) ||
@@ -196,7 +226,6 @@ internal partial class SAM
                GetCooldownRemainingTime(Senei) >= 25 && Kenki >= kenkiOvercapAmount;
     }
 
-    // Pre-Enhanced Senei (Ikishoten-era pooling).
     private static bool ShouldSpendKenkiPreEnhanced(int kenkiOvercapAmount) =>
         !EnhancedSenei &&
         (GetCooldownRemainingTime(Ikishoten) > 10 && Kenki >= kenkiOvercapAmount ||
@@ -219,30 +248,17 @@ internal partial class SAM
 
     #region Combo Resolution
 
-    private static uint DoStCombo(
-        bool useTrueNorth,
+    private static uint DoCombo(
+        bool onAoE,
+        bool useTrueNorth = true,
         bool useYukikaze = true,
         bool useKasha = true,
         bool useGekko = true,
+        bool useOka = true,
         int trueNorthCharges = 0) =>
         HasStatusEffect(Buffs.MeikyoShisui)
-            ? DoMeikyoCombo(useTrueNorth, useYukikaze, useKasha, useGekko, trueNorthCharges)
-            : DoBasicCombo(useTrueNorth, useYukikaze, useKasha, useGekko, trueNorthCharges);
-
-    private static uint DoAoECombo(bool useOka = true)
-    {
-        if (ComboTimer is 0 && !HasStatusEffect(Buffs.MeikyoShisui))
-            return OriginalHook(Fuga);
-
-        if (useOka && LevelChecked(Oka) && (!HasKa || !HasStatusEffect(Buffs.Fuka)))
-            return Oka;
-
-        if (LevelChecked(Mangetsu) &&
-            (!HasGetsu || !HasStatusEffect(Buffs.Fugetsu) || !LevelChecked(Oka) || !useOka))
-            return Mangetsu;
-
-        return OriginalHook(Fuga);
-    }
+            ? DoMeikyoCombo(onAoE, useTrueNorth, useYukikaze, useKasha, useGekko, useOka, trueNorthCharges)
+            : ContinueBasicCombo(onAoE, useTrueNorth, useYukikaze, useKasha, useGekko, useOka, trueNorthCharges);
 
     private static bool CanAoESenGcd(
         out uint action,
@@ -344,7 +360,6 @@ internal partial class SAM
         {
             if (EnhancedSenei)
             {
-                // ~6:00 even-burst Meikyo reset after Kaeshi: Namikiri (Icy Veins 2.14 drift recovery)
                 if (GetRemainingCharges(MeikyoShisui) >= 1 &&
                     JustUsed(KaeshiNamikiri, 10f) &&
                     GetCooldownChargeRemainingTime(MeikyoShisui) is >= 35 and <= 43)
@@ -368,12 +383,30 @@ internal partial class SAM
     }
 
     private static uint DoMeikyoCombo(
+        bool onAoE = false,
         bool useTrueNorth = true,
         bool useYukikaze = true,
         bool useKasha = true,
         bool useGekko = true,
+        bool useOka = true,
         int trueNorthCharges = 0)
     {
+        if (onAoE)
+        {
+            if (useOka && LevelChecked(Oka) &&
+                (!HasKa || !HasStatusEffect(Buffs.Fuka) ||
+                 SenCount is 2 or 3 && RefreshFuka))
+                return Oka;
+
+            if (LevelChecked(Mangetsu) &&
+                HasStatusEffect(Buffs.Fuka) &&
+                (!HasGetsu || !HasStatusEffect(Buffs.Fugetsu) || !useOka || !LevelChecked(Oka) ||
+                 SenCount is 2 or 3 && RefreshFugetsu))
+                return Mangetsu;
+
+            return OriginalHook(Fuga);
+        }
+
         if (useYukikaze &&
             LevelChecked(Yukikaze) && !HasSetsu &&
             (HasKa || !useGekko) &&
@@ -854,3 +887,4 @@ internal partial class SAM
 
     #endregion
 }
+

--- a/WrathCombo/Combos/PvE/VPR/VPR.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR.cs
@@ -46,11 +46,11 @@ internal partial class VPR : Melee
             if (CanVicewinderCombo(ref actionID))
                 return actionID;
 
-            if (UncoiledFuryOvercapProtection(false))
-                return UncoiledFury;
-
             if (CanReawaken())
                 return Reawaken;
+
+            if (UncoiledFuryOvercapProtection(false))
+                return UncoiledFury;
 
             if (CanUseVicewinder)
                 return UseVicewinder();
@@ -103,11 +103,11 @@ internal partial class VPR : Melee
             if (UseVicepitCombo(ref actionID))
                 return actionID;
 
-            if (UncoiledFuryOvercapProtection(true))
-                return UncoiledFury;
-
             if (CanReawaken(true) && InActionRange(Reawaken))
                 return Reawaken;
+
+            if (UncoiledFuryOvercapProtection(true))
+                return UncoiledFury;
 
             if (CanVicepit())
                 return Vicepit;
@@ -170,13 +170,13 @@ internal partial class VPR : Melee
                 CanVicewinderCombo(ref actionID, VPR_VicewinderBuffPrio))
                 return actionID;
 
-            if (IsEnabled(Preset.VPR_ST_UncoiledFury) &&
-                UncoiledFuryOvercapProtection(false))
-                return UncoiledFury;
-
             if (IsEnabled(Preset.VPR_ST_Reawaken) &&
                 CanReawaken(hpThresholdUsage: ReawakenHPThreshold(), hpThresholdDontSave: VPR_ST_ReAwakenAlwaysUse))
                 return Reawaken;
+
+            if (IsEnabled(Preset.VPR_ST_UncoiledFury) &&
+                UncoiledFuryOvercapProtection(false))
+                return UncoiledFury;
 
             if (IsEnabled(Preset.VPR_ST_Vicewinder) &&
                 CanUseVicewinder)
@@ -248,14 +248,14 @@ internal partial class VPR : Melee
                 UseVicepitCombo(ref actionID, VPR_AoE_VicepitComboRangeCheck == 1))
                 return actionID;
 
-            if (IsEnabled(Preset.VPR_AoE_UncoiledFury) &&
-                UncoiledFuryOvercapProtection(true))
-                return UncoiledFury;
-
             if (IsEnabled(Preset.VPR_AoE_Reawaken) &&
                 CanReawaken(true, hpThresholdUsageAoE: VPR_AoE_ReawakenHPThreshold) &&
                 (InActionRange(Reawaken) || VPR_AoE_ReawakenRangecheck == 1))
                 return Reawaken;
+
+            if (IsEnabled(Preset.VPR_AoE_UncoiledFury) &&
+                UncoiledFuryOvercapProtection(true))
+                return UncoiledFury;
 
             if (IsEnabled(Preset.VPR_AoE_Vicepit) &&
                 CanVicepit(VPR_AoE_VicepitRangeCheck == 1))

--- a/WrathCombo/Combos/PvE/VPR/VPR.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR.cs
@@ -49,7 +49,7 @@ internal partial class VPR : Melee
             if (CanReawaken())
                 return Reawaken;
 
-            if (UncoiledFuryOvercapProtection(false))
+            if (OvercapUncoiledFuryProtection(false))
                 return UncoiledFury;
 
             if (CanUseVicewinder)
@@ -106,7 +106,7 @@ internal partial class VPR : Melee
             if (CanReawaken(true) && InActionRange(Reawaken))
                 return Reawaken;
 
-            if (UncoiledFuryOvercapProtection(true))
+            if (OvercapUncoiledFuryProtection(true))
                 return UncoiledFury;
 
             if (CanVicepit())
@@ -175,7 +175,7 @@ internal partial class VPR : Melee
                 return Reawaken;
 
             if (IsEnabled(Preset.VPR_ST_UncoiledFury) &&
-                UncoiledFuryOvercapProtection(false))
+                OvercapUncoiledFuryProtection(false))
                 return UncoiledFury;
 
             if (IsEnabled(Preset.VPR_ST_Vicewinder) &&
@@ -254,7 +254,7 @@ internal partial class VPR : Melee
                 return Reawaken;
 
             if (IsEnabled(Preset.VPR_AoE_UncoiledFury) &&
-                UncoiledFuryOvercapProtection(true))
+                OvercapUncoiledFuryProtection(true))
                 return UncoiledFury;
 
             if (IsEnabled(Preset.VPR_AoE_Vicepit) &&
@@ -278,7 +278,7 @@ internal partial class VPR : Melee
             if (actionID is not ReavingFangs)
                 return actionID;
 
-            if (DeathRattleWeave &&
+            if (IsDeathRattleWeave &&
                 LevelChecked(SerpentsTail) && InActionRange(DeathRattle))
                 return OriginalHook(SerpentsTail);
 
@@ -378,7 +378,7 @@ internal partial class VPR : Melee
                 {
                     return IsEnabled(Preset.VPR_ReawakenLegacyWeaves) &&
                            TraitLevelChecked(Traits.SerpentsLegacy) &&
-                           HasStatusEffect(Buffs.Reawakened) && LegacyWeaves
+                           HasStatusEffect(Buffs.Reawakened) && IsLegacyWeaveReady
                         ? OriginalHook(SerpentsTail)
                         : ReawakenCombo(actionID);
                 }
@@ -445,8 +445,8 @@ internal partial class VPR : Melee
 
             return actionID switch
             {
-                SteelFangs or ReavingFangs when DeathRattleWeave => OriginalHook(SerpentsTail),
-                SteelMaw or ReavingMaw when LastLashWeave => OriginalHook(SerpentsTail),
+                SteelFangs or ReavingFangs when IsDeathRattleWeave => OriginalHook(SerpentsTail),
+                SteelMaw or ReavingMaw when IsLastLashWeave => OriginalHook(SerpentsTail),
                 var _ => actionID
             };
         }

--- a/WrathCombo/Combos/PvE/VPR/VPR.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR.cs
@@ -282,7 +282,7 @@ internal partial class VPR : Melee
                 LevelChecked(SerpentsTail) && InActionRange(DeathRattle))
                 return OriginalHook(SerpentsTail);
 
-            return DoBasicCombo(actionID);
+            return DoBasicCombo();
         }
     }
 

--- a/WrathCombo/Combos/PvE/VPR/VPR.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR.cs
@@ -46,11 +46,11 @@ internal partial class VPR : Melee
             if (CanVicewinderCombo(ref actionID))
                 return actionID;
 
-            if (CanReawaken())
-                return Reawaken;
-
             if (UncoiledFuryOvercapProtection(false))
                 return UncoiledFury;
+
+            if (CanReawaken())
+                return Reawaken;
 
             if (CanUseVicewinder)
                 return UseVicewinder();
@@ -103,11 +103,11 @@ internal partial class VPR : Melee
             if (UseVicepitCombo(ref actionID))
                 return actionID;
 
-            if (CanReawaken(true) && InActionRange(Reawaken))
-                return Reawaken;
-
             if (UncoiledFuryOvercapProtection(true))
                 return UncoiledFury;
+
+            if (CanReawaken(true) && InActionRange(Reawaken))
+                return Reawaken;
 
             if (CanVicepit())
                 return Vicepit;
@@ -170,13 +170,13 @@ internal partial class VPR : Melee
                 CanVicewinderCombo(ref actionID, VPR_VicewinderBuffPrio))
                 return actionID;
 
-            if (IsEnabled(Preset.VPR_ST_Reawaken) &&
-                CanReawaken(hpThresholdUsage: ReawakenHPThreshold(), hpThresholdDontSave: VPR_ST_ReAwakenAlwaysUse))
-                return Reawaken;
-
             if (IsEnabled(Preset.VPR_ST_UncoiledFury) &&
                 UncoiledFuryOvercapProtection(false))
                 return UncoiledFury;
+
+            if (IsEnabled(Preset.VPR_ST_Reawaken) &&
+                CanReawaken(hpThresholdUsage: ReawakenHPThreshold(), hpThresholdDontSave: VPR_ST_ReAwakenAlwaysUse))
+                return Reawaken;
 
             if (IsEnabled(Preset.VPR_ST_Vicewinder) &&
                 CanUseVicewinder)
@@ -248,14 +248,14 @@ internal partial class VPR : Melee
                 UseVicepitCombo(ref actionID, VPR_AoE_VicepitComboRangeCheck == 1))
                 return actionID;
 
+            if (IsEnabled(Preset.VPR_AoE_UncoiledFury) &&
+                UncoiledFuryOvercapProtection(true))
+                return UncoiledFury;
+
             if (IsEnabled(Preset.VPR_AoE_Reawaken) &&
                 CanReawaken(true, hpThresholdUsageAoE: VPR_AoE_ReawakenHPThreshold) &&
                 (InActionRange(Reawaken) || VPR_AoE_ReawakenRangecheck == 1))
                 return Reawaken;
-
-            if (IsEnabled(Preset.VPR_AoE_UncoiledFury) &&
-                UncoiledFuryOvercapProtection(true))
-                return UncoiledFury;
 
             if (IsEnabled(Preset.VPR_AoE_Vicepit) &&
                 CanVicepit(VPR_AoE_VicepitRangeCheck == 1))

--- a/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
@@ -182,7 +182,7 @@ internal partial class VPR
         UsedVicewinder || UsedHuntersCoil || UsedSwiftskinsCoil ||
         UsedVicepit || UsedHuntersDen || UsedSwiftskinsDen;
 
-    private static bool ShouldDeferNewTwinblade =>
+    private static bool ShouldHoldNewTwinblade =>
         ShouldHoldTwinbladeForIre && !InTwinbladeCombo && !IsEmpowermentExpiring(4);
 
     private static bool ShouldSaveOfferingForBurst =>
@@ -396,7 +396,7 @@ internal partial class VPR
         GetTargetHPPercent() < hpThreshold && HasRattlingCoilStacks;
 
     private static bool CanUseUncoiledFuryInRotation(bool onAoE) =>
-        !ShouldDeferNewTwinblade &&
+        !ShouldHoldNewTwinblade &&
         HasBothBuffs &&
         !HasStatusEffect(Buffs.Reawakened) && !HasStatusEffect(Buffs.ReadyToReawaken) &&
         !JustUsed(Ouroboros) &&
@@ -459,7 +459,7 @@ internal partial class VPR
 
     private static bool CanVicepit(bool ignoreRange = false) =>
         WithinGcd(Vicepit) && !HasStatusEffect(Buffs.Reawakened) && !JustUsed(Vicepit) &&
-        !ShouldDeferNewTwinblade &&
+        !ShouldHoldNewTwinblade &&
         (ignoreRange || InActionRange(Vicepit)) &&
         (!HasBothBuffs || IreCD >= GCDTotal * 4 || !LevelChecked(SerpentsIre));
 
@@ -496,7 +496,7 @@ internal partial class VPR
 
     private static bool CanUseVicewinder =>
         WithinGcd(Vicewinder) && InActionRange(Vicewinder) && InCombat() &&
-        !ShouldDeferNewTwinblade &&
+        !ShouldHoldNewTwinblade &&
         !IsComboExpiring(6) && !IsVenomExpiring(4) && !IsHoningExpiring(4) &&
         !UsedVicewinder && !UsedHuntersCoil && !UsedSwiftskinsCoil &&
         !JustUsed(SerpentsIre, GCDTotal * 4) && !JustUsed(Vicewinder) &&

--- a/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game.ClientState.JobGauge.Enums;
+using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
 using System;
 using System.Collections.Generic;
@@ -222,11 +222,9 @@ internal partial class VPR
             GetTargetHPPercent() < hpThresholdDontSave)
             return true;
 
-        // Standard double burst: one GCD after Ire, then first Reawaken
         if (!JustUsed(SerpentsIre, GCDTotal) && HasStatusEffect(Buffs.ReadyToReawaken))
             return true;
 
-        // Second Reawaken back-to-back after Ouroboros when gauge is ready
         if (UsesBurstAlignment && JustUsed(Ouroboros, GCDTotal * 12) && SerpentOffering >= 50)
             return true;
 
@@ -239,7 +237,6 @@ internal partial class VPR
         if (!LevelChecked(Ouroboros) && JustUsed(FourthGeneration))
             return true;
 
-        // ~1min offering Reawaken; defer when pooling for an imminent Ire burst
         if (IreCD is >= 50 and <= 62 &&
             SerpentOffering >= 50 &&
             (!UsesBurstAlignment || !ShouldSaveOfferingForBurst))
@@ -428,7 +425,6 @@ internal partial class VPR
         if (!ActionReady(UncoiledFury) || !InActionRange(UncoiledFury))
             return false;
 
-        // ST range uptime
         if (!onAoE && HasRattlingCoilStacks && !InMeleeRange() && HasBattleTarget())
             return true;
 
@@ -515,7 +511,6 @@ internal partial class VPR
             LevelChecked(Vicewinder) && InActionRange(Vicewinder) &&
             !HasStatusEffect(Buffs.Reawakened))
         {
-            // Swiftskin's Coil (Rear)
             if (UsedVicewinder &&
                 (!HasStatusEffect(Buffs.Swiftscaled) ||
                  HasBothBuffs && (!OnTargetsFlank() || !TargetNeedsPositionals()) ||
@@ -526,7 +521,6 @@ internal partial class VPR
                 return true;
             }
 
-            // Hunter's Coil (Flank)
             if (UsedVicewinder &&
                 (!HasStatusEffect(Buffs.HuntersInstinct) ||
                  HasBothBuffs && (!OnTargetsRear() || !TargetNeedsPositionals()) ||
@@ -823,3 +817,4 @@ internal partial class VPR
 
     #endregion
 }
+

--- a/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
@@ -392,7 +392,6 @@ internal partial class VPR
 
     private static bool CanSerpentsIre(int hpThreshold = 0) =>
         InCombat() && !MaxCoils && ActionReady(SerpentsIre) &&
-        HasBothBuffs &&
         GetTargetHPPercent() > hpThreshold;
 
     private static bool ShouldSpendCoilStacks(int holdCharges, int hpThreshold) =>
@@ -411,11 +410,13 @@ internal partial class VPR
               !IsComboExpiring(2) && !IsVenomExpiring(2) && !IsHoningExpiring(2) && !IsEmpowermentExpiring(3));
 
     private static bool UncoiledFuryOvercapProtection(bool onAoE) =>
-        onAoE
-            ? MaxCoils && !HasStatusEffect(Buffs.Reawakened) &&
-              (HasCharges(Vicepit) && NoAoEComboWeaves || IreCD <= GCDTotal * 2)
-            : MaxCoils && !HasStatusEffect(Buffs.Reawakened) &&
-              (HasCharges(Vicewinder) && NoSTComboWeaves || IreCD <= GCDTotal * 3);
+        MaxCoils &&
+        ActionReady(UncoiledFury) &&
+        InActionRange(UncoiledFury) &&
+        !HasStatusEffect(Buffs.Reawakened) &&
+        (onAoE ? NoAoEComboWeaves : NoSTComboWeaves) &&
+        (LevelChecked(SerpentsIre) && IreCD <= GCDTotal * (onAoE ? 2 : 3) ||
+         HasCharges(onAoE ? Vicepit : Vicewinder));
 
     private static bool CanUseUncoiledFury(
         bool onAoE = false,

--- a/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
@@ -598,6 +598,10 @@ internal partial class VPR
             TwinfangBite //35
         ];
 
+        public override Preset Preset => Preset.VPR_ST_Opener;
+
+        internal override UserData ContentCheckConfig => VPR_Balance_Content;
+
         public override List<(int[], uint, Func<bool>)> SubstitutionSteps { get; set; } =
         [
             ([30], SwiftskinsCoil, OnTargetsRear),
@@ -615,8 +619,6 @@ internal partial class VPR
             ([28], () => !IsDeathRattleWeave && !JustUsed(HindstingStrike))
         ];
 
-        internal override UserData ContentCheckConfig => VPR_Balance_Content;
-        public override Preset Preset => Preset.VPR_ST_Opener;
         public override bool HasCooldowns() =>
             IsOriginal(ReavingFangs) &&
             GetRemainingCharges(Vicewinder) is 2 &&
@@ -667,6 +669,10 @@ internal partial class VPR
             UncoiledTwinblood //34
         ];
 
+        public override Preset Preset => Preset.VPR_ST_Opener;
+
+        internal override UserData ContentCheckConfig => VPR_Balance_Content;
+
         public override List<(int[], uint, Func<bool>)> SubstitutionSteps { get; set; } =
         [
             ([23], SwiftskinsCoil, OnTargetsRear),
@@ -682,8 +688,6 @@ internal partial class VPR
             ([19, 20, 21, 29, 30, 31, 32, 33, 34], () => VPR_Opener_ExcludeUF || !HasCharges(RattlingCoil))
         ];
 
-        internal override UserData ContentCheckConfig => VPR_Balance_Content;
-        public override Preset Preset => Preset.VPR_ST_Opener;
         public override bool HasCooldowns() =>
             IsOriginal(ReavingFangs) &&
             GetRemainingCharges(Vicewinder) is 2 &&

--- a/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
@@ -13,7 +13,7 @@ internal partial class VPR
 {
     #region Basic Combo
 
-    private static bool TrueNorthReady(bool useTrueNorth, int trueNorthCharges = 0, bool dynamicHoldCharge = false) =>
+    private static bool IsTrueNorthReady(bool useTrueNorth, int trueNorthCharges = 0, bool dynamicHoldCharge = false) =>
         useTrueNorth &&
         (dynamicHoldCharge && GetRemainingCharges(Role.TrueNorth) is 2 ||
          !dynamicHoldCharge) &&
@@ -70,11 +70,11 @@ internal partial class VPR
             if (ComboAction is ReavingFangs or SteelFangs)
             {
                 if (LevelChecked(SwiftskinsSting) &&
-                    (HasHindVenom || NoSwiftscaled || NoBasicComboVenom))
+                    (HasHindVenom || IsMissingSwiftscaled || IsMissingBasicComboVenom))
                     return OriginalHook(ReavingFangs);
 
                 if (LevelChecked(HuntersSting) &&
-                    (HasFlankVenom || NoHuntersInstinct))
+                    (HasFlankVenom || IsMissingHuntersInstinct))
                     return OriginalHook(SteelFangs);
             }
 
@@ -82,7 +82,7 @@ internal partial class VPR
             {
                 if ((HasStatusEffect(Buffs.FlanksbaneVenom) || HasStatusEffect(Buffs.HindsbaneVenom)) &&
                     LevelChecked(HindstingStrike))
-                    return TrueNorthReady(useTrueNorth, trueNorthCharges, dynamicHoldCharge) &&
+                    return IsTrueNorthReady(useTrueNorth, trueNorthCharges, dynamicHoldCharge) &&
                            (!OnTargetsRear() && HasStatusEffect(Buffs.HindsbaneVenom) ||
                             !OnTargetsFlank() && HasStatusEffect(Buffs.FlanksbaneVenom))
                         ? Role.TrueNorth
@@ -90,7 +90,7 @@ internal partial class VPR
 
                 if ((HasStatusEffect(Buffs.FlankstungVenom) || HasStatusEffect(Buffs.HindstungVenom)) &&
                     LevelChecked(FlanksbaneFang))
-                    return TrueNorthReady(useTrueNorth, trueNorthCharges, dynamicHoldCharge) &&
+                    return IsTrueNorthReady(useTrueNorth, trueNorthCharges, dynamicHoldCharge) &&
                            (!OnTargetsRear() && HasStatusEffect(Buffs.HindstungVenom) ||
                             !OnTargetsFlank() && HasStatusEffect(Buffs.FlankstungVenom))
                         ? Role.TrueNorth
@@ -119,7 +119,7 @@ internal partial class VPR
     private static float IreCD =>
         GetCooldownRemainingTime(SerpentsIre);
 
-    private static bool MaxCoils =>
+    private static bool IsCoilsCapped =>
         TraitLevelChecked(Traits.EnhancedVipersRattle) && RattlingCoilStacks > 2 ||
         !TraitLevelChecked(Traits.EnhancedVipersRattle) && RattlingCoilStacks > 1;
 
@@ -134,25 +134,25 @@ internal partial class VPR
         HasStatusEffect(Buffs.FlankstungVenom) ||
         HasStatusEffect(Buffs.FlanksbaneVenom);
 
-    private static bool NoSwiftscaled =>
+    private static bool IsMissingSwiftscaled =>
         !HasStatusEffect(Buffs.Swiftscaled);
 
-    private static bool NoHuntersInstinct =>
+    private static bool IsMissingHuntersInstinct =>
         !HasStatusEffect(Buffs.HuntersInstinct);
 
-    private static bool NoBasicComboVenom =>
+    private static bool IsMissingBasicComboVenom =>
         !HasStatusEffect(Buffs.FlanksbaneVenom) &&
         !HasStatusEffect(Buffs.FlankstungVenom) &&
         !HasStatusEffect(Buffs.HindsbaneVenom) &&
         !HasStatusEffect(Buffs.HindstungVenom);
 
-    private static bool NoSTComboWeaves =>
+    private static bool IsSTComboWeaveBlocked =>
         !HasStatusEffect(Buffs.HuntersVenom) &&
         !HasStatusEffect(Buffs.SwiftskinsVenom) &&
         !HasStatusEffect(Buffs.PoisedForTwinblood) &&
         !HasStatusEffect(Buffs.PoisedForTwinfang);
 
-    private static bool NoAoEComboWeaves =>
+    private static bool IsAoEComboWeaveBlocked =>
         !HasStatusEffect(Buffs.FellhuntersVenom) &&
         !HasStatusEffect(Buffs.FellskinsVenom) &&
         !HasStatusEffect(Buffs.PoisedForTwinblood) &&
@@ -203,7 +203,7 @@ internal partial class VPR
         {
             if (!ActionReady(Reawaken) || GetTargetHPPercent() <= hpThresholdUsageAoE ||
                 !HasStatusEffect(Buffs.Swiftscaled) || !HasStatusEffect(Buffs.HuntersInstinct) ||
-                HasStatusEffect(Buffs.Reawakened) || !NoAoEComboWeaves)
+                HasStatusEffect(Buffs.Reawakened) || !IsAoEComboWeaveBlocked)
                 return false;
 
             if (UsesBurstAlignment && JustUsed(Ouroboros, GCDTotal * 12) && SerpentOffering >= 50)
@@ -213,7 +213,7 @@ internal partial class VPR
         }
 
         if (!(ActionReady(Reawaken) && !HasStatusEffect(Buffs.Reawakened) &&
-              InActionRange(Reawaken) && NoSTComboWeaves && HasBattleTarget() &&
+              InActionRange(Reawaken) && IsSTComboWeaveBlocked && HasBattleTarget() &&
               !IsEmpowermentExpiring(6) && !IsComboExpiring(6) &&
               GetTargetHPPercent() > hpThresholdUsage))
             return false;
@@ -305,7 +305,7 @@ internal partial class VPR
         return Instance()->Combo.Timer != 0 && Instance()->Combo.Timer < gcd;
     }
 
-    private static bool WithinGcd(uint actionId) =>
+    private static bool WithinGCD(uint actionId) =>
         LevelChecked(actionId) && (HasCharges(actionId) || GetCooldownRemainingTime(actionId) <= GCDTotal);
 
     #endregion
@@ -316,9 +316,9 @@ internal partial class VPR
         LevelChecked(SerpentsTail) &&
         ((allowDeathRattle &&
           (onAoE
-              ? LastLashWeave && InActionRange(LastLash)
-              : DeathRattleWeave && InActionRange(DeathRattle))) ||
-         allowLegacy && LegacyWeaves && InActionRange(FirstLegacy));
+              ? IsLastLashWeave && InActionRange(LastLash)
+              : IsDeathRattleWeave && InActionRange(DeathRattle))) ||
+         allowLegacy && IsLegacyWeaveReady && InActionRange(FirstLegacy));
 
     private static bool UsePoisedTwinWeaves(out uint action, bool enabled = true)
     {
@@ -388,7 +388,7 @@ internal partial class VPR
     }
 
     private static bool CanSerpentsIre(int hpThreshold = 0) =>
-        InCombat() && !MaxCoils && ActionReady(SerpentsIre) &&
+        InCombat() && !IsCoilsCapped && ActionReady(SerpentsIre) &&
         GetTargetHPPercent() > hpThreshold;
 
     private static bool ShouldSpendCoilStacks(int holdCharges, int hpThreshold) =>
@@ -401,17 +401,17 @@ internal partial class VPR
         !HasStatusEffect(Buffs.Reawakened) && !HasStatusEffect(Buffs.ReadyToReawaken) &&
         !JustUsed(Ouroboros) &&
         (onAoE
-            ? !UsedVicepit && !UsedHuntersDen && !UsedSwiftskinsDen && NoAoEComboWeaves &&
+            ? !UsedVicepit && !UsedHuntersDen && !UsedSwiftskinsDen && IsAoEComboWeaveBlocked &&
               !JustUsed(JaggedMaw, GCDTotal) && !JustUsed(BloodiedMaw, GCDTotal) && !JustUsed(SerpentsIre, GCDTotal)
-            : !UsedVicewinder && !UsedHuntersCoil && !UsedSwiftskinsCoil && NoSTComboWeaves &&
+            : !UsedVicewinder && !UsedHuntersCoil && !UsedSwiftskinsCoil && IsSTComboWeaveBlocked &&
               !IsComboExpiring(2) && !IsVenomExpiring(2) && !IsHoningExpiring(2) && !IsEmpowermentExpiring(3));
 
-    private static bool UncoiledFuryOvercapProtection(bool onAoE) =>
-        MaxCoils &&
+    private static bool OvercapUncoiledFuryProtection(bool onAoE) =>
+        IsCoilsCapped &&
         ActionReady(UncoiledFury) &&
         InActionRange(UncoiledFury) &&
         !HasStatusEffect(Buffs.Reawakened) &&
-        (onAoE ? NoAoEComboWeaves : NoSTComboWeaves) &&
+        (onAoE ? IsAoEComboWeaveBlocked : IsSTComboWeaveBlocked) &&
         (LevelChecked(SerpentsIre) && IreCD <= GCDTotal * (onAoE ? 2 : 3) ||
          HasCharges(onAoE ? Vicepit : Vicewinder));
 
@@ -458,7 +458,7 @@ internal partial class VPR
     }
 
     private static bool CanVicepit(bool ignoreRange = false) =>
-        WithinGcd(Vicepit) && !HasStatusEffect(Buffs.Reawakened) && !JustUsed(Vicepit) &&
+        WithinGCD(Vicepit) && !HasStatusEffect(Buffs.Reawakened) && !JustUsed(Vicepit) &&
         !ShouldHoldNewTwinblade &&
         (ignoreRange || InActionRange(Vicepit)) &&
         (!HasBothBuffs || IreCD >= GCDTotal * 4 || !LevelChecked(SerpentsIre));
@@ -495,7 +495,7 @@ internal partial class VPR
     #region Vicewinder & Uncoiled Fury Combo
 
     private static bool CanUseVicewinder =>
-        WithinGcd(Vicewinder) && InActionRange(Vicewinder) && InCombat() &&
+        WithinGCD(Vicewinder) && InActionRange(Vicewinder) && InCombat() &&
         !ShouldHoldNewTwinblade &&
         !IsComboExpiring(6) && !IsVenomExpiring(4) && !IsHoningExpiring(4) &&
         !UsedVicewinder && !UsedHuntersCoil && !UsedSwiftskinsCoil &&
@@ -612,7 +612,7 @@ internal partial class VPR
         [
             ([21, 22, 23, 24, 25, 26], () => VPR_Opener_ExcludeUF || !HasCharges(RattlingCoil)),
             ([27], () => ComboAction is not SwiftskinsSting),
-            ([28], () => !DeathRattleWeave && !JustUsed(HindstingStrike))
+            ([28], () => !IsDeathRattleWeave && !JustUsed(HindstingStrike))
         ];
 
         internal override UserData ContentCheckConfig => VPR_Balance_Content;
@@ -716,16 +716,16 @@ internal partial class VPR
 
     private static SerpentCombo SerpentCombo => Gauge.SerpentCombo;
 
-    private static bool LegacyWeaves =>
+    private static bool IsLegacyWeaveReady =>
         HasStatusEffect(Buffs.Reawakened) &&
         (SerpentCombo.HasFlag(SerpentCombo.FirstLegacy) ||
          SerpentCombo.HasFlag(SerpentCombo.SecondLegacy) ||
          SerpentCombo.HasFlag(SerpentCombo.ThirdLegacy) ||
          SerpentCombo.HasFlag(SerpentCombo.FourthLegacy));
 
-    private static bool DeathRattleWeave => Gauge.SerpentCombo is SerpentCombo.DeathRattle;
+    private static bool IsDeathRattleWeave => Gauge.SerpentCombo is SerpentCombo.DeathRattle;
 
-    private static bool LastLashWeave => Gauge.SerpentCombo is SerpentCombo.LastLash;
+    private static bool IsLastLashWeave => Gauge.SerpentCombo is SerpentCombo.LastLash;
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
@@ -20,7 +20,7 @@ internal partial class VPR
         GetRemainingCharges(Role.TrueNorth) > trueNorthCharges &&
         Role.CanTrueNorth();
 
-    private static uint DoBasicCombo(uint actionId, bool useTrueNorth = false, bool onAoE = false, int trueNorthCharges = 0,
+    private static uint DoBasicCombo(bool useTrueNorth = false, bool onAoE = false, int trueNorthCharges = 0,
         bool dynamicHoldCharge = false)
     {
         if (onAoE)
@@ -491,7 +491,7 @@ internal partial class VPR
         bool dynamicHoldCharge = false) =>
         useReawakenCombo && HasStatusEffect(Buffs.Reawakened)
             ? ReawakenCombo(actionId)
-            : DoBasicCombo(actionId, useTrueNorth, onAoE, trueNorthCharges, dynamicHoldCharge);
+            : DoBasicCombo(useTrueNorth, onAoE, trueNorthCharges, dynamicHoldCharge);
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
@@ -817,4 +817,3 @@ internal partial class VPR
 
     #endregion
 }
-

--- a/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR_Helper.cs
@@ -206,7 +206,7 @@ internal partial class VPR
                 HasStatusEffect(Buffs.Reawakened) || !IsAoEComboWeaveBlocked)
                 return false;
 
-            if (UsesBurstAlignment && JustUsed(Ouroboros, GCDTotal * 12) && SerpentOffering >= 50)
+            if (UsesBurstAlignment && JustUsed(Ouroboros, GCD * 12) && SerpentOffering >= 50)
                 return true;
 
             return HasStatusEffect(Buffs.ReadyToReawaken) || SerpentOffering >= 50;
@@ -222,10 +222,10 @@ internal partial class VPR
             GetTargetHPPercent() < hpThresholdDontSave)
             return true;
 
-        if (!JustUsed(SerpentsIre, GCDTotal) && HasStatusEffect(Buffs.ReadyToReawaken))
+        if (!JustUsed(SerpentsIre, GCD) && HasStatusEffect(Buffs.ReadyToReawaken))
             return true;
 
-        if (UsesBurstAlignment && JustUsed(Ouroboros, GCDTotal * 12) && SerpentOffering >= 50)
+        if (UsesBurstAlignment && JustUsed(Ouroboros, GCD * 12) && SerpentOffering >= 50)
             return true;
 
         if (SerpentOffering >= 100)
@@ -273,9 +273,11 @@ internal partial class VPR
 
     #region Combos
 
+    private static float GCD => GetCooldown(OriginalHook(ReavingFangs)).CooldownTotal;
+
     private static bool IsHoningExpiring(float times)
     {
-        float gcd = GCDTotal * times;
+        float gcd = GCD * times;
 
         return HasStatusEffect(Buffs.HonedSteel) && GetStatusEffectRemainingTime(Buffs.HonedSteel) < gcd ||
                HasStatusEffect(Buffs.HonedReavers) && GetStatusEffectRemainingTime(Buffs.HonedReavers) < gcd;
@@ -283,7 +285,7 @@ internal partial class VPR
 
     private static bool IsVenomExpiring(float times)
     {
-        float gcd = GCDTotal * times;
+        float gcd = GCD * times;
 
         return HasStatusEffect(Buffs.FlankstungVenom) && GetStatusEffectRemainingTime(Buffs.FlankstungVenom) < gcd ||
                HasStatusEffect(Buffs.FlanksbaneVenom) && GetStatusEffectRemainingTime(Buffs.FlanksbaneVenom) < gcd ||
@@ -293,20 +295,20 @@ internal partial class VPR
 
     private static bool IsEmpowermentExpiring(float times)
     {
-        float gcd = GCDTotal * times;
+        float gcd = GCD * times;
 
         return GetStatusEffectRemainingTime(Buffs.Swiftscaled) < gcd || GetStatusEffectRemainingTime(Buffs.HuntersInstinct) < gcd;
     }
 
     private static unsafe bool IsComboExpiring(float times)
     {
-        float gcd = GCDTotal * times;
+        float gcd = GCD * times;
 
         return Instance()->Combo.Timer != 0 && Instance()->Combo.Timer < gcd;
     }
 
     private static bool WithinGCD(uint actionId) =>
-        LevelChecked(actionId) && (HasCharges(actionId) || GetCooldownRemainingTime(actionId) <= GCDTotal);
+        LevelChecked(actionId) && (HasCharges(actionId) || GetCooldownRemainingTime(actionId) <= GCD);
 
     #endregion
 
@@ -402,7 +404,7 @@ internal partial class VPR
         !JustUsed(Ouroboros) &&
         (onAoE
             ? !UsedVicepit && !UsedHuntersDen && !UsedSwiftskinsDen && IsAoEComboWeaveBlocked &&
-              !JustUsed(JaggedMaw, GCDTotal) && !JustUsed(BloodiedMaw, GCDTotal) && !JustUsed(SerpentsIre, GCDTotal)
+              !JustUsed(JaggedMaw, GCD) && !JustUsed(BloodiedMaw, GCD) && !JustUsed(SerpentsIre, GCD)
             : !UsedVicewinder && !UsedHuntersCoil && !UsedSwiftskinsCoil && IsSTComboWeaveBlocked &&
               !IsComboExpiring(2) && !IsVenomExpiring(2) && !IsHoningExpiring(2) && !IsEmpowermentExpiring(3));
 
@@ -412,7 +414,7 @@ internal partial class VPR
         InActionRange(UncoiledFury) &&
         !HasStatusEffect(Buffs.Reawakened) &&
         (onAoE ? IsAoEComboWeaveBlocked : IsSTComboWeaveBlocked) &&
-        (LevelChecked(SerpentsIre) && IreCD <= GCDTotal * (onAoE ? 2 : 3) ||
+        (LevelChecked(SerpentsIre) && IreCD <= GCD * (onAoE ? 2 : 3) ||
          HasCharges(onAoE ? Vicepit : Vicewinder));
 
     private static bool CanUseUncoiledFury(
@@ -461,7 +463,7 @@ internal partial class VPR
         WithinGCD(Vicepit) && !HasStatusEffect(Buffs.Reawakened) && !JustUsed(Vicepit) &&
         !ShouldHoldNewTwinblade &&
         (ignoreRange || InActionRange(Vicepit)) &&
-        (!HasBothBuffs || IreCD >= GCDTotal * 4 || !LevelChecked(SerpentsIre));
+        (!HasBothBuffs || IreCD >= GCD * 4 || !LevelChecked(SerpentsIre));
 
     private static uint UseVicewinder(
         bool useSimpleTrueNorth = true,
@@ -499,11 +501,11 @@ internal partial class VPR
         !ShouldHoldNewTwinblade &&
         !IsComboExpiring(6) && !IsVenomExpiring(4) && !IsHoningExpiring(4) &&
         !UsedVicewinder && !UsedHuntersCoil && !UsedSwiftskinsCoil &&
-        !JustUsed(SerpentsIre, GCDTotal * 4) && !JustUsed(Vicewinder) &&
+        !JustUsed(SerpentsIre, GCD * 4) && !JustUsed(Vicewinder) &&
         !JustUsed(Ouroboros) && !HasStatusEffect(Buffs.Reawakened) &&
         (!HasBothBuffs ||
          IsEmpowermentExpiring(4) ||
-         IreCD >= GCDTotal * 3 && InBossEncounter() || !InBossEncounter() || !LevelChecked(SerpentsIre));
+         IreCD >= GCD * 3 && InBossEncounter() || !InBossEncounter() || !LevelChecked(SerpentsIre));
 
     private static bool CanVicewinderCombo(ref uint actionId, bool vicewinderBuffPrio = false)
     {
@@ -514,7 +516,7 @@ internal partial class VPR
             if (UsedVicewinder &&
                 (!HasStatusEffect(Buffs.Swiftscaled) ||
                  HasBothBuffs && (!OnTargetsFlank() || !TargetNeedsPositionals()) ||
-                 vicewinderBuffPrio && GetStatusEffectRemainingTime(Buffs.Swiftscaled) < GCDTotal * 6) ||
+                 vicewinderBuffPrio && GetStatusEffectRemainingTime(Buffs.Swiftscaled) < GCD * 6) ||
                 UsedHuntersCoil)
             {
                 actionId = SwiftskinsCoil;
@@ -524,7 +526,7 @@ internal partial class VPR
             if (UsedVicewinder &&
                 (!HasStatusEffect(Buffs.HuntersInstinct) ||
                  HasBothBuffs && (!OnTargetsRear() || !TargetNeedsPositionals()) ||
-                 vicewinderBuffPrio && GetStatusEffectRemainingTime(Buffs.HuntersInstinct) < GCDTotal * 6) ||
+                 vicewinderBuffPrio && GetStatusEffectRemainingTime(Buffs.HuntersInstinct) < GCD * 6) ||
                 UsedSwiftskinsCoil)
             {
                 actionId = HuntersCoil;

--- a/WrathCombo/Resources/Localization/JobConfigs/DRG_Config.Designer.cs
+++ b/WrathCombo/Resources/Localization/JobConfigs/DRG_Config.Designer.cs
@@ -95,5 +95,23 @@ namespace WrathCombo.Resources.Localization.JobConfigs {
                 return ResourceManager.GetString("BurstMirageDuringLoTD", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Early Buff Opener.
+        /// </summary>
+        internal static string EarlyBuffOpener {
+            get {
+                return ResourceManager.GetString("EarlyBuffOpener", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use early buff opener..
+        /// </summary>
+        internal static string UseEarlyBuffOpener {
+            get {
+                return ResourceManager.GetString("UseEarlyBuffOpener", resourceCulture);
+            }
+        }
     }
 }

--- a/WrathCombo/Resources/Localization/JobConfigs/DRG_Config.resx
+++ b/WrathCombo/Resources/Localization/JobConfigs/DRG_Config.resx
@@ -1,110 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema 
-    
-    Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-    
-    Example:
-    
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-    
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-    
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-    <xsd:element name="root" msdata:IsDataSet="true">
-      <xsd:complexType>
-        <xsd:choice maxOccurs="unbounded">
-          <xsd:element name="metadata">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" />
-              </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string" />
-              <xsd:attribute name="type" type="xsd:string" />
-              <xsd:attribute name="mimetype" type="xsd:string" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="assembly">
-            <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string" />
-              <xsd:attribute name="name" type="xsd:string" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="data">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="resheader">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" />
-            </xsd:complexType>
-          </xsd:element>
-        </xsd:choice>
-      </xsd:complexType>
-    </xsd:element>
-  </xsd:schema>
+  <schema />
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:element name="root" msdata:IsDataSet="true"></xsd:element>
   </xsd:schema>
@@ -132,5 +28,11 @@ Works best on 2.50 GCD.</value>
   </data>
   <data name="BurstMirageDuringLoTD" xml:space="preserve">
     <value>Burst {0} During {1}</value>
+  </data>
+  <data name="EarlyBuffOpener" xml:space="preserve">
+    <value>Early Buff Opener</value>
+  </data>
+  <data name="UseEarlyBuffOpener" xml:space="preserve">
+    <value>Use early buff opener.</value>
   </data>
 </root>


### PR DESCRIPTION
#### BLM ####
- Fix `polyglot` usage.
- Add `Leylines` skip in openers.
#### DRG ####
- Add `Early buffs opener`
 #### MCH ####
- Tighten on when `Reassemble` can be weaved.
#### MNK ####
- Add `Winds Reply` protection so its used when about to expire.
- Fix Chakra spender weaving before buffs.
- Fix `Masterfull Blitz` going off with only `Brotherhood`.
- Fix `Perfect Balance` even windows below lvl 92.
#### RPR ####
- Add overcap protection so it doesn't keep 2 charges of `SoulSlice`.
- Fix pre burst `Shadow of Death` usage.
#### SAM ####
- Fix AoE combo.
#### VPR ####
- Remove buffcheck of `Serpents Ire`.
- Adjust `Uncoiled Fury` overcap protection to be better.
#### General ####
- Cleanup of unused variables.