### PR TITLE
Fix for Role Combos being checked for all classes / jobs

### DIFF
--- a/WrathCombo/Attributes/JobInfoAttribute.cs
+++ b/WrathCombo/Attributes/JobInfoAttribute.cs
@@ -28,8 +28,10 @@ internal class JobInfoAttribute : Attribute
         };
 
         Order = order;
-        Role = GetRoleFromJob(Job);
         RoleForIcon = jobRoleIcon == JobRole.All ? null : jobRoleIcon;
+        // For Normal Jobs, get the role. For Roles & Content, use the Icon if given
+        Role = job is Job.ADV ? jobRoleIcon : GetRoleFromJob(job); ;
+
     }
 
     /// <summary> Associated job ID (with gathering jobs mapped to MIN). </summary>

--- a/WrathCombo/Core/ActionReplacer.cs
+++ b/WrathCombo/Core/ActionReplacer.cs
@@ -223,8 +223,6 @@ internal sealed class ActionReplacer : IDisposable
     {
         var playerJob = Player.Job;
         var upgradedJob = playerJob.GetUpgradedJob();
-        if (upgradedJob is Job.BTN or Job.FSH)
-            upgradedJob = Job.MIN; // Allow all DoL jobs to be used for DoL combos
 
         FilteredCombos = CustomCombos.Where(x =>
         {
@@ -235,11 +233,17 @@ internal sealed class ActionReplacer : IDisposable
             if (presetData.IsPvP != CustomComboFunctions.InPvP()) // Are we in PvP?
                 return false;
 
-            return
-                // Role & Content
-                (presetData.JobInfo.Job is Job.ADV && presetData.JobInfo.Role is JobRole role && role.MatchesPlayerJob()) ||
-                // Job Specific
-                presetData.JobInfo.Job == upgradedJob;
+            return presetData.JobInfo.Job switch
+            {
+                // Role & Content - Custom Combos for Roles & Content are not top level. Read the role from the Root Parent
+                Job.ADV => presetData.RootParent.Attributes().JobInfo.Role.MatchesPlayerJob(),
+
+                // DoL - Check role match for gatherer jobs
+                Job.BTN or Job.MIN or Job.FSH => presetData.JobInfo.Role.MatchesPlayerJob(),
+
+                // Job Specific - Match against the upgraded job
+                _ => presetData.JobInfo.Job == upgradedJob
+            };
         });
 
         var filteredCombos = FilteredCombos as CustomCombo[] ?? FilteredCombos.ToArray();

--- a/WrathCombo/Window/ConfigWindow.cs
+++ b/WrathCombo/Window/ConfigWindow.cs
@@ -66,7 +66,7 @@ internal class ConfigWindow : Dalamud.Interface.Windowing.Window
             .Where(kvp => (int)kvp.Key > 100)
             .Where(kvp => kvp.Value.Parent == null)
             .Where(kvp => kvp.Value.JobInfo != null)
-            .OrderBy(kvp => GetRoleOrder(kvp.Value.JobInfo.Role))
+            .OrderBy(kvp => kvp.Value.JobInfo.Job is Job.ADV ? 5 : GetRoleOrder(kvp.Value.JobInfo.Role))
             .ThenByDescending(kvp => kvp.Value.JobInfo.Job is Job.ADV)
             .ThenByDescending(kvp => kvp.Value.JobInfo.Job is Job.MIN)
             .ThenBy(kvp => kvp.Value.JobInfo.Job)


### PR DESCRIPTION
- [JobRole] Role: If it's a Roles & Combat (R&C) combo and Job.ADV, it will assign itself the Role based on RoleForIcon if one is specified
- Updated main menu sorting to always put R&C at the bottom, because the above fix puts it back at the top (Global Tank Option now belonging to Tank Roles pushes it to the top)
- Adjustments to UpdateFilteredCombos
  - Job Role Top level items are not Combos (ie Global Tank Feature), their first tier children are, unlike normal jobs. FilteredCombos will account for that, by role checking the root preset (Role = RoleIcon fix)
  - Reorganized FilteredCombos final checks into a switch processing Job.ADV, DoL Jobs, then regular jobs