### PR TITLE
Abacus Refiner

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -801,6 +801,9 @@ internal unsafe class AutoRotationController
             if (LocalPlayer is not { } player)
                 return false;
 
+            if (ActionManager.Instance()->QueuedActionId != 0)
+                return true;
+
             var target = !cfg.DPSSettings.AoEIgnoreManual && cfg.DPSRotationMode == DPSRotationMode.Manual ?
     Svc.Targets.Target : DPSTargeting.BaseSelection.MaxBy(x => NumberOfEnemiesInRange(OriginalHook(gameAct), x, true));
 
@@ -925,6 +928,9 @@ internal unsafe class AutoRotationController
         {
             if (LocalPlayer is not { } player)
                 return false;
+
+            if (ActionManager.Instance()->QueuedActionId != 0)
+                return true;
 
             var target = GetSingleTarget(mode);
 

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -807,7 +807,7 @@ internal unsafe class AutoRotationController
             var target = !cfg.DPSSettings.AoEIgnoreManual && cfg.DPSRotationMode == DPSRotationMode.Manual ?
     Svc.Targets.Target : DPSTargeting.BaseSelection.MaxBy(x => NumberOfEnemiesInRange(OriginalHook(gameAct), x, true));
 
-            if (target is null && cfg.PauseWhenNoTarget) return true;
+            if ((target is not { } t || (!t.IsHostile() && !t.IsFriendly())) && cfg.PauseWhenNoTarget) return true;
 
             if (attributes.AutoAction!.IsHeal)
             {
@@ -934,7 +934,7 @@ internal unsafe class AutoRotationController
 
             var target = GetSingleTarget(mode);
 
-            if (target is null && cfg.PauseWhenNoTarget) return true;
+            if ((target is not { } t || (!t.IsHostile() && !t.IsFriendly())) && cfg.PauseWhenNoTarget) return true;
 
             OverrideTarget = target ?? OverrideTarget;
             var outAct = OriginalHook(InvokeCombo(preset, attributes, ref gameAct, target));

--- a/WrathCombo/Combos/PvE/SGE/SGE.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE.cs
@@ -148,7 +148,7 @@ internal partial class SGE : Healer
 
             //Eukrasia for DoT
             if (hasDotTarget &&
-                IsOffCooldown(Eukrasia) &&
+                ActionReady(Eukrasia) &&
                 !JustUsed(EukrasianDyskrasia) && //AoE DoT can be slow to take affect, doesn't apply to target first before others
                 TraitLevelChecked(Traits.OffensiveMagicMasteryII))
                 return Eukrasia;

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -277,7 +277,8 @@ public static class ActionWatching
                             Svc.Framework.RunOnTick(() => member.HPUpdatePending = false, TimeSpan.FromSeconds(1.5));
                         }
 
-                        PendingHPChanges.Add(new PendingHPChange(effObjectId, eff.DamageHealValue, effType == ActionEffectType.Heal, header->GlobalSequence));
+                        if (Service.Configuration.OpCodes is { } codes && codes.GameVersion == Framework.Instance()->GameVersionString)
+                            PendingHPChanges.Add(new PendingHPChange(effObjectId, eff.DamageHealValue, effType == ActionEffectType.Heal, header->GlobalSequence));
                     }
 
                     // Event: MP Gain or MP Loss

--- a/WrathCombo/Data/SimpleTargetState.cs
+++ b/WrathCombo/Data/SimpleTargetState.cs
@@ -54,8 +54,12 @@ namespace WrathCombo.Data
             {
                 if (o.GameObjectID.GetObject() is IBattleChara t)
                 {
-                    var totalDiff = ActionWatching.PendingHPChanges.Where(x => x.gameObjectId == o.GameObjectID).Sum(x => x.positiveChange ? x.value : -x.value);
-                    o.CurrentHP = Math.Clamp((uint)(t.CurrentHp + totalDiff), 0, t.MaxHp);
+                    int hpDelta = ActionWatching.PendingHPChanges
+                                .Where(x => x.gameObjectId == o.GameObjectID)
+                                .Sum(x => x.positiveChange ? x.value : -x.value);
+
+                    long currentHp = t.CurrentHp;
+                    o.CurrentHP = (uint)Math.Clamp(currentHp + hpDelta, 0L, (long)t.MaxHp);
                 }
             }
         }

--- a/WrathCombo/Native/CustomActionManager.cs
+++ b/WrathCombo/Native/CustomActionManager.cs
@@ -247,6 +247,9 @@ public sealed unsafe class CustomActionManager : IDisposable
                 IconInjectEntry e = _pendingInjects[i];
                 AtkComponentIcon* icon = (AtkComponentIcon*)e.ComponentPtr;
 
