### PR TITLE
Filtered Presets Fix

### DIFF
--- a/WrathCombo/Core/ActionReplacer.cs
+++ b/WrathCombo/Core/ActionReplacer.cs
@@ -233,9 +233,11 @@ internal sealed class ActionReplacer : IDisposable
             if (presetData.IsPvP != CustomComboFunctions.InPvP()) // Are we in PvP?
                 return false;
 
-            return (presetData.JobInfo.Role is JobRole role &&
-                role.MatchesPlayerJob())
-                || presetData.JobInfo.Job == upgradedJob;
+            return
+                // Role & Content
+                (presetData.JobInfo.Job is Job.ADV && presetData.JobInfo.Role is JobRole role && role.MatchesPlayerJob()) ||
+                // Job Specific
+                presetData.JobInfo.Job == upgradedJob;
         });
 
         var filteredCombos = FilteredCombos as CustomCombo[] ?? FilteredCombos.ToArray();


### PR DESCRIPTION
Fixed issue where extra presets / combos were loaded and executed because it would load all enabled combos of the same job role (SGE saw WHM/AST/SCH presets, etc)