### PR TITLE
Battle Data and BattleChara

### DIFF
--- a/WrathCombo/Data/BattleData/BattleData.cs
+++ b/WrathCombo/Data/BattleData/BattleData.cs
@@ -8,6 +8,7 @@ using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using WrathCombo.CustomComboNS;
+using WrathCombo.Extensions;
 using WrathCombo.Services;
 using static ECommons.ExcelServices.ExcelTerritoryHelper;
 
@@ -106,7 +107,7 @@ namespace WrathCombo.Data.BattleData
             return target is not null
                 && target.IsCasting
                 && IsTankbuster(target.CastActionId)
-                && target.TargetObject == Player.Object;
+                && target.TargetObject.GameObjectId == Player.Object.GameObjectId;
         }
 
         // Raidwides
@@ -168,8 +169,12 @@ namespace WrathCombo.Data.BattleData
         /// <returns></returns>
         private static bool CheckForGazeCasts(uint actionID)
         {
-            var battleChars = Svc.Objects.Where(x => x is IBattleChara).Cast<IBattleChara>();
-            return battleChars.Any(x => x.IsCasting && x.CastActionId == actionID && (x.TotalCastTime - x.CurrentCastTime) <= Service.Configuration.PenaltyPause);
+            return Svc.Objects
+                .GetBattleCharas()
+                .Any(x =>
+                    x.IsCasting &&
+                    x.CastActionId == actionID &&
+                    (x.TotalCastTime - x.CurrentCastTime) <= Service.Configuration.PenaltyPause);
         }
 
         /// <summary>
@@ -181,7 +186,7 @@ namespace WrathCombo.Data.BattleData
         public static bool CheckForGazeCasts(uint baseId, uint actionID)
         {
             return Svc.Objects
-                .OfType<IBattleChara>()
+                .GetBattleCharas()
                 .Any(x =>
                     x.BaseId == baseId &&
                     x.IsCasting &&

--- a/WrathCombo/Data/BattleData/BattleData_5.0_ShB.cs
+++ b/WrathCombo/Data/BattleData/BattleData_5.0_ShB.cs
@@ -5,6 +5,7 @@ using ECommons.ExcelServices;
 using ECommons.GameFunctions;
 using ECommons.GameHelpers;
 using System.Linq;
+using WrathCombo.Extensions;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 
 namespace WrathCombo.Data.BattleData
@@ -27,15 +28,24 @@ namespace WrathCombo.Data.BattleData
                     break;
                 case 846: // Crown of the Immaculate (normal)
 
-                    _invincibleCheck = (tar, id, _) =>
+                    _invincibleCheck = (target, targetID, _) =>
                     {
-                        if (Svc.Objects.OfType<IBattleChara>().TryGetFirst(y => y.BaseId == 11247, out var venery))
+                        // During the phase where Venery is not targettable and going to eat the shames, check for a tether vfx
+                        if (targetID is 11246 && // Shames
+                           Svc.Objects.GetBattleCharas().FirstOrDefault(x => x.BaseId is 11247 && !x.IsTargetable) is not null) // Venery
                         {
-                            return venery.IsCasting && tar.ObjectId != venery.CastTargetObjectId ? Invincible.True : Invincible.False;
+                            return Result(target.GetTethers().Count is 0); // Ignore if it doesn't have the tether vfx
                         }
 
                         return Invincible.False;
                     };
+
+                    _pauseActions = () =>
+                    {
+                        if (CheckForGazeCasts(10491, 16025)) return true; // Chonky Innocence casting Enthrall
+                        return false;
+                    };
+
                     break;
                 case 887: // The Epic of Alexander (Ultimate)
                           // Jagd Doll = NameId 3759

--- a/WrathCombo/Data/BattleData/BattleData_7.0_DT.cs
+++ b/WrathCombo/Data/BattleData/BattleData_7.0_DT.cs
@@ -1,10 +1,10 @@
-﻿using Dalamud.Game.ClientState.Objects.Types;
-using ECommons.DalamudServices;
+﻿using ECommons.DalamudServices;
 using ECommons.GameFunctions;
 using ECommons.GameHelpers;
 using ECommons.MathHelpers;
 using System.Collections.Frozen;
 using System.Linq;
+using WrathCombo.Extensions;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 
 
@@ -130,16 +130,9 @@ namespace WrathCombo.Data.BattleData
                         bool pause = false;
 
                         // There can be two of these objects, only one appears to be active.
-                        IGameObject? motionScannerHelper;
-                        unsafe
-                        {
-                            motionScannerHelper = Svc.Objects.FirstOrDefault(x =>
-                                x.BaseId == 0x4C2D &&
-                                x.Address != 0 &&
-                                (int)x.Struct()->RenderFlags == 0);
-                        }
-
-                        if (motionScannerHelper is IGameObject scanner)
+                        if (Svc.Objects.GetBattleCharas().FirstOrDefault(x =>
+                            x.BaseId == 0x4C2D &&
+                            x.IsCharacterVisible()) is { } scanner)
                         {
                             var facingdirection = MathHelper.GetCardinalDirection(MathHelper.RadToDeg(scanner.Rotation));
 

--- a/WrathCombo/Extensions/ObjectTableExtensions.cs
+++ b/WrathCombo/Extensions/ObjectTableExtensions.cs
@@ -1,0 +1,36 @@
+﻿using Dalamud.Plugin.Services;
+using Dalamud.Game.ClientState.Objects.Types;
+using System.Collections.Generic;
+
+namespace WrathCombo.Extensions
+{
+    internal static class ObjectTableExtensions
+    {
+        // Narrower search scope
+        // https://github.com/aers/FFXIVClientStructs/blob/main/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObjectManager.cs
+        public static IEnumerable<IBattleChara> GetBattleCharas(this IObjectTable objects, bool searchNonNetwork = false)
+        {
+            // Networked battle characters (0-199, every other index)
+            // Their minions/mounts/etc are the number skipped over
+            for (var index = 0; index < 200; index += 2)
+            {
+                if (objects[index] is IBattleChara battleChara)
+                {
+                    yield return battleChara;
+                }
+            }
+
+            if (searchNonNetwork)
+            {
+                // Non-networked objects (200-448)
+                for (var index = 200; index < 449; index++)
+                {
+                    if (objects[index] is IBattleChara battleChara)
+                    {
+                        yield return battleChara;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Added an ObjectTable Extension to look for IBattleCharas in their allocated spot in the Svc.Objects Table without going through all of the Objects. Should help get faster results in large FATES/Hunts for potato pcs. Mimics Dalamud's Svc.Objects.PlayerObjects but without the ObjectKind.Player filter https://github.com/goatcorp/Dalamud/blob/master/Dalamud/Game/ClientState/Objects/ObjectTable.cs#L164
- Battle Data
  - Crown of the Immaculate: Using ECommon's Tether VFX detection code for faster results on which Forsaken Shame to target. Added Gaze check for fatty.
  - The Clyteum: Cleaned up Motion Scanner NPC detection (thanks again ECommons)