+                if (icon == null)
+                    continue;
+
                 int framesLeft = e.FramesLeft - 1;
                 if (((uint)icon->Flags & 0x400u) != 0 && framesLeft > 0)
                 {

--- a/WrathCombo/Native/CustomActionManager.cs
+++ b/WrathCombo/Native/CustomActionManager.cs
@@ -240,50 +240,57 @@ public sealed unsafe class CustomActionManager : IDisposable
 
     private void OnFrameworkUpdate(IFramework fw)
     {
-        for (int i = _pendingInjects.Count - 1; i >= 0; i--)
+        try
         {
-            IconInjectEntry e = _pendingInjects[i];
-            AtkComponentIcon* icon = (AtkComponentIcon*)e.ComponentPtr;
-
-            int framesLeft = e.FramesLeft - 1;
-            if (((uint)icon->Flags & 0x400u) != 0 && framesLeft > 0)
+            for (int i = _pendingInjects.Count - 1; i >= 0; i--)
             {
-                _pendingInjects[i] = e with { FramesLeft = framesLeft };
-                continue;
-            }
+                IconInjectEntry e = _pendingInjects[i];
+                AtkComponentIcon* icon = (AtkComponentIcon*)e.ComponentPtr;
 
-            IDalamudTextureWrap? wrap = e.Tex.GetWrapOrDefault();
-            if (wrap == null)
-            {
-                _pendingInjects[i] = e with { FramesLeft = framesLeft };
-                continue;
-            }
+                int framesLeft = e.FramesLeft - 1;
+                if (((uint)icon->Flags & 0x400u) != 0 && framesLeft > 0)
+                {
+                    _pendingInjects[i] = e with { FramesLeft = framesLeft };
+                    continue;
+                }
 
-            AtkImageNode* imgNode = icon->IconImage;
-            if (imgNode == null)
-            {
+                IDalamudTextureWrap? wrap = e.Tex.GetWrapOrDefault();
+                if (wrap == null)
+                {
+                    _pendingInjects[i] = e with { FramesLeft = framesLeft };
+                    continue;
+                }
+
+                AtkImageNode* imgNode = icon->IconImage;
+                if (imgNode == null)
+                {
+                    _pendingInjects.RemoveAt(i);
+                    continue;
+                }
+
+                AtkUldPartsList* partsList = imgNode->PartsList;
+                if (partsList == null || partsList->PartCount == 0)
+                {
+                    _pendingInjects.RemoveAt(i);
+                    continue;
+                }
+
+                AtkUldPart* part = partsList->Parts;
+                if (part == null)
+                {
+                    _pendingInjects.RemoveAt(i);
+                    continue;
+                }
+
+                (*part).LoadTexture(wrap);
+
+                _loadIconHook.Original(icon, icon->IconId);
                 _pendingInjects.RemoveAt(i);
-                continue;
             }
-
-            AtkUldPartsList* partsList = imgNode->PartsList;
-            if (partsList == null || partsList->PartCount == 0)
-            {
-                _pendingInjects.RemoveAt(i);
-                continue;
-            }
-
-            AtkUldPart* part = partsList->Parts;
-            if (part == null)
-            {
-                _pendingInjects.RemoveAt(i);
-                continue;
-            }
-
-            (*part).LoadTexture(wrap);
-
-            _loadIconHook.Original(icon, icon->IconId);
-            _pendingInjects.RemoveAt(i);
+        }
+        catch(Exception ex)
+        {
+            ex.Log("Error with icon injection");
         }
     }
 

--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -29,7 +29,6 @@ using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
 using WrathCombo.Data.Conflicts;
-using WrathCombo.Extensions;
 using WrathCombo.Native;
 using WrathCombo.Resources.Localization.UI.MainWindow;
 using WrathCombo.Services;
@@ -37,7 +36,6 @@ using WrathCombo.Services.ActionRequestIPC;
 using WrathCombo.Services.IPC;
 using WrathCombo.Services.IPC_Subscriber;
 using WrathCombo.Window;
-using WrathCombo.Window.Functions;
 using WrathCombo.Window.Tabs;
 using GenericHelpers = ECommons.GenericHelpers;
 
@@ -148,12 +146,12 @@ public sealed partial class WrathCombo : IDalamudPlugin
             if (!Player.Available)
                 return false;
 
-            WrathOpener.SelectOpener();
             P.ActionRetargeting.ClearCachedRetargets();
             if (onJobChange)
                 PvEFeatures.OpenToCurrentJob(true);
             if (onJobChange || firstRun)
             {
+                WrathOpener.SelectOpener();
                 Service.ActionReplacer.UpdateFilteredCombos();
                 Svc.Framework.RunOnTick(Provider.BuildCachesAction());
                 P.IPCSearch.UpdateActiveJobPresets();


### PR DESCRIPTION
- Fixes underflow issue
- Doesn't use pending HP if opcodes aren't updated to pop them