### PR TITLE
[PLD] Added early buff opener

### DIFF
--- a/WrathCombo/Combos/PvE/PLD/PLD_Config.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD_Config.cs
@@ -92,11 +92,15 @@ internal partial class PLD
                 #region ST
 
                 case Preset.PLD_ST_AdvancedMode_BalanceOpener:
+                    DrawRadioButton(PLD_SelectedOpener, Generics.StandardOpener, "", 0);
+                    DrawRadioButton(PLD_SelectedOpener, "Early Buff Window Opener",
+                        "Moves the buff window forward about 1 GCD.", 1, descriptionAsTooltip: true);
+                    ImGui.NewLine();
                     DrawBossOnlyChoice(PLD_Balance_Content);
                     ImGui.NewLine();
-                    DrawHorizontalRadioButton(PLD_ST_AdvancedMode_BalanceOpener_Intervene, FormatAndCache(Generics.Use0, Intervene.ActionName()), 
+                    DrawHorizontalRadioButton(PLD_ST_AdvancedMode_BalanceOpener_Intervene, FormatAndCache(Generics.Use0, Intervene.ActionName()),
                         FormatAndCache(Generics.GapcloserUse, Intervene.ActionName()), 0);
-                    DrawHorizontalRadioButton(PLD_ST_AdvancedMode_BalanceOpener_Intervene, FormatAndCache(Generics.DontUse0, Intervene.ActionName()), 
+                    DrawHorizontalRadioButton(PLD_ST_AdvancedMode_BalanceOpener_Intervene, FormatAndCache(Generics.DontUse0, Intervene.ActionName()),
                         FormatAndCache(Generics.GapcloseSkip, Intervene.ActionName()), 1);
                     break;
 
@@ -326,6 +330,7 @@ internal partial class PLD
 
             //ST
             PLD_Balance_Content = new("PLD_Balance_Content", 1),
+            PLD_SelectedOpener = new("PLD_SelectedOpener"),
             PLD_ST_AdvancedMode_BalanceOpener_Intervene = new("PLD_ST_AdvancedMode_BalanceOpener_Intervene"),
             PLD_ST_Intervene_Charges = new("PLD_ST_Intervene_Charges"),
             PLD_ST_Intervene_Movement = new("PLD_ST_Intervene_Movement"),

--- a/WrathCombo/Combos/PvE/PLD/PLD_Helper.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD_Helper.cs
@@ -765,13 +765,14 @@ internal partial class PLD
     #region Openers
 
     internal static PLDLvl100StandardOpener Lvl100StandardOpener = new();
+    internal static PLDLvl100EarlyBuffOpener Lvl100EarlyBuffOpener = new();
 
     internal static WrathOpener Opener()
     {
-        if (Lvl100StandardOpener.LevelChecked)
-            return Lvl100StandardOpener;
+        if (PLD_SelectedOpener == 1 && Lvl100EarlyBuffOpener.LevelChecked)
+            return Lvl100EarlyBuffOpener;
 
-        return WrathOpener.Dummy;
+        return Lvl100StandardOpener.LevelChecked ? Lvl100StandardOpener : WrathOpener.Dummy;
     }
 
     internal class PLDLvl100StandardOpener : WrathOpener
@@ -806,6 +807,53 @@ internal partial class PLD
         public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
         [
             ([11, 13], () => !HasCharges(Intervene) || PLD_ST_AdvancedMode_BalanceOpener_Intervene != 0)
+        ];
+
+        public override Preset Preset => Preset.PLD_ST_AdvancedMode_BalanceOpener;
+        internal override UserData ContentCheckConfig => PLD_Balance_Content;
+
+        public override bool HasCooldowns() =>
+            IsOffCooldown(FightOrFlight) &&
+            IsOffCooldown(Imperator) &&
+            IsOffCooldown(CircleOfScorn) &&
+            IsOffCooldown(Expiacion) &&
+            IsOffCooldown(GoringBlade);
+    }
+
+    internal class PLDLvl100EarlyBuffOpener : WrathOpener
+    {
+        public override int MinOpenerLevel => 100;
+        public override int MaxOpenerLevel => 109;
+
+        public override List<uint> OpenerActions { get; set; } =
+        [
+            HolySpirit,
+            FastBlade,
+            FightOrFlight,
+            Imperator,
+            RiotBlade,
+            CircleOfScorn,
+            Expiacion,
+            RoyalAuthority,
+            Intervene,
+            Intervene,
+            GoringBlade,
+            Confiteor,
+            BladeOfFaith,
+            BladeOfTruth,
+            BladeOfValor,
+            BladeOfHonor,
+            HolySpirit
+        ];
+
+        public override List<(int[] Steps, uint NewAction, Func<bool> Condition)> SubstitutionSteps { get; set; } =
+        [
+            ([1], FastBlade, () => !HasTarget())
+        ];
+
+        public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
+        [
+            ([9, 10], () => !HasCharges(Intervene) || PLD_ST_AdvancedMode_BalanceOpener_Intervene != 0)
         ];
 
         public override Preset Preset => Preset.PLD_ST_AdvancedMode_BalanceOpener;

--- a/WrathCombo/Combos/PvE/PLD/PLD_Helper.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD_Helper.cs
@@ -857,7 +857,8 @@ internal partial class PLD
         public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
         [
             ([2], () => ComboAction == FastBlade),
-            ([9, 10], () => !HasCharges(Intervene) || PLD_ST_AdvancedMode_BalanceOpener_Intervene != 0)
+            ([9, 10], () => !HasCharges(Intervene) || PLD_ST_AdvancedMode_BalanceOpener_Intervene != 0),
+            ([18, 19, 20], () => !InMeleeRange())
         ];
 
         public override Preset Preset => Preset.PLD_ST_AdvancedMode_BalanceOpener;

--- a/WrathCombo/Combos/PvE/PLD/PLD_Helper.cs
+++ b/WrathCombo/Combos/PvE/PLD/PLD_Helper.cs
@@ -836,23 +836,27 @@ internal partial class PLD
             Expiacion,
             RoyalAuthority,
             Intervene,
-            Intervene,
             GoringBlade,
+            Intervene,
             Confiteor,
             BladeOfFaith,
             BladeOfTruth,
             BladeOfValor,
             BladeOfHonor,
-            HolySpirit
+            HolySpirit,
+            Atonement,
+            Supplication,
+            Sepulchre
         ];
 
         public override List<(int[] Steps, uint NewAction, Func<bool> Condition)> SubstitutionSteps { get; set; } =
         [
-            ([1], FastBlade, () => !HasTarget())
+            ([1], FastBlade, () => !HasTarget() || InCombat())
         ];
 
         public override List<(int[] Steps, Func<bool> Condition)> SkipSteps { get; set; } =
         [
+            ([2], () => ComboAction == FastBlade),
             ([9, 10], () => !HasCharges(Intervene) || PLD_ST_AdvancedMode_BalanceOpener_Intervene != 0)
         ];
 


### PR DESCRIPTION
Adds an optional Early Buff Window opener for PLD Advanced ST, selectable next to
the Standard one (default stays Standard). It pushes Fight or Flight / Imperator
about a GCD earlier.

Hooked into the existing opener options, so the content (All/Boss Only) and
Intervene toggles work with it too. First GCD is Holy Spirit on a target, else
Fast Blade. If you're out of melee range the Atonement combo at the end is
skipped and the opener just finishes, so ranged uptime takes over.