### PR TITLE
IPC Work (Presets)

### DIFF
--- a/WrathCombo/Core/Presets.cs
+++ b/WrathCombo/Core/Presets.cs
@@ -29,11 +29,33 @@ internal static class PresetStorage
     /// </summary>
     internal static readonly FrozenSet<Preset> ConflictingCombos = BuildConflictingCombos();
 
+    /// <summary>
+    ///     A frozen lookup from a preset's internal name (case-insensitive) to
+    ///     the <see cref="Preset" /> itself, used by <see cref="GetPresetByName" />
+    ///     so that resolving a name doesn't require scanning every preset.
+    /// </summary>
+    private static readonly FrozenDictionary<string, Preset> PresetsByName =
+        AllPresets.Values.ToFrozenDictionary(
+            data => data.InternalName,
+            data => data.Preset,
+            StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    ///     A frozen lookup from a preset's underlying integer ID to the
+    ///     <see cref="Preset" /> itself, used by <see cref="GetPresetByInt" />
+    ///     so that resolving an ID doesn't require scanning every preset.
+    /// </summary>
+    private static readonly FrozenDictionary<int, Preset> PresetsById =
+        AllPresets.Keys.ToFrozenDictionary(preset => (int)preset, preset => preset);
+
     internal class PresetData
     {
         public Preset Preset { get; }
+        //UI Facing Name and Description
         public string Name => PresetLocalization.GetName(Preset);
         public string Description => PresetLocalization.GetDescription(Preset);
+        //The Enum Name
+        public string InternalName { get; }
         public bool IsPvP { get; }
         public bool IsAoE { get; }
         public Preset[] Conflicts;
@@ -62,6 +84,7 @@ internal static class PresetStorage
         public PresetData(Preset preset)
         {
             Preset = preset;
+            InternalName = preset.ToString();
             IsPvP = preset.GetAttribute<PvPCustomComboAttribute>() != null;
             Conflicts = preset.GetAttribute<ConflictingCombosAttribute>()?.ConflictingPresets ?? [];
             Parent = preset.GetAttribute<ParentComboAttribute>()?.ParentPreset;
@@ -76,7 +99,7 @@ internal static class PresetStorage
             JobInfo = preset.GetAttribute<JobInfoAttribute>();
             AutoAction = preset.GetAttribute<AutoActionAttribute>();
             IsAoE = AutoAction?.IsAoE
-                ?? preset.ToString().Contains("_AoE_", StringComparison.OrdinalIgnoreCase);
+                ?? InternalName.Contains("_AoE_", StringComparison.OrdinalIgnoreCase);
             IsHidden = preset.GetAttribute<HiddenAttribute>() != null;
             ComboType = GetComboType(preset);
             if (AutoAction != null)
@@ -275,28 +298,30 @@ internal static class PresetStorage
     /// <returns> The conflicting presets. </returns>
     public static Preset[] GetConflicts(Preset preset) => AllPresets[preset].Conflicts;
 
-    public static Preset? GetPresetByString(string value)
+    public static Preset? GetPresetByName(string value) =>
+        !string.IsNullOrEmpty(value) &&
+        PresetsByName.TryGetValue(value, out var preset)
+            ? preset
+            : null;
+
+    public static Preset? GetPresetByInt(int value) =>
+        PresetsById.TryGetValue(value, out var preset) ? preset : null;
+
+    /// <summary>
+    ///     Gets a preset by either its internal name or numeric ID.
+    /// </summary>
+    /// <param name="value">
+    ///     The preset identifier - either the enum member name (e.g., "DRK_Delirium")
+    ///     or its numeric ID (e.g., "123").
+    /// </param>
+    /// <returns>
+    ///     The Preset if found, or null if neither the name nor ID match any preset.
+    /// </returns>
+    public static Preset? GetPresetByIdentifier(string value)
     {
-        if (string.IsNullOrEmpty(value))
-            return null;
-
-        foreach (var preset in AllPresets.Keys)
-        {
-            if (string.Equals(preset.ToString(), value, StringComparison.OrdinalIgnoreCase))
-                return preset;
-        }
-
-        return null;
-    }
-
-    public static Preset? GetPresetByInt(int value)
-    {
-        foreach (var preset in AllPresets.Keys)
-        {
-            if ((int)preset == value)
-                return preset;
-        }
-        return null;
+        return int.TryParse(value, out var numericId)
+                ? PresetStorage.GetPresetByInt(numericId)
+                : PresetStorage.GetPresetByName(value);
     }
 
     private static object GetControlledText(Preset preset)
@@ -392,7 +417,7 @@ internal static class PresetStorage
 
     public static bool EnablePreset
         (string preset, ConfigChangeSource? source = null) =>
-        GetPresetByString(preset) is { } pre &&
+        GetPresetByName(preset) is { } pre &&
         EnablePreset(pre, source);
 
     public static bool EnablePreset
@@ -419,7 +444,7 @@ internal static class PresetStorage
 
     public static bool DisablePreset
         (string preset, ConfigChangeSource? source = null) =>
-        GetPresetByString(preset) is { } pre &&
+        GetPresetByName(preset) is { } pre &&
         DisablePreset(pre, source);
 
     public static bool DisablePreset
@@ -443,7 +468,7 @@ internal static class PresetStorage
 
     public static bool TogglePreset
         (string preset, ConfigChangeSource? source = null) =>
-        GetPresetByString(preset) is { } pre &&
+        GetPresetByName(preset) is { } pre &&
         TogglePreset(pre, source);
 
     public static bool TogglePreset
@@ -473,7 +498,7 @@ internal static class PresetStorage
 
     public static bool EnableAutoModeForPreset
         (string preset, ConfigChangeSource? source = null) =>
-        GetPresetByString(preset) is { } pre &&
+        GetPresetByName(preset) is { } pre &&
         EnableAutoModeForPreset(pre, source);
 
     public static bool EnableAutoModeForPreset
@@ -501,7 +526,7 @@ internal static class PresetStorage
 
     public static bool DisableAutoModeForPreset
         (string preset, ConfigChangeSource? source = null) =>
-        GetPresetByString(preset) is { } pre &&
+        GetPresetByName(preset) is { } pre &&
         DisableAutoModeForPreset(pre, source);
 
     public static bool DisableAutoModeForPreset
@@ -529,7 +554,7 @@ internal static class PresetStorage
 
     public static bool ToggleAutoModeForPreset
         (string preset, ConfigChangeSource? source = null) =>
-        GetPresetByString(preset) is { } pre &&
+        GetPresetByName(preset) is { } pre &&
         ToggleAutoModeForPreset(pre, source);
 
     public static bool ToggleAutoModeForPreset

--- a/WrathCombo/Services/IPC/Helper.cs
+++ b/WrathCombo/Services/IPC/Helper.cs
@@ -79,7 +79,6 @@ public partial class Helper(ref Leasing leasing)
     /// <returns>The Opposite-mode preset.</returns>
     internal static Preset? GetOppositeModeCombo(Preset preset)
     {
-        const StringComparison lower = StringComparison.CurrentCultureIgnoreCase;
         var presetData = preset.Attributes();
 
         // Bail if it is not one of the main combos
@@ -112,11 +111,13 @@ public partial class Helper(ref Leasing leasing)
                         [presetData.JobInfo.Job]
                     [targetType][simplicityLevelToSearchFor];
 
+            // Bail if there's no opposite-mode preset for this target type
+            // (e.g. no Advanced healer combos for the same target type)
+            if (categorizedPreset.Count == 0)
+                return null;
+
             // Return the opposite mode, as a proper preset
-            var oppositeMode = categorizedPreset.FirstOrDefault().Key;
-            var oppositeModePreset = (Preset)
-                Enum.Parse(typeof(Preset), oppositeMode, true);
-            return oppositeModePreset;
+            return categorizedPreset.Keys.First();
         }
         catch (Exception ex)
         {
@@ -179,29 +180,23 @@ public partial class Helper(ref Leasing leasing)
 
         #region Override the Values with any IPC-control
 
-        Preset? simpleComboPreset = simpleHigher is null
-            ? null
-            : (Preset)
-            Enum.Parse(typeof(Preset), simpleHigher.Value.Key, true);
+        var simpleComboPreset = simpleHigher?.Key;
         if (simpleComboPreset is not null)
         {
             simple[ComboStateKeys.AutoMode] =
-                P.IPCSearch.AutoActions[(Preset)simpleComboPreset];
+                P.IPCSearch.AutoActions[simpleComboPreset.Value];
             simple[ComboStateKeys.Enabled] =
-                P.IPCSearch.EnabledActions.Contains(
-                    (Preset)simpleComboPreset);
+                P.IPCSearch.EnabledActions.Contains(simpleComboPreset.Value);
         }
 
         #endregion
 
         // Get the Advanced Mode settings
-        var (advancedKey, advancedValue) =
+        var (advancedComboPreset, advancedValue) =
             comboStates[mode][ComboSimplicityLevelKeys.Advanced].First();
 
         #region Override the Values with any IPC-control
 
-        var advancedComboPreset = (Preset)
-            Enum.Parse(typeof(Preset), advancedKey, true);
         advancedValue[ComboStateKeys.AutoMode] =
             P.IPCSearch.AutoActions[advancedComboPreset];
         advancedValue[ComboStateKeys.Enabled] =
@@ -271,14 +266,15 @@ public partial class Helper(ref Leasing leasing)
 
         if (stSimple is not null)
             combos.Add(comboStates[ComboTargetTypeKeys.SingleTarget]
-                [ComboSimplicityLevelKeys.Simple].First().Key);
+                [ComboSimplicityLevelKeys.Simple].First().Key.ToString());
         else
         {
             var stAdvanced = comboStates[ComboTargetTypeKeys.SingleTarget]
                 [ComboSimplicityLevelKeys.Advanced].First().Key;
-            combos.Add(stAdvanced);
+            var stAdvancedName = stAdvanced.ToString();
+            combos.Add(stAdvancedName);
             if (includeOptions)
-                combos.AddRange(P.IPCSearch.OptionNamesByJob[job][stAdvanced]);
+                combos.AddRange(P.IPCSearch.OptionNamesByJob[job][stAdvancedName]);
         }
 
         #endregion
@@ -292,14 +288,15 @@ public partial class Helper(ref Leasing leasing)
 
         if (mtSimple is not null)
             combos.Add(comboStates[ComboTargetTypeKeys.MultiTarget]
-                [ComboSimplicityLevelKeys.Simple].First().Key);
+                [ComboSimplicityLevelKeys.Simple].First().Key.ToString());
         else
         {
             var mtAdvanced = comboStates[ComboTargetTypeKeys.MultiTarget]
                 [ComboSimplicityLevelKeys.Advanced].First().Key;
-            combos.Add(mtAdvanced);
+            var mtAdvancedName = mtAdvanced.ToString();
+            combos.Add(mtAdvancedName);
             if (includeOptions)
-                combos.AddRange(P.IPCSearch.OptionNamesByJob[job][mtAdvanced]);
+                combos.AddRange(P.IPCSearch.OptionNamesByJob[job][mtAdvancedName]);
         }
 
         #endregion
@@ -308,26 +305,28 @@ public partial class Helper(ref Leasing leasing)
 
         if (comboStates.TryGetValue(ComboTargetTypeKeys.HealST, out var healResults))
             combos.Add(healResults
-                [ComboSimplicityLevelKeys.Other].First().Key);
+                [ComboSimplicityLevelKeys.Other].First().Key.ToString());
         var healST = healResults?.FirstOrDefault().Key;
         if (healST is not null)
         {
             var healSTPreset = comboStates[ComboTargetTypeKeys.HealST]
                 [ComboSimplicityLevelKeys.Other].First().Key;
             if (includeOptions)
-                combos.AddRange(P.IPCSearch.OptionNamesByJob[job][healSTPreset]);
+                combos.AddRange(P.IPCSearch.OptionNamesByJob[job][
+                    healSTPreset.ToString()]);
         }
 
         if (comboStates.TryGetValue(ComboTargetTypeKeys.HealMT, out healResults))
             combos.Add(healResults
-                [ComboSimplicityLevelKeys.Other].First().Key);
+                [ComboSimplicityLevelKeys.Other].First().Key.ToString());
         var healMT = healResults?.FirstOrDefault().Key;
         if (healMT is not null)
         {
             var healMTPreset = comboStates[ComboTargetTypeKeys.HealMT]
                 [ComboSimplicityLevelKeys.Other].First().Key;
             if (includeOptions)
-                combos.AddRange(P.IPCSearch.OptionNamesByJob[job][healMTPreset]);
+                combos.AddRange(P.IPCSearch.OptionNamesByJob[job][
+                    healMTPreset.ToString()]);
         }
 
         #endregion

