### PR TITLE
Misc Work

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -57,8 +57,6 @@ internal unsafe class AutoRotationController
     public static int AutorotRaidwides = 0;
     public static bool TankbusterHandled = false;
 
-    private const ushort TranscendantBuff = 418; // Post-raise invincibility
-
     private static Dictionary<Preset, bool> _autoActions => Presets.GetJobAutorots;
 
     public AutoRotationController()
@@ -112,8 +110,8 @@ internal unsafe class AutoRotationController
         x.BattleChara.IsTargetable &&
         (cfg.HealerSettings.AutoRezOutOfParty || GetPartyMembers().Any(y => y.GameObjectId == x.BattleChara.GameObjectId)) &&
         GetTargetDistance(x.BattleChara) <= QueryRange &&
-        !HasStatusEffect(2648, x.BattleChara, true) && // Transcendent Effect
-        !HasStatusEffect(148, x.BattleChara, true) && // Raise Effect
+        !TargetHasRaiseStatus(x.BattleChara) &&
+        !TargetHasRaiseInvincibility(x.BattleChara) &&
         TimeSpentDead(x.BattleChara.GameObjectId).TotalSeconds > 2;
 
     public static bool LockedST
@@ -151,6 +149,7 @@ internal unsafe class AutoRotationController
                || Player.Mounted
                || !EzThrottler.Throttle("Autorot", cfg.Throttler)
                || (ActionManager.Instance()->QueuedActionId > 0)
+               || TargetHasRaiseInvincibility(Player.Object)
                || Paused;
     }
 
@@ -407,10 +406,6 @@ internal unsafe class AutoRotationController
             if ((action.IsAoE && LockedST) || (!action.IsAoE && LockedAoE))
                 continue;
 
-            // Skip if rez invuln is up
-            if (!action.IsHeal && HasStatusEffect(TranscendantBuff))
-                continue;
-
             uint gameAct = attributes.ReplaceSkill!.ActionIDs.First();
             var status = ActionManager.Instance()->GetActionStatus(ActionType.Action, gameAct, checkCastingActive: false, checkRecastActive: false);
 
