### PR TITLE
Add Pausing Actions

### DIFF
--- a/WrathCombo/CustomCombo/Functions/Action.cs
+++ b/WrathCombo/CustomCombo/Functions/Action.cs
@@ -488,4 +488,11 @@ internal abstract partial class CustomComboFunctions
     }
 
     public static bool ActionIsFriendly(uint actionId) => ActionSheet.TryGetValue(actionId, out var s) && s.Unknown4 == 2;
+
+    internal static List<uint> PausingActions =
+    [
+        17856, //Petro Eyes - Supay - A-Rank
+        29821, //Death Forseen - Beatrice - Fell Court of Troia
+        29828, //Death Forseen x2 - Beatrice - Fell Court of Troia
+    ];
 }

--- a/WrathCombo/CustomCombo/Functions/Status.cs
+++ b/WrathCombo/CustomCombo/Functions/Status.cs
@@ -256,7 +256,6 @@ internal abstract partial class CustomComboFunctions
                 break;
         }
 
-        Svc.Log.Debug($"Penalty? {hasActionPenalty}");
         if (hasActionPenalty)
         {
             Svc.Targets.Target = null;

--- a/WrathCombo/CustomCombo/Functions/Status.cs
+++ b/WrathCombo/CustomCombo/Functions/Status.cs
@@ -8,6 +8,7 @@ using ECommons.MathHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using WrathCombo.Data;
 using WrathCombo.Extensions;
@@ -170,7 +171,7 @@ internal abstract partial class CustomComboFunctions
 
     public static bool HasPhantomDispelStatus(IGameObject? target) => StatusCache.HasDamageUp(target) || StatusCache.HasEvasionUp(target) || HasStatusEffect(4355, target) || TargetIsInvincible(target);
 
-    public static DateTime ActionPenaltyResolvedAt;
+    public static List<(DateTime Start, DateTime End)> ActionPenaltyResolvedAtList = [];
 
     /// <summary>
     /// Checks to see if the player has a status that should stop all actions and unselect targets
@@ -252,7 +253,7 @@ internal abstract partial class CustomComboFunctions
                         // Others
                         StatusCache.PausingStatuses.Misc.Contains(s.StatusId)
 
-                    ) == true || DateTime.Now < ActionPenaltyResolvedAt;
+                    ) == true || ActionPenaltyResolvedAtList.Any(x => x.Start <= DateTime.Now && x.End >= DateTime.Now);
                 break;
         }
 

--- a/WrathCombo/CustomCombo/Functions/Status.cs
+++ b/WrathCombo/CustomCombo/Functions/Status.cs
@@ -170,6 +170,8 @@ internal abstract partial class CustomComboFunctions
 
     public static bool HasPhantomDispelStatus(IGameObject? target) => StatusCache.HasDamageUp(target) || StatusCache.HasEvasionUp(target) || HasStatusEffect(4355, target) || TargetIsInvincible(target);
 
+    public static DateTime ActionPenaltyResolvedAt;
+
     /// <summary>
     /// Checks to see if the player has a status that should stop all actions and unselect targets
     /// Acceleration bombs and Pyretics
@@ -250,10 +252,11 @@ internal abstract partial class CustomComboFunctions
                         // Others
                         StatusCache.PausingStatuses.Misc.Contains(s.StatusId)
 
-                    ) == true;
+                    ) == true || DateTime.Now < ActionPenaltyResolvedAt;
                 break;
         }
 
+        Svc.Log.Debug($"Penalty? {hasActionPenalty}");
         if (hasActionPenalty)
         {
             Svc.Targets.Target = null;

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -103,7 +103,7 @@ public static class ActionWatching
         {
             var act = Svc.Data.GetExcelSheet<Action>().GetRow(packet->ActionId);
             var castTime = (act.Cast100ms + act.ExtraCastTime100ms) * 100;
-            var penaltyResolveWindow = (DateTime.Now + TimeSpan.FromMilliseconds(castTime - 1500f), DateTime.Now + TimeSpan.FromMilliseconds(castTime + 1500f));
+            var penaltyResolveWindow = (DateTime.Now + TimeSpan.FromMilliseconds(castTime - 1500f), DateTime.Now + TimeSpan.FromMilliseconds(castTime + 300f));
             ActionPenaltyResolvedAtList.Add(penaltyResolveWindow);
             Svc.Log.Verbose($"Resolving action penalty at {penaltyResolveWindow.Item2.TimeOfDay}");
         }

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -102,10 +102,16 @@ public static class ActionWatching
         if (PausingActions.Any(x => x == packet->ActionId) && packet->ActionType == 1)
         {
             var act = Svc.Data.GetExcelSheet<Action>().GetRow(packet->ActionId);
-            var castTime = act.Cast100ms * 100 + act.ExtraCastTime100ms * 100;
-            ActionPenaltyResolvedAt = DateTime.Now + TimeSpan.FromSeconds(castTime + 0.2f);
-            Svc.Log.Verbose($"Resolving action penalty at {ActionPenaltyResolvedAt.TimeOfDay}");
+            var castTime = (act.Cast100ms + act.ExtraCastTime100ms) * 100;
+            var penaltyResolveWindow = (DateTime.Now + TimeSpan.FromMilliseconds(castTime - 1500f), DateTime.Now + TimeSpan.FromMilliseconds(castTime + 1500f));
+            ActionPenaltyResolvedAtList.Add(penaltyResolveWindow);
+            Svc.Log.Verbose($"Resolving action penalty at {penaltyResolveWindow.Item2.TimeOfDay}");
         }
+    }
+
+    public static void ClearActionPenaltys()
+    {
+        ActionPenaltyResolvedAtList.RemoveAll(x => x.End < DateTime.Now);
     }
 
     private static unsafe void OnReceivePacketDetour(PacketDispatcher* thisPtr, uint targetId, nint packet)

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -8,6 +8,7 @@ using ECommons.GameHelpers;
 using ECommons.Logging;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