--- a/WrathCombo/Services/IPC/Leasing.cs
+++ b/WrathCombo/Services/IPC/Leasing.cs
@@ -13,6 +13,7 @@ using System.Security.Cryptography;
 using System.Text;
 using WrathCombo.API.Enum;
 using WrathCombo.Combos;
+using WrathCombo.Core;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Extensions;
 using CancellationReasonEnum = WrathCombo.API.Enum.CancellationReason;
@@ -467,7 +468,7 @@ public partial class Leasing
         else
         {
             locking = false;
-            stringKeys = combos.Select(k => k.ToString())
+            stringKeys = combos
                 .Concat(registration.CombosControlled.Keys
                     .Select(k => k.ToString()).ToArray())
                 .ToArray();
@@ -484,12 +485,8 @@ public partial class Leasing
 
             // Enable the option, or lock the option to its current state
             var state = true;
-            if (locking)
-            {
-                var ccpOption = (Preset)
-                    Enum.Parse(typeof(Preset), option);
+            if (locking && PresetStorage.GetPresetByIdentifier(option) is { } ccpOption)
                 state = CustomComboFunctions.IsEnabled(ccpOption);
-            }
 
             AddRegistrationForOption(lease, option, state);
         }
@@ -569,23 +566,15 @@ public partial class Leasing
     /// <seealso cref="Provider.GetComboState" />
     internal (bool enabled, bool autoMode)? CheckComboControlled(string combo)
     {
-        Preset Preset;
-        try
-        {
-            Preset = (Preset)
-                Enum.Parse(typeof(Preset), combo, true);
-        }
-        catch
-        {
+        if (PresetStorage.GetPresetByIdentifier(combo) is not { } preset)
             return null;
-        }
 
         var lease = Registrations.Values
-            .Where(l => l.CombosControlled.ContainsKey(Preset))
+            .Where(l => l.CombosControlled.ContainsKey(preset))
             .OrderByDescending(l => l.LastUpdated)
             .FirstOrDefault();
 
-        return lease?.CombosControlled[Preset];
+        return lease?.CombosControlled[preset];
     }
 
     /// <summary>