@@ -550,7 +545,6 @@ internal unsafe class AutoRotationController
     // Note: Similar to Kardia, because this has its own set of rules but regarding timings I'm not sure if I want to wire this up to retargeting
     private static void RezParty()
     {
-        if (HasStatusEffect(TranscendantBuff)) return;
         uint resSpell = 0;
 
         if (OccultCrescent.IsEnabledAndUsable(Preset.Phantom_Chemist_Revive, OccultCrescent.Revive))
@@ -663,11 +657,11 @@ internal unsafe class AutoRotationController
 
     private static void CleanseParty()
     {
-        if (HasStatusEffect(TranscendantBuff) || LocalPlayer is not { } || !EzThrottler.Throttle("CleanseThrottle", 50)) return;
+        if (Player.Object is not { } || !EzThrottler.Throttle("CleanseThrottle", 50)) return;
 
         if (SimpleTarget.Stack.AllyToEsuna is IBattleChara memberBC)
         {
-            var res = ActionManager.GetActionInRangeOrLoS(Healer.Role.Esuna, LocalPlayer.GameObject(), memberBC.GameObject());
+            var res = ActionManager.GetActionInRangeOrLoS(Healer.Role.Esuna, Player.GameObject, memberBC.GameObject());
             if (res is 0 or 565)
             {
                 Svc.Log.Debug($"Cleansing {memberBC.Name}");
@@ -680,14 +674,13 @@ internal unsafe class AutoRotationController
     // it is known if it acts funny with the standalone retarget then that's what causes it.
     private static void UpdateKardiaTarget()
     {
-        if (HasStatusEffect(TranscendantBuff)) return;
         if (!LevelChecked(SGE.Kardia)) return;
         if (CombatEngageDuration().TotalSeconds < 3) return;
 
         foreach (var member in GetPartyMembers().Where(x => !x.BattleChara.IsDead).OrderByDescending(x => x.BattleChara?.GetRole() is CombatRole.Tank))
         {
             if (cfg.HealerSettings.KardiaTanksOnly && member.BattleChara?.GetRole() is not CombatRole.Tank &&
-                !HasStatusEffect(3615, member.BattleChara, true)) continue;
+                !HasStatusEffect(3615, member.BattleChara, true)) continue; // Duty Support Gosetsu Tank Stance
 
             var enemiesTargeting = Svc.Objects.GetBattleCharas().Count(x => x.IsTargetable && x.IsHostile() && x.TargetObjectId == member.BattleChara.GameObjectId);
             if (enemiesTargeting > 0 && !HasStatusEffect(SGE.Buffs.Kardion, member.BattleChara))
@@ -1202,7 +1195,7 @@ internal unsafe class AutoRotationController
                             x.BattleChara.IsTargetable &&
                             GetTargetDistance(x.BattleChara) <= QueryRange &&
                             !TargetHasImmortality(x.BattleChara) &&
-                            !x.BattleChara.StatusList.Any(x => StatusCache.DoNotHealStatuses.Contains(x.StatusId)) &&
+                            !StatusCache.HasStatusInCacheList(StatusCache.DoNotHealStatuses,x.BattleChara) &&
                             GetTargetHPPercent(x.BattleChara, cfg.HealerSettings.IncludeShields) <=
                             (TargetHasExcog(x.BattleChara) ? cfg.HealerSettings.SingleTargetExcogHPP :
                                 TargetHasRegen(x.BattleChara) ? cfg.HealerSettings.SingleTargetRegenHPP :

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -104,7 +104,7 @@ internal unsafe class AutoRotationController
             Paused = false;
     }
 
-    static Func<WrathPartyMember, bool> RezQuery => x =>
+    static bool CheckRezTarget(WrathPartyMember x) =>
         x.BattleChara is not null &&
         x.BattleChara.IsDead &&
         x.BattleChara.IsTargetable &&
@@ -458,7 +458,7 @@ internal unsafe class AutoRotationController
 
         if (regenSpell != 0 && !JustUsed(regenSpell, 4) && SimpleTarget.FocusTarget != null && (!HasStatusEffect(regenBuff, out var regen, SimpleTarget.FocusTarget) || regen?.RemainingTime <= 5f))
         {
-            var query = Svc.Objects.Where(x => !x.IsDead && x.IsTargetable && x.IsHostile());
+            var query = Svc.Objects.GetBattleCharas().Where(x => !x.IsDead && x.IsTargetable && x.IsHostile());
             if (!query.Any())
                 return;
 
@@ -522,7 +522,7 @@ internal unsafe class AutoRotationController
                 }
             }
 
-            var query = Svc.Objects.Where(x => !x.IsDead && x.IsTargetable && x.IsHostile());
+            var query = Svc.Objects.GetBattleCharas().Where(x => !x.IsDead && x.IsTargetable && x.IsHostile());
             if (!query.Any())
                 return;
 
@@ -592,7 +592,7 @@ internal unsafe class AutoRotationController
             if ((timeSinceLastRez != -1f && timeSinceLastRez < 4f) || Player.Object.IsCasting())
                 return;
 
-            if (deadPeople.Where(RezQuery).FindFirst(x => x is not null, out var member))
+            if (deadPeople.Where(CheckRezTarget).FindFirst(x => x is not null, out var member))
             {
                 if (resSpell == OccultCrescent.Revive)
                 {
@@ -688,7 +688,7 @@ internal unsafe class AutoRotationController
             if (cfg.HealerSettings.KardiaTanksOnly && member.BattleChara?.GetRole() is not CombatRole.Tank &&
                 !HasStatusEffect(3615, member.BattleChara, true)) continue;
 
-            var enemiesTargeting = Svc.Objects.Count(x => x.IsTargetable && x.IsHostile() && x.TargetObjectId == member.BattleChara.GameObjectId);
+            var enemiesTargeting = Svc.Objects.GetBattleCharas().Count(x => x.IsTargetable && x.IsHostile() && x.TargetObjectId == member.BattleChara.GameObjectId);
             if (enemiesTargeting > 0 && !HasStatusEffect(SGE.Buffs.Kardion, member.BattleChara))
             {
                 ActionManager.Instance()->UseAction(ActionType.Action, SGE.Kardia.Retarget(member.BattleChara), member.BattleChara.GameObjectId);
@@ -1055,8 +1055,7 @@ internal unsafe class AutoRotationController
 
     public class DPSTargeting
     {
-        private static bool Query(IGameObject x) =>
-            x is IBattleChara chara &&
+        private static bool Query(IBattleChara chara) =>
             !chara.IsDead &&
             GetTargetCurrentHP(chara, true) > 0 &&
             chara.IsTargetable &&
@@ -1068,31 +1067,28 @@ internal unsafe class AutoRotationController
             ((cfg.DPSSettings.OnlyAttackInCombat && chara.Struct()->InCombat) || !cfg.DPSSettings.OnlyAttackInCombat) &&
             IsInLineOfSight(chara);
 
-        public static IEnumerable<IGameObject> BaseSelection => Svc.Objects.Any(x => Query(x) && IsPriority(x))
-            ? Svc.Objects.Where(x => Query(x) && IsPriority(x))
-            : Svc.Objects.Where(x => Query(x));
-
-        private static bool IsPriority(IGameObject x)
+        public static IEnumerable<IBattleChara> BaseSelection
         {
-            if (x is IBattleChara chara)
+            get
             {
-                bool isFate = cfg.DPSSettings.FATEPriority && x.Struct()->FateId != 0 && InFATE();
-                bool isQuest = cfg.DPSSettings.QuestPriority && IsQuestMob(x);
-
-                return isFate || isQuest;
+                var priorityMatches = Svc.Objects.GetBattleCharas().Where(x => Query(x) && IsPriority(x)).ToList();
+                return priorityMatches.Count != 0 ? priorityMatches : Svc.Objects.GetBattleCharas().Where(x => Query(x));
             }
-            return false;
         }
 
-        public static bool IsCombatPriority(IGameObject x)
+        private static bool IsPriority(IBattleChara x)
         {
-            if (x is IBattleChara chara)
-            {
-                if (!cfg.DPSSettings.PreferNonCombat) return true;
-                bool inCombat = cfg.DPSSettings.PreferNonCombat && !chara.Struct()->InCombat;
-                return inCombat;
-            }
-            return false;
+            bool isFate = cfg.DPSSettings.FATEPriority && x.Struct()->FateId != 0 && InFATE();
+            bool isQuest = cfg.DPSSettings.QuestPriority && IsQuestMob(x);
+
+            return isFate || isQuest;
+        }
+
+        public static bool IsCombatPriority(IBattleChara x)
+        {
+            if (!cfg.DPSSettings.PreferNonCombat) return true;
+            bool inCombat = cfg.DPSSettings.PreferNonCombat && !x.Struct()->InCombat;
+            return inCombat;
         }
 
         public static IGameObject? GetTankTarget()
@@ -1104,7 +1100,7 @@ internal unsafe class AutoRotationController
             return tank.BattleChara.TargetObject;
         }
 
-        public static IGameObject? GetNearestTarget()
+        public static IBattleChara? GetNearestTarget()
         {
             return BaseSelection
                 .OrderByDescending(x => IsCombatPriority(x))
@@ -1112,7 +1108,7 @@ internal unsafe class AutoRotationController
                 .FirstOrDefault();
         }
 
-        public static IGameObject? GetFurthestTarget()
+        public static IBattleChara? GetFurthestTarget()
         {
             return BaseSelection
                 .OrderByDescending(x => IsCombatPriority(x))
@@ -1120,7 +1116,7 @@ internal unsafe class AutoRotationController
                 .FirstOrDefault();
         }
 
-        public static IGameObject? GetLowestCurrentTarget()
+        public static IBattleChara? GetLowestCurrentTarget()
         {
             return BaseSelection
                 .OrderByDescending(x => IsCombatPriority(x))
@@ -1128,7 +1124,7 @@ internal unsafe class AutoRotationController
                 .FirstOrDefault();
         }
 
-        public static IGameObject? GetHighestCurrentTarget()
+        public static IBattleChara? GetHighestCurrentTarget()
         {
             return BaseSelection
                 .OrderByDescending(x => IsCombatPriority(x))
@@ -1136,7 +1132,7 @@ internal unsafe class AutoRotationController
                 .FirstOrDefault();
         }
 
-        public static IGameObject? GetLowestMaxTarget()
+        public static IBattleChara? GetLowestMaxTarget()
         {
 
             return BaseSelection
@@ -1147,7 +1143,7 @@ internal unsafe class AutoRotationController
                 .FirstOrDefault();
         }
 
-        public static IGameObject? GetHighestMaxTarget()
+        public static IBattleChara? GetHighestMaxTarget()
         {
             return BaseSelection
                 .OrderByDescending(x => IsCombatPriority(x))
@@ -1188,7 +1184,7 @@ internal unsafe class AutoRotationController
             return HealTargets().ThenBy(x => GetTargetHPPercent(x)).FirstOrDefault();
         }
 
-        internal static IOrderedEnumerable<IGameObject?> HealTargets()
+        internal static IOrderedEnumerable<IBattleChara?> HealTargets()
         {
             return GetPartyMembers()
                 .Where(x => !x.BattleChara.IsDead &&
@@ -1207,27 +1203,18 @@ internal unsafe class AutoRotationController
 
         internal static bool CanAoEHeal(uint outAct = 0)
         {
-            int memberCount;
-            try
-            {
-                var members = GetPartyMembers()
-                    .Where(x => x.BattleChara is not null &&
-                                !x.BattleChara.IsDead &&
-                                x.BattleChara.IsTargetable &&
-                                !x.IsOutOfPartyNPC &&
-                                !x.BattleChara.StatusList.Any(x => StatusCache.DoNotHealStatuses.Contains(x.StatusId)) &&
-                                (outAct == 0
-                                    ? GetTargetDistance(x.BattleChara) <= 20f
-                                    : InActionRange(outAct, x.BattleChara)) &&
-                                GetTargetHPPercent(x.BattleChara, cfg.HealerSettings.IncludeShields) <= cfg.HealerSettings.AoETargetHPP);
-                memberCount = members.Count();
-            }
-            catch { memberCount = 0; }
+            int healableCount = GetPartyMembers()
+                .Count(x => x.BattleChara is not null &&
+                            !x.BattleChara.IsDead &&
+                            x.BattleChara.IsTargetable &&
+                            !x.IsOutOfPartyNPC &&
+                            !(x.BattleChara.SafeStatusList?.Any(s => StatusCache.DoNotHealStatuses.Contains(s.StatusId)) ?? false) &&
+                            (outAct == 0
+                                ? GetTargetDistance(x.BattleChara) <= 20f
+                                : InActionRange(outAct, x.BattleChara)) &&
+                            GetTargetHPPercent(x.BattleChara, cfg.HealerSettings.IncludeShields) <= cfg.HealerSettings.AoETargetHPP);
 
-            if (memberCount < cfg.HealerSettings.AoEHealTargetCount)
-                return false;
-
-            return true;
+            return healableCount >= cfg.HealerSettings.AoEHealTargetCount;
         }
 
         private static bool TargetHasRegen(IGameObject? target)
@@ -1245,7 +1232,7 @@ internal unsafe class AutoRotationController
             return target is not null && HasStatusEffect(SCH.Buffs.Excogitation, target, true);
         }
         /// Used to skip the healing of tanks that are invuln but still receive damage
-        private static bool TargetHasImmortality(IGameObject? target)
+        private static bool TargetHasImmortality(IBattleChara? target)
         {
             if (target is null) return false;
 
@@ -1254,7 +1241,7 @@ internal unsafe class AutoRotationController
                    GetStatusEffectRemainingTime(WAR.Buffs.Holmgang, target, true) >= 5;
         }
         /// Used to de-prioritize (not skip) the healing of invuln tanks
-        private static bool TargetHasTrueInvuln(IGameObject? target)
+        private static bool TargetHasTrueInvuln(IBattleChara? target)
         {
             if (target is null) return false;
 
@@ -1265,7 +1252,7 @@ internal unsafe class AutoRotationController
 
     public static class TankTargeting
     {
-        public static IGameObject? GetLowestCurrentTarget()
+        public static IBattleChara? GetLowestCurrentTarget()
         {
             return DPSTargeting.BaseSelection
                 .OrderByDescending(x => DPSTargeting.IsCombatPriority(x))
@@ -1274,7 +1261,7 @@ internal unsafe class AutoRotationController
                 .ThenBy(x => GetTargetHPPercent(x)).FirstOrDefault();
         }
 
-        public static IGameObject? GetHighestCurrentTarget()
+        public static IBattleChara? GetHighestCurrentTarget()
         {
             return DPSTargeting.BaseSelection
                 .OrderByDescending(x => DPSTargeting.IsCombatPriority(x))
@@ -1283,7 +1270,7 @@ internal unsafe class AutoRotationController
                 .ThenBy(x => GetTargetHPPercent(x)).FirstOrDefault();
         }
 
-        public static IGameObject? GetLowestMaxTarget()
+        public static IBattleChara? GetLowestMaxTarget()
         {
             var t = DPSTargeting.BaseSelection
                 .OrderByDescending(x => DPSTargeting.IsCombatPriority(x))
@@ -1294,7 +1281,7 @@ internal unsafe class AutoRotationController
             return t;
         }
 
-        public static IGameObject? GetHighestMaxTarget()
+        public static IBattleChara? GetHighestMaxTarget()
         {
             return DPSTargeting.BaseSelection
                 .OrderByDescending(x => DPSTargeting.IsCombatPriority(x))

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -112,7 +112,6 @@ internal unsafe class AutoRotationController
         GetTargetDistance(x.BattleChara) <= QueryRange &&
         !HasStatusEffect(2648, x.BattleChara, true) && // Transcendent Effect
         !HasStatusEffect(148, x.BattleChara, true) && // Raise Effect
-        !HasStatusEffect(4263, x.BattleChara, true) && // Raise Denied (OC)
         TimeSpentDead(x.BattleChara.GameObjectId).TotalSeconds > 2;
 
     public static bool LockedST
@@ -576,9 +575,9 @@ internal unsafe class AutoRotationController
         if (resSpell == 0)
             return;
 
-        IEnumerable<WrathPartyMember> deadPeople = DeadPeople;
+        IEnumerable<WrathPartyMember> deadPeople = DeadPeople.Where(x => x.BattleChara.CanUseOn(resSpell));
 
-        if (cfg.HealerSettings.AutoRezDPSJobsHealersOnly && Player.Job is Job.RDM or Job.SMN)
+        if (cfg.HealerSettings.AutoRezDPSJobsHealersOnly && (resSpell is RDM.Verraise || Player.Job is Job.SMN))
         {
             deadPeople = deadPeople.Where(x => x.GetRole() is CombatRole.Healer || x.RealJob?.GetJob() is Job.SMN or Job.RDM);
         }

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -577,7 +577,7 @@ internal unsafe class AutoRotationController
 
         IEnumerable<WrathPartyMember> deadPeople = DeadPeople.Where(x => x.BattleChara.CanUseOn(resSpell));
 
-        if (cfg.HealerSettings.AutoRezDPSJobsHealersOnly && (resSpell is RDM.Verraise || Player.Job is Job.SMN))
+        if (cfg.HealerSettings.AutoRezDPSJobsHealersOnly && (resSpell is RDM.Verraise || (Player.Job is Job.SMN && resSpell is SCH.Resurrection)))
         {
             deadPeople = deadPeople.Where(x => x.GetRole() is CombatRole.Healer || x.RealJob?.GetJob() is Job.SMN or Job.RDM);
         }

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -57,6 +57,8 @@ internal unsafe class AutoRotationController
     public static int AutorotRaidwides = 0;
     public static bool TankbusterHandled = false;
 
+    private const ushort TranscendantBuff = 418; // Post-raise invincibility
+
     private static Dictionary<Preset, bool> _autoActions => Presets.GetJobAutorots;
 
     public AutoRotationController()
@@ -407,7 +409,7 @@ internal unsafe class AutoRotationController
                 continue;
 
             // Skip if rez invuln is up
-            if (!action.IsHeal && HasStatusEffect(418))
+            if (!action.IsHeal && HasStatusEffect(TranscendantBuff))
                 continue;
 
             uint gameAct = attributes.ReplaceSkill!.ActionIDs.First();
@@ -549,7 +551,7 @@ internal unsafe class AutoRotationController
     // Note: Similar to Kardia, because this has its own set of rules but regarding timings I'm not sure if I want to wire this up to retargeting
     private static void RezParty()
     {
-        if (HasStatusEffect(418)) return;
+        if (HasStatusEffect(TranscendantBuff)) return;
         uint resSpell = 0;
 
         if (OccultCrescent.IsEnabledAndUsable(Preset.Phantom_Chemist_Revive, OccultCrescent.Revive))
@@ -662,7 +664,7 @@ internal unsafe class AutoRotationController
 
     private static void CleanseParty()
     {
-        if (HasStatusEffect(418) || LocalPlayer is not { } || !EzThrottler.Throttle("CleanseThrottle", 50)) return;
+        if (HasStatusEffect(TranscendantBuff) || LocalPlayer is not { } || !EzThrottler.Throttle("CleanseThrottle", 50)) return;
 
         if (SimpleTarget.Stack.AllyToEsuna is IBattleChara memberBC)
         {
@@ -679,7 +681,7 @@ internal unsafe class AutoRotationController
     // it is known if it acts funny with the standalone retarget then that's what causes it.
     private static void UpdateKardiaTarget()
     {
-        if (HasStatusEffect(418)) return;
+        if (HasStatusEffect(TranscendantBuff)) return;
         if (!LevelChecked(SGE.Kardia)) return;
         if (CombatEngageDuration().TotalSeconds < 3) return;
 
@@ -1071,17 +1073,25 @@ internal unsafe class AutoRotationController
         {
             get
             {
-                var priorityMatches = Svc.Objects.GetBattleCharas().Where(x => Query(x) && IsPriority(x)).ToList();
-                return priorityMatches.Count != 0 ? priorityMatches : Svc.Objects.GetBattleCharas().Where(x => Query(x));
+                var validTargets = Svc.Objects.GetBattleCharas()
+                    .Where(Query)
+                    .ToList();
+
+                if (!cfg.DPSSettings.FATEPriority && !cfg.DPSSettings.QuestPriority)
+                    return validTargets;
+
+                bool playerInFate = cfg.DPSSettings.FATEPriority && InFATE();
+
+                var priorityMatches = validTargets
+                    .Where(x =>
+                        (playerInFate && x.Struct()->FateId != 0) ||
+                        (cfg.DPSSettings.QuestPriority && IsQuestMob(x)))
+                    .ToList();
+
+                return priorityMatches.Count > 0
+                    ? priorityMatches
+                    : validTargets;
             }
-        }
-
-        private static bool IsPriority(IBattleChara x)
-        {
-            bool isFate = cfg.DPSSettings.FATEPriority && x.Struct()->FateId != 0 && InFATE();
-            bool isQuest = cfg.DPSSettings.QuestPriority && IsQuestMob(x);
-
-            return isFate || isQuest;
         }
 
         public static bool IsCombatPriority(IBattleChara x)
@@ -1093,7 +1103,9 @@ internal unsafe class AutoRotationController
 
         public static IGameObject? GetTankTarget()
         {
-            var tank = GetPartyMembers().FirstOrDefault(x => x.BattleChara?.GetRole() == CombatRole.Tank || HasStatusEffect(3615, x.BattleChara, true));
+            var tank = GetPartyMembers().FirstOrDefault(x => x.BattleChara?.GetRole() == CombatRole.Tank ||
+                HasStatusEffect(1719, x.BattleChara, true) || // BLU Mighty Guard
+                HasStatusEffect(3615, x.BattleChara, true));  // Duty Support Gosetsu Tank Stance
             if (tank == null)
                 return null;
 

--- a/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Helper.cs
@@ -496,7 +496,7 @@ internal partial class BRD
 
         if (flags.HasFlag(Combo.ST) && troubadourEnabled && ActionReady(Troubadour) && GroupDamageIncoming() && CanWeave() &&
             NumberOfAlliesInRange(Troubadour) >= GetPartyMembers().Count * .75 &&
-            !JustUsed(NaturesMinne) && !HasAnyStatusEffects([Buffs.Troubadour, Buffs.NaturesMinne, DNC.Buffs.ShieldSamba, MCH.Buffs.Tactician], anyOwner: true))
+            !JustUsed(NaturesMinne) && !HasStatusEffects([Buffs.Troubadour, Buffs.NaturesMinne, DNC.Buffs.ShieldSamba, MCH.Buffs.Tactician], anyOwner: true))
         {
             actionID = Troubadour;
             return true;
@@ -504,7 +504,7 @@ internal partial class BRD
 
         if (flags.HasFlag(Combo.ST) && naturesMinneEnabled && ActionReady(NaturesMinne) && GroupDamageIncoming() && CanWeave() &&
             NumberOfAlliesInRange(NaturesMinne) >= GetPartyMembers().Count * .75 &&
-            !JustUsed(Troubadour) && !HasAnyStatusEffects([Buffs.Troubadour, Buffs.NaturesMinne], anyOwner: true))
+            !JustUsed(Troubadour) && !HasStatusEffects([Buffs.Troubadour, Buffs.NaturesMinne], anyOwner: true))
         {
             actionID = NaturesMinne;
             return true;

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -288,7 +288,7 @@ internal partial class DNC : PhysicalRanged
                 if (ActionReady(ShieldSamba) &&
                     IsEnabled(Preset.DNC_ST_Adv_ShieldSamba) && GroupDamageIncoming() && 
                     NumberOfAlliesInRange(ShieldSamba) >= GetPartyMembers().Count * .75 &&
-                    !HasAnyStatusEffects ([BRD.Buffs.Troubadour, Buffs.ShieldSamba, MCH.Buffs.Tactician], anyOwner: true))
+                    !HasStatusEffects([BRD.Buffs.Troubadour, Buffs.ShieldSamba, MCH.Buffs.Tactician], anyOwner: true))
                     return ShieldSamba;
 
                 // ST Panic Heals
@@ -619,7 +619,7 @@ internal partial class DNC : PhysicalRanged
                 }
                 if (ActionReady(ShieldSamba) && GroupDamageIncoming() && 
                     NumberOfAlliesInRange(ShieldSamba) >= GetPartyMembers().Count * .75 &&
-                    !HasAnyStatusEffects ([BRD.Buffs.Troubadour, Buffs.ShieldSamba, MCH.Buffs.Tactician], anyOwner: true))
+                    !HasStatusEffects([BRD.Buffs.Troubadour, Buffs.ShieldSamba, MCH.Buffs.Tactician], anyOwner: true))
                     return ShieldSamba;
 
                 // ST Panic Heals

--- a/WrathCombo/Combos/PvE/MCH/MCH.cs
+++ b/WrathCombo/Combos/PvE/MCH/MCH.cs
@@ -249,7 +249,7 @@ internal partial class MCH : PhysicalRanged
                     if (IsEnabled(Preset.MCH_ST_Adv_Tactician) &&
                         ActionReady(Tactician) && GroupDamageIncoming() &&
                         !JustUsed(Dismantle, 6) && NumberOfAlliesInRange(Tactician) >= GetPartyMembers().Count * .75 &&
-                        !HasAnyStatusEffects([BRD.Buffs.Troubadour, DNC.Buffs.ShieldSamba, Buffs.Tactician], anyOwner: true))
+                        !HasStatusEffects([BRD.Buffs.Troubadour, DNC.Buffs.ShieldSamba, Buffs.Tactician], anyOwner: true))
                         return Tactician;
 
                     // Healing

--- a/WrathCombo/Combos/PvE/WAR/WAR_Helper.cs
+++ b/WrathCombo/Combos/PvE/WAR/WAR_Helper.cs
@@ -28,7 +28,7 @@ internal partial class WAR : Tank
     #endregion
 
     #region Openers
-    
+
     internal static WAROpenerMaxLevel1 Opener1 = new();
     internal static WrathOpener Opener()
     {
@@ -83,9 +83,9 @@ internal partial class WAR : Tank
     }
 
     #endregion
-    
+
     #region Rotation
-    
+
     #region Flag Stuff
     [Flags]
     private enum Combo
@@ -99,7 +99,7 @@ internal partial class WAR : Tank
         Simple = 1 << 3, // 8
         Basic = 1 << 4, // 16
     }
-    
+
     /// <summary>
     ///     Checks whether a given preset is enabled, and the flags match it.
     /// </summary>
@@ -112,7 +112,7 @@ internal partial class WAR : Tank
     private static bool IsAoEEnabled(Combo flags, Preset preset) =>
         flags.HasFlag(Combo.AoE) && IsEnabled(preset);
     #endregion
-    
+
     #region OGCD Attacks
     private static bool TryOGCDAttacks(Combo flags, ref uint actionID)
     {
@@ -121,75 +121,75 @@ internal partial class WAR : Tank
              flags.HasFlag(Combo.Simple) ||
              IsSTEnabled(flags, Preset.WAR_ST_Interrupt) ||
              IsAoEEnabled(flags, Preset.WAR_AoE_Interrupt);
-        
-        bool lowBlowEnabled = 
+
+        bool lowBlowEnabled =
             flags.HasFlag(Combo.Simple) ||
             IsSTEnabled(flags, Preset.WAR_ST_Stun) ||
             IsAoEEnabled(flags, Preset.WAR_AoE_Stun);
-        
+
         bool innerReleaseEnabled =
             flags.HasFlag(Combo.Simple) ||
             IsSTEnabled(flags, Preset.WAR_ST_InnerRelease) ||
             IsAoEEnabled(flags, Preset.WAR_AoE_InnerRelease);
-        
+
         bool infuriateEnabled =
             flags.HasFlag(Combo.Simple) ||
             IsSTEnabled(flags, Preset.WAR_ST_Infuriate) ||
             IsAoEEnabled(flags, Preset.WAR_AoE_Infuriate);
-        
+
         bool onslaughtEnabled =
             flags.HasFlag(Combo.Simple) ||
             IsSTEnabled(flags, Preset.WAR_ST_Onslaught) ||
             IsAoEEnabled(flags, Preset.WAR_AoE_Onslaught);
-        
+
         bool upheavalEnabled =
             flags.HasFlag(Combo.Simple) ||
             IsSTEnabled(flags, Preset.WAR_ST_Upheaval) ||
             IsAoEEnabled(flags, Preset.WAR_AoE_Orogeny);
-        
+
         bool primalWrathEnabled =
             flags.HasFlag(Combo.Simple) ||
             IsSTEnabled(flags, Preset.WAR_ST_PrimalWrath) ||
             IsAoEEnabled(flags, Preset.WAR_AoE_PrimalWrath);
-        
+
         #endregion
-        
+
         #region Configs
         int innerReleaseThresholdST = WAR_ST_InnerRelease_Threshold_SubOption == 1 || !InBossEncounter() ? WAR_ST_InnerRelease_Threshold : 0; //Boss Check
         int innerReleaseThresholdAoE = WAR_AoE_InnerRelease_Threshold_SubOption == 1 || !InBossEncounter() ? WAR_AoE_InnerRelease_Threshold : 0; //Boss Check
-        int innerReleaseStopThreshold = 
-            flags.HasFlag(Combo.Simple) ? 0 : 
+        int innerReleaseStopThreshold =
+            flags.HasFlag(Combo.Simple) ? 0 :
             flags.HasFlag(Combo.ST) ? innerReleaseThresholdST : innerReleaseThresholdAoE;
-        
-        bool poolOnslaughtForManual = !flags.HasFlag(Combo.Simple) && 
+
+        bool poolOnslaughtForManual = !flags.HasFlag(Combo.Simple) &&
                                       (flags.HasFlag(Combo.ST) && WAR_ST_Onslaught_ManualPooling ||
                                        flags.HasFlag(Combo.AoE) && WAR_AoE_Onslaught_ManualPooling);
-        
-        int infuriateGaugeThreshold = 
-            flags.HasFlag(Combo.Simple) ? 40 : 
+
+        int infuriateGaugeThreshold =
+            flags.HasFlag(Combo.Simple) ? 40 :
             flags.HasFlag(Combo.ST) ? WAR_ST_Infuriate_Gauge : WAR_AoE_Infuriate_Gauge;
-        
-        int infuriateChargeThreshold = 
-            flags.HasFlag(Combo.Simple) ? 0 : 
+
+        int infuriateChargeThreshold =
+            flags.HasFlag(Combo.Simple) ? 0 :
             flags.HasFlag(Combo.ST) ? WAR_ST_Infuriate_Charges : WAR_AoE_Infuriate_Charges;
-        
-        int onslaughtChargeThreshold = 
-            flags.HasFlag(Combo.Simple) ? 0 : 
+
+        int onslaughtChargeThreshold =
+            flags.HasFlag(Combo.Simple) ? 0 :
             flags.HasFlag(Combo.ST) ? WAR_ST_Onslaught_Charges : WAR_AoE_Onslaught_Charges;
-        
-        float onslaughtDistanceThreshold = 
-            flags.HasFlag(Combo.Simple) ? 3 : 
+
+        float onslaughtDistanceThreshold =
+            flags.HasFlag(Combo.Simple) ? 3 :
             flags.HasFlag(Combo.ST) ? WAR_ST_Onslaught_Distance : WAR_AoE_Onslaught_Distance;
-        
-        int onslaughtMovement = 
-            flags.HasFlag(Combo.Simple) ? 0 : 
+
+        int onslaughtMovement =
+            flags.HasFlag(Combo.Simple) ? 0 :
             flags.HasFlag(Combo.ST) ? WAR_ST_Onslaught_Movement : WAR_AoE_Onslaught_Movement;
-        
-        float onslaughtTimeStoodStill = 
-            flags.HasFlag(Combo.Simple) ? 2 : 
+
+        float onslaughtTimeStoodStill =
+            flags.HasFlag(Combo.Simple) ? 2 :
             flags.HasFlag(Combo.ST) ? WAR_ST_Onslaught_TimeStill : WAR_AoE_Onslaught_TimeStill;
         #endregion
-        
+
         if (InCombat() && HasBattleTarget() && CanWeave())
         {
             if (interruptEnabled && Role.CanInterject())
@@ -203,7 +203,7 @@ internal partial class WAR : Tank
                 actionID = Role.LowBlow;
                 return true;
             }
-            
+
             if (innerReleaseEnabled &&
                 ActionReady(OriginalHook(Berserk)) && HasSurgingTempest && !HasWrathful &&
                 GetTargetHPPercent() >= innerReleaseStopThreshold) //Health Threshold Check, boss check built into config
@@ -211,17 +211,17 @@ internal partial class WAR : Tank
                 actionID = OriginalHook(Berserk);
                 return true;
             }
-            
-            if (infuriateEnabled && 
-                ActionReady(Infuriate) && !HasNascentChaos && !JustUsed(Infuriate) && !HasIR.Stacks && 
+
+            if (infuriateEnabled &&
+                ActionReady(Infuriate) && !HasNascentChaos && !JustUsed(Infuriate) && !HasIR.Stacks &&
                 BeastGauge <= infuriateGaugeThreshold && //Gauge slider check
                 GetRemainingCharges(Infuriate) > infuriateChargeThreshold) //Charge slider check
             {
                 actionID = Infuriate;
                 return true;
             }
-                
-            if (onslaughtEnabled && 
+
+            if (onslaughtEnabled &&
                 ActionReady(Onslaught) && HasSurgingTempest &&
                 (!innerReleaseEnabled && !poolOnslaughtForManual || IR.Cooldown > 40) && //Buff Window Check
                 GetRemainingCharges(Onslaught) > onslaughtChargeThreshold &&  //Charge Slider Check
@@ -236,7 +236,7 @@ internal partial class WAR : Tank
             if (upheavalEnabled &&
                 ActionReady(Upheaval) && HasSurgingTempest && InActionRange(Upheaval))
             {
-                if (flags.HasFlag(Combo.ST) || 
+                if (flags.HasFlag(Combo.ST) ||
                     flags.HasFlag(Combo.AoE) && !LevelChecked(Orogeny)) //Use Upheaval if too low level
                 {
                     actionID = Upheaval;
@@ -249,7 +249,7 @@ internal partial class WAR : Tank
                 }
             }
 
-            if (primalWrathEnabled && 
+            if (primalWrathEnabled &&
                 LevelChecked(PrimalWrath)  && HasWrathful && HasSurgingTempest && GetTargetDistance() <= 4.99f)
             {
                 actionID = PrimalWrath;
@@ -259,7 +259,7 @@ internal partial class WAR : Tank
         return false;
     }
     #endregion
-    
+
     #region GCD Attacks
     private static bool TryGCDAttacks(Combo flags, ref uint actionID)
     {
@@ -268,23 +268,23 @@ internal partial class WAR : Tank
             flags.HasFlag(Combo.Simple) ||
             IsSTEnabled(flags, Preset.WAR_ST_PrimalRend) ||
             IsAoEEnabled(flags, Preset.WAR_AoE_PrimalRend);
-        
+
         bool rangedUptimeEnabled =
             flags.HasFlag(Combo.Simple) ||
             IsSTEnabled(flags, Preset.WAR_ST_RangedUptime) ||
             IsAoEEnabled(flags, Preset.WAR_AoE_RangedUptime);
-        
+
         bool primalRuinationEnabled =
             flags.HasFlag(Combo.Simple) ||
             IsSTEnabled(flags, Preset.WAR_ST_PrimalRuination) ||
             IsAoEEnabled(flags, Preset.WAR_AoE_PrimalRuination);
-        
+
         bool fellCleaveEnabled =
             flags.HasFlag(Combo.Simple) ||
             IsSTEnabled(flags, Preset.WAR_ST_FellCleave) ||
             IsAoEEnabled(flags, Preset.WAR_AoE_Decimate);
         #endregion
-        
+
         #region Configs
         int fellCleaveGaugeThresholdST =
             WAR_ST_FellCleave_Pooling //is pooling enabled
@@ -292,51 +292,51 @@ internal partial class WAR : Tank
                     ? !JustUsed(OriginalHook(Berserk), 20f) //not in Burst Window
                         ? ComboAction is HeavySwing
                             ? 100 //Use to prevent Overcap from Maim
-                            : ComboAction is Maim  
+                            : ComboAction is Maim
                                 ? 90 //Use to prevent Overcap
                                 : 110 //Dont use it
                         : 50 // In Burst Window, Dump at 50
                     : 50 //Option not selected and not in Boss encounter, dump at 50
                 : WAR_ST_FellCleave_Gauge; //Pooling not enabled, follow slider
-            
-        int decimateGaugeThresholdAoE = 
+
+        int decimateGaugeThresholdAoE =
             WAR_AoE_Decimate_Pooling //is pooling enabled
                 ? !WAR_AoE_Decimate_Pooling_BossOnly || InBossEncounter() //Is pooling not boss only or in a boss encounter
                     ? !JustUsed(OriginalHook(Berserk), 20f) //not in Burst Window
-                        ?ComboAction is Overpower 
+                        ?ComboAction is Overpower
                             ? 90 //Use to prevent Overcap
                             : 110 //Dont use it
                         : 50 // In Burst Window, Dump at 50
                     : 50 //Option not selected and not in Boss encounter, dump at 50
                 : WAR_AoE_Decimate_Gauge; //Pooling not enabled, follow slider
-        
-        int spenderGaugeThreshold = 
-            flags.HasFlag(Combo.Simple) ? 50 : 
+
+        int spenderGaugeThreshold =
+            flags.HasFlag(Combo.Simple) ? 50 :
             flags.HasFlag(Combo.ST) ? fellCleaveGaugeThresholdST : decimateGaugeThresholdAoE;
-        
-        float primalRendDistanceThreshold = 
-            flags.HasFlag(Combo.Simple) ? 3 : 
+
+        float primalRendDistanceThreshold =
+            flags.HasFlag(Combo.Simple) ? 3 :
             flags.HasFlag(Combo.ST) ? WAR_ST_PrimalRend_Distance : WAR_AoE_PrimalRend_Distance;
-        
-        int primalRendMovement = 
-            flags.HasFlag(Combo.Simple) ? 0 : 
+
+        int primalRendMovement =
+            flags.HasFlag(Combo.Simple) ? 0 :
             flags.HasFlag(Combo.ST) ? WAR_ST_PrimalRend_Movement : WAR_AoE_PrimalRend_Movement;
-        
-        float primalRendTimeStoodStill = 
-            flags.HasFlag(Combo.Simple) ? 2 : 
+
+        float primalRendTimeStoodStill =
+            flags.HasFlag(Combo.Simple) ? 2 :
             flags.HasFlag(Combo.ST) ? WAR_ST_PrimalRend_TimeStill : WAR_AoE_PrimalRend_TimeStill;
-        
-        int primalRendTiming = 
-            flags.HasFlag(Combo.Simple) ? 0 : 
+
+        int primalRendTiming =
+            flags.HasFlag(Combo.Simple) ? 0 :
             flags.HasFlag(Combo.ST) ? WAR_ST_PrimalRend_EarlyLate : WAR_AoE_PrimalRend_EarlyLate;
-        
-        bool useSmartAoE = flags.HasFlag(Combo.Simple) ? true : WAR_AoE_Decimate_Smart; 
+
+        bool useSmartAoE = flags.HasFlag(Combo.Simple) ? true : WAR_AoE_Decimate_Smart;
         #endregion
-        
-        if (HasBattleTarget())  
+
+        if (HasBattleTarget())
         {
             #region Primal Rend
-            if (primalRendEnabled && HasSurgingTempest && HasStatusEffect(Buffs.PrimalRendReady) && 
+            if (primalRendEnabled && HasSurgingTempest && HasStatusEffect(Buffs.PrimalRendReady) &&
                 GetTargetDistance() <= primalRendDistanceThreshold && //Distance Slider Check
                 (primalRendMovement == 1 || //Any Movement
                  primalRendMovement == 0 && !IsMoving() && TimeStoodStill > TimeSpan.FromSeconds(primalRendTimeStoodStill)) && //Time Stood Still Slider Check
@@ -363,7 +363,7 @@ internal partial class WAR : Tank
                  BeastGauge >= spenderGaugeThreshold)) //Use if you have Nascent Buff
             {
                 int enemyCount = NumberOfEnemiesInRange(Role.Reprisal);
-                
+
                 if (InMeleeRange() && //Melee range check for single target
                     (flags.HasFlag(Combo.ST) || //Fell Cleave in ST
                      flags.HasFlag(Combo.AoE) && LevelChecked(FellCleave) && useSmartAoE && (!LevelChecked(Decimate) && enemyCount < 5 || //Fell Cleave in Aoe if Decimate too low level
@@ -392,26 +392,26 @@ internal partial class WAR : Tank
         return false;
     }
     #endregion
-    
+
     #region Basic Combos
     internal static uint STCombo
-        => ComboTimer > 0 
+        => ComboTimer > 0
             ? LevelChecked(Maim) && ComboAction == HeavySwing // Logic for Combo 2
                 ? Maim
                 : LevelChecked(StormsPath) && ComboAction == Maim //Logic for Combos 3.1 and 3.2
-                    ? LevelChecked(StormsEye) && ((IsEnabled(Preset.WAR_ST_Simple) && GetStatusEffectRemainingTime(Buffs.SurgingTempest) <= 29) || 
+                    ? LevelChecked(StormsEye) && ((IsEnabled(Preset.WAR_ST_Simple) && GetStatusEffectRemainingTime(Buffs.SurgingTempest) <= 29) ||
                                                   (IsEnabled(Preset.WAR_ST_Advanced) && IsEnabled(Preset.WAR_ST_StormsEye) && GetStatusEffectRemainingTime(Buffs.SurgingTempest) <= WAR_SurgingRefreshRange))
                         ? StormsEye //return if ST is needed
                         : StormsPath //return if ST is not needed
                     : HeavySwing  //return if cant Storms Path
             : HeavySwing; //Return of cant Maim
-    
-    internal static uint AoECombo 
-        => ComboTimer > 0 && LevelChecked(MythrilTempest) && ComboAction == Overpower 
-            ? MythrilTempest 
+
+    internal static uint AoECombo
+        => ComboTimer > 0 && LevelChecked(MythrilTempest) && ComboAction == Overpower
+            ? MythrilTempest
             : Overpower;
     #endregion
-    
+
     #endregion
 
     #region One-Button Mitigation Combo Priorities
@@ -484,31 +484,31 @@ internal partial class WAR : Tank
     }
 
     #endregion
-    
+
     #region Auto Mitigation System
-    
+
     [Flags]
     private enum RotationMode{
         simple = 1 << 0,
         advanced = 1 << 1
     }
-    
+
     private static bool TryUseMits(RotationMode rotationFlags, ref uint actionID) => CanUseNonBossMits(rotationFlags, ref actionID) || CanUseBossMits(rotationFlags, ref actionID);
-    
+
     private static bool CanUseNonBossMits(RotationMode rotationFlags, ref uint actionID)
     {
         #region Variables
         var numberOfEnemies = NumberOfEnemiesInRange(Role.Reprisal);
         var pre56Mitigation = !LevelChecked(RawIntuition) && numberOfEnemies >= 3;
-        
+
         var mitigationRunning = HasStatusEffect(Role.Buffs.ArmsLength) ||
-                                HasStatusEffect(Role.Buffs.Rampart) || 
+                                HasStatusEffect(Role.Buffs.Rampart) ||
                                 HasStatusEffect(Buffs.Holmgang) ||
                                 HasStatusEffect(Buffs.ThrillOfBattle) ||
-                                HasStatusEffect(Buffs.Vengeance) || 
+                                HasStatusEffect(Buffs.Vengeance) ||
                                 HasStatusEffect(Buffs.Damnation) ||
                                 HasStatusEffect(Role.Debuffs.Reprisal, CurrentTarget);
-        
+
         var justMitted = JustUsed(OriginalHook(ThrillOfBattle)) ||
                           JustUsed(OriginalHook(Vengeance)) ||
                           JustUsed(OriginalHook(RawIntuition)) ||
@@ -517,18 +517,18 @@ internal partial class WAR : Tank
                           JustUsed(Role.Rampart) ||
                           JustUsed(Holmgang);
         #endregion
-        
+
         #region Initial Bailout
-        if (!InCombat() ||  
-            InBossEncounter() || 
-            !IsEnabled(Preset.WAR_Mitigation_NonBoss) || 
+        if (!InCombat() ||
+            InBossEncounter() ||
+            !IsEnabled(Preset.WAR_Mitigation_NonBoss) ||
             (CombatEngageDuration().TotalSeconds <= 15 && IsMoving()))
             return false;
         #endregion
-        
+
         #region HolmGang Invulnerability
         var holmgangThreshold = rotationFlags.HasFlag(RotationMode.simple) ? 10 : WAR_Mitigation_NonBoss_Holmgang_Health;
-        
+
         if (IsEnabled(Preset.WAR_Mitigation_NonBoss_Holmgang) && ActionReady(Holmgang) &&
             PlayerHealthPercentageHp() <= holmgangThreshold)
         {
@@ -536,28 +536,28 @@ internal partial class WAR : Tank
             return true;
         }
         #endregion
-        
+
         #region Raw Intuition/Bloodwhetting
-        if (IsEnabled(Preset.WAR_Mitigation_NonBoss_RawIntuition) && 
+        if (IsEnabled(Preset.WAR_Mitigation_NonBoss_RawIntuition) &&
             ActionReady(OriginalHook(RawIntuition)) && CanWeave() && !justMitted)
         {
             actionID = OriginalHook(RawIntuition);
             return true;
         }
         #endregion
-        
+
         #region Mitigation Threshold Bailout Canweave/Justmitted Check
-        float mitigationThreshold = rotationFlags.HasFlag(RotationMode.simple) 
-            ? 10 
+        float mitigationThreshold = rotationFlags.HasFlag(RotationMode.simple)
+            ? 10
             : WAR_Mitigation_NonBoss_MitigationThreshold;
-        if (GetAvgEnemyHPPercentInRange(10f) <= mitigationThreshold || !CanWeave() || justMitted) 
+        if (GetAvgEnemyHPPercentInRange(10f) <= mitigationThreshold || !CanWeave() || justMitted)
             return false;
         #endregion
-        
+
         #region Equilibrium
         var equilibriumThreshold = rotationFlags.HasFlag(RotationMode.simple) ? 65 : WAR_Mitigation_NonBoss_Equilibrium_Health;
-        
-        if (IsEnabled(Preset.WAR_Mitigation_NonBoss_Equilibrium) && 
+
+        if (IsEnabled(Preset.WAR_Mitigation_NonBoss_Equilibrium) &&
             ActionReady(Equilibrium) &&
             PlayerHealthPercentageHp() <= equilibriumThreshold)
         {
@@ -565,12 +565,12 @@ internal partial class WAR : Tank
             return true;
         }
         #endregion
-        
+
         #region Shake It Off
         var shakeItOffThreshold = rotationFlags.HasFlag(RotationMode.simple) ? 80 : WAR_Mitigation_NonBoss_ShakeItOff_Health;
-        var safeToShakeItOff = !HasAnyStatusEffects([Buffs.ThrillOfBattle, Buffs.Damnation, Buffs.Vengeance, Buffs.BloodwhettingDefenseLong]);
-        
-        if (IsEnabled(Preset.WAR_Mitigation_NonBoss_ShakeItOff) && 
+        var safeToShakeItOff = !HasStatusEffects([Buffs.ThrillOfBattle, Buffs.Damnation, Buffs.Vengeance, Buffs.BloodwhettingDefenseLong]);
+
+        if (IsEnabled(Preset.WAR_Mitigation_NonBoss_ShakeItOff) &&
             ActionReady(ShakeItOff) && safeToShakeItOff &&
             PlayerHealthPercentageHp() <= shakeItOffThreshold)
         {
@@ -578,9 +578,9 @@ internal partial class WAR : Tank
             return true;
         }
         #endregion
-        
+
         if (mitigationRunning || numberOfEnemies <= 2) return false; //Bail if already Mitted or too few enemies
-        
+
         #region Mitigation 5+
         if (numberOfEnemies >= 5 || pre56Mitigation)
         {
@@ -601,48 +601,48 @@ internal partial class WAR : Tank
             }
         }
         #endregion
-        
+
         #region Mitigation 3+
         if (Role.CanRampart() && IsEnabled(Preset.WAR_Mitigation_NonBoss_Rampart))
         {
             actionID = Role.Rampart;
             return true;
         }
-            
+
         if (ActionReady(ThrillOfBattle) && IsEnabled(Preset.WAR_Mitigation_NonBoss_ThrillOfBattle))
         {
             actionID = ThrillOfBattle;
             return true;
         }
         #endregion
-        
+
         return false;
-        
+
         bool IsEnabled(Preset preset)
         {
             if (rotationFlags.HasFlag(RotationMode.simple))
                 return true;
-            
+
             return CustomComboFunctions.IsEnabled(preset);
         }
     }
-    
+
     private static bool CanUseBossMits(RotationMode rotationFlags, ref uint actionID)
     {
         #region Initial Bailout
         if (!InCombat() || !CanWeave() || !InBossEncounter() || !IsEnabled(Preset.WAR_Mitigation_Boss)) return false;
         #endregion
-        
+
         #region Vengeance
         var vengeanceFirst = rotationFlags.HasFlag(RotationMode.simple)
             ? false
             : WAR_Mitigation_Boss_Vengeance_First;
-        
-        var vengeanceInMitigationContent = rotationFlags.HasFlag(RotationMode.simple) || 
+
+        var vengeanceInMitigationContent = rotationFlags.HasFlag(RotationMode.simple) ||
                                            ContentCheck.IsInConfiguredContent(WAR_Mitigation_Boss_Vengeance_Difficulty, WAR_Boss_Mit_DifficultyListSet);
-        
-        if (IsEnabled(Preset.WAR_Mitigation_Boss_Vengeance) && 
-            ActionReady(OriginalHook(Vengeance)) && vengeanceInMitigationContent && HasIncomingTankBusterEffect() 
+
+        if (IsEnabled(Preset.WAR_Mitigation_Boss_Vengeance) &&
+            ActionReady(OriginalHook(Vengeance)) && vengeanceInMitigationContent && HasIncomingTankBusterEffect()
             && !JustUsed(Role.Rampart, 20f) && // Prevent double big mits
             (!ActionReady(Role.Rampart) || vengeanceFirst)) //Vengeance First or don't use unless rampart is on cd.
         {
@@ -650,61 +650,61 @@ internal partial class WAR : Tank
             return true;
         }
         #endregion
-        
+
         #region Rampart
-        var rampartInMitigationContent = rotationFlags.HasFlag(RotationMode.simple) || 
+        var rampartInMitigationContent = rotationFlags.HasFlag(RotationMode.simple) ||
                                          ContentCheck.IsInConfiguredContent(WAR_Mitigation_Boss_Rampart_Difficulty, WAR_Boss_Mit_DifficultyListSet);
-        
-        if (IsEnabled(Preset.WAR_Mitigation_Boss_Rampart) && 
-            ActionReady(Role.Rampart) && rampartInMitigationContent && HasIncomingTankBusterEffect() && 
+
+        if (IsEnabled(Preset.WAR_Mitigation_Boss_Rampart) &&
+            ActionReady(Role.Rampart) && rampartInMitigationContent && HasIncomingTankBusterEffect() &&
             !JustUsed(OriginalHook(Vengeance), 15f)) // Prevent double big mits
         {
             actionID = Role.Rampart;
             return true;
         }
         #endregion
-        
+
         #region Raw Intuition/Bloodwhetting
         var RawIntuitionOnCDInMitigationContent = rotationFlags.HasFlag(RotationMode.simple) ||
                                               ContentCheck.IsInConfiguredContent(WAR_Mitigation_Boss_RawIntuition_OnCD_Difficulty, WAR_Boss_Mit_DifficultyListSet);
-        
+
         var RawIntuitionTankBusterInMitigationContent = rotationFlags.HasFlag(RotationMode.simple) ||
                                               ContentCheck.IsInConfiguredContent(WAR_Mitigation_Boss_RawIntuition_TankBuster_Difficulty, WAR_Boss_Mit_DifficultyListSet);
-        var RawIntuitionHealthThreshold = rotationFlags.HasFlag(RotationMode.simple) 
+        var RawIntuitionHealthThreshold = rotationFlags.HasFlag(RotationMode.simple)
             ? 80
             : WAR_Mitigation_Boss_RawIntuition_Health;
-        
-        var rawIntuitionDelay = rotationFlags.HasFlag(RotationMode.simple) 
+
+        var rawIntuitionDelay = rotationFlags.HasFlag(RotationMode.simple)
             ? 0
             : WAR_Mitigation_Boss_RawIntuitionDelay;
-        
+
         bool rawIntuitionOnCD = IsEnabled(Preset.WAR_Mitigation_Boss_RawIntuition_OnCD) &&  PlayerHealthPercentageHp() <= RawIntuitionHealthThreshold && IsPlayerTargeted() && RawIntuitionOnCDInMitigationContent;
-        bool rawIntuitionTankbuster = IsEnabled(Preset.WAR_Mitigation_Boss_RawIntuition_TankBuster) && RawIntuitionTankBusterInMitigationContent && 
+        bool rawIntuitionTankbuster = IsEnabled(Preset.WAR_Mitigation_Boss_RawIntuition_TankBuster) && RawIntuitionTankBusterInMitigationContent &&
                                       HasIncomingTankBusterEffect(out var incomingBusterAge) && incomingBusterAge >= rawIntuitionDelay;
-            
+
         if (ActionReady(OriginalHook(RawIntuition)) && (rawIntuitionOnCD || rawIntuitionTankbuster))
         {
             actionID = OriginalHook(RawIntuition);
             return true;
         }
         #endregion
-        
+
         #region Thrill of Battle
         float emergencyThrillThreshold = rotationFlags.HasFlag(RotationMode.simple)
             ? 80
             : WAR_Mitigation_Boss_ThrillOfBattle_Threshold;
-        
+
         var alignThrillOfBattle = rotationFlags.HasFlag(RotationMode.simple)
             ? true
             : WAR_Mitigation_Boss_ThrillOfBattle_Align;
-        
-        var ThrillOfBattleInMitigationContent = rotationFlags.HasFlag(RotationMode.simple) || 
+
+        var ThrillOfBattleInMitigationContent = rotationFlags.HasFlag(RotationMode.simple) ||
                                          ContentCheck.IsInConfiguredContent(WAR_Mitigation_Boss_ThrillOfBattle_Difficulty, WAR_Boss_Mit_DifficultyListSet);
 
         bool emergencyThrillOfBattle = PlayerHealthPercentageHp() <= emergencyThrillThreshold;
         bool noOtherMitsToUse = !ActionReady(OriginalHook(Vengeance)) && !JustUsed(OriginalHook(Vengeance), 13f) && !ActionReady(Role.Rampart) && !JustUsed(Role.Rampart, 18f);
         bool alignThrillOfBattleWithRampart = JustUsed(Role.Rampart, 20f) && alignThrillOfBattle;
-        
+
         if (IsEnabled(Preset.WAR_Mitigation_Boss_ThrillOfBattle) && ActionReady(ThrillOfBattle) && HasIncomingTankBusterEffect() && ThrillOfBattleInMitigationContent &&
             (emergencyThrillOfBattle || noOtherMitsToUse || alignThrillOfBattleWithRampart))
         {
@@ -712,25 +712,25 @@ internal partial class WAR : Tank
             return true;
         }
         #endregion
-        
+
         #region Equilibrium
         var equilibriumEmergencyThreshold = rotationFlags.HasFlag(RotationMode.simple) ? 30 : WAR_Mitigation_Boss_Equilibrium_Health;
         var equilibriumTankbusterThreshold = rotationFlags.HasFlag(RotationMode.simple) ? 80 : WAR_Mitigation_Boss_Tankbuster_Equilibrium_Health;
-        if (IsEnabled(Preset.WAR_Mitigation_Boss_Equilibrium) && 
+        if (IsEnabled(Preset.WAR_Mitigation_Boss_Equilibrium) &&
             ActionReady(Equilibrium) &&
-            (PlayerHealthPercentageHp() <= equilibriumEmergencyThreshold || 
+            (PlayerHealthPercentageHp() <= equilibriumEmergencyThreshold ||
             (PlayerHealthPercentageHp() <= equilibriumTankbusterThreshold && HasIncomingTankBusterEffect())))
         {
             actionID = Equilibrium;
             return true;
         }
         #endregion
-        
+
         #region Reprisal
         var ReprisalInMitigationContent = rotationFlags.HasFlag(RotationMode.simple) ||
                                           ContentCheck.IsInConfiguredContent(WAR_Mitigation_Boss_Reprisal_Difficulty, WAR_Boss_Mit_DifficultyListSet);
-        
-        if (IsEnabled(Preset.WAR_Mitigation_Boss_Reprisal) && 
+
+        if (IsEnabled(Preset.WAR_Mitigation_Boss_Reprisal) &&
             Role.CanReprisal(enemyCount:1) && GroupDamageIncoming() && ReprisalInMitigationContent &&
             !JustUsed(ShakeItOff, 10f))
         {
@@ -738,12 +738,12 @@ internal partial class WAR : Tank
             return true;
         }
         #endregion
-        
+
         #region Shake it Off
         var ShakeItOffInMitigationContent = rotationFlags.HasFlag(RotationMode.simple) ||
                                             ContentCheck.IsInConfiguredContent(WAR_Mitigation_Boss_ShakeItOff_Difficulty, WAR_Boss_Mit_DifficultyListSet);
-        
-        if (IsEnabled(Preset.WAR_Mitigation_Boss_ShakeItOff) && 
+
+        if (IsEnabled(Preset.WAR_Mitigation_Boss_ShakeItOff) &&
             !JustUsed(Role.Reprisal, 10f) && GroupDamageIncoming() && ShakeItOffInMitigationContent &&
             ActionReady(ShakeItOff))
         {
@@ -751,18 +751,18 @@ internal partial class WAR : Tank
             return true;
         }
         #endregion
-       
+
         return false;
-        
+
         bool IsEnabled(Preset preset)
         {
             if (rotationFlags.HasFlag(RotationMode.simple))
                 return true;
-            
+
             return CustomComboFunctions.IsEnabled(preset);
         }
     }
-    
+
     #endregion
 
     #region IDs

--- a/WrathCombo/CustomCombo/Functions/Party.cs
+++ b/WrathCombo/CustomCombo/Functions/Party.cs
@@ -120,7 +120,7 @@ internal abstract partial class CustomComboFunctions
             var existingIds = new HashSet<ulong>(field.Select(x => x.GameObjectId));
 
             foreach (var pc in Svc.Objects.GetBattleCharas()
-                         .Where(x => x.CanUseOn(WHM.Raise) && x.IsDead))
+                         .Where(x => x.IsDead))
             {
                 if (pc.SafeStatusList?.Any(x => x.StatusId == All.Buffs.Raised) == true)
                     continue;

--- a/WrathCombo/CustomCombo/Functions/Party.cs
+++ b/WrathCombo/CustomCombo/Functions/Party.cs
@@ -116,21 +116,27 @@ internal abstract partial class CustomComboFunctions
         get
         {
             field ??= new();
-            foreach (var pc in Svc.Objects
-                         .Where(x => x is IBattleChara && x.CanUseOn(WHM.Raise))
-                         .Cast<IBattleChara>().ToList())
+
+            var existingIds = new HashSet<ulong>(field.Select(x => x.GameObjectId));
+
+            foreach (var pc in Svc.Objects.GetBattleCharas()
+                         .Where(x => x.CanUseOn(WHM.Raise) && x.IsDead))
             {
-                if (pc.IsDead && !pc.StatusList.Any(x => x.StatusId == All.Buffs.Raised))
+                if (pc.SafeStatusList?.Any(x => x.StatusId == All.Buffs.Raised) == true)
+                    continue;
+
+                if (!existingIds.Contains(pc.GameObjectId))
                 {
-                    if (!field.Any(x => x.GameObjectId == pc.GameObjectId))
-                        field.Add(new WrathPartyMember
-                        {
-                            GameObjectId = pc.GameObjectId,
-                            CurrentHP = pc.CurrentHp,
-                            NPCClassJob = pc.ClassJob.RowId
-                        });
+                    field.Add(new WrathPartyMember
+                    {
+                        GameObjectId = pc.GameObjectId,
+                        CurrentHP = pc.CurrentHp,
+                        NPCClassJob = pc.ClassJob.RowId
+                    });
+                    existingIds.Add(pc.GameObjectId);
                 }
             }
+
             field.RemoveAll(x => x.BattleChara is null || !x.BattleChara.IsDead);
             return field;
         }

--- a/WrathCombo/CustomCombo/Functions/Status.cs
+++ b/WrathCombo/CustomCombo/Functions/Status.cs
@@ -3,13 +3,13 @@ using Dalamud.Game.ClientState.Statuses;
 using ECommons.DalamudServices;
 using ECommons.GameFunctions;
 using ECommons.GameHelpers;
-using ECommons.MathHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using System;
+using System.Collections.Generic;
 using System.Linq;
-using WrathCombo.Data.BattleData;
 using WrathCombo.Data;
+using WrathCombo.Data.BattleData;
 using WrathCombo.Extensions;
 using WrathCombo.Services;
 
@@ -65,24 +65,39 @@ internal abstract partial class CustomComboFunctions
     }
 
     /// <summary>
-    /// Checks to see if any statuses are on the Player or an optional target
+    /// Checks to see if any or all statuses are on the Player or an optional target
     /// </summary>
-    /// <param name="statusId">List Of StatusIDs</param>
+    /// <param name="statusIds">List Of StatusIDs</param>
     /// <param name="target">Optional Target</param>
     /// <param name="anyOwner">Check if the Player owns/created the statuses, true means anyone owns</param>
+    /// <param name="matchAll">If true, target must have all of the statuses</param>
     /// <seealso cref="HasStatusEffect(ushort statusId, IGameObject? target = null, bool anyOwner = false)"/>
-    public static bool HasAnyStatusEffects(ushort[] status, IGameObject? target = null, bool anyOwner = false) =>
-        status.Any(statusId => HasStatusEffect(statusId, target ?? LocalPlayer, anyOwner));
+    public static bool HasStatusEffects(ushort[] statusIds, IGameObject? target = null, bool anyOwner = false, bool matchAll = false)
+    {
+        target ??= LocalPlayer;
+        if (target is not IBattleChara chara)
+            return false;
 
-    /// <summary>
-    /// Checks to see if all statuses are on the Player or an optional target
-    /// </summary>
-    /// <param name="statusId">List Of StatusIDs</param>
-    /// <param name="target">Optional Target</param>
-    /// <param name="anyOwner">Check if the Player owns/created the statuses, true means anyone owns</param>
-    /// <seealso cref="HasStatusEffect(ushort statusId, IGameObject? target = null, bool anyOwner = false)"/>
-    public static bool HasAllStatusEffects(ushort[] status, IGameObject? target = null, bool anyOwner = false) =>
-        status.All(statusId => HasStatusEffect(statusId, target ?? LocalPlayer, anyOwner));
+        var statuses = chara.SafeStatusList;
+        if (statuses is null)
+            return false;
+
+        ulong? sourceId = !anyOwner ? LocalPlayer.GameObjectId : null;
+        var statusIdSet = new HashSet<uint>(statusIds.Select(s => (uint)s));
+
+        if (matchAll)
+        {
+            // Check that ALL status IDs we're looking for exist on the target
+            return statusIdSet.All(statusId => statuses.Any(s => s.StatusId == statusId &&
+                (!sourceId.HasValue || s.SourceId == 0 || s.SourceId == sourceId)));
+        }
+        else
+        {
+            // Check if ANY status matches
+            return statuses.Any(s => statusIdSet.Contains(s.StatusId) &&
+                (!sourceId.HasValue || s.SourceId == 0 || s.SourceId == sourceId));
+        }
+    }
 
     /// <summary>
     /// Gets remaining time of a Status Effect
@@ -153,6 +168,9 @@ internal abstract partial class CustomComboFunctions
 
         return HasStatusEffect(44, target, true); //Brink of Death = 44
     }
+
+    public static bool TargetHasRaiseInvincibility(IBattleChara? target) => StatusCache.HasRaiseInvincibility(target);
+    public static bool TargetHasRaiseStatus(IBattleChara? target) => StatusCache.HasRaiseStatus(target);
 
     /// <summary>
     /// Checks if the target has a debuff that can be dispelled.
@@ -234,11 +252,8 @@ internal abstract partial class CustomComboFunctions
             BattleData.Invincible.True => true,
             // Are we to bother with checking statuses per Battle Data
             BattleData.Invincible.False => false,
-            // General invincibility check
-            // Due to large size of InvincibleStatuses, best to check process this way
-            BattleData.Invincible.CheckStatuses => StatusCache.CompareLists(
-                                StatusCache.InvincibleStatuses,
-                                targetStatuses),
+            // General invincibility check, not using StatusCache.HasStatusInCacheList because statuses is derived from SafeStatusList
+            BattleData.Invincible.CheckStatuses => statuses.Any(s => StatusCache.InvincibleStatuses.Contains(s.StatusId)),
             _ => false,
         };
     }

--- a/WrathCombo/Data/BattleData/BattleData_3.0_HW.cs
+++ b/WrathCombo/Data/BattleData/BattleData_3.0_HW.cs
@@ -1,5 +1,9 @@
-﻿using ECommons.ExcelServices;
+﻿using ECommons.DalamudServices;
+using ECommons.ExcelServices;
+using ECommons.GameFunctions;
 using ECommons.GameHelpers;
+using System.Linq;
+using WrathCombo.Extensions;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
 
 namespace WrathCombo.Data.BattleData
@@ -35,6 +39,26 @@ namespace WrathCombo.Data.BattleData
                         return Invincible.False;
                     };
                     break;
+
+                case 637: // Containment Bay Z1T9 Zurvan
+                    _invincibleCheck = (_, targetID, _) =>
+                    {
+                        // Note, would need a Player.CombatRole not Tank if this is built out further for Extreme/Unreal, presuming NPC base IDs are the same for Ex
+                        if (targetID is 6556 or 6553) // Ignore Execrated Thew (6556) or Wills (6553) (mostly Wills) when Execrated Witts (6554) are around
+                            return Result(Svc.Objects.GetBattleCharas().Any(x => x.BaseId is 6554 && !x.IsDead && x.IsCharacterVisible()));
+                        return Invincible.False;
+                    };
+                    break;
+
+                case 1114: // Baelsar's Wall
+                    _invincibleCheck = (_, targetID, _) =>
+                    {
+                        if (targetID is 6461) // The Griffin. Ignore when Restraint Collar shows (hiddden NPC helper)
+                            return Result(Svc.Objects.GetBattleCharas().Any(x => x.BaseId is 6462 && !x.IsDead && x.IsCharacterVisible()));
+                        return Invincible.False;
+                    };
+                    break;
+
                 default:
                     dataLoaded = false;
                     break;

--- a/WrathCombo/Data/BattleData/BattleData_4.0_SB.cs
+++ b/WrathCombo/Data/BattleData/BattleData_4.0_SB.cs
@@ -30,6 +30,15 @@ namespace WrathCombo.Data.BattleData
 
                     break;
 
+                case 788: // Saint Mocianne's Arboretum (Hard)
+                    _pauseActions = () =>
+                    {
+                        // Lakhamu's Empty Gaze
+                        if (CheckForGazeCasts(9257, 12587)) return true;
+                        return false;
+                    };
+                    break;
+
                 case 801 or 805 or 1122: // Interdimensional Rift (Omega 12 / Alphascape 4), Regular/Savage?/Ultimate?
                                          // Omega-M = 9339
                                          // Omega-F = 9340

--- a/WrathCombo/Data/StatusCache.cs
+++ b/WrathCombo/Data/StatusCache.cs
@@ -96,15 +96,15 @@ internal class StatusCache
 
     public static bool HasDamageUp(IGameObject? target) => HasStatusInCacheList(DamageUpStatuses, target);
 
-    private static readonly FrozenSet<uint> evasionUpStatuses =
-        ENStatusSheet.TryGetValue(61, out var refRow)
+    private static readonly FrozenSet<uint> EvasionUpStatuses =
+        ENStatusSheet.TryGetValue(31, out var refRow)
             ? ENStatusSheet
                 .Where(x => x.Value.Name.ToString().Contains(refRow.Name.ToString(), StringComparison.CurrentCultureIgnoreCase))
                 .Select(x => x.Key)
                 .ToFrozenSet()
             : [];
 
-    public static bool HasEvasionUp(IGameObject? target) => HasStatusInCacheList(evasionUpStatuses, target);
+    public static bool HasEvasionUp(IGameObject? target) => HasStatusInCacheList(EvasionUpStatuses, target);
 
     /// <summary>
     /// A cached set of dispellable status IDs for quick lookup.
@@ -126,7 +126,7 @@ internal class StatusCache
             .Select(kvp => kvp.Key)
             .ToFrozenSet();
 
-    public static bool HasBeneficialStatus(IGameObject? targt) => HasStatusInCacheList(BeneficialStatuses, targt);
+    public static bool HasBeneficialStatus(IGameObject? target) => HasStatusInCacheList(BeneficialStatuses, target);
 
     /// <summary>
     /// A set of status effect IDs that grant general invincibility.
@@ -145,6 +145,22 @@ internal class StatusCache
                 3052, 3054, 4175
             })
             .ToFrozenSet();
+
+    private static readonly FrozenSet<uint> RaiseInvincibilityStatuses =
+        StatusSheet
+            .Where(row => row.Value.Icon == 215273) // Transcendant statuses, based on Icon
+            .Select(row => row.Key)
+            .ToFrozenSet();
+
+    public static bool HasRaiseInvincibility(IBattleChara? target) => HasStatusInCacheList(RaiseInvincibilityStatuses, target);
+
+    private static readonly FrozenSet<uint> RaiseStatuses =
+        StatusSheet
+            .Where(row => row.Value.Icon == 210406) // Raise statuses, based on Icon
+            .Select(row => row.Key)
+            .ToFrozenSet();
+
+    public static bool HasRaiseStatus(IBattleChara? target) => HasStatusInCacheList(RaiseStatuses, target);
 
     internal static readonly FrozenSet<uint> DoNotHealStatuses = new uint[]
     {
@@ -210,30 +226,15 @@ internal class StatusCache
     /// <param name="statusList">Hashset of Status IDs to check</param>
     /// <param name="gameObject">GameObject to check</param>
     /// <returns></returns>
-    internal static bool HasStatusInCacheList(FrozenSet<uint> statusList, IGameObject? gameObject = null)
+    internal static bool HasStatusInCacheList(FrozenSet<uint> statusList, IGameObject? gameObject)
     {
         if (gameObject is not IBattleChara chara)
             return false;
 
         var statuses = chara.SafeStatusList;
-
         if (statuses is null)
             return false;
 
-        var targetStatuses = statuses.Select(s => s.StatusId).ToHashSet();
-        return statusList.Count switch
-        {
-            0 => false,
-            _ => CompareLists(statusList, targetStatuses)
-        };
+         return statuses.Any(s => statusList.Contains(s.StatusId));
     }
-
-    /// <summary>
-    /// Compares two hashsets, in this case, used to compare a cached set of status IDs against a character's StatusID list
-    /// </summary>
-    /// <param name="statusList"></param>
-    /// <param name="charaStatusList"></param>
-    /// <returns></returns>
-    internal static bool CompareLists(FrozenSet<uint> statusList, HashSet<uint> charaStatusList) =>
-        charaStatusList.Any(id => statusList.Contains(id));
 }

--- a/WrathCombo/Data/StatusCache.cs
+++ b/WrathCombo/Data/StatusCache.cs
@@ -160,7 +160,9 @@ internal class StatusCache
                     .Select(row => row.Key)
             )
             {
+            1132, // Baelsar's Wall - Extreme Caution
             4130 // Authority's Hold
+
             }.ToFrozenSet();
 
         internal static readonly FrozenSet<uint> Pyretics =

--- a/WrathCombo/Extensions/ObjectTableExtensions.cs
+++ b/WrathCombo/Extensions/ObjectTableExtensions.cs
@@ -6,7 +6,12 @@ namespace WrathCombo.Extensions
 {
     internal static class ObjectTableExtensions
     {
-        // Narrower search scope
+        /// <summary>
+        /// Searches the IObjectTable for IBattleCharas in the specific locations in which they are stored
+        /// </summary>
+        /// <param name="objects">The Dalamud Game ObjectTable (ie Svc.Objects)</param>
+        /// <param name="searchNonNetwork">IBattleCharas that "aren't networked" can exist, but 99.99% of the time looking in the non networked area is not required.</param>
+        /// <returns>IEnumbable of non null IBattleCharas</returns>
         // https://github.com/aers/FFXIVClientStructs/blob/main/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObjectManager.cs
         public static IEnumerable<IBattleChara> GetBattleCharas(this IObjectTable objects, bool searchNonNetwork = false)
         {


### PR DESCRIPTION
- ObjectTableExtensions GetBattleCharas: Added function summary
- BattleData
  - Containment Bay Z1T9: Prioritize Witts
  - Baelsar's Wall: Prioritize Restraint Collar
  - Saint Mocianne's Arboretum (Hard): Gaze Check
- Party
  - DeadPeople: Attempt to streamline lookups by using a temporary hashset
- AutoRotationController
  - Many functions updated from IGameObject to IBattleChara due to GetBattleCharas returning only IBattleCharas
  - Converted RezQuery delegate property to CheckRezTarget method
  - PreEmptiveHot, PreEmptiveShield, & UpdateKardiaTarget: Implemented GetBattleCharas in search
  - Commented a few magic static numbers
  - DPSTargeting
    - BaseSelection: Set as IBattleChara. Instead of two object searches, performs one at minimum, a second only if there are no priority matches
  - HealerTargeting
    - CanAoEHeal: Implemented SafeStatusList, refactored statement to just get a count return
- Status / StatusCache
  - Added TargetHasRaiseStatus && TargetHasRaiseInvincibility because we now have more than one of each status for the exact same thing/name thanks to some SE intern
  - Added TargetHasRaiseInvincibility to ShouldSkipAutorotation, and removed various checks throughout AutoRotationController
  - DoNotHealStatuses uses HasStatusInCacheList now to use SafeStatusList
  - Combined HasAnyStatusEffect & HasAllStatusEffects to HasStatusEffects with matchAll boolean
  - StatusCache AccelerationBombs: Added Baelsar's Wall Extreme Caution