### PR TITLE
[NIN] Fixes for (Single Target) Throwing Daggers

### DIFF
--- a/WrathCombo/Combos/PvE/NIN/NIN.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN.cs
@@ -1,7 +1,5 @@
-using ECommons.DalamudServices;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using System.Linq;
-using System.Reflection.Metadata.Ecma335;
 using WrathCombo.CustomComboNS;
 using WrathCombo.Extensions;
 using WrathCombo.Native;
@@ -99,7 +97,7 @@ internal partial class NIN : Melee
             if (CanThrowingDaggers)
                 return OriginalHook(ThrowingDaggers);
 
-            if (CanRaiju)
+            if (CanRaiju && InMeleeRange())
                 return FleetingRaiju;
 
             if (CanPhantomKamaitachi)
@@ -359,13 +357,15 @@ internal partial class NIN : Melee
             #endregion
 
             #region GCDS
-            if (IsEnabled(Preset.NIN_ST_AdvancedMode_ThrowingDaggers) && CanThrowingDaggers && !MudraPhase)
-                return OriginalHook(ThrowingDaggers);
 
             if (IsEnabled(Preset.NIN_ST_AdvancedMode_Raiju) && CanRaiju)
-                return NIN_ST_AdvancedMode_ForkedRaiju && !InMeleeRange()
-                    ? ForkedRaiju
-                    : FleetingRaiju;
+            {
+                if (InMeleeRange()) return FleetingRaiju;
+                else if (NIN_ST_AdvancedMode_ForkedRaiju) return ForkedRaiju;
+            }
+
+            if (IsEnabled(Preset.NIN_ST_AdvancedMode_ThrowingDaggers) && CanThrowingDaggers && !MudraPhase)
+                return OriginalHook(ThrowingDaggers);
 
             if (IsEnabled(Preset.NIN_ST_AdvancedMode_PhantomKamaitachi) && CanPhantomKamaitachi)
                 return PhantomKamaitachi;

--- a/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
+++ b/WrathCombo/Combos/PvE/NIN/NIN_Helper.cs
@@ -198,7 +198,7 @@ internal partial class NIN
     internal static bool CanUseFumaShuriken => ActionReady(Ten);
 
     internal static bool CanUseRaiton => LevelChecked(Raiton) && ActionReady(Ten) &&
-                                          (!HasKassatsu || IsNotEnabled(Preset.NIN_ST_AdvancedMode_Ninjitsus_Hyosho) && !STSimpleMode || !LevelChecked(HyoshoRanryu)) && //Use kassatsu on it if Hyosho isn't selected. 
+                                          (!HasKassatsu || IsNotEnabled(Preset.NIN_ST_AdvancedMode_Ninjitsus_Hyosho) && !STSimpleMode || !LevelChecked(HyoshoRanryu)) && //Use kassatsu on it if Hyosho isn't selected.
                                            (TrickDebuff || // Buff Window
                                            !LevelChecked(Suiton) || //Dont Pool because of Suiton not learned yet
                                            GetCooldownChargeRemainingTime(Ten) < 1 && TrickCD > 18 || // Spend to avoid cap
@@ -235,8 +235,7 @@ internal partial class NIN
     internal static bool CanPhantomKamaitachi => !MudraPhase && HasStatusEffect(Buffs.PhantomReady) &&
                                                  (TrickDebuff && ComboAction != GustSlash ||
                                                   !TrickDebuff);
-    internal static bool CanThrowingDaggers => !MudraPhase && ActionReady(ThrowingDaggers) && HasTarget() && !InMeleeRange() &&
-                                               !HasStatusEffect(Buffs.RaijuReady);
+    internal static bool CanThrowingDaggers => !MudraPhase && ActionReady(ThrowingDaggers) && HasTarget() && !InMeleeRange();
     internal static bool CanThrowingDaggersAoE => !MudraPhase && ActionReady(ThrowingDaggers) && HasTarget() && GetTargetDistance() >= 4.5 && InActionRange(ThrowingDaggers) &&
                                                   !HasStatusEffect(Buffs.RaijuReady);
     internal static bool CanRaiju => !MudraPhase && HasStatusEffect(Buffs.RaijuReady);
@@ -548,7 +547,7 @@ internal partial class NIN
         }
         #endregion
 
-        #region Hyosho Ranryu 
+        #region Hyosho Ranryu
         public bool CastHyoshoRanryu(ref uint actionID) // Ten Jin
         {
             if (HyoshoRanryu.LevelChecked() && CurrentMudra is MudraState.None or MudraState.CastingHyoshoRanryu)


### PR DESCRIPTION
- Removed Raiju buff check from single target throwing daggers
- Simple ST: Fleeting Raiju has a InMeleeRange check, shouldn't lock out other actions
- Adv ST: Prioritized Raiju over throwing daggers for Forked(Gap Closer) use, but will check melee range for Fleeting as well to not lock out throwing daggers