### PR TITLE
Deliver lease cancellation callbacks to the correct leasee's prefix

### DIFF
--- a/WrathCombo/Services/IPC/Helper.cs
+++ b/WrathCombo/Services/IPC/Helper.cs
@@ -1,9 +1,9 @@
-﻿#region
+#region
 
 using Dalamud.Networking.Http;
 using ECommons;
+using ECommons.DalamudServices;
 using ECommons.ExcelServices;
-using ECommons.EzIpcManager;
 using ECommons.GameHelpers;
 using ECommons.Logging;
 using System;
@@ -341,23 +341,25 @@ public partial class Helper(ref Leasing leasing)
 
     #region IPC Callback
 
-    public static string? PrefixForIPC;
-
     /// <summary>
-    ///     Method to set up an IPC, call the Wrath Combo callback, and dispose
-    ///     of the IPC.
+    ///     Calls the leasee's <c>{prefix}.WrathComboCallback</c> IPC method.
     /// </summary>
-    /// <param name="prefix">The leasee's </param>
-    /// <param name="reason"></param>
-    /// <param name="additionalInfo"></param>
+    /// <param name="prefix">The leasee's IPC prefix for the callback.</param>
+    /// <param name="reason">The cancellation reason, passed as an int.</param>
+    /// <param name="additionalInfo">Any additional info about the cancellation.</param>
+    /// <remarks>
+    ///     Subscribes per call, so the callback always reaches the gate of the
+    ///     leasee actually being cancelled — independent of any other leasees.
+    /// </remarks>
     internal static void CallIPCCallback(string prefix, CancellationReason reason,
         string additionalInfo = "")
     {
         try
         {
-            PrefixForIPC = prefix;
-            LeaseeIPC.WrathComboCallback((int)reason, additionalInfo);
-            LeaseeIPC.Dispose();
+            Svc.PluginInterface
+                .GetIpcSubscriber<int, string, object>(
+                    $"{prefix}.WrathComboCallback")
+                .InvokeAction((int)reason, additionalInfo);
         }
         catch
         {
@@ -497,21 +499,3 @@ internal static class Logging
         PluginLog.Error(Prefix + PrefixMethod + message + "\n" + (StackTrace));
 }
 
-internal static class LeaseeIPC
-{
-    private static EzIPCDisposalToken[]? _disposalTokens =
-        EzIPC.Init(typeof(LeaseeIPC), Helper.PrefixForIPC, SafeWrapper.IPCException);
-
-#pragma warning disable CS0649, CS8618 // Complaints of the method
-    [EzIPC] internal static readonly Action<int, string> WrathComboCallback;
-#pragma warning restore CS8618, CS0649
-
-    public static void Dispose()
-    {
-        if (_disposalTokens is null)
-            return;
-        foreach (var token in _disposalTokens)
-            token.Dispose();
-        _disposalTokens = null;
-    }
-}

--- a/WrathCombo/Services/IPC/Provider.cs
+++ b/WrathCombo/Services/IPC/Provider.cs
@@ -1,4 +1,4 @@
-﻿#region
+#region
 
 using Dalamud.Plugin.Ipc;
 using ECommons.DalamudServices;
@@ -258,9 +258,8 @@ public partial class Provider : IDisposable
     ///     The <see cref="CancellationReason" /> (cast as an int) and a string with
     ///     any additional info will be passed to your method.<br />
     ///     The method should be of the form
-    ///     <c>void WrathComboCallback(int, string)</c>.<br />
-    ///     See <see cref="LeaseeIPC.WrathComboCallback" /> for the exact signature that
-    ///     will be called.
+    ///     <c>void WrathComboCallback(int, string)</c>, provided as the IPC gate
+    ///     <c>{yourPrefix}.WrathComboCallback</c>.
     /// </remarks>
     /// <seealso cref="RegisterForLease(string,string)" />
     [EzIPC]


### PR DESCRIPTION
`LeaseeIPC` is a static class whose `EzIPC.Init` runs in a static field initializer once per plugin load, capturing whatever `Helper.PrefixForIPC` holds at first touch. The subscriber delegate is bound to that first prefix's gate name permanently; setting `PrefixForIPC` on later cancellations has no effect, and `LeaseeIPC.Dispose()` nulls the tokens so subsequent disposes are no-ops.

With more than one leasee plugin registered with callbacks, every cancellation after the first is delivered to whichever plugin triggered the first-ever cancellation: that plugin receives phantom cancellation callbacks for leases it doesn't own, and the plugin actually being cancelled never learns its lease died (so it can't react to user revocation, job changes, or IPC suspension).

Found this while working on my own plugin.