@@ -602,8 +591,13 @@ public partial class Leasing
         (Guid lease, string combo, bool newState, bool newAutoState)
     {
         var registration = Registrations[lease];
-        var preset = (Preset)
-            Enum.Parse(typeof(Preset), combo, true);
+
+        if (PresetStorage.GetPresetByIdentifier(combo) is not { } preset)
+        {
+            Logging.Warn($"{registration.PluginName}: Invalid combo name " +
+                         $"'{combo}'.");
+            return SetResult.InvalidConfiguration;
+        }
 
         // Disable the combo of the opposite type mode, if one exists
         var oppositeModeCombo = Helper.GetOppositeModeCombo(preset);
@@ -627,6 +621,7 @@ public partial class Leasing
 
         registration.LastUpdated = DateTime.Now;
         CombosUpdated = DateTime.Now;
+        P.IPCSearch.UpdateDue = true;
 
         Logging.Log(
             $"{registration.PluginName}: Registered Combo ({combo}){oppositeText}");
@@ -643,23 +638,15 @@ public partial class Leasing
     /// <seealso cref="Provider.GetComboOptionState" />
     internal bool? CheckComboOptionControlled(string option)
     {
-        Preset Preset;
-        try
-        {
-            Preset = (Preset)
-                Enum.Parse(typeof(Preset), option, true);
-        }
-        catch
-        {
+        if (PresetStorage.GetPresetByIdentifier(option) is not { } preset)
             return null;
-        }
 
         var lease = Registrations.Values
-            .Where(l => l.OptionsControlled.ContainsKey(Preset))
+            .Where(l => l.OptionsControlled.ContainsKey(preset))
             .OrderByDescending(l => l.LastUpdated)
             .FirstOrDefault();
 
-        return lease?.OptionsControlled[Preset];
+        return lease?.OptionsControlled[preset];
     }
 
     /// <summary>
@@ -675,8 +662,13 @@ public partial class Leasing
         (Guid lease, string option, bool newState)
     {
         var registration = Registrations[lease];
-        var preset = (Preset)
-            Enum.Parse(typeof(Preset), option, true);
+
+        if (PresetStorage.GetPresetByIdentifier(option) is not { } preset)
+        {
+            Logging.Warn($"{registration.PluginName}: Invalid option name " +
+                         $"'{option}'.");
+            return SetResult.InvalidConfiguration;
+        }
 
         registration.OptionsControlled[preset] = newState;
 
@@ -691,6 +683,7 @@ public partial class Leasing
 
         registration.LastUpdated = DateTime.Now;
         OptionsUpdated = DateTime.Now;
+        P.IPCSearch.UpdateDue = true;
 
         Logging.Log($"{registration.PluginName}: Registered Option ({option})");
         return SetResult.Okay;

--- a/WrathCombo/Services/IPC/Search.cs
+++ b/WrathCombo/Services/IPC/Search.cs
@@ -9,19 +9,44 @@ using System.IO;
 using System.Linq;
 using WrathCombo.API.Enum;
 using WrathCombo.Attributes;
-using WrathCombo.Combos;
 using WrathCombo.Core;
 using static WrathCombo.CustomComboNS.Functions.Jobs;
 using WrathCombo.CustomComboNS.Functions;
-using WrathCombo.Extensions;
-using WrathCombo.Window.Tabs;
-using EZ = ECommons.Throttlers.EzThrottler;
-using TS = System.TimeSpan;
-using System.Diagnostics;
 
 #endregion
 
 namespace WrathCombo.Services.IPC;
+
+/// <summary>
+///     Wraps a <see cref="PresetStorage.PresetData" /> reference together with
+///     its current, mutable runtime state (enabled / auto-mode) as seen
+///     through the IPC layer (i.e. accounting for lease overrides).
+/// </summary>
+/// <remarks>
+///     Callers that need attribute data (<see cref="PresetStorage.PresetData.AutoAction" />,
+///     <see cref="PresetStorage.PresetData.Parent" />, etc.) alongside runtime
+///     state can read <see cref="Data" /> directly, instead of re-deriving a
+///     <see cref="Preset" /> from a string and re-querying its attributes.
+/// </remarks>
+internal sealed class PresetRuntimeState(PresetStorage.PresetData data)
+{
+    /// <summary>
+    ///     The static, attribute-derived data for this preset.
+    /// </summary>
+    public PresetStorage.PresetData Data { get; } = data;
+
+    /// <summary>
+    ///     Whether the preset is currently enabled, including any lease
+    ///     override.
+    /// </summary>
+    public required bool Enabled { get; init; }
+
+    /// <summary>
+    ///     Whether the preset is currently in Auto-Mode, including any lease
+    ///     override.
+    /// </summary>
+    public required bool AutoMode { get; init; }
+}
 
 public class Search(Leasing leasing)
 {
@@ -216,99 +241,144 @@ public class Search(Leasing leasing)
     }
 
     /// <summary>
-    ///     When <see cref="PresetStates" /> was last built.
+    ///     Set to <c>true</c> to force <see cref="PresetRuntimeStates" />/
+    ///     <see cref="PresetStates" /> to rebuild on next access. Cleared
+    ///     automatically once the rebuild completes.
     /// </summary>
-    private DateTime _lastCacheUpdateForPresetStates = DateTime.MinValue;
+    internal bool UpdateDue = true;
+
+    private Dictionary<Preset, PresetRuntimeState>? _presetRuntimeStates;
+
+    private Dictionary<string, Dictionary<ComboStateKeys, bool>>?
+        _presetStatesByName;
 
     /// <summary>
-    ///     Cached list of <see cref="Preset">Presets</see>, and most of
-    ///     their attribute-based information.
+    ///     Rebuilds the preset-state caches if <see cref="UpdateDue" /> is
+    ///     set. Otherwise a no-op.
     /// </summary>
-    [field: AllowNull, MaybeNull]
-    // ReSharper disable once MemberCanBePrivate.Global
-    internal Dictionary<string, (Job Job, Preset ID,
-        PresetStorage.PresetData presetData, bool HasParentCombo, bool IsVariant, string
-        ParentComboName, ComboType ComboType)> Presets
+    /// <remarks>
+    ///     This is the single source of truth for preset runtime state:
+    ///     <see cref="PresetRuntimeStates" /> (keyed by <see cref="Preset" />,
+    ///     for internal use, carrying a direct <see cref="PresetStorage.PresetData" />
+    ///     reference) and <see cref="PresetStates" /> (keyed by internal name
+    ///     string, for the IPC boundary) are both projected from the same
+    ///     build, so nothing downstream needs to re-derive a <see cref="Preset" />
+    ///     from a string, or re-run this work per access.
+    /// </remarks>
+    private void EnsurePresetStatesCurrent()
+    {
+        if (_presetRuntimeStates != null && !UpdateDue)
+            return;
+
+        // Walk every lease once, keeping only the most-recently-updated
+        // combo override per Preset — avoids an O(leases) scan being
+        // repeated for every preset below.
+        var latestComboOverrides = _leasing.Registrations.Values
+        .SelectMany(registration =>
+            registration.CombosControlled
+                .Select(pair => new
+                {
+                    pair.Key,
+                    pair.Value.enabled,
+                    pair.Value.autoMode,
+                    registration.LastUpdated,
+                })
+            .Concat(registration.OptionsControlled
+                .Select(pair => new
+                {
+                    pair.Key,
+                    enabled = pair.Value,
+                    autoMode = false, // Options don't have auto-mode
+                    registration.LastUpdated,
+                })))
+        .GroupBy(x => x.Key)
+        .ToDictionary(
+            g => g.Key,
+            g =>
+            {
+                var latest = g.OrderByDescending(x => x.LastUpdated).First();
+                return (enabled: latest.enabled, autoMode: latest.autoMode);
+            }
+        );
+
+        _presetRuntimeStates = PresetStorage.AllPresets
+            .ToDictionary(
+                preset => preset.Key,
+                preset =>
+                {
+                    bool isEnabled, isAutoMode;
+
+                    // If a lease controls this preset, use its values exclusively
+                    if (latestComboOverrides.TryGetValue(preset.Key, out var ipcOverride))
+                    {
+                        isEnabled = ipcOverride.enabled;
+                        isAutoMode = ipcOverride.autoMode && preset.Value.AutoAction != null;
+                    }
+                    else
+                    {
+                        // No lease control - use config as fallback
+                        isEnabled = CustomComboFunctions.IsEnabled(preset.Key);
+                        isAutoMode = Service.Configuration.AutoActions.TryGetValue(
+                            preset.Key, out var autoMode) &&
+                            autoMode && preset.Value.AutoAction != null;
+                    }
+
+                    return new PresetRuntimeState(preset.Value)
+                    {
+                        Enabled = isEnabled,
+                        AutoMode = isAutoMode,
+                    };
+                }
+            );
+
+        _presetStatesByName = _presetRuntimeStates.ToDictionary(
+            preset => preset.Value.Data.InternalName,
+            preset => new Dictionary<ComboStateKeys, bool>
+            {
+                { ComboStateKeys.Enabled, preset.Value.Enabled },
+                { ComboStateKeys.AutoMode, preset.Value.AutoMode },
+            }
+        );
+
+        UpdateDue = false;
+    }
+
+    /// <summary>
+    ///     Cached list of <see cref="Preset">Presets</see> and their current
+    ///     runtime state, keyed by <see cref="Preset" /> for internal
+    ///     (non-IPC) use. Each entry carries a direct reference to its
+    ///     <see cref="PresetStorage.PresetData" />, so callers never need to
+    ///     re-derive attribute data via string parsing.
+    /// </summary>
+    internal Dictionary<Preset, PresetRuntimeState> PresetRuntimeStates
     {
         get
         {
-            return field ??= PresetStorage.AllPresets!
-            .Select(preset => new
-            {
-                ID = preset.Key,
-                JobId = preset.Value.JobInfo!.Job,
-                InternalName = preset.Key.ToString(),
-                presetData = preset.Value,
-                HasParentCombo = preset.Value.Parent != null,
-                IsVariant = preset.Value.IsVariant,
-                ParentComboName = preset.Value.Parent != null
-                    ? preset.Value.RootParent.ToString()
-                    : string.Empty,
-                preset.Value.ComboType,
-            })
-            .Where(combo =>
-                !combo.InternalName.EndsWith("any", ToLower))
-            .ToDictionary(
-                combo => combo.InternalName,
-                combo => (
-                    combo.JobId,
-                    combo.ID,
-                    combo.presetData,
-                    combo.HasParentCombo,
-                    combo.IsVariant,
-                    combo.ParentComboName,
-                    combo.ComboType)
-            );
+            EnsurePresetStatesCurrent();
+            return _presetRuntimeStates!;
         }
     }
 
-    internal bool UpdateDue = true;
-
     /// <summary>
     ///     Cached list of <see cref="Preset">Presets</see>, and the
-    ///     state and Auto-Mode state of each.
+    ///     state and Auto-Mode state of each, keyed by internal name string.
     /// </summary>
     /// <remarks>
-    ///     Rebuilt if the <see cref="ConfigFilePath">Config File</see> has been
-    ///     updated since
-    ///     <see cref="_lastCacheUpdateForPresetStates">last cached</see>.
+    ///     This string-keyed shape exists for the IPC boundary
+    ///     (<see cref="Provider.GetComboState" />,
+    ///     <see cref="Provider.GetComboOptionState" />), since external
+    ///     plugins can only address presets by name/ID across the IPC
+    ///     boundary, not by the internal <see cref="Preset" /> enum type.
+    ///     Internal (non-IPC) callers should prefer
+    ///     <see cref="PresetRuntimeStates" /> instead.
     /// </remarks>
-    [field: AllowNull, MaybeNull]
     // ReSharper disable once MemberCanBePrivate.Global
     internal Dictionary<string, Dictionary<ComboStateKeys, bool>> PresetStates
     {
         get
         {
-            field ??= [];
-
-            if (UpdateDue)
-            {
-                field = Presets
-                    .ToDictionary(
-                        preset => preset.Key,
-                        preset =>
-                        {
-                            var isEnabled =
-                                CustomComboFunctions.IsEnabled(preset.Value.ID);
-                            var ipcAutoMode = _leasing.CheckComboControlled(
-                                preset.Value.ID.ToString())?.autoMode ?? false;
-                            var isAutoMode =
-                                Service.Configuration.AutoActions.TryGetValue(
-                                    preset.Value.ID, out var autoMode) &&
-                                autoMode && preset.Value.ID.Attributes().AutoAction !=
-                                null;
-                            return new Dictionary<ComboStateKeys, bool>
-                            {
-                            { ComboStateKeys.Enabled, isEnabled },
-                            { ComboStateKeys.AutoMode, isAutoMode || ipcAutoMode },
-                            };
-                        }
-                    );
-
-                UpdateDue = false;
-            }
-
-            return field;
+            EnsurePresetStatesCurrent();
+            return _presetStatesByName!;
         }
     }
 
@@ -332,14 +402,13 @@ public class Search(Leasing leasing)
     ///     Job -> <c>list</c> of combo internal names.
     /// </value>
     internal Dictionary<Job, List<string>> ComboNamesByJob =>
-        Presets
+        PresetRuntimeStates
             .Where(preset =>
-                preset.Value is { IsVariant: false, HasParentCombo: false } &&
-                !preset.Key.Contains("pvp", ToLower))
-            .GroupBy(preset => preset.Value.Job)
+                preset.Value.Data is { IsVariant: false, Parent: null, IsPvP: false })
+            .GroupBy(preset => preset.Value.Data.JobInfo!.Job)
             .ToDictionary(
                 g => g.Key,
-                g => g.Select(preset => preset.Key).ToList()
+                g => g.Select(preset => preset.Value.Data.InternalName).ToList()
             );
 
     /// <summary>
@@ -369,15 +438,21 @@ public class Search(Leasing leasing)
     /// <value>
     ///     Job -> <see cref="ComboTargetTypeKeys">Target Key</see> ->
     ///     <see cref="ComboSimplicityLevelKeys">Simplicity Key</see> ->
-    ///     Internal Name ->
+    ///     <see cref="Preset" /> ->
     ///     <see cref="ComboStateKeys">State Key</see> -><br />
     ///     <c>bool</c> - Whether the state is enabled or not.
     /// </value>
+    /// <remarks>
+    ///     Keyed by <see cref="Preset" /> (rather than internal name string)
+    ///     since this is internal-only — see <see cref="ComboNamesByJob" />/
+    ///     <see cref="OptionNamesByJob" /> for the string-keyed, IPC-facing
+    ///     equivalents.
+    /// </remarks>
     [field: AllowNull, MaybeNull]
     internal Dictionary<Job,
             Dictionary<ComboTargetTypeKeys,
                 Dictionary<ComboSimplicityLevelKeys,
-                    Dictionary<string, Dictionary<ComboStateKeys, bool>>>>>
+                    Dictionary<Preset, Dictionary<ComboStateKeys, bool>>>>>
         CurrentJobComboStatesCategorized
     {
         get
@@ -387,32 +462,19 @@ public class Search(Leasing leasing)
             if (field != null && field.ContainsKey(job))
                 return field;
 
-            field = Presets
+            field = PresetRuntimeStates
                 .Where(preset =>
-                    preset.Value is
-                        { IsVariant: false, HasParentCombo: false } &&
-                    preset.Value.Job == job &&
-                    !preset.Key.Contains("pvp", ToLower))
-                .SelectMany(preset => new[]
-                {
-                    new
-                    {
-                        Job = preset.Value.Job,
-                        Combo = preset.Key,
-                        preset.Value,
-                        preset.Value.ComboType,
-                    },
-                })
-                .GroupBy(x => x.Job)
+                    preset.Value.Data is
+                    { IsVariant: false, Parent: null, IsPvP: false } &&
+                    preset.Value.Data.JobInfo!.Job == job)
+                .GroupBy(preset => preset.Value.Data.JobInfo!.Job)
                 .ToDictionary(
                     g => g.Key,
-                    g => g.GroupBy(x =>
-                            x.Value.presetData.TargetType
-                        )
+                    g => g.GroupBy(x => x.Value.Data.TargetType)
                         .ToDictionary(
                             g2 => g2.Key,
                             g2 => g2.GroupBy(x =>
-                                    x.ComboType switch
+                                    x.Value.Data.ComboType switch
                                     {
                                         ComboType.Advanced =>
                                             ComboSimplicityLevelKeys.Advanced,
@@ -424,8 +486,18 @@ public class Search(Leasing leasing)
                                 .ToDictionary(
                                     g3 => g3.Key,
                                     g3 => g3.ToDictionary(
-                                        x => x.Combo,
-                                        x => ComboStatesByJob[x.Job][x.Combo]
+                                        x => x.Key,
+                                        x => new Dictionary<ComboStateKeys, bool>
+                                        {
+                                            {
+                                                ComboStateKeys.Enabled,
+                                                x.Value.Enabled
+                                            },
+                                            {
+                                                ComboStateKeys.AutoMode,
+                                                x.Value.AutoMode
+                                            },
+                                        }
                                     )
                                 )
                         )
@@ -452,17 +524,20 @@ public class Search(Leasing leasing)
             Dictionary<string,
                 List<string>>>
         OptionNamesByJob =>
-        Presets
+        PresetRuntimeStates
             .Where(preset =>
-                preset.Value is { IsVariant: false, HasParentCombo: true } &&
-                !preset.Key.Contains("pvp", ToLower))
-            .GroupBy(preset => preset.Value.Job)
+                preset.Value.Data is
+                { IsVariant: false, Parent: not null, IsPvP: false })
+            .GroupBy(preset => preset.Value.Data.JobInfo!.Job)
             .ToDictionary(
                 g => g.Key,
-                g => g.GroupBy(preset => preset.Value.ParentComboName)
+                g => g.GroupBy(preset =>
+                        PresetStorage.AllPresets[preset.Value.Data.RootParent]
+                            .InternalName)
                     .ToDictionary(
                         g2 => g2.Key,
-                        g2 => g2.Select(preset => preset.Key).ToList()
+                        g2 => g2.Select(preset => preset.Value.Data.InternalName)
+                            .ToList()
                     )
             );
 
@@ -528,11 +603,12 @@ public class Search(Leasing leasing)
         if (!VariantParentNames.TryGetValue(role, out var parent))
             return [];
 
-        return Presets
+        return PresetRuntimeStates
             .Where(preset =>
-                preset.Value is { IsVariant: true, HasParentCombo: true } &&
-                preset.Value.ParentComboName == parent)
-            .Select(preset => preset.Key)
+                preset.Value.Data is { IsVariant: true, Parent: not null } &&
+                PresetStorage.AllPresets[preset.Value.Data.RootParent]
+                    .InternalName == parent)
+            .Select(preset => preset.Value.Data.InternalName)
             .ToList();
     }
 
@@ -543,13 +619,11 @@ public class Search(Leasing leasing)
     ///     IPC settings on top.
     /// </summary>
     internal Dictionary<Preset, bool> AutoActions =>
-        PresetStates
-            .Where(x =>
-                Enum.Parse<Preset>(x.Key).Attributes()
-                    .AutoAction is not null)
+        PresetRuntimeStates
+            .Where(preset => preset.Value.Data.AutoAction is not null)
             .ToDictionary(
-                preset => Enum.Parse<Preset>(preset.Key),
-                preset => preset.Value[ComboStateKeys.AutoMode]
+                preset => preset.Key,
+                preset => preset.Value.AutoMode
             );
 
     /// <summary>
@@ -557,9 +631,9 @@ public class Search(Leasing leasing)
     ///     IPC settings on top.
     /// </summary>
     internal HashSet<Preset> EnabledActions =>
-        PresetStates
-            .Where(preset => preset.Value[ComboStateKeys.Enabled])
-            .Select(preset => Enum.Parse<Preset>(preset.Key))
+        PresetRuntimeStates
+            .Where(preset => preset.Value.Enabled)
+            .Select(preset => preset.Key)
             .ToHashSet();
 
     #endregion

--- a/WrathCombo/Services/IPC/Search.cs
+++ b/WrathCombo/Services/IPC/Search.cs
@@ -296,7 +296,7 @@ public class Search(Leasing leasing)
             g => g.Key,
             g =>
             {
-                var latest = g.OrderByDescending(x => x.LastUpdated).First();
+                var latest = g.MaxBy(x => x.LastUpdated);
                 return (enabled: latest.enabled, autoMode: latest.autoMode);
             }
         );


### PR DESCRIPTION
- Presets.cs
  - Added PresetData.InternalName, the enum name cached once in the constructor, instead of being figured out by ToString() where possible.
  - Added PresetsByName Dictionary for IPC use (name + presetdata)
  - GetPresetsByString -> GetPresetsByName and using dictionary lookup

- Search.cs
  - Removed the old Presets dictionary (wasn't updated when I built up PresetStorage)
  - Added PresetRuntimeState. Wraps PresetData with runtime bools Enabled & AutoMode
  - Replaced PresetStates with function to grab data from PresetRuntimeState 
  - AutoActions/EnabledActions read from PresetRuntimeState 

- Leasing.cs
  - CheckComboControlled, CheckComboOptionControl, AddRegistrationForCombo, & AddRegistrationForOption use GetPresetsByEnumName instead of try/except or praying the enum exists