+using FFXIVClientStructs.FFXIV.Client.Game.Network;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using FFXIVClientStructs.FFXIV.Client.Network;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
@@ -71,6 +72,7 @@ public static class ActionWatching
     public static readonly Hook<ActionManager.Delegates.IsActionOffCooldown> CanQueueAction;
     public static readonly Hook<PacketDispatcher.Delegates.HandleActorControlPacket> ActorControlPacketHook;
     public static readonly Hook<PacketDispatcher.Delegates.OnReceivePacket> OnRecievePacketHook;
+    public static readonly Hook<PacketDispatcher.Delegates.HandleActorCastPacket> OnActorCastHook;
 
     private static Task UpdateActionTask = null!;
     private static CancellationTokenSource source = new CancellationTokenSource();
@@ -88,8 +90,22 @@ public static class ActionWatching
         CanQueueAction ??= Svc.Hook.HookFromAddress<ActionManager.Delegates.IsActionOffCooldown>(ActionManager.Addresses.IsActionOffCooldown.Value, CanQueueActionDetour);
         ActorControlPacketHook ??= Svc.Hook.HookFromAddress<PacketDispatcher.Delegates.HandleActorControlPacket>(PacketDispatcher.Addresses.HandleActorControlPacket.Value, ActorControlDetour);
         OnRecievePacketHook ??= Svc.Hook.HookFromAddress<PacketDispatcher.Delegates.OnReceivePacket>((nint)PacketDispatcher.StaticVirtualTablePointer->OnReceivePacket, OnReceivePacketDetour);
+        OnActorCastHook ??= Svc.Hook.HookFromAddress<PacketDispatcher.Delegates.HandleActorCastPacket>(PacketDispatcher.Addresses.HandleActorCastPacket.Value, ActorCastDetour);
         OnCastInterrupted += CancelPendingLastActionUpdate;
 
+    }
+
+    private static unsafe void ActorCastDetour(uint entityId, ActorCastPacket* packet)
+    {
+        OnActorCastHook.Original(entityId, packet);
+        Svc.Log.Verbose($"[ActorCastPacket] {((ulong)entityId).GetObject()?.Name} -> {packet->ActionId.ActionName()} ({packet->ActionId}) {packet->CastTime}");
+        if (PausingActions.Any(x => x == packet->ActionId) && packet->ActionType == 1)
+        {
+            var act = Svc.Data.GetExcelSheet<Action>().GetRow(packet->ActionId);
+            var castTime = act.Cast100ms * 100 + act.ExtraCastTime100ms * 100;
+            ActionPenaltyResolvedAt = DateTime.Now + TimeSpan.FromSeconds(castTime + 0.2f);
+            Svc.Log.Verbose($"Resolving action penalty at {ActionPenaltyResolvedAt.TimeOfDay}");
+        }
     }
 
     private static unsafe void OnReceivePacketDetour(PacketDispatcher* thisPtr, uint targetId, nint packet)
@@ -188,6 +204,7 @@ public static class ActionWatching
         CanQueueAction?.Enable();
         ActorControlPacketHook?.Enable();
         OnRecievePacketHook?.Enable();
+        OnActorCastHook?.Enable();
         Svc.Condition.ConditionChange += ResetActions;
     }
 
@@ -202,6 +219,7 @@ public static class ActionWatching
         CanQueueAction?.Dispose();
         ActorControlPacketHook?.Dispose();
         OnRecievePacketHook?.Dispose();
+        OnActorCastHook?.Dispose();
         OnCastInterrupted -= CancelPendingLastActionUpdate;
     }
 
@@ -704,11 +722,9 @@ public static class ActionWatching
         CanQueueAction?.Disable();
         ActorControlPacketHook?.Disable();
         OnRecievePacketHook?.Disable();
+        OnActorCastHook?.Disable();
         Svc.Condition.ConditionChange -= ResetActions;
     }
-
-    [Obsolete("Use CustomComboFunctions.GetActionName instead. This method will be removed in a future update.")]
-    public static string GetActionName(uint id) => CustomComboFunctions.GetActionName(id);
 
     public static unsafe bool OutOfRange(uint actionId, IGameObject source, IGameObject target)
     {

--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -404,6 +404,7 @@ public sealed partial class WrathCombo : IDalamudPlugin
                 CustomComboFunctions.PlayGroupwideAlert();
 
             SimpleTargetState.ManageStateList();
+            ActionWatching.ClearActionPenaltys();
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Similar to pausing statuses, this will trigger when a cast is fired out which should be paused for until resolved, i.e gazes.