### PR TITLE
[NIN]

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -837,7 +837,7 @@ internal unsafe class AutoRotationController
             }
             else
             {
-                if (!NIN.InMudra)
+                if (!LockedAoE)
                 {
                     var st = GetSingleTarget(mode);
                     var maxHit = NumberOfEnemiesInRange(DontChangeForAoe(gameAct) ? gameAct : OriginalHook(gameAct), target, true);
@@ -847,15 +847,8 @@ internal unsafe class AutoRotationController
                         target = st;
 
                     if (cfg.DPSSettings.DPSAoETargets == null || maxHit < cfg.DPSSettings.DPSAoETargets)
-                    {
-                        LockedAoE = false;
                         return false;
-                    }
-                    else
-                    {
-                        LockedAoE = true;
-                        LockedST = false;
-                    }
+
                 }
 
                 OverrideTarget = target ?? OverrideTarget;

--- a/WrathCombo/Combos/PvE/NIN/NIN.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN.cs
@@ -1,5 +1,6 @@
 using Dalamud.Game.ClientState.JobGauge.Types;
 using ECommons;
+using ECommons.DalamudServices;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using System.Linq;
 using WrathCombo.CustomComboNS;
@@ -21,15 +22,12 @@ internal partial class NIN : Melee
         {
             if (!CustomActionHelper.OneButtonRotationChecker(actionID, CustomActionType.SingleTargetDPS, SpinningEdge)) return actionID;
 
-            //if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat() ||
-            //    ActionWatching.LastAction == OriginalHook(Ninjutsu) ||
-            //    ActionWatching.LastAction == Raiton || //added because oddly, raiton and katon were not resetting the mudra state with original hook. 
-            //    ActionWatching.LastAction == Katon)
-            //    MudraState.CurrentMudra = MudraCasting.MudraState.None;
+            if (MudraFromFlags is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
+                return MudraFromFlags;
 
-            if (OriginalHook(Ninjutsu) is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
-                return OriginalHook(Ninjutsu);
-            
+            if (BlockDueToLag)
+                return All.SavageBlade;
+
             if (InMudra && MudraState.ContinueCurrentMudra(ref actionID))
                 return actionID;
             
@@ -142,15 +140,12 @@ internal partial class NIN : Melee
         {
             if (!CustomActionHelper.OneButtonRotationChecker(actionID, CustomActionType.AoEDPS, DeathBlossom)) return actionID;
 
-            //if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat() ||
-            //    ActionWatching.LastAction == OriginalHook(Ninjutsu) ||
-            //    ActionWatching.LastAction == Raiton || //added because oddly, raiton and katon were not resetting the mudra state with original hook. 
-            //    ActionWatching.LastAction == Katon)
-            //    MudraState.CurrentMudra = MudraCasting.MudraState.None;
+            if (MudraFromFlags is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
+                return MudraFromFlags;
 
-            if (OriginalHook(Ninjutsu) is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
-                return OriginalHook(Ninjutsu);
-            
+            if (BlockDueToLag)
+                return All.SavageBlade;
+
             if (InMudra && MudraState.ContinueCurrentMudra(ref actionID))
                 return actionID;
 
@@ -258,23 +253,18 @@ internal partial class NIN : Melee
         {
             if (!CustomActionHelper.OneButtonRotationChecker(actionID, CustomActionType.SingleTargetDPS, SpinningEdge)) return actionID;
 
-            //Troubleshooting tool Do Not Remove Please
-            //PluginLog.Debug($"Current MudraState: {MudraState.CurrentMudra}");
-
-            //if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat() ||
-            //    ActionWatching.LastAction == OriginalHook(Ninjutsu) ||
-            //    ActionWatching.LastAction == Raiton || //added because oddly, raiton and katon were not resetting the mudra state with original hook. 
-            //    ActionWatching.LastAction == Katon)
-            //    MudraState.CurrentMudra = MudraCasting.MudraState.None;
 
             if (IsEnabled(Preset.NIN_ST_AdvancedMode_BalanceOpener) &&
                 Opener().FullOpener(ref actionID))
                 return actionID;
 
             if (IsEnabled(Preset.NIN_ST_AdvancedMode_Ninjitsus) &&
-                OriginalHook(Ninjutsu) is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
-                return OriginalHook(Ninjutsu);
-            
+                MudraFromFlags is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
+                return MudraFromFlags;
+
+            if (BlockDueToLag)
+                return All.SavageBlade;
+
             if (IsEnabled(Preset.NIN_ST_AdvancedMode_Ninjitsus) && InMudra && MudraState.ContinueCurrentMudra(ref actionID))
                 return actionID;
             
@@ -415,16 +405,14 @@ internal partial class NIN : Melee
         {
             if (!CustomActionHelper.OneButtonRotationChecker(actionID, CustomActionType.AoEDPS, DeathBlossom)) return actionID;
 
-            //if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat() ||
-            //    ActionWatching.LastAction == OriginalHook(Ninjutsu) ||
-            //    ActionWatching.LastAction == Raiton || //added because oddly, raiton and katon were not resetting the mudra state with original hook. 
-            //    ActionWatching.LastAction == Katon)
-            //    MudraState.CurrentMudra = MudraCasting.MudraState.None;
 
             if (IsEnabled(Preset.NIN_AoE_AdvancedMode_Ninjitsus) &&
-                OriginalHook(Ninjutsu) is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
-                return OriginalHook(Ninjutsu);
-            
+                MudraFromFlags is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
+                return MudraFromFlags;
+
+            if (BlockDueToLag)
+                return All.SavageBlade;
+
             if (IsEnabled(Preset.NIN_AoE_AdvancedMode_Ninjitsus) && InMudra && MudraState.ContinueCurrentMudra(ref actionID))
                 return actionID;
            
@@ -705,17 +693,17 @@ internal partial class NIN : Melee
             {
                 if (Ten.LevelChecked() && actionID == Ten)
                 {
-                    if (Jin.LevelChecked() && OriginalHook(Ninjutsu) is Raiton)
+                    if (Jin.LevelChecked() && MudraFromFlags is Raiton)
                     {
                         return OriginalHook(JinCombo);
                     }
 
-                    if (Chi.LevelChecked() && OriginalHook(Ninjutsu) is HyoshoRanryu)
+                    if (Chi.LevelChecked() && MudraFromFlags is HyoshoRanryu)
                     {
                         return OriginalHook(ChiCombo);
                     }
 
-                    if (OriginalHook(Ninjutsu) == FumaShuriken)
+                    if (MudraFromFlags == FumaShuriken)
                     {
                         if (HasStatusEffect(Buffs.Kassatsu) && Traits.EnhancedKasatsu.TraitLevelChecked())
                             return JinCombo;
@@ -730,12 +718,12 @@ internal partial class NIN : Melee
 
                 if (Chi.LevelChecked() && actionID == Chi)
                 {
-                    if (OriginalHook(Ninjutsu) is Hyoton)
+                    if (MudraFromFlags is Hyoton)
                     {
                         return OriginalHook(TenCombo);
                     }
 
-                    if (Jin.LevelChecked() && OriginalHook(Ninjutsu) == FumaShuriken)
+                    if (Jin.LevelChecked() && MudraFromFlags == FumaShuriken)
                     {
                         return OriginalHook(JinCombo);
                     }
@@ -743,30 +731,30 @@ internal partial class NIN : Melee
 
                 if (Jin.LevelChecked() && actionID == Jin)
                 {
-                    if (OriginalHook(Ninjutsu) is GokaMekkyaku or Katon)
+                    if (MudraFromFlags is GokaMekkyaku or Katon)
                     {
                         return OriginalHook(ChiCombo);
                     }
 
-                    if (OriginalHook(Ninjutsu) == FumaShuriken)
+                    if (MudraFromFlags == FumaShuriken)
                     {
                         return OriginalHook(TenCombo);
                     }
                 }
 
-                return OriginalHook(Ninjutsu);
+                return MudraFromFlags;
             }
 
             if (mudrapath == 2)
             {
                 if (Ten.LevelChecked() && actionID == Ten)
                 {
-                    if (Chi.LevelChecked() && OriginalHook(Ninjutsu) is Hyoton or HyoshoRanryu)
+                    if (Chi.LevelChecked() && MudraFromFlags is Hyoton or HyoshoRanryu)
                     {
                         return OriginalHook(Chi);
                     }
 
-                    if (OriginalHook(Ninjutsu) == FumaShuriken)
+                    if (MudraFromFlags == FumaShuriken)
                     {
                         if (Jin.LevelChecked())
                             return OriginalHook(JinCombo);
@@ -778,12 +766,12 @@ internal partial class NIN : Melee
 
                 if (Chi.LevelChecked() && actionID == Chi)
                 {
-                    if (Jin.LevelChecked() && OriginalHook(Ninjutsu) is Katon or GokaMekkyaku)
+                    if (Jin.LevelChecked() && MudraFromFlags is Katon or GokaMekkyaku)
                     {
                         return OriginalHook(Jin);
                     }
 
-                    if (OriginalHook(Ninjutsu) == FumaShuriken)
+                    if (MudraFromFlags == FumaShuriken)
                     {
                         return OriginalHook(Ten);
                     }
@@ -791,17 +779,17 @@ internal partial class NIN : Melee
 
                 if (Jin.LevelChecked() && actionID == Jin)
                 {
-                    if (OriginalHook(Ninjutsu) is Raiton)
+                    if (MudraFromFlags is Raiton)
                     {
                         return OriginalHook(Ten);
                     }
 
-                    if (OriginalHook(Ninjutsu) == GokaMekkyaku)
+                    if (MudraFromFlags == GokaMekkyaku)
                     {
                         return OriginalHook(Chi);
                     }
 
-                    if (OriginalHook(Ninjutsu) == FumaShuriken)
+                    if (MudraFromFlags == FumaShuriken)
                     {
                         if (HasStatusEffect(Buffs.Kassatsu) && Traits.EnhancedKasatsu.TraitLevelChecked())
                             return OriginalHook(Ten);
@@ -809,7 +797,7 @@ internal partial class NIN : Melee
                     }
                 }
 
-                return OriginalHook(Ninjutsu);
+                return MudraFromFlags;
             }
 
             return actionID;
@@ -825,7 +813,7 @@ internal partial class NIN : Melee
             if (!MudraSigns.Any(x => x == actionID))
                 return actionID;
 
-            if (OriginalHook(Ninjutsu) == Rabbit)
+            if (MudraFromFlags == Rabbit)
                 return Rabbit;
 
             switch (actionID)

--- a/WrathCombo/Combos/PvE/NIN/NIN.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN.cs
@@ -1,10 +1,8 @@
-using Dalamud.Game.ClientState.JobGauge.Types;
-using ECommons;
 using ECommons.DalamudServices;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using System.Linq;
+using System.Reflection.Metadata.Ecma335;
 using WrathCombo.CustomComboNS;
-using WrathCombo.Data;
 using WrathCombo.Extensions;
 using WrathCombo.Native;
 using static WrathCombo.Combos.PvE.NIN.Config;
@@ -31,7 +29,7 @@ internal partial class NIN : Melee
 
             if (InMudra && MudraState.ContinueCurrentMudra(ref actionID))
                 return actionID;
-            
+
             if (STTenChiJin(ref actionID))
                 return actionID;
 
@@ -69,7 +67,7 @@ internal partial class NIN : Melee
 
                 if (CanTrickST && CombatEngageDuration().TotalSeconds > 5)
                     return OriginalHook(TrickAttack);
-                
+
                 if (Role.CanFeint() && GroupDamageIncoming() && CanWeave())
                     return Role.Feint;
             }
@@ -151,8 +149,7 @@ internal partial class NIN : Melee
             if (InMudra && MudraState.ContinueCurrentMudra(ref actionID))
                 return actionID;
 
-            if (DotonRemaining < 3 && AoETenChiJinDoton(ref actionID) ||
-                DotonRemaining >= 3 && AoETenChiJinSuiton(ref actionID))
+            if (AoETenChiJin(ref actionID, false))
                 return actionID;
 
             #region Special Content
@@ -269,7 +266,7 @@ internal partial class NIN : Melee
 
             if (IsEnabled(Preset.NIN_ST_AdvancedMode_Ninjitsus) && InMudra && MudraState.ContinueCurrentMudra(ref actionID))
                 return actionID;
-            
+
             if (NIN_ST_AdvancedMode_TenChiJin_Auto &&
                 STTenChiJin(ref actionID))
                 return actionID;
@@ -341,7 +338,7 @@ internal partial class NIN : Melee
             #region Selfcare
             if ((!MudraPhase || HasKassatsu && TrickCD > 5) && CanWeave())
             {
-                if (IsEnabled(Preset.NIN_ST_AdvancedMode_Feint) && 
+                if (IsEnabled(Preset.NIN_ST_AdvancedMode_Feint) &&
                     Role.CanFeint() &&
                     GroupDamageIncoming())
                     return Role.Feint;
@@ -417,10 +414,8 @@ internal partial class NIN : Melee
 
             if (IsEnabled(Preset.NIN_AoE_AdvancedMode_Ninjitsus) && InMudra && MudraState.ContinueCurrentMudra(ref actionID))
                 return actionID;
-           
-            if (NIN_AoE_AdvancedMode_TenChiJin_Auto && 
-                (NIN_AoE_AdvancedMode_TenChiJin_Doton && DotonRemaining < 3 && AoETenChiJinDoton(ref actionID) || 
-                 AoETenChiJinSuiton(ref actionID)))
+
+            if (NIN_AoE_AdvancedMode_TenChiJin_Auto && AoETenChiJin(ref actionID, true))
                 return actionID;
 
             #region Special Content
@@ -466,7 +461,7 @@ internal partial class NIN : Melee
                 if (IsEnabled(Preset.NIN_AoE_AdvancedMode_TrickAttack) && CanTrickAoE && CombatEngageDuration().TotalSeconds > 5 &&
                     GetTargetHPPercent() > AoETrickThreshold)
                     return OriginalHook(TrickAttack);
-                
+
                 if (IsEnabled(Preset.NIN_AoE_AdvancedMode_StunInterupt) && CanWeave() && !MudraPhase &&
                     RoleActions.Melee.CanLegSweep())
                     return Role.LegSweep;
@@ -547,22 +542,22 @@ internal partial class NIN : Melee
             switch (actionID)
             {
                 case ShadeShift when NIN_MudraProtection_Options[0] && MudraPhase:
-                        
+
                 case Shukuchi when NIN_MudraProtection_Options[1] && MudraPhase:
-                
+
                 case RoleActions.Melee.Feint when NIN_MudraProtection_Options[2] && (MudraPhase || HasStatusEffect(RoleActions.Melee.Debuffs.Feint, CurrentTarget, true)):
-                    
+
                 case RoleActions.Melee.Bloodbath when NIN_MudraProtection_Options[3] && MudraPhase:
-                        
+
                 case RoleActions.Physical.SecondWind when NIN_MudraProtection_Options[4] && MudraPhase:
-                
+
                 case RoleActions.Melee.LegSweep when NIN_MudraProtection_Options[5] && MudraPhase:
                     return All.SavageBlade;
             }
-            
+
             return actionID;
         }
-    }    
+    }
 
     internal class NIN_ST_AeolianEdgeCombo : CustomCombo
     {
@@ -614,20 +609,20 @@ internal partial class NIN : Melee
         {
             if (actionID is not Hide)
                 return actionID;
-            
-            
+
+
             if (NIN_HideMug_Toggle && HasStatusEffect(Buffs.Hidden) &&
                 (LevelChecked(Suiton) || !NIN_HideMug_ToggleLevelCheck)) //Check level to get ShadowWalker buff.
                 StatusManager.ExecuteStatusOff(Buffs.Hidden);
 
-            if (NIN_HideMug_Trick && 
+            if (NIN_HideMug_Trick &&
                 (!NIN_HideMug_Mug || !NIN_HideMug_TrickAfterMug || IsOnCooldown(OriginalHook(Mug)) || !InCombat()) && //Check mug if you want mug to have priority
                 (HasStatusEffect(Buffs.Hidden) || HasStatusEffect(Buffs.ShadowWalker))) //Check for ability to use trick
                 return OriginalHook(TrickAttack);
 
             if (InCombat() && NIN_HideMug_Mug)
                 return OriginalHook(Mug);
-            
+
             return InCombat() && NIN_HideMug_Trick ? OriginalHook(TrickAttack) : actionID;
         }
     }
@@ -805,7 +800,7 @@ internal partial class NIN : Melee
             return actionID;
         }
     }
-    
+
     internal class NIN_Simple_MudrasAlt : CustomCombo
     {
         protected internal override Preset Preset => Preset.NIN_Simple_Mudras_Alt;
@@ -845,6 +840,6 @@ internal partial class NIN : Melee
             }
         }
     }
-    
+
     #endregion
 }

--- a/WrathCombo/Combos/PvE/NIN/NIN.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN.cs
@@ -23,8 +23,8 @@ internal partial class NIN : Melee
             MudraState.AssociatedPreset = Preset;
             if (!CustomActionHelper.OneButtonRotationChecker(actionID, CustomActionType.SingleTargetDPS, SpinningEdge)) return actionID;
 
-            if (MudraFromFlags is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
-                return MudraFromFlags;
+            if (JutsuFromFlags is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
+                return JutsuFromFlags;
 
             if (BlockDueToLag)
                 return All.SavageBlade;
@@ -142,8 +142,8 @@ internal partial class NIN : Melee
             MudraState.AssociatedPreset = Preset;
             if (!CustomActionHelper.OneButtonRotationChecker(actionID, CustomActionType.AoEDPS, DeathBlossom)) return actionID;
 
-            if (MudraFromFlags is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
-                return MudraFromFlags;
+            if (JutsuFromFlags is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
+                return JutsuFromFlags;
 
             if (BlockDueToLag)
                 return All.SavageBlade;
@@ -261,8 +261,8 @@ internal partial class NIN : Melee
                 return actionID;
 
             if (IsEnabled(Preset.NIN_ST_AdvancedMode_Ninjitsus) &&
-                MudraFromFlags is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
-                return MudraFromFlags;
+                JutsuFromFlags is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
+                return JutsuFromFlags;
 
             if (BlockDueToLag)
                 return All.SavageBlade;
@@ -409,8 +409,8 @@ internal partial class NIN : Melee
             if (!CustomActionHelper.OneButtonRotationChecker(actionID, CustomActionType.AoEDPS, DeathBlossom)) return actionID;
 
             if (IsEnabled(Preset.NIN_AoE_AdvancedMode_Ninjitsus) &&
-                MudraFromFlags is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
-                return MudraFromFlags;
+                JutsuFromFlags is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
+                return JutsuFromFlags;
 
             if (BlockDueToLag)
                 return All.SavageBlade;
@@ -695,17 +695,17 @@ internal partial class NIN : Melee
             {
                 if (Ten.LevelChecked() && actionID == Ten)
                 {
-                    if (Jin.LevelChecked() && MudraFromFlags is Raiton)
+                    if (Jin.LevelChecked() && JutsuFromFlags is Raiton)
                     {
                         return OriginalHook(JinCombo);
                     }
 
-                    if (Chi.LevelChecked() && MudraFromFlags is HyoshoRanryu)
+                    if (Chi.LevelChecked() && JutsuFromFlags is HyoshoRanryu)
                     {
                         return OriginalHook(ChiCombo);
                     }
 
-                    if (MudraFromFlags == FumaShuriken)
+                    if (JutsuFromFlags == FumaShuriken)
                     {
                         if (HasStatusEffect(Buffs.Kassatsu) && Traits.EnhancedKasatsu.TraitLevelChecked())
                             return JinCombo;
@@ -720,12 +720,12 @@ internal partial class NIN : Melee
 
                 if (Chi.LevelChecked() && actionID == Chi)
                 {
-                    if (MudraFromFlags is Hyoton)
+                    if (JutsuFromFlags is Hyoton)
                     {
                         return OriginalHook(TenCombo);
                     }
 
-                    if (Jin.LevelChecked() && MudraFromFlags == FumaShuriken)
+                    if (Jin.LevelChecked() && JutsuFromFlags == FumaShuriken)
                     {
                         return OriginalHook(JinCombo);
                     }
@@ -733,30 +733,30 @@ internal partial class NIN : Melee
 
                 if (Jin.LevelChecked() && actionID == Jin)
                 {
-                    if (MudraFromFlags is GokaMekkyaku or Katon)
+                    if (JutsuFromFlags is GokaMekkyaku or Katon)
                     {
                         return OriginalHook(ChiCombo);
                     }
 
-                    if (MudraFromFlags == FumaShuriken)
+                    if (JutsuFromFlags == FumaShuriken)
                     {
                         return OriginalHook(TenCombo);
                     }
                 }
 
-                return MudraFromFlags;
+                return JutsuFromFlags;
             }
 
             if (mudrapath == 2)
             {
                 if (Ten.LevelChecked() && actionID == Ten)
                 {
-                    if (Chi.LevelChecked() && MudraFromFlags is Hyoton or HyoshoRanryu)
+                    if (Chi.LevelChecked() && JutsuFromFlags is Hyoton or HyoshoRanryu)
                     {
                         return OriginalHook(Chi);
                     }
 
-                    if (MudraFromFlags == FumaShuriken)
+                    if (JutsuFromFlags == FumaShuriken)
                     {
                         if (Jin.LevelChecked())
                             return OriginalHook(JinCombo);
@@ -768,12 +768,12 @@ internal partial class NIN : Melee
 
                 if (Chi.LevelChecked() && actionID == Chi)
                 {
-                    if (Jin.LevelChecked() && MudraFromFlags is Katon or GokaMekkyaku)
+                    if (Jin.LevelChecked() && JutsuFromFlags is Katon or GokaMekkyaku)
                     {
                         return OriginalHook(Jin);
                     }
 
-                    if (MudraFromFlags == FumaShuriken)
+                    if (JutsuFromFlags == FumaShuriken)
                     {
                         return OriginalHook(Ten);
                     }
@@ -781,17 +781,17 @@ internal partial class NIN : Melee
 
                 if (Jin.LevelChecked() && actionID == Jin)
                 {
-                    if (MudraFromFlags is Raiton)
+                    if (JutsuFromFlags is Raiton)
                     {
                         return OriginalHook(Ten);
                     }
 
-                    if (MudraFromFlags == GokaMekkyaku)
+                    if (JutsuFromFlags == GokaMekkyaku)
                     {
                         return OriginalHook(Chi);
                     }
 
-                    if (MudraFromFlags == FumaShuriken)
+                    if (JutsuFromFlags == FumaShuriken)
                     {
                         if (HasStatusEffect(Buffs.Kassatsu) && Traits.EnhancedKasatsu.TraitLevelChecked())
                             return OriginalHook(Ten);
@@ -799,7 +799,7 @@ internal partial class NIN : Melee
                     }
                 }
 
-                return MudraFromFlags;
+                return JutsuFromFlags;
             }
 
             return actionID;
@@ -815,7 +815,7 @@ internal partial class NIN : Melee
             if (!MudraSigns.Any(x => x == actionID))
                 return actionID;
 
-            if (MudraFromFlags == Rabbit)
+            if (JutsuFromFlags == Rabbit)
                 return Rabbit;
 
             switch (actionID)

--- a/WrathCombo/Combos/PvE/NIN/NIN.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN.cs
@@ -20,6 +20,7 @@ internal partial class NIN : Melee
         protected internal override Preset Preset => Preset.NIN_ST_SimpleMode;
         protected override uint Invoke(uint actionID)
         {
+            MudraState.AssociatedPreset = Preset;
             if (!CustomActionHelper.OneButtonRotationChecker(actionID, CustomActionType.SingleTargetDPS, SpinningEdge)) return actionID;
 
             if (MudraFromFlags is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
@@ -138,6 +139,7 @@ internal partial class NIN : Melee
         protected internal override Preset Preset => Preset.NIN_AoE_SimpleMode;
         protected override uint Invoke(uint actionID)
         {
+            MudraState.AssociatedPreset = Preset;
             if (!CustomActionHelper.OneButtonRotationChecker(actionID, CustomActionType.AoEDPS, DeathBlossom)) return actionID;
 
             if (MudraFromFlags is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)
@@ -251,8 +253,8 @@ internal partial class NIN : Melee
         protected internal override Preset Preset => Preset.NIN_ST_AdvancedMode;
         protected override uint Invoke(uint actionID)
         {
+            MudraState.AssociatedPreset = Preset;
             if (!CustomActionHelper.OneButtonRotationChecker(actionID, CustomActionType.SingleTargetDPS, SpinningEdge)) return actionID;
-
 
             if (IsEnabled(Preset.NIN_ST_AdvancedMode_BalanceOpener) &&
                 Opener().FullOpener(ref actionID))
@@ -403,8 +405,8 @@ internal partial class NIN : Melee
         protected internal override Preset Preset => Preset.NIN_AoE_AdvancedMode;
         protected override uint Invoke(uint actionID)
         {
+            MudraState.AssociatedPreset = Preset;
             if (!CustomActionHelper.OneButtonRotationChecker(actionID, CustomActionType.AoEDPS, DeathBlossom)) return actionID;
-
 
             if (IsEnabled(Preset.NIN_AoE_AdvancedMode_Ninjitsus) &&
                 MudraFromFlags is Rabbit or Huton or Suiton or Doton or GokaMekkyaku or HyoshoRanryu)

--- a/WrathCombo/Combos/PvE/NIN/NIN_Config.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN_Config.cs
@@ -199,7 +199,7 @@ internal partial class NIN
 
                     if (NIN_AoE_AdvancedMode_TenChiJin_Auto)
                     {
-                        DrawSliderFloat(1, 17, NIN_AoE_AdvancedMode_TCJ_Doton_Timer, "Doton Remaing Timer For Doton Path", decimals: 1);
+                        DrawSliderFloat(1, 17, NIN_AoE_AdvancedMode_TCJ_Doton_Timer, "Doton Remaining Timer For Doton Path", decimals: 1);
                     }
                     break;
 

--- a/WrathCombo/Combos/PvE/NIN/NIN_Config.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN_Config.cs
@@ -44,7 +44,6 @@ internal partial class NIN
             NIN_AoE_AdvancedMode_Ninjitsus_Katon_Pooling = new("NIN_AoE_AdvancedMode_Ninjitsus_Katon_Pooling"),
             NIN_AoE_AdvancedMode_Ninjitsus_Katon_Uptime = new("NIN_AoE_AdvancedMode_Ninjitsus_Katon_Uptime"),
             NIN_AoE_AdvancedMode_TenChiJin_Auto = new("NIN_AoE_AdvancedMode_TenChiJin_Auto"),
-            NIN_AoE_AdvancedMode_TenChiJin_Doton = new("NIN_AoE_AdvancedMode_TenChiJin_Doton"),
             NIN_AoE_AdvancedMode_HellfrogMedium_Pooling = new("Ninki_HellfrogPooling"),
             NIN_AoE_AdvancedMode_ShadeShiftRaidwide = new("NIN_AoE_AdvancedMode_ShadeShiftRaidwide"),
             NIN_HideMug_TrickAfterMug = new("NIN_HideMug_TrickAfterMug"),
@@ -57,7 +56,8 @@ internal partial class NIN
             NIN_MudraProtection_Options = new("NIN_MudraProtection_Options");
 
         internal static UserFloat
-            NIN_AoE_AdvancedMode_Ninjitsus_Doton_TimeStill = new("NIN_AoE_AdvancedMode_Ninjitsus_Doton_TimeStill", 3f);
+            NIN_AoE_AdvancedMode_Ninjitsus_Doton_TimeStill = new("NIN_AoE_AdvancedMode_Ninjitsus_Doton_TimeStill", 3f),
+            NIN_AoE_AdvancedMode_TCJ_Doton_Timer = new("NIN_AoE_AdvancedMode_TCJ_Doton_Timer", 3f);
         #endregion
 
         internal static void Draw(Preset preset)
@@ -193,10 +193,13 @@ internal partial class NIN
 
 
                 case Preset.NIN_AoE_AdvancedMode_TenChiJin:
-                    DrawAdditionalBoolChoice(NIN_AoE_AdvancedMode_TenChiJin_Auto, "Auto TCJ Option", "Will automatically Fuma Shuriken then Raiton then Suiton");
+                    DrawAdditionalBoolChoice(NIN_AoE_AdvancedMode_TenChiJin_Auto, "Auto TCJ Option", $"Will output TCJ actions in the following order\n" +
+                        $"{Doton.ActionName()} buff less than {NIN_AoE_AdvancedMode_TCJ_Doton_Timer.Value}s = [{FumaShuriken.ActionName()} -> {Katon.ActionName()} -> {Doton.ActionName()}]\n" +
+                        $"{Doton.ActionName()} buff more than {NIN_AoE_AdvancedMode_TCJ_Doton_Timer.Value}s = [{FumaShuriken.ActionName()} -> {Raiton.ActionName()} -> {Suiton.ActionName()}]");
+
                     if (NIN_AoE_AdvancedMode_TenChiJin_Auto)
                     {
-                        DrawAdditionalBoolChoice(NIN_AoE_AdvancedMode_TenChiJin_Doton, "Doton Option", "Adds Doton to Auto TCJ Option when no Doton is Down");
+                        DrawSliderFloat(1, 17, NIN_AoE_AdvancedMode_TCJ_Doton_Timer, "Doton Remaing Timer For Doton Path", decimals: 1);
                     }
                     break;
 

--- a/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
@@ -352,6 +352,9 @@ internal partial class NIN
 
         public MudraState CurrentMudra = MudraState.None;
 
+        public bool PresetEnabled => AssociatedPreset is { } pre && IsEnabled(pre);
+        internal Preset? AssociatedPreset;
+
         public MudraCasting()
         {
             OnStatusChanged += StatusChanged;
@@ -359,12 +362,17 @@ internal partial class NIN
 
         private void StatusChanged(uint statusId, bool onPlayer)
         {
+            if (!PresetEnabled) return;
+
             if (statusId == Buffs.Mudra)
             {
-                Svc.Log.Debug($"Mudra {(onPlayer ? "gained" : "lost")}");
-                if (!InMudra)
+                if (InMudra)
                 {
-                    Svc.Log.Debug($"{CurrentMudra} reset to none");
+                    Svc.Log.Debug($"{AssociatedPreset} -> {CurrentMudra} set");
+                }
+                else 
+                {
+                    Svc.Log.Debug($"{AssociatedPreset} -> {CurrentMudra} reset to none");
                     CurrentMudra = MudraState.None;
                     ActionWatching.LastAction = 0;
                 }

--- a/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
@@ -312,19 +312,39 @@ internal partial class NIN
     #region TCJ Methods
     internal static bool STTenChiJin(ref uint actionID)
     {
-        if (!JustUsed(TenChiJin, 6f))
-            return false;
-
-        var original = actionID;
-        actionID = ActionWatching.LastAction switch
+        if (HasStatusEffect(Buffs.TenChiJin))
         {
-            TenChiJin => TCJFumaShurikenTen,
-            TCJFumaShurikenTen => TCJRaiton,
-            TCJRaiton => TCJSuiton,
-            _ => actionID,
-        };
+            if (FirstMudra == MudraFlags.None)
+            {
+                actionID = TCJFumaShurikenTen;
+                return true;
+            }
 
-        return ActionWatching.LastAction is not TCJSuiton && original != actionID;
+            if (SecondMudra == MudraFlags.None)
+            {
+                if (FirstMudra == MudraFlags.TenFirst)
+                    actionID = TCJRaiton;
+                else if (FirstMudra == MudraFlags.JinFirst)
+                    actionID = TCJKaton;
+                else
+                    actionID = TCJHyoton;
+
+                return true;
+            }
+            else
+            {
+                if (UnusedJutsus.Contains(Ten))
+                    actionID = TCJHuton;
+                else if (UnusedJutsus.Contains(Chi))
+                    actionID = TCJDoton;
+                else
+                    actionID = TCJSuiton;
+
+                return true;
+            }
+
+        }
+        return false;
     }
     internal static bool AoETenChiJin(ref uint actionID, bool advancedMode)
     {
@@ -394,7 +414,7 @@ internal partial class NIN
                 {
                     Svc.Log.Debug($"{AssociatedPreset} -> {CurrentMudra} set");
                 }
-                else 
+                else
                 {
                     Svc.Log.Debug($"{AssociatedPreset} -> {CurrentMudra} reset to none");
                     CurrentMudra = MudraState.None;

--- a/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
@@ -23,12 +23,12 @@ internal partial class NIN
     {
         get
         {
-            return ActionWatching.LastAction != LastJutsu && MudraSigns.Any(x => x == ActionWatching.LastAction);
+            return ActionWatching.LastAction != LastMudra && MudraSigns.Any(x => x == ActionWatching.LastAction);
         }
     }
 
     #region Mudra Logic
-    public enum JutsuFlags
+    public enum MudraFlags
     {
         None = 0,
         TenFirst = 1,
@@ -44,14 +44,14 @@ internal partial class NIN
     }
 
     public static uint CurrentNinjutsu => OriginalHook(Ninjutsu);
-    internal static bool InMudra => MudraFromFlags > 0;
+    internal static bool InMudra => JutsuFromFlags > 0;
 
-    internal static JutsuFlags Flags => HasStatusEffect(Buffs.Mudra) ? (JutsuFlags)(GetStatusEffect(Buffs.Mudra).Param) : JutsuFlags.None;
-    internal static JutsuFlags FirstMudra => Flags & JutsuFlags.JinFirst;
-    internal static JutsuFlags SecondMudra => Flags & JutsuFlags.JinSecond;
-    internal static JutsuFlags ThirdMudra => Flags & JutsuFlags.JinThird;
+    internal static MudraFlags Flags => HasStatusEffect(Buffs.Mudra) ? (MudraFlags)(GetStatusEffect(Buffs.Mudra).Param) : MudraFlags.None;
+    internal static MudraFlags FirstMudra => Flags & MudraFlags.JinFirst;
+    internal static MudraFlags SecondMudra => Flags & MudraFlags.JinSecond;
+    internal static MudraFlags ThirdMudra => Flags & MudraFlags.JinThird;
 
-    internal static uint LastJutsu
+    internal static uint LastMudra
     {
         get
         {
@@ -59,29 +59,29 @@ internal partial class NIN
 
             return ThirdMudra switch
             {
-                not JutsuFlags.None => ThirdMudra switch
+                not MudraFlags.None => ThirdMudra switch
                 {
-                    JutsuFlags.TenThird => TenCombo,
-                    JutsuFlags.ChiThird => ChiCombo,
-                    JutsuFlags.JinThird => JinCombo,
+                    MudraFlags.TenThird => TenCombo,
+                    MudraFlags.ChiThird => ChiCombo,
+                    MudraFlags.JinThird => JinCombo,
                     _ => 0
                 },
 
                 _ => SecondMudra switch
                 {
-                    not JutsuFlags.None => SecondMudra switch
+                    not MudraFlags.None => SecondMudra switch
                     {
-                        JutsuFlags.TenSecond => TenCombo,
-                        JutsuFlags.ChiSecond => ChiCombo,
-                        JutsuFlags.JinSecond => JinCombo,
+                        MudraFlags.TenSecond => TenCombo,
+                        MudraFlags.ChiSecond => ChiCombo,
+                        MudraFlags.JinSecond => JinCombo,
                         _ => 0
                     },
 
                     _ => FirstMudra switch
                     {
-                        JutsuFlags.TenFirst => HasKassatsu ? TenCombo : Ten,
-                        JutsuFlags.ChiFirst => HasKassatsu ? ChiCombo : Chi,
-                        JutsuFlags.JinFirst => HasKassatsu ? JinCombo : Jin,
+                        MudraFlags.TenFirst => HasKassatsu ? TenCombo : Ten,
+                        MudraFlags.ChiFirst => HasKassatsu ? ChiCombo : Chi,
+                        MudraFlags.JinFirst => HasKassatsu ? JinCombo : Jin,
                         _ => 0
                     }
                 }
@@ -89,38 +89,38 @@ internal partial class NIN
         }
     }
 
-    internal static uint MudraFromFlags
+    internal static uint JutsuFromFlags
     {
         get
         {
-            if (FailedMudra || Flags == JutsuFlags.Rabbit)
+            if (FailedJutsu || Flags == MudraFlags.Rabbit)
                 return Rabbit;
 
             return ThirdMudra switch
             {
-                not JutsuFlags.None => ThirdMudra switch
+                not MudraFlags.None => ThirdMudra switch
                 {
-                    JutsuFlags.TenThird => Huton,
-                    JutsuFlags.ChiThird => Doton,
-                    JutsuFlags.JinThird => Suiton,
+                    MudraFlags.TenThird => Huton,
+                    MudraFlags.ChiThird => Doton,
+                    MudraFlags.JinThird => Suiton,
                     _ => 0
                 },
 
                 _ => SecondMudra switch
                 {
-                    not JutsuFlags.None => SecondMudra switch
+                    not MudraFlags.None => SecondMudra switch
                     {
-                        JutsuFlags.TenSecond => HasKassatsu ? GokaMekkyaku : Katon,
-                        JutsuFlags.ChiSecond => Raiton,
-                        JutsuFlags.JinSecond => HasKassatsu ? HyoshoRanryu : Hyoton,
+                        MudraFlags.TenSecond => HasKassatsu ? GokaMekkyaku : Katon,
+                        MudraFlags.ChiSecond => Raiton,
+                        MudraFlags.JinSecond => HasKassatsu ? HyoshoRanryu : Hyoton,
                         _ => 0
                     },
 
                     _ => FirstMudra switch
                     {
-                        JutsuFlags.TenFirst => FumaShuriken,
-                        JutsuFlags.ChiFirst => FumaShuriken,
-                        JutsuFlags.JinFirst => FumaShuriken,
+                        MudraFlags.TenFirst => FumaShuriken,
+                        MudraFlags.ChiFirst => FumaShuriken,
+                        MudraFlags.JinFirst => FumaShuriken,
                         _ => 0
                     }
                 }
@@ -128,23 +128,23 @@ internal partial class NIN
         }
     }
 
-    internal static bool FailedMudra =>
+    internal static bool FailedJutsu =>
         (
-            (FirstMudra == JutsuFlags.TenFirst ? 1 : 0) +
-            (SecondMudra == JutsuFlags.TenSecond ? 1 : 0) +
-            (ThirdMudra == JutsuFlags.TenThird ? 1 : 0)
+            (FirstMudra == MudraFlags.TenFirst ? 1 : 0) +
+            (SecondMudra == MudraFlags.TenSecond ? 1 : 0) +
+            (ThirdMudra == MudraFlags.TenThird ? 1 : 0)
         ) > 1
         ||
         (
-            (FirstMudra == JutsuFlags.ChiFirst ? 1 : 0) +
-            (SecondMudra == JutsuFlags.ChiSecond ? 1 : 0) +
-            (ThirdMudra == JutsuFlags.ChiThird ? 1 : 0)
+            (FirstMudra == MudraFlags.ChiFirst ? 1 : 0) +
+            (SecondMudra == MudraFlags.ChiSecond ? 1 : 0) +
+            (ThirdMudra == MudraFlags.ChiThird ? 1 : 0)
         ) > 1
         ||
         (
-            (FirstMudra == JutsuFlags.JinFirst ? 1 : 0) +
-            (SecondMudra == JutsuFlags.JinSecond ? 1 : 0) +
-            (ThirdMudra == JutsuFlags.JinThird ? 1 : 0)
+            (FirstMudra == MudraFlags.JinFirst ? 1 : 0) +
+            (SecondMudra == MudraFlags.JinSecond ? 1 : 0) +
+            (ThirdMudra == MudraFlags.JinThird ? 1 : 0)
         ) > 1;
 
     internal static bool Rabbitting => GetStatusEffect(Buffs.Mudra)?.Param == 255;
@@ -416,7 +416,7 @@ internal partial class NIN
             if (CurrentMudra is MudraState.None or MudraState.CastingFumaShuriken)
             {
                 // Finish the Mudra
-                if (LastJutsu is Ten or TenCombo)
+                if (LastMudra is Ten or TenCombo)
                 {
                     actionID = FumaShuriken;
                     return true;
@@ -437,7 +437,7 @@ internal partial class NIN
             if (Raiton.LevelChecked() && CurrentMudra is MudraState.None or MudraState.CastingRaiton)
             {
                 // Finish the Mudra
-                switch (LastJutsu)
+                switch (LastMudra)
                 {
                     case Ten or TenCombo or Jin or JinCombo:
                         actionID = ChiCombo;
@@ -462,7 +462,7 @@ internal partial class NIN
             if (Suiton.LevelChecked() && CurrentMudra is MudraState.None or MudraState.CastingSuiton)
             {
                 //Finish the Mudra
-                switch (LastJutsu)
+                switch (LastMudra)
                 {
                     case Ten or TenCombo:
                         actionID = ChiCombo;
@@ -490,7 +490,7 @@ internal partial class NIN
             if (HyoshoRanryu.LevelChecked() && CurrentMudra is MudraState.None or MudraState.CastingHyoshoRanryu)
             {
                 //Finish the Mudra
-                switch (LastJutsu)
+                switch (LastMudra)
                 {
                     case Ten or TenCombo or Chi or ChiCombo:
                         actionID = JinCombo;
@@ -515,7 +515,7 @@ internal partial class NIN
             if (Katon.LevelChecked() && CurrentMudra is MudraState.None or MudraState.CastingKaton)
             {
                 //Finish the Mudra
-                switch (LastJutsu)
+                switch (LastMudra)
                 {
                     case Jin or JinCombo or Chi or ChiCombo:
                         actionID = TenCombo;
@@ -540,7 +540,7 @@ internal partial class NIN
             if (Doton.LevelChecked() && CurrentMudra is MudraState.None or MudraState.CastingDoton)
             {
                 //Finish the Mudra
-                switch (LastJutsu)
+                switch (LastMudra)
                 {
                     case Jin or JinCombo:
                         actionID = TenCombo;
@@ -568,7 +568,7 @@ internal partial class NIN
             if (Huton.LevelChecked() && CurrentMudra is MudraState.None or MudraState.CastingHuton)
             {
                 //Finish the Mudra
-                switch (LastJutsu)
+                switch (LastMudra)
                 {
                     case Jin or JinCombo:
                         actionID = ChiCombo;
@@ -596,7 +596,7 @@ internal partial class NIN
             if (GokaMekkyaku.LevelChecked() && CurrentMudra is MudraState.None or MudraState.CastingGokaMekkyaku)
             {
                 //Finish the Mudra
-                switch (LastJutsu)
+                switch (LastMudra)
                 {
                     case Jin or JinCombo or Chi or ChiCombo:
                         actionID = TenCombo;
@@ -621,33 +621,33 @@ internal partial class NIN
     // Single Target
     internal static uint UseFumaShuriken(ref uint actionId)
     {
-        return actionId = LastJutsu is Ten or Chi or Jin ? FumaShuriken : Ten;
+        return actionId = LastMudra is Ten or Chi or Jin ? FumaShuriken : Ten;
     }
     internal static uint UseRaiton(ref uint actionId) // Ten Chi
     {
-        if (LastJutsu == OriginalTen || LastJutsu == OriginalJin)
+        if (LastMudra == OriginalTen || LastMudra == OriginalJin)
             actionId = ChiCombo;
-        else if (LastJutsu == ChiCombo)
+        else if (LastMudra == ChiCombo)
             actionId = Raiton;
 
         return actionId;
     }
     internal static uint UseHyoshoRanryu(ref uint actionId) // Ten Jin
     {
-        if (LastJutsu is TenCombo or ChiCombo)
+        if (LastMudra is TenCombo or ChiCombo)
             actionId = JinCombo;
-        else if (LastJutsu == JinCombo)
+        else if (LastMudra == JinCombo)
             actionId = HyoshoRanryu;
 
         return actionId;
     }
     internal static uint UseSuiton(ref uint actionId) // Ten Chi Jin
     {
-        if (LastJutsu == OriginalTen)
+        if (LastMudra == OriginalTen)
             actionId = ChiCombo;
-        else if (LastJutsu == ChiCombo)
+        else if (LastMudra == ChiCombo)
             actionId = JinCombo;
-        else if (LastJutsu == JinCombo)
+        else if (LastMudra == JinCombo)
             actionId = Suiton;
 
         return actionId;
@@ -655,29 +655,29 @@ internal partial class NIN
     //Multi Target
     internal static uint UseGokaMekkyaku(ref uint actionId) // Chi Ten
     {
-        if (LastJutsu == OriginalChi)
+        if (LastMudra == OriginalChi)
             actionId = TenCombo;
-        else if (LastJutsu is TenCombo)
+        else if (LastMudra is TenCombo)
             actionId = GokaMekkyaku;
 
         return actionId;
     }
     internal static uint UseKaton(ref uint actionId) // Chi Ten
     {
-        if (LastJutsu == OriginalChi)
+        if (LastMudra == OriginalChi)
             actionId = TenCombo;
-        else if (LastJutsu is TenCombo)
+        else if (LastMudra is TenCombo)
             actionId = Katon;
 
         return actionId;
     }
     internal static uint UseDoton(ref uint actionId)  //Jin Ten Chi
     {
-        if (LastJutsu == OriginalJin)
+        if (LastMudra == OriginalJin)
             actionId = TenCombo;
-        else if (LastJutsu is TenCombo)
+        else if (LastMudra is TenCombo)
             actionId = ChiCombo;
-        else if (LastJutsu is ChiCombo)
+        else if (LastMudra is ChiCombo)
             actionId = Doton;
 
         return actionId;
@@ -685,11 +685,11 @@ internal partial class NIN
 
     internal static uint UseHuton(ref uint actionId) // Jin Chi Ten
     {
-        if (LastJutsu == OriginalChi)
+        if (LastMudra == OriginalChi)
             actionId = JinCombo;
-        else if (LastJutsu is JinCombo)
+        else if (LastMudra is JinCombo)
             actionId = TenCombo;
-        else if (LastJutsu is TenCombo)
+        else if (LastMudra is TenCombo)
             actionId = Huton;
 
         return actionId;

--- a/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
@@ -46,7 +46,7 @@ internal partial class NIN
     public static uint CurrentNinjutsu => OriginalHook(Ninjutsu);
     internal static bool InMudra => JutsuFromFlags > 0;
 
-    internal static MudraFlags Flags => HasStatusEffect(Buffs.Mudra) ? (MudraFlags)(GetStatusEffect(Buffs.Mudra).Param) : MudraFlags.None;
+    internal static MudraFlags Flags => HasStatusEffect(Buffs.Mudra) ? (MudraFlags)(GetStatusEffect(Buffs.Mudra).Param) : HasStatusEffect(Buffs.TenChiJin) ? (MudraFlags)(GetStatusEffect(Buffs.TenChiJin).Param) : MudraFlags.None;
     internal static MudraFlags FirstMudra => Flags & MudraFlags.JinFirst;
     internal static MudraFlags SecondMudra => Flags & MudraFlags.JinSecond;
     internal static MudraFlags ThirdMudra => Flags & MudraFlags.JinThird;
@@ -146,6 +146,22 @@ internal partial class NIN
             (SecondMudra == MudraFlags.JinSecond ? 1 : 0) +
             (ThirdMudra == MudraFlags.JinThird ? 1 : 0)
         ) > 1;
+
+    internal static List<uint> UnusedJutsus
+    {
+        get
+        {
+            List<uint> output = [];
+            if (FirstMudra != MudraFlags.TenFirst && SecondMudra != MudraFlags.TenSecond && ThirdMudra != MudraFlags.TenThird)
+                output.Add(Ten);
+            if (FirstMudra != MudraFlags.ChiFirst && SecondMudra != MudraFlags.ChiSecond && ThirdMudra != MudraFlags.ChiThird)
+                output.Add(Chi);
+            if (FirstMudra != MudraFlags.JinFirst && SecondMudra != MudraFlags.JinSecond && ThirdMudra != MudraFlags.JinThird)
+                output.Add(Jin);
+
+            return output;
+        }
+    }
 
     internal static bool Rabbitting => GetStatusEffect(Buffs.Mudra)?.Param == 255;
     internal static bool MudraPhase => WasLastAction(Ten) || WasLastAction(Chi) || WasLastAction(Jin) || WasLastAction(TenCombo) || WasLastAction(ChiCombo) || WasLastAction(JinCombo);
@@ -310,39 +326,47 @@ internal partial class NIN
 
         return ActionWatching.LastAction is not TCJSuiton && original != actionID;
     }
-    internal static bool AoETenChiJinDoton(ref uint actionID)
+    internal static bool AoETenChiJin(ref uint actionID, bool advancedMode)
     {
-        if (!JustUsed(TenChiJin, 6f))
-            return false;
-
-        var original = actionID;
-        actionID = ActionWatching.LastAction switch
+        if (HasStatusEffect(Buffs.TenChiJin))
         {
-            TenChiJin => TCJFumaShurikenJin,
-            TCJFumaShurikenJin => TCJKaton,
-            TCJKaton => TCJDoton,
-            _ => actionID,
-        };
+            if (FirstMudra == MudraFlags.None)
+            {
+                if (DotonRemaining >= (advancedMode ? NIN_AoE_AdvancedMode_TCJ_Doton_Timer : 3))
+                    actionID = TCJFumaShurikenTen;
+                else
+                    actionID = TCJFumaShurikenJin;
 
-        return ActionWatching.LastAction is not TCJDoton && original != actionID;
+                return true;
+            }
+
+            if (SecondMudra == MudraFlags.None)
+            {
+                if (FirstMudra == MudraFlags.TenFirst)
+                    actionID = TCJRaiton;
+                else if (FirstMudra == MudraFlags.JinFirst)
+                    actionID = TCJKaton;
+                else
+                    actionID = TCJHyoton;
+
+                return true;
+            }
+            else
+            {
+                if (UnusedJutsus.Contains(Ten))
+                    actionID = TCJHuton;
+                else if (UnusedJutsus.Contains(Chi))
+                    actionID = TCJDoton;
+                else
+                    actionID = TCJSuiton;
+
+                return true;
+            }
+
+        }
+        return false;
     }
 
-    internal static bool AoETenChiJinSuiton(ref uint actionID)
-    {
-        if (!JustUsed(TenChiJin, 6f))
-            return false;
-
-        var original = actionID;
-        actionID = ActionWatching.LastAction switch
-        {
-            TenChiJin => TCJFumaShurikenChi,
-            TCJFumaShurikenChi => TCJKaton,
-            TCJKaton => TCJSuiton,
-            _ => actionID,
-        };
-
-        return ActionWatching.LastAction is not TCJSuiton && original != actionID;
-    }
     #endregion
 
     #region Mudra

--- a/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
@@ -3,6 +3,7 @@ using ECommons.DalamudServices;
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Linq;
 using WrathCombo.CustomComboNS;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
@@ -18,14 +19,136 @@ internal partial class NIN
     public static FrozenSet<uint> NormalJutsus = [FumaShuriken, Raiton, Katon, Doton, Suiton, Hyoton, HyoshoRanryu, GokaMekkyaku];
     internal static bool STSimpleMode => IsEnabled(Preset.NIN_ST_SimpleMode);
     internal static bool AoESimpleMode => IsEnabled(Preset.NIN_AoE_SimpleMode);
-    internal static bool NinjaWeave => CanWeave(.3f, 10);
+    internal static bool BlockDueToLag
+    {
+        get
+        {
+            return ActionWatching.LastAction != LastJutsu && MudraSigns.Any(x => x == ActionWatching.LastAction);
+        }
+    }
 
     #region Mudra Logic
+    public enum JutsuFlags
+    {
+        None = 0,
+        TenFirst = 1,
+        ChiFirst = 2,
+        JinFirst = 3,
+        TenSecond = 4,
+        ChiSecond = 8,
+        JinSecond = 12,
+        TenThird = 16,
+        ChiThird = 32,
+        JinThird = 48,
+        Rabbit = 255,
+    }
+
     public static uint CurrentNinjutsu => OriginalHook(Ninjutsu);
-    internal static bool InMudra = false;
+    internal static bool InMudra => MudraFromFlags > 0;
+
+    internal static JutsuFlags Flags => HasStatusEffect(Buffs.Mudra) ? (JutsuFlags)(GetStatusEffect(Buffs.Mudra).Param) : JutsuFlags.None;
+    internal static JutsuFlags FirstMudra => Flags & JutsuFlags.JinFirst;
+    internal static JutsuFlags SecondMudra => Flags & JutsuFlags.JinSecond;
+    internal static JutsuFlags ThirdMudra => Flags & JutsuFlags.JinThird;
+
+    internal static uint LastJutsu
+    {
+        get
+        {
+            int raw = (int)Flags;
+
+            return ThirdMudra switch
+            {
+                not JutsuFlags.None => ThirdMudra switch
+                {
+                    JutsuFlags.TenThird => TenCombo,
+                    JutsuFlags.ChiThird => ChiCombo,
+                    JutsuFlags.JinThird => JinCombo,
+                    _ => 0
+                },
+
+                _ => SecondMudra switch
+                {
+                    not JutsuFlags.None => SecondMudra switch
+                    {
+                        JutsuFlags.TenSecond => TenCombo,
+                        JutsuFlags.ChiSecond => ChiCombo,
+                        JutsuFlags.JinSecond => JinCombo,
+                        _ => 0
+                    },
+
+                    _ => FirstMudra switch
+                    {
+                        JutsuFlags.TenFirst => HasKassatsu ? TenCombo : Ten,
+                        JutsuFlags.ChiFirst => HasKassatsu ? ChiCombo : Chi,
+                        JutsuFlags.JinFirst => HasKassatsu ? JinCombo : Jin,
+                        _ => 0
+                    }
+                }
+            };
+        }
+    }
+
+    internal static uint MudraFromFlags
+    {
+        get
+        {
+            if (FailedMudra || Flags == JutsuFlags.Rabbit)
+                return Rabbit;
+
+            return ThirdMudra switch
+            {
+                not JutsuFlags.None => ThirdMudra switch
+                {
+                    JutsuFlags.TenThird => Huton,
+                    JutsuFlags.ChiThird => Doton,
+                    JutsuFlags.JinThird => Suiton,
+                    _ => 0
+                },
+
+                _ => SecondMudra switch
+                {
+                    not JutsuFlags.None => SecondMudra switch
+                    {
+                        JutsuFlags.TenSecond => HasKassatsu ? GokaMekkyaku : Katon,
+                        JutsuFlags.ChiSecond => Raiton,
+                        JutsuFlags.JinSecond => HasKassatsu ? HyoshoRanryu : Hyoton,
+                        _ => 0
+                    },
+
+                    _ => FirstMudra switch
+                    {
+                        JutsuFlags.TenFirst => FumaShuriken,
+                        JutsuFlags.ChiFirst => FumaShuriken,
+                        JutsuFlags.JinFirst => FumaShuriken,
+                        _ => 0
+                    }
+                }
+            };
+        }
+    }
+
+    internal static bool FailedMudra =>
+        (
+            (FirstMudra == JutsuFlags.TenFirst ? 1 : 0) +
+            (SecondMudra == JutsuFlags.TenSecond ? 1 : 0) +
+            (ThirdMudra == JutsuFlags.TenThird ? 1 : 0)
+        ) > 1
+        ||
+        (
+            (FirstMudra == JutsuFlags.ChiFirst ? 1 : 0) +
+            (SecondMudra == JutsuFlags.ChiSecond ? 1 : 0) +
+            (ThirdMudra == JutsuFlags.ChiThird ? 1 : 0)
+        ) > 1
+        ||
+        (
+            (FirstMudra == JutsuFlags.JinFirst ? 1 : 0) +
+            (SecondMudra == JutsuFlags.JinSecond ? 1 : 0) +
+            (ThirdMudra == JutsuFlags.JinThird ? 1 : 0)
+        ) > 1;
+
     internal static bool Rabbitting => GetStatusEffect(Buffs.Mudra)?.Param == 255;
     internal static bool MudraPhase => WasLastAction(Ten) || WasLastAction(Chi) || WasLastAction(Jin) || WasLastAction(TenCombo) || WasLastAction(ChiCombo) || WasLastAction(JinCombo);
-    internal static bool MudraReady => MudraCasting.CanCast();
     internal static uint MudraCharges => GetRemainingCharges(Ten);
     internal static bool MudraAlmostReady => MudraCharges == 1 && GetCooldownChargeRemainingTime(Ten) < 3;
     #endregion
@@ -36,17 +159,17 @@ internal partial class NIN
     internal static bool DotonStoppedMoving => TimeStoodStill >= TimeSpan.FromSeconds(DotonTimeStill);
     internal static float DotonTimeStill => AoESimpleMode ? 1.5f : NIN_AoE_AdvancedMode_Ninjitsus_Doton_TimeStill;
 
-    internal static bool CanUseFumaShuriken => LevelChecked(FumaShuriken) && MudraReady;
+    internal static bool CanUseFumaShuriken => ActionReady(Ten);
 
-    internal static bool CanUseRaiton => LevelChecked(Raiton) && MudraReady &&
+    internal static bool CanUseRaiton => LevelChecked(Raiton) && ActionReady(Ten) &&
                                           (!HasKassatsu || IsNotEnabled(Preset.NIN_ST_AdvancedMode_Ninjitsus_Hyosho) && !STSimpleMode || !LevelChecked(HyoshoRanryu)) && //Use kassatsu on it if Hyosho isn't selected. 
                                            (TrickDebuff || // Buff Window
                                            !LevelChecked(Suiton) || //Dont Pool because of Suiton not learned yet
-                                           GetCooldownChargeRemainingTime(Ten) < 1 && TrickCD > 18|| // Spend to avoid cap
+                                           GetCooldownChargeRemainingTime(Ten) < 1 && TrickCD > 18 || // Spend to avoid cap
                                            !NIN_ST_AdvancedMode_Ninjitsus_Raiton_Pooling && !STSimpleMode || //Dont Pool because of Raiton Option
                                            NIN_ST_AdvancedMode_Ninjitsus_Raiton_Uptime && !InMeleeRange() && GetCooldownChargeRemainingTime(Ten) <= TrickCD - 10); //Uptime option
 
-    internal static bool CanUseKaton => LevelChecked(Katon) && MudraReady &&
+    internal static bool CanUseKaton => LevelChecked(Katon) && ActionReady(Ten) &&
                                          (!HasKassatsu || IsNotEnabled(Preset.NIN_AoE_AdvancedMode_Ninjitsus_Goka) && !STSimpleMode) &&
                                          (TrickDebuff || //Buff Window
                                           !LevelChecked(Huton) || //Dont Pool because of Huton not learned yet
@@ -55,18 +178,18 @@ internal partial class NIN
                                           NIN_AoE_AdvancedMode_Ninjitsus_Katon_Uptime && !InMeleeRange() &&
                                           GetCooldownChargeRemainingTime(Ten) <= TrickCD - 10); //Uptime option
 
-    internal static bool CanUseDoton => LevelChecked(Doton) && MudraReady && DotonStoppedMoving && !JustUsed(Doton) &&
+    internal static bool CanUseDoton => LevelChecked(Doton) && ActionReady(Ten) && DotonStoppedMoving && !JustUsed(Doton) &&
                                         (!HasDoton || DotonRemaining <= 2) && //No doton down
                                         (TrickDebuff || GetCooldownChargeRemainingTime(Ten) < 3); //Pool for buff window
 
-    internal static bool CanUseSuiton => LevelChecked(Suiton) && MudraReady && !HasStatusEffect(Buffs.ShadowWalker);
+    internal static bool CanUseSuiton => LevelChecked(Suiton) && ActionReady(Ten) && !HasStatusEffect(Buffs.ShadowWalker);
 
-    internal static bool CanUseHuton => LevelChecked(Huton) && MudraReady && !HasStatusEffect(Buffs.ShadowWalker);
+    internal static bool CanUseHuton => LevelChecked(Huton) && ActionReady(Ten) && !HasStatusEffect(Buffs.ShadowWalker);
 
-    internal static bool CanUseHyoshoRanryu => LevelChecked(HyoshoRanryu) && MudraReady && HasKassatsu &&
+    internal static bool CanUseHyoshoRanryu => LevelChecked(HyoshoRanryu) && ActionReady(Ten) && HasKassatsu &&
                                                (BuffWindow || IsNotEnabled(Preset.NIN_ST_AdvancedMode_TrickAttack) && !STSimpleMode || KassatsuRemaining < 3);
 
-    internal static bool CanUseGokaMekkyaku => LevelChecked(GokaMekkyaku) && MudraReady && HasKassatsu &&
+    internal static bool CanUseGokaMekkyaku => LevelChecked(GokaMekkyaku) && ActionReady(Ten) && HasKassatsu &&
                                                (BuffWindow || IsNotEnabled(Preset.NIN_ST_AdvancedMode_TrickAttack) && !STSimpleMode || KassatsuRemaining < 3);
     #endregion
 
@@ -96,9 +219,9 @@ internal partial class NIN
     internal static float TrickCD => GetCooldownRemainingTime(OriginalHook(TrickAttack));
     internal static float MugCD => GetCooldownRemainingTime(OriginalHook(Mug));
 
-    internal static bool CanTrickST => ActionReady(OriginalHook(TrickAttack)) && NinjaWeave && CanApplyStatus(CurrentTarget, [Debuffs.TrickAttack, Debuffs.KunaisBane]) && HasStatusEffect(Buffs.ShadowWalker) && !MudraPhase &&
+    internal static bool CanTrickST => ActionReady(OriginalHook(TrickAttack)) && CanWeave() && CanApplyStatus(CurrentTarget, [Debuffs.TrickAttack, Debuffs.KunaisBane]) && HasStatusEffect(Buffs.ShadowWalker) && !MudraPhase &&
                                      (MugDebuff || MugCD >= 45 || MugDisabledST);
-    internal static bool CanTrickAoE => ActionReady(OriginalHook(TrickAttack)) && NinjaWeave && CanApplyStatus(CurrentTarget, [Debuffs.TrickAttack, Debuffs.KunaisBane]) && HasStatusEffect(Buffs.ShadowWalker) && !MudraPhase &&
+    internal static bool CanTrickAoE => ActionReady(OriginalHook(TrickAttack)) && CanWeave() && CanApplyStatus(CurrentTarget, [Debuffs.TrickAttack, Debuffs.KunaisBane]) && HasStatusEffect(Buffs.ShadowWalker) && !MudraPhase &&
                                      (MugDebuff || MugCD >= 45 || MugDisabledAoE);
 
     internal static bool CanMugST => ActionReady(OriginalHook(Mug)) && CanApplyStatus(CurrentTarget, [Debuffs.Mug, Debuffs.Dokumori]) && CanDelayedWeave(1.25f, .6f, 10) && !MudraPhase &&
@@ -114,10 +237,10 @@ internal partial class NIN
 
     #region Ninki Use Logic
     internal static bool NinkiWillOvercap => gauge.Ninki > 50;
-    internal static bool CanBunshin => NinjaWeave && !MudraPhase && LevelChecked(Bunshin) && IsOffCooldown(Bunshin) && gauge.Ninki >= 50;
-    internal static bool CanBhavacakra => NinjaWeave && gauge.Ninki >= 50 && !MudraPhase &&
+    internal static bool CanBunshin => CanWeave() && !MudraPhase && ActionReady(Bunshin) && gauge.Ninki >= 50;
+    internal static bool CanBhavacakra => CanWeave() && gauge.Ninki >= 50 && !MudraPhase &&
                                           (!HasStatusEffect(Buffs.Higi) || BuffWindow || TrickDisabledST);
-    internal static bool CanHellfrogMedium => NinjaWeave && gauge.Ninki >= 50 && LevelChecked(HellfrogMedium) && !MudraPhase &&
+    internal static bool CanHellfrogMedium => CanWeave() && gauge.Ninki >= 50 && LevelChecked(HellfrogMedium) && !MudraPhase &&
                                               (!HasStatusEffect(Buffs.Higi) || BuffWindow || TrickDisabledAoE);
 
     internal static bool NinkiPooling => gauge.Ninki >= NinkiPool();
@@ -138,32 +261,32 @@ internal partial class NIN
     #region Kassatsu, Meisui, Assassinate, TenChiJin Logic
     internal static bool HasKassatsu => HasStatusEffect(Buffs.Kassatsu) || JustUsed(Kassatsu, 1);
     internal static float KassatsuRemaining => GetStatusEffectRemainingTime(Buffs.Kassatsu);
-    internal static bool CanKassatsu => !MudraPhase && ActionReady(Kassatsu) && NinjaWeave &&
+    internal static bool CanKassatsu => !MudraPhase && ActionReady(Kassatsu) && CanWeave() &&
                                         (TrickCD < 10 && HasStatusEffect(Buffs.ShadowWalker) ||
                                          BuffWindow ||
                                          TrickDisabledST);
 
-    internal static bool CanKassatsuAoE => !MudraPhase && ActionReady(Kassatsu) && NinjaWeave &&
+    internal static bool CanKassatsuAoE => !MudraPhase && ActionReady(Kassatsu) && CanWeave() &&
                                         (TrickCD < 10 && HasStatusEffect(Buffs.ShadowWalker) ||
                                          BuffWindow ||
                                          TrickDisabledAoE);
 
-    internal static bool CanMeisui => !MudraPhase && ActionReady(Meisui) && NinjaWeave && HasStatusEffect(Buffs.ShadowWalker) &&
+    internal static bool CanMeisui => !MudraPhase && ActionReady(Meisui) && CanWeave() && HasStatusEffect(Buffs.ShadowWalker) &&
                                       (BuffWindow || TrickDisabledST);
-    internal static bool CanMeisuiAoE => !MudraPhase && ActionReady(Meisui) && NinjaWeave && HasStatusEffect(Buffs.ShadowWalker) &&
+    internal static bool CanMeisuiAoE => !MudraPhase && ActionReady(Meisui) && CanWeave() && HasStatusEffect(Buffs.ShadowWalker) &&
                                       (BuffWindow || TrickDisabledAoE);
 
-    internal static bool CanAssassinate => !MudraPhase && ActionReady(OriginalHook(Assassinate)) && NinjaWeave &&
+    internal static bool CanAssassinate => !MudraPhase && ActionReady(OriginalHook(Assassinate)) && CanWeave() &&
                                            (BuffWindow || TrickDisabledST || !LevelChecked(Suiton));
-    internal static bool CanAssassinateAoE => !MudraPhase && ActionReady(OriginalHook(Assassinate)) && NinjaWeave &&
+    internal static bool CanAssassinateAoE => !MudraPhase && ActionReady(OriginalHook(Assassinate)) && CanWeave() &&
                                            (BuffWindow || TrickDisabledAoE || !LevelChecked(Huton));
 
-    internal static bool CanTenChiJin => !MudraPhase && !MudraAlmostReady && IsOffCooldown(TenChiJin) && LevelChecked(TenChiJin) && NinjaWeave &&
+    internal static bool CanTenChiJin => !MudraPhase && !MudraAlmostReady && ActionReady(TenChiJin) && CanWeave() &&
                                          (BuffWindow || TrickDisabledST);
-    internal static bool CanTenChiJinAoE => !MudraPhase && !MudraAlmostReady && IsOffCooldown(TenChiJin) && LevelChecked(TenChiJin) && NinjaWeave &&
+    internal static bool CanTenChiJinAoE => !MudraPhase && !MudraAlmostReady && ActionReady(TenChiJin) && CanWeave() &&
                                             (BuffWindow || TrickDisabledAoE);
 
-    internal static bool CanTenriJindo => NinjaWeave && HasStatusEffect(Buffs.TenriJendoReady);
+    internal static bool CanTenriJindo => CanWeave() && HasStatusEffect(Buffs.TenriJendoReady);
 
     internal static uint OriginalTen => HasKassatsu ? TenCombo : Ten;
     internal static uint OriginalJin => HasKassatsu ? JinCombo : Jin;
@@ -229,6 +352,25 @@ internal partial class NIN
 
         public MudraState CurrentMudra = MudraState.None;
 
+        public MudraCasting()
+        {
+            OnStatusChanged += StatusChanged;
+        }
+
+        private void StatusChanged(uint statusId, bool onPlayer)
+        {
+            if (statusId == Buffs.Mudra)
+            {
+                Svc.Log.Debug($"Mudra {(onPlayer ? "gained" : "lost")}");
+                if (!InMudra)
+                {
+                    Svc.Log.Debug($"{CurrentMudra} reset to none");
+                    CurrentMudra = MudraState.None;
+                    ActionWatching.LastAction = 0;
+                }
+            }
+        }
+
         public enum MudraState
         {
             None,
@@ -244,28 +386,6 @@ internal partial class NIN
 
         public bool ContinueCurrentMudra(ref uint actionID)
         {
-            if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 2 && OriginalHook(Ninjutsu) is Rabbit or Ninjutsu)
-            {
-                InMudra = false;
-                ActionWatching.LastAction = 0;
-                CurrentMudra = MudraState.None;
-                return false;
-            }
-
-            if (ActionWatching.LastAction == FumaShuriken ||
-                ActionWatching.LastAction == Katon ||
-                ActionWatching.LastAction == Raiton ||
-                ActionWatching.LastAction == Hyoton ||
-                ActionWatching.LastAction == Huton ||
-                ActionWatching.LastAction == Doton ||
-                ActionWatching.LastAction == Suiton ||
-                ActionWatching.LastAction == GokaMekkyaku ||
-                ActionWatching.LastAction == HyoshoRanryu)
-            {
-                CurrentMudra = MudraState.None;
-                InMudra = false;
-            }
-
             return CurrentMudra switch
             {
                 MudraState.None => false,
@@ -282,34 +402,13 @@ internal partial class NIN
         }
         #endregion
 
-        #region Mudra Cast Check
-        public static bool CanCast()
-        {
-            if (InMudra) return true;
-
-            if (GetCooldown(GustSlash).CooldownTotal == 0.5) return true;
-
-            if (GetRemainingCharges(Ten) == 0 &&
-                !HasStatusEffect(Buffs.Mudra) &&
-                !HasStatusEffect(Buffs.Kassatsu))
-                return false;
-            return true;
-        }
-        #endregion
-
         #region Fuma Shuriken
         public bool CastFumaShuriken(ref uint actionID) // Ten
         {
             if (CurrentMudra is MudraState.None or MudraState.CastingFumaShuriken)
             {
-                // Reset State
-                if (!CanCast() || ActionWatching.LastAction == FumaShuriken)
-                {
-                    CurrentMudra = MudraState.None;
-                    return false;
-                }
                 // Finish the Mudra
-                if (ActionWatching.LastAction is Ten or TenCombo)
+                if (LastJutsu is Ten or TenCombo)
                 {
                     actionID = FumaShuriken;
                     return true;
@@ -330,7 +429,7 @@ internal partial class NIN
             if (Raiton.LevelChecked() && CurrentMudra is MudraState.None or MudraState.CastingRaiton)
             {
                 // Finish the Mudra
-                switch (ActionWatching.LastAction)
+                switch (LastJutsu)
                 {
                     case Ten or TenCombo or Jin or JinCombo:
                         actionID = ChiCombo;
@@ -355,7 +454,7 @@ internal partial class NIN
             if (Suiton.LevelChecked() && CurrentMudra is MudraState.None or MudraState.CastingSuiton)
             {
                 //Finish the Mudra
-                switch (ActionWatching.LastAction)
+                switch (LastJutsu)
                 {
                     case Ten or TenCombo:
                         actionID = ChiCombo;
@@ -383,7 +482,7 @@ internal partial class NIN
             if (HyoshoRanryu.LevelChecked() && CurrentMudra is MudraState.None or MudraState.CastingHyoshoRanryu)
             {
                 //Finish the Mudra
-                switch (ActionWatching.LastAction)
+                switch (LastJutsu)
                 {
                     case Ten or TenCombo or Chi or ChiCombo:
                         actionID = JinCombo;
@@ -408,7 +507,7 @@ internal partial class NIN
             if (Katon.LevelChecked() && CurrentMudra is MudraState.None or MudraState.CastingKaton)
             {
                 //Finish the Mudra
-                switch (ActionWatching.LastAction)
+                switch (LastJutsu)
                 {
                     case Jin or JinCombo or Chi or ChiCombo:
                         actionID = TenCombo;
@@ -433,7 +532,7 @@ internal partial class NIN
             if (Doton.LevelChecked() && CurrentMudra is MudraState.None or MudraState.CastingDoton)
             {
                 //Finish the Mudra
-                switch (ActionWatching.LastAction)
+                switch (LastJutsu)
                 {
                     case Jin or JinCombo:
                         actionID = TenCombo;
@@ -461,7 +560,7 @@ internal partial class NIN
             if (Huton.LevelChecked() && CurrentMudra is MudraState.None or MudraState.CastingHuton)
             {
                 //Finish the Mudra
-                switch (ActionWatching.LastAction)
+                switch (LastJutsu)
                 {
                     case Jin or JinCombo:
                         actionID = ChiCombo;
@@ -489,7 +588,7 @@ internal partial class NIN
             if (GokaMekkyaku.LevelChecked() && CurrentMudra is MudraState.None or MudraState.CastingGokaMekkyaku)
             {
                 //Finish the Mudra
-                switch (ActionWatching.LastAction)
+                switch (LastJutsu)
                 {
                     case Jin or JinCombo or Chi or ChiCombo:
                         actionID = TenCombo;
@@ -514,33 +613,33 @@ internal partial class NIN
     // Single Target
     internal static uint UseFumaShuriken(ref uint actionId)
     {
-        return actionId = ActionWatching.LastAction is Ten or Chi or Jin ? FumaShuriken : Ten;
+        return actionId = LastJutsu is Ten or Chi or Jin ? FumaShuriken : Ten;
     }
     internal static uint UseRaiton(ref uint actionId) // Ten Chi
     {
-        if (ActionWatching.LastAction == OriginalTen || ActionWatching.LastAction == OriginalJin)
+        if (LastJutsu == OriginalTen || LastJutsu == OriginalJin)
             actionId = ChiCombo;
-        else if (ActionWatching.LastAction == ChiCombo)
+        else if (LastJutsu == ChiCombo)
             actionId = Raiton;
 
         return actionId;
     }
     internal static uint UseHyoshoRanryu(ref uint actionId) // Ten Jin
     {
-        if (ActionWatching.LastAction is TenCombo or ChiCombo)
+        if (LastJutsu is TenCombo or ChiCombo)
             actionId = JinCombo;
-        else if (ActionWatching.LastAction == JinCombo)
+        else if (LastJutsu == JinCombo)
             actionId = HyoshoRanryu;
 
         return actionId;
     }
     internal static uint UseSuiton(ref uint actionId) // Ten Chi Jin
     {
-        if (ActionWatching.LastAction == OriginalTen)
+        if (LastJutsu == OriginalTen)
             actionId = ChiCombo;
-        else if (ActionWatching.LastAction == ChiCombo)
+        else if (LastJutsu == ChiCombo)
             actionId = JinCombo;
-        else if (ActionWatching.LastAction == JinCombo)
+        else if (LastJutsu == JinCombo)
             actionId = Suiton;
 
         return actionId;
@@ -548,29 +647,29 @@ internal partial class NIN
     //Multi Target
     internal static uint UseGokaMekkyaku(ref uint actionId) // Chi Ten
     {
-        if (ActionWatching.LastAction == OriginalChi)
+        if (LastJutsu == OriginalChi)
             actionId = TenCombo;
-        else if (ActionWatching.LastAction is TenCombo)
+        else if (LastJutsu is TenCombo)
             actionId = GokaMekkyaku;
 
         return actionId;
     }
     internal static uint UseKaton(ref uint actionId) // Chi Ten
     {
-        if (ActionWatching.LastAction == OriginalChi)
+        if (LastJutsu == OriginalChi)
             actionId = TenCombo;
-        else if (ActionWatching.LastAction is TenCombo)
+        else if (LastJutsu is TenCombo)
             actionId = Katon;
 
         return actionId;
     }
     internal static uint UseDoton(ref uint actionId)  //Jin Ten Chi
     {
-        if (ActionWatching.LastAction == OriginalJin)
+        if (LastJutsu == OriginalJin)
             actionId = TenCombo;
-        else if (ActionWatching.LastAction is TenCombo)
+        else if (LastJutsu is TenCombo)
             actionId = ChiCombo;
-        else if (ActionWatching.LastAction is ChiCombo)
+        else if (LastJutsu is ChiCombo)
             actionId = Doton;
 
         return actionId;
@@ -578,11 +677,11 @@ internal partial class NIN
 
     internal static uint UseHuton(ref uint actionId) // Jin Chi Ten
     {
-        if (ActionWatching.LastAction == OriginalChi)
+        if (LastJutsu == OriginalChi)
             actionId = JinCombo;
-        else if (ActionWatching.LastAction is JinCombo)
+        else if (LastJutsu is JinCombo)
             actionId = TenCombo;
-        else if (ActionWatching.LastAction is TenCombo)
+        else if (LastJutsu is TenCombo)
             actionId = Huton;
 
         return actionId;

--- a/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
@@ -16,7 +16,7 @@ internal partial class NIN
 {
     static NINGauge gauge = GetJobGauge<NINGauge>();
     public static FrozenSet<uint> MudraSigns = [Ten, Chi, Jin, TenCombo, ChiCombo, JinCombo];
-    public static FrozenSet<uint> NormalJutsus = [FumaShuriken, Raiton, Katon, Doton, Suiton, Hyoton, HyoshoRanryu, GokaMekkyaku];
+    public static FrozenSet<uint> NormalJutsus = [FumaShuriken, Raiton, Katon, Doton, Suiton, Hyoton, HyoshoRanryu, GokaMekkyaku, Rabbit];
     internal static bool STSimpleMode => IsEnabled(Preset.NIN_ST_SimpleMode);
     internal static bool AoESimpleMode => IsEnabled(Preset.NIN_AoE_SimpleMode);
     internal static bool BlockDueToLag

--- a/WrathCombo/CustomCombo/Functions/Config.cs
+++ b/WrathCombo/CustomCombo/Functions/Config.cs
@@ -34,6 +34,7 @@ internal class UserFloat : UserData
 
     public float Value
     {
+        get => Configuration.GetCustomFloatValue(ConfigName);
         set => Configuration.SetCustomFloatValue(ConfigName, value);
     }
 

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -435,9 +435,6 @@ public static class ActionWatching
                 UpdateLastUsedAction(actionId, actionType, targetObjectId, Math.Max(castTime - 480, 0)),
                 TimeSpan.FromMilliseconds(Math.Max(castTime - 480, 0)), cancellationToken: token);
 
-                // Update Helpers
-                NIN.InMudra = NIN.MudraSigns.Contains(actionId);
-
                 if (castTime > 0)
                 {
                     TimeLastActionUsed = DateTime.Now;

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -552,7 +552,9 @@ public static class ActionWatching
                 var changed = CheckForChangedTarget(original, ref changedTargetId,
                     out var replacedWith); //Passes the original action to the retargeting framework, outputs a targetId and a replaced action
 
-                if ((!Service.ActionReplacer.LastActionInvokeFor.ContainsKey(actionId) && actionId >= All.SingleTargetDPS) || (Service.ActionReplacer.LastActionInvokeFor.TryGetValue(actionId, out var p) && p >= All.SingleTargetDPS))
+                replacedWith = Service.ActionReplacer.LastActionInvokeFor.ContainsKey(actionId) ? Service.ActionReplacer.LastActionInvokeFor[actionId] : actionId;
+
+                if (replacedWith >= All.SingleTargetDPS)
                 {
                     Svc.Toasts.ShowError("This is a custom action, it does nothing on its own.");
                     return false;
@@ -597,7 +599,6 @@ public static class ActionWatching
                 if ((areaTargeted && changed) || AutoRotationController.WouldLikeToGroundTarget)
                 {
                     var location = Player.Position;
-                    replacedWith = Service.ActionReplacer.LastActionInvokeFor.TryGetValue(actionId, out var replacedGT) ? replacedGT : replacedWith;
 
                     if (IsOverGround(targetObject) &&
                         Vector3.Distance(Player.Position, targetObject.Position) <= replacedWith.ActionRange()) // not GetTargetDistance or something, as hitboxes should not count here
@@ -634,7 +635,7 @@ public static class ActionWatching
 
                 Svc.Log.Verbose($"[QueuedTargetUpdate] A:{actionManager->QueuedActionId.ActionName()} Q:{Svc.Objects.SearchById(actionManager->QueuedTargetId)?.Name} T:{Svc.Objects.SearchById(targetId)?.Name} M:{mode} W:{willQueue}");
 
-                Svc.Log.Verbose($"[FinalUse] Target changed is {changed}. Using {replacedWith.ActionName()} on {(changed ? targetId.GetObject()?.Name : originalTargetId.GetObject()?.Name)}");
+                Svc.Log.Verbose($"[FinalUse] Target changed is {changed}. Using {actionId.ActionName()} ({actionId}) -> {replacedWith.ActionName()} ({replacedWith}) on {(changed ? targetId.GetObject()?.Name : originalTargetId.GetObject()?.Name)} ({(changed? targetId : originalTargetId):X})");
                 var hookResult = changed ? UseActionHook.Original(actionManager, actionType, actionId, targetId, extraParam, mode, comboRouteId, outOptAreaTargeted) :
                     UseActionHook.Original(actionManager, actionType, actionId, originalTargetId, extraParam, mode, comboRouteId, outOptAreaTargeted);
 

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -541,6 +541,16 @@ public static class ActionWatching
             }
             if (actionType is ActionType.Action)
             {
+
+                if (actionManager->QueuedActionId > 0 && NIN.InMudra && !NIN.MudraSigns.Any(x => x == actionManager->QueuedActionId) && !NIN.NormalJutsus.Any(x => x == actionManager->QueuedActionId))
+                {
+#if DEBUG
+                    DuoLog.Debug($"Blocked NIN flub");
+#endif
+                    actionManager->QueuedActionId = 0;
+                    return false;
+                }
+
                 var disablingReplacingTemp = (mode == ActionManager.UseActionMode.Queue || AutoRotationController.AutorotRaidwiding) && actionId < All.SingleTargetDPS;
                 if (disablingReplacingTemp) // This is so we can remove queue suppression
                     Service.ActionReplacer.DisableActionReplacingIfRequired(); // It gets re-enabled at the end of sending. 

--- a/WrathCombo/Extensions/GameObjectExtensions.cs
+++ b/WrathCombo/Extensions/GameObjectExtensions.cs
@@ -408,6 +408,7 @@ public static class GameObjectExtensions
     /// <param name="id">The GameObjectID to convert.</param>
     /// <returns>An IGameObject if found in the object table; otherwise, null.</returns>
     public static IGameObject? GetObject(this ulong id) =>
+        id == 0xE0000000 ? Player.Object :
         GetObjectFrom(id);
 
     /// <summary>

--- a/WrathCombo/Window/Tabs/Debug.cs
+++ b/WrathCombo/Window/Tabs/Debug.cs
@@ -364,7 +364,7 @@ internal class Debug : ConfigWindow, IDisposable
 
             ImGuiEx.Spacing(new Vector2(0f, SpacingSmall));
 
-            CustomStyleText("Job Gauge Data", string.Empty);
+            CustomStyleText("Job Specific Data", string.Empty);
             ImGui.Separator();
             switch (Player.Job)
             {
@@ -396,6 +396,12 @@ internal class Debug : ConfigWindow, IDisposable
                     Util.ShowStruct(&JobGaugeManager.Instance()->Scholar);
                     break;
                 case Job.NIN:
+                    CustomStyleText($"First Mudra:", $"{NIN.FirstMudra}");
+                    CustomStyleText($"Second Mudra:", $"{NIN.SecondMudra}");
+                    CustomStyleText($"Third Mudra:", $"{NIN.ThirdMudra}");
+                    CustomStyleText($"JutsuFromFlag:", $"{NIN.JutsuFromFlags.ActionName()}");
+                    CustomStyleText($"LastUsedMudra:", $"{NIN.LastMudra.ActionName()}");
+                    CustomStyleText($"UnusedJutsus:", $"{string.Join(", ", NIN.UnusedJutsus.Select(x => x.ActionName()))}");
                     Util.ShowStruct(&JobGaugeManager.Instance()->Ninja);
                     break;
                 case Job.MCH:
@@ -432,8 +438,6 @@ internal class Debug : ConfigWindow, IDisposable
                     Util.ShowStruct(&JobGaugeManager.Instance()->Pictomancer);
                     break;
             }
-
-            Util.ShowObject(player.Struct()->CastInfo);
 
             ImGuiEx.Spacing(new Vector2(0f, SpacingSmall));
 


### PR DESCRIPTION
- Alleviate laggy players by blocking next mudras with savage blade until buff has caught up.
- As a results, adds checks for the current jutsu and last used mudra sign to base the last used action off the buff